### PR TITLE
fix(mick): fence greetings and read-only speech from motion

### DIFF
--- a/crates/kirra-actuation-consumer/tests/spoken_governed_loop.rs
+++ b/crates/kirra-actuation-consumer/tests/spoken_governed_loop.rs
@@ -45,7 +45,7 @@ use kirra_planner::{
     PlanInput, PlanOutput, Planner, Pose, TrajectoryPoint,
 };
 use kirra_release_token::ros_twist::issue_ros_release;
-use kirra_sidecars::mick::{IntentRequest, IntentService};
+use kirra_sidecars::mick::{IntentOutcome, IntentRequest, IntentService};
 use kirra_sidecars::speech::{
     narration_sentence, pcm16_wav_bytes, speech_turn, utterance_for, Speaker, SpeechTurn,
     Transcriber,
@@ -282,7 +282,12 @@ fn spoken_turn<M: ModelClient>(
             context: None,
         };
         match door.handle_text(&req, now_ms) {
-            Ok((_, accepted)) => Ok(accepted.to_post_wire()),
+            Ok(IntentOutcome::Accepted(_, accepted)) => Ok(accepted.to_post_wire()),
+            // The same body `mick_service` returns for deterministically
+            // non-motion speech: a success carrying no intent. Unreachable for
+            // this drill's utterances (they are explicit requests), but the
+            // binding has to stay a faithful mirror of the route.
+            Ok(IntentOutcome::NonMotion(_)) => Ok(r#"{"ok":true,"intent":null}"#.to_string()),
             Err(code) => Err(code.to_string()),
         }
     };

--- a/crates/kirra-sidecars/src/bin/mick_service.rs
+++ b/crates/kirra-sidecars/src/bin/mick_service.rs
@@ -12,6 +12,9 @@
 //!   POST /intent          {"text":"take me to the loading dock",
 //!                          "context"?: {"ego_speed_mps":..,"posture":"NOMINAL",..}}
 //!     → 200 {"ok":true,"seq":n,"at_ms":t,"intent":{"intent":"go_to",...}}
+//!     → 200 {"ok":true,"intent":null}   (deterministic non-motion: a greeting or
+//!                                        read-only question; no model call, no
+//!                                        intent, latch and seq UNCHANGED)
 //!     → 422 {"ok":false,"error":"MICK_JSON_PARSE_ERROR"}   (fail-closed: no intent latched)
 //!     → 429 {"ok":false,"error":"MICK_RATE_LIMITED"}
 //!   GET  /intent/last     → {"intent":{...},"seq":n,"at_ms":t} | {"intent":null}
@@ -35,7 +38,7 @@ use std::net::{TcpListener, TcpStream};
 use kirra_mick::OllamaClient;
 use kirra_planner::LlmBrain;
 use kirra_sidecars::http::{read_request, respond, respond_error};
-use kirra_sidecars::mick::{IntentRequest, IntentService};
+use kirra_sidecars::mick::{IntentOutcome, IntentRequest, IntentService};
 use kirra_sidecars::narrator::{fetch_last_verdict, NarratorConfig};
 use kirra_sidecars::net::{allow_nonlocal_from_env, enforce_bind_policy, now_ms};
 
@@ -55,7 +58,16 @@ fn serve(
                 // The accepted slice embeds verbatim — validated as a
                 // standalone JSON object at acceptance, so there is no
                 // re-parse and no silent-null fallback here.
-                Ok((_, accepted)) => respond(&mut stream, "200 OK", &accepted.to_post_wire()),
+                Ok(IntentOutcome::Accepted(_, accepted)) => {
+                    respond(&mut stream, "200 OK", &accepted.to_post_wire())
+                }
+                // Deterministic non-motion: a SUCCESS that carries no intent.
+                // `{"intent":null}` is the shape `GET /intent/last` already
+                // publishes for "nothing latched", so consumers parse one null
+                // form, not two. The latch and seq are untouched.
+                Ok(IntentOutcome::NonMotion(_)) => {
+                    respond(&mut stream, "200 OK", "{\"ok\":true,\"intent\":null}")
+                }
                 Err("MICK_RATE_LIMITED") => respond(
                     &mut stream,
                     "429 Too Many Requests",

--- a/crates/kirra-sidecars/src/lib.rs
+++ b/crates/kirra-sidecars/src/lib.rs
@@ -23,6 +23,7 @@
 
 pub mod http;
 pub mod mick;
+pub mod mick_fence;
 pub mod narrator;
 pub mod net;
 pub mod planner;

--- a/crates/kirra-sidecars/src/mick.rs
+++ b/crates/kirra-sidecars/src/mick.rs
@@ -14,6 +14,15 @@
 //! intent there is no goal, no plan, no proposal. There is no default goal
 //! and no "proceed cautiously" arm anywhere on this path.
 //!
+//! **Deterministic non-motion fence:** obvious conversational and read-only
+//! text (`hello rabbit`, `what do you see`) is classified BEFORE the model runs
+//! and returns [`IntentOutcome::NonMotion`] — no LLM call, no intent, and
+//! critically no latch or `seq` change, so `GET /intent/last` cannot present an
+//! older motion command as newly requested. Defense in depth only; the deployed
+//! model returns valid-looking MOTION json for those utterances and the parse
+//! correctly admits it, because the parse checks shape, not whether motion was
+//! asked for. See [`crate::mick_fence`].
+//!
 //! Mick can only ever SLOW the system down: the intent is advice to the doer;
 //! Occy grounds it, KIRRA bounds it, and the verifying consumer enforces it —
 //! all in other processes, across the actuation fence.
@@ -21,6 +30,7 @@
 use kirra_planner::{LlmBrain, MickIntent, ModelClient, WorldContext};
 use serde::Deserialize;
 
+use crate::mick_fence::{classify_non_motion, NonMotionKind};
 use crate::net::RateLimiter;
 
 /// LLM-call rate bound (burst / steady-state per second). A plumbing bound:
@@ -120,6 +130,22 @@ impl AcceptedIntent {
     }
 }
 
+/// The outcome of one typed-text request.
+///
+/// Three states, not two: a request can be accepted, REFUSED (an `Err`,
+/// fail-closed), or recognised as deterministically non-motion. The last is a
+/// success that carries no intent — an enum rather than an `Option` so a caller
+/// cannot silently treat "the operator said hello" as "the model failed".
+#[derive(Clone, Debug, PartialEq)]
+pub enum IntentOutcome {
+    /// The model produced an intent that passed the fail-closed parse; it is
+    /// latched and `seq` has advanced.
+    Accepted(MickIntent, AcceptedIntent),
+    /// Deterministically non-motion text. No model call was made, no intent
+    /// exists, and the latch and `seq` are UNCHANGED.
+    NonMotion(NonMotionKind),
+}
+
 /// The service core: brain + latch + rate limit. Single-threaded, like the
 /// serve loop that drives it.
 pub struct IntentService<M: ModelClient> {
@@ -127,6 +153,11 @@ pub struct IntentService<M: ModelClient> {
     limiter: RateLimiter,
     last: Option<AcceptedIntent>,
     seq: u64,
+    /// How many requests the deterministic fence has absorbed this process.
+    non_motion_fenced: u64,
+    /// Last kind announced, so a greeting arriving at voice rate logs once per
+    /// episode rather than once per utterance.
+    announced_kind: Option<NonMotionKind>,
 }
 
 impl<M: ModelClient> IntentService<M> {
@@ -137,6 +168,8 @@ impl<M: ModelClient> IntentService<M> {
             limiter: RateLimiter::new(MICK_RATE_BURST, MICK_RATE_PER_S),
             last: None,
             seq: 0,
+            non_motion_fenced: 0,
+            announced_kind: None,
         }
     }
 
@@ -148,11 +181,36 @@ impl<M: ModelClient> IntentService<M> {
         &mut self,
         req: &IntentRequest,
         now_ms: u64,
-    ) -> Result<(MickIntent, AcceptedIntent), &'static str> {
+    ) -> Result<IntentOutcome, &'static str> {
         if !self.limiter.admit(now_ms) {
             return Err("MICK_RATE_LIMITED");
         }
         let ctx = world_context(req.context.as_ref().unwrap_or(&ContextReq::default()))?;
+        // Deterministic fence, BEFORE the model and before any state moves.
+        // Ordering is deliberate: after the rate limit (so the fence cannot be
+        // used to bypass shedding) and after context validation (so a caller's
+        // malformed context still surfaces), but before the LLM call — which is
+        // the only thing this needs to prevent.
+        if let Some(kind) = classify_non_motion(&req.text) {
+            self.non_motion_fenced += 1;
+            // Announce once per episode, not once per utterance: a greeting can
+            // arrive at voice rate. No transcript is logged — the kind and the
+            // running count carry the signal without the speech.
+            if self.announced_kind != Some(kind) {
+                self.announced_kind = Some(kind);
+                eprintln!(
+                    "mick: non-motion fence engaged (kind={}, fenced={}) — no model call, \
+                     no intent, latch unchanged",
+                    kind.as_str(),
+                    self.non_motion_fenced
+                );
+            }
+            // NOTHING mutates: not `last`, not `seq`. An unchanged `seq` is what
+            // stops a consumer re-reading the previous motion intent as fresh —
+            // the doer applies an intent at most once by tracking the last seq
+            // it consumed, so a stalled seq is a no-op there by construction.
+            return Ok(IntentOutcome::NonMotion(kind));
+        }
         let (intent, slice) = self.brain.decide_request(&ctx, &req.text)?;
         // The slice must stand alone as a JSON object for verbatim
         // re-publication (`to_wire`). `parse_llm_json` guarantees this; if
@@ -171,7 +229,14 @@ impl<M: ModelClient> IntentService<M> {
             intent_json: slice,
         };
         self.last = Some(accepted.clone());
-        Ok((intent, accepted))
+        self.announced_kind = None; // a real intent ends the fenced episode
+        Ok(IntentOutcome::Accepted(intent, accepted))
+    }
+
+    /// How many requests the deterministic fence has absorbed this process.
+    #[must_use]
+    pub fn non_motion_fenced(&self) -> u64 {
+        self.non_motion_fenced
     }
 
     /// The last accepted intent, if any (the `GET /intent/last` source).
@@ -200,9 +265,12 @@ mod tests {
     #[test]
     fn accepted_intent_is_latched_and_wire_round_trips_through_the_one_parse() {
         let mut svc = service(r#"{"intent":"go_to","x_m":12.0,"y_m":-2.0}"#);
-        let (intent, accepted) = svc
+        let IntentOutcome::Accepted(intent, accepted) = svc
             .handle_text(&req("take me to the dock"), 10_000)
-            .unwrap();
+            .unwrap()
+        else {
+            panic!("a motion request must be accepted, not fenced");
+        };
         assert_eq!(
             intent,
             MickIntent::GoTo {
@@ -274,6 +342,163 @@ mod tests {
             }),
         };
         assert_eq!(svc.handle_text(&r, 10_000).unwrap_err(), "MICK_BAD_CONTEXT");
+    }
+
+    // --- deterministic non-motion fence ------------------------------------
+
+    /// A model that counts calls, so "never reached the LLM" is an assertion
+    /// about a counter rather than about a log line.
+    struct CountingModel {
+        reply: String,
+        calls: std::rc::Rc<std::cell::Cell<u32>>,
+    }
+
+    impl kirra_planner::ModelClient for CountingModel {
+        fn complete(&self, _prompt: &str) -> Result<String, kirra_planner::ModelError> {
+            self.calls.set(self.calls.get() + 1);
+            Ok(self.reply.clone())
+        }
+    }
+
+    /// A service whose model reports how many times it was asked. The reply is
+    /// the MOTION json gemma3:4b actually returned for "hello rabbit" — so if
+    /// the fence ever stops working, these tests latch a cruise intent and fail
+    /// loudly rather than passing on a coincidence.
+    /// Returns the service and a HANDLE to the call counter — the test holds
+    /// its own reference rather than reaching into `LlmBrain`'s private model,
+    /// so proving "no LLM call" costs no API surface in another crate.
+    fn counting_service(
+        reply: &str,
+    ) -> (
+        IntentService<CountingModel>,
+        std::rc::Rc<std::cell::Cell<u32>>,
+    ) {
+        let calls = std::rc::Rc::new(std::cell::Cell::new(0));
+        let svc = IntentService::new(LlmBrain::new(CountingModel {
+            reply: reply.to_string(),
+            calls: std::rc::Rc::clone(&calls),
+        }));
+        (svc, calls)
+    }
+
+    const LIVE_CRUISE_REPLY: &str = r#"{"intent":"cruise","target_speed_mps":5.0}"#;
+
+    #[test]
+    fn the_observed_live_non_motion_inputs_never_reach_the_model() {
+        for text in ["hello rabbit", "hello parker", "what do you see"] {
+            let (mut svc, calls) = counting_service(LIVE_CRUISE_REPLY);
+            let out = svc.handle_text(&req(text), 10_000).unwrap();
+            assert!(
+                matches!(out, IntentOutcome::NonMotion(_)),
+                "{text:?} must be fenced, got {out:?}"
+            );
+            assert_eq!(calls.get(), 0, "{text:?} reached the LLM");
+            assert!(svc.last().is_none(), "{text:?} latched an intent");
+        }
+    }
+
+    #[test]
+    fn a_real_motion_request_still_takes_the_model_path() {
+        let (mut svc, calls) = counting_service(r#"{"intent":"go_to","x_m":1.0,"y_m":0.0}"#);
+        let out = svc
+            .handle_text(&req("drive forward one meter"), 10_000)
+            .unwrap();
+        let IntentOutcome::Accepted(intent, accepted) = out else {
+            panic!("an explicit motion request must not be fenced");
+        };
+        assert_eq!(intent, MickIntent::GoTo { x_m: 1.0, y_m: 0.0 });
+        assert_eq!(calls.get(), 1);
+        assert_eq!(accepted.seq, 1);
+        assert_eq!(svc.last(), Some(&accepted));
+    }
+
+    #[test]
+    fn a_wake_prefix_with_a_command_still_reaches_the_model() {
+        for text in [
+            "hello rabbit, drive forward one meter",
+            "hey parker turn left",
+            "rabbit, stop",
+        ] {
+            let (mut svc, calls) = counting_service(r#"{"intent":"hold"}"#);
+            let out = svc.handle_text(&req(text), 10_000).unwrap();
+            assert!(
+                matches!(out, IntentOutcome::Accepted(..)),
+                "{text:?} must reach the model, got {out:?}"
+            );
+            assert_eq!(calls.get(), 1, "{text:?}");
+        }
+    }
+
+    // --- the state rule: a greeting must not re-present an old command ------
+
+    #[test]
+    fn a_greeting_after_a_motion_intent_advances_nothing() {
+        // The hazard: the operator says "go to the dock", the doer consumes
+        // seq 1, then the operator says "hello rabbit". If the greeting bumped
+        // seq (or relatched), the doer would see a "new" intent whose payload
+        // is the OLD drive command and move again, unasked.
+        let (mut svc, calls) = counting_service(r#"{"intent":"go_to","x_m":12.0,"y_m":-2.0}"#);
+        let IntentOutcome::Accepted(_, first) = svc
+            .handle_text(&req("take me to the dock"), 10_000)
+            .unwrap()
+        else {
+            panic!("setup: the motion request must be accepted");
+        };
+        let before = svc.last().cloned();
+        assert_eq!(first.seq, 1);
+
+        for (i, text) in ["hello rabbit", "what do you see", "thanks"]
+            .iter()
+            .enumerate()
+        {
+            let out = svc
+                .handle_text(&req(text), 11_000 + i as u64 * 1_000)
+                .unwrap();
+            assert!(matches!(out, IntentOutcome::NonMotion(_)), "{text:?}");
+            assert_eq!(
+                svc.last().cloned(),
+                before,
+                "{text:?} changed the latch — a consumer would re-read the drive command"
+            );
+        }
+        // seq is still 1: the doer's apply-once check (`seq <= last_consumed`)
+        // makes the stale latch a structural no-op, not a matter of timing.
+        assert_eq!(svc.last().unwrap().seq, 1);
+        assert_eq!(calls.get(), 1, "only the real request called the model");
+
+        // And a genuine follow-up command still advances normally.
+        let IntentOutcome::Accepted(_, next) = svc
+            .handle_text(&req("take me to the dock"), 20_000)
+            .unwrap()
+        else {
+            panic!("a later real request must still be accepted");
+        };
+        assert_eq!(next.seq, 2, "the fence must not stall real intents");
+    }
+
+    #[test]
+    fn a_greeting_before_any_intent_leaves_intent_last_empty() {
+        // `GET /intent/last` renders `{"intent":null}` when nothing is latched;
+        // a greeting must not conjure a first intent out of nothing.
+        let (mut svc, calls) = counting_service(LIVE_CRUISE_REPLY);
+        assert!(matches!(
+            svc.handle_text(&req("hello rabbit"), 10_000).unwrap(),
+            IntentOutcome::NonMotion(_)
+        ));
+        assert!(svc.last().is_none());
+        assert_eq!(calls.get(), 0);
+    }
+
+    #[test]
+    fn the_fence_counter_tracks_absorbed_requests() {
+        let (mut svc, calls) = counting_service(LIVE_CRUISE_REPLY);
+        assert_eq!(svc.non_motion_fenced(), 0);
+        for (i, text) in ["hello", "hi", "thanks"].iter().enumerate() {
+            svc.handle_text(&req(text), 10_000 + i as u64 * 2_000)
+                .unwrap();
+        }
+        assert_eq!(svc.non_motion_fenced(), 3);
+        assert_eq!(calls.get(), 0, "no fenced request may reach the LLM");
     }
 
     #[test]

--- a/crates/kirra-sidecars/src/mick_fence.rs
+++ b/crates/kirra-sidecars/src/mick_fence.rs
@@ -1,0 +1,326 @@
+//! Deterministic non-motion fence for Mick's text→intent boundary.
+//!
+//! **Why this exists.** The deployed `gemma3:4b` returns valid-looking MOTION
+//! JSON for plainly conversational text. Observed live against
+//! `POST /intent`:
+//!
+//! | text | model reply |
+//! |---|---|
+//! | `hello rabbit` | `{"intent":"cruise","target_speed_mps":5}` |
+//! | `hello parker` | `{"intent":"cruise","target_speed_mps":10}` |
+//! | `what do you see` | `{"intent":"route_to","x_m":120,"y_m":40}` |
+//!
+//! Each is well-formed, in-schema, and finite, so the fail-closed parse admits
+//! it — correctly, because the parse checks SHAPE, not whether the utterance
+//! asked for motion at all. The gap is upstream of the parse.
+//!
+//! **Defense in depth, not a safety boundary.** Occy grounds an intent, KIRRA
+//! bounds it, and the verifying consumer enforces it — all unchanged, all still
+//! authoritative. A greeting that slipped through would still be clamped by the
+//! governor. This just stops it becoming an intent in the first place, which is
+//! cheaper and far easier to explain to an operator than a governor clamp.
+//!
+//! **Exact whole-utterance matching, deliberately.** The allowlist is compared
+//! against the WHOLE normalized utterance, never as a substring. That single
+//! decision buys both properties the fence needs:
+//!
+//!   - `drive to the hello sign` contains "hello" and is NOT fenced;
+//!   - `hello rabbit, drive forward one meter` carries an explicit command, so
+//!     it is not an exact match either and continues to the model.
+//!
+//! Anything not on the list goes to the model exactly as before. The fence can
+//! only ever REMOVE motion, never create or alter it.
+
+/// Why an utterance was fenced. Telemetry only — every kind has the same
+/// effect (no intent, no latch change).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum NonMotionKind {
+    /// A bare wake phrase: the operator got the listener's attention and said
+    /// nothing else yet.
+    WakePhrase,
+    /// A greeting or conversational acknowledgement.
+    Greeting,
+    /// A read-only perception/status question — answering it is Rabbit's job,
+    /// and it must never move the platform.
+    StatusQuestion,
+}
+
+impl NonMotionKind {
+    /// Stable token for logs and counters.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::WakePhrase => "wake_phrase",
+            Self::Greeting => "greeting",
+            Self::StatusQuestion => "status_question",
+        }
+    }
+}
+
+/// Bare wake phrases. The listener's attention word plus a name is not a
+/// request; `hello rabbit, drive forward` is, and is not an exact match here.
+const WAKE_PHRASES: &[&str] = &[
+    "hello rabbit",
+    "hey rabbit",
+    "yo rabbit",
+    "hello parker",
+    "hey parker",
+    "yo parker",
+    // The bare names, for a listener that already consumed the wake word.
+    "rabbit",
+    "parker",
+];
+
+/// Greetings and acknowledgements.
+const GREETINGS: &[&str] = &[
+    "hello",
+    "hi",
+    "hey",
+    "good morning",
+    "good afternoon",
+    "good evening",
+    "thanks",
+    "thank you",
+    "how are you",
+    "are you there",
+];
+
+/// Read-only perception / status questions.
+///
+/// Written in NORMALIZED form — apostrophes are dropped by [`normalize`], so
+/// `what's around us` and `whats around us` both arrive here as
+/// `whats around us` and one entry covers both.
+const STATUS_QUESTIONS: &[&str] = &[
+    "what do you see",
+    "what can you see",
+    "what is around us",
+    "whats around us",
+    "are we okay",
+    "are we ok",
+    "why did we stop",
+    "what stopped us",
+    "run diagnostics",
+    "how are your systems",
+    "what is your status",
+];
+
+/// Normalize an utterance to lowercase space-separated word tokens.
+///
+/// - case folded;
+/// - apostrophes (ASCII `'` and the typographic `’` a phone keyboard emits)
+///   are DROPPED, not spaced, so `what's` → `whats` and one allowlist entry
+///   covers both spellings;
+/// - every other non-alphanumeric character becomes a separator, so
+///   punctuation and surrounding whitespace cannot defeat a match;
+/// - runs of separators collapse.
+///
+/// Token-based rather than substring-based: the caller compares the WHOLE
+/// result, so a normalized utterance either is a known conversational form or
+/// is not.
+#[must_use]
+pub fn normalize(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut pending_space = false;
+    for ch in text.chars() {
+        if ch == '\'' || ch == '\u{2019}' {
+            continue; // contraction — join the halves
+        }
+        if ch.is_alphanumeric() {
+            if pending_space && !out.is_empty() {
+                out.push(' ');
+            }
+            pending_space = false;
+            for lower in ch.to_lowercase() {
+                out.push(lower);
+            }
+        } else {
+            pending_space = true;
+        }
+    }
+    out
+}
+
+/// Classify an utterance as deterministically non-motion, or `None` to let the
+/// model decide.
+///
+/// Pure: no model call, no network, no I/O, no clock. `None` is the default for
+/// everything unrecognised — the fence narrows what reaches the model, it never
+/// widens what is accepted.
+#[must_use]
+pub fn classify_non_motion(text: &str) -> Option<NonMotionKind> {
+    let normalized = normalize(text);
+    if normalized.is_empty() {
+        // An empty request is already MICK_EMPTY_REQUEST downstream; that is a
+        // client error worth surfacing, not a conversational turn to absorb.
+        return None;
+    }
+    if WAKE_PHRASES.contains(&normalized.as_str()) {
+        return Some(NonMotionKind::WakePhrase);
+    }
+    if GREETINGS.contains(&normalized.as_str()) {
+        return Some(NonMotionKind::Greeting);
+    }
+    if STATUS_QUESTIONS.contains(&normalized.as_str()) {
+        return Some(NonMotionKind::StatusQuestion);
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- the observed live regressions --------------------------------------
+
+    #[test]
+    fn the_four_observed_live_inputs_classify_as_intended() {
+        // Three that produced motion JSON from gemma3:4b and must not reach it.
+        assert_eq!(
+            classify_non_motion("hello rabbit"),
+            Some(NonMotionKind::WakePhrase)
+        );
+        assert_eq!(
+            classify_non_motion("hello parker"),
+            Some(NonMotionKind::WakePhrase)
+        );
+        assert_eq!(
+            classify_non_motion("what do you see"),
+            Some(NonMotionKind::StatusQuestion)
+        );
+        // The one that IS a motion request must still reach the model.
+        assert_eq!(classify_non_motion("drive forward one meter"), None);
+    }
+
+    // --- normalization ------------------------------------------------------
+
+    #[test]
+    fn case_punctuation_and_whitespace_do_not_defeat_a_match() {
+        for text in [
+            "Hello, Rabbit!",
+            "  hello rabbit  ",
+            "HELLO RABBIT",
+            "Yo Rabbit?",
+            "hey parker",
+            "\thello   rabbit\n",
+        ] {
+            assert!(
+                classify_non_motion(text).is_some(),
+                "must be fenced: {text:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn both_apostrophe_spellings_normalize_together() {
+        // A phone keyboard emits U+2019; a shell emits U+0027; a transcriber
+        // may emit neither. One allowlist entry has to cover all three.
+        assert_eq!(normalize("what's around us"), "whats around us");
+        assert_eq!(normalize("what\u{2019}s around us"), "whats around us");
+        assert_eq!(normalize("whats around us"), "whats around us");
+        for text in [
+            "what's around us",
+            "what\u{2019}s around us",
+            "whats around us",
+        ] {
+            assert_eq!(
+                classify_non_motion(text),
+                Some(NonMotionKind::StatusQuestion),
+                "{text:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn normalize_collapses_separators_and_never_leads_or_trails() {
+        assert_eq!(normalize("  a,,,  b  "), "a b");
+        assert_eq!(normalize("!!!"), "");
+        assert_eq!(normalize(""), "");
+    }
+
+    // --- wake prefix PLUS a command must still reach the model --------------
+
+    #[test]
+    fn a_wake_prefix_followed_by_a_command_is_not_fenced() {
+        // The load-bearing case. Exact whole-utterance matching is what makes
+        // this fall through: "hello rabbit drive forward one meter" is not the
+        // entry "hello rabbit".
+        for text in [
+            "hello rabbit, drive forward one meter",
+            "hey parker turn left",
+            "rabbit, stop",
+            "hello rabbit take me to the dock",
+            "hey rabbit pull over",
+        ] {
+            assert_eq!(
+                classify_non_motion(text),
+                None,
+                "must reach the model: {text:?}"
+            );
+        }
+    }
+
+    // --- false-positive resistance ------------------------------------------
+
+    #[test]
+    fn conversational_words_inside_a_command_do_not_fence_it() {
+        // None of these may be caught merely for containing hello/see/status/stop.
+        for text in [
+            "drive to the hello sign",
+            "go see the loading dock",
+            "stop at the status board",
+            "turn toward Parker Street",
+            "how are you going to reach the dock",
+            "are we okay to proceed to the ramp",
+            "what do you see on the left, then go there",
+        ] {
+            assert_eq!(
+                classify_non_motion(text),
+                None,
+                "must reach the model: {text:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn every_allowlist_entry_is_already_normalized() {
+        // A non-normalized entry would be dead: nothing could ever equal it.
+        for entry in WAKE_PHRASES.iter().chain(GREETINGS).chain(STATUS_QUESTIONS) {
+            assert_eq!(
+                &normalize(entry),
+                entry,
+                "allowlist entry is not in normalized form and can never match"
+            );
+        }
+    }
+
+    #[test]
+    fn the_allowlists_do_not_overlap() {
+        // Overlap would make the reported kind depend on match order, which
+        // would quietly mislabel telemetry.
+        let mut seen: Vec<&str> = Vec::new();
+        for entry in WAKE_PHRASES.iter().chain(GREETINGS).chain(STATUS_QUESTIONS) {
+            assert!(
+                !seen.contains(entry),
+                "duplicate allowlist entry: {entry:?}"
+            );
+            seen.push(entry);
+        }
+    }
+
+    #[test]
+    fn empty_and_blank_text_is_left_to_the_existing_empty_request_error() {
+        assert_eq!(classify_non_motion(""), None);
+        assert_eq!(classify_non_motion("   \t\n "), None);
+        assert_eq!(classify_non_motion("?!."), None);
+    }
+
+    #[test]
+    fn classification_is_pure_and_repeatable() {
+        for text in ["hello rabbit", "drive forward one meter", "what do you see"] {
+            let first = classify_non_motion(text);
+            for _ in 0..5 {
+                assert_eq!(classify_non_motion(text), first);
+            }
+        }
+    }
+}

--- a/crates/kirra-sidecars/tests/mick_non_motion_endpoint.rs
+++ b/crates/kirra-sidecars/tests/mick_non_motion_endpoint.rs
@@ -1,0 +1,155 @@
+//! Endpoint-level contract for Mick's deterministic non-motion fence.
+//!
+//! Drives `IntentService::handle_text` — the exact call `mick_service`'s
+//! `POST /intent` arm makes — and renders the SAME wire strings that arm
+//! responds with, so what is asserted here is what a caller receives.
+//!
+//! The four inputs are the ones observed live against the deployed
+//! `gemma3:4b`, three of which returned valid-looking MOTION json:
+//!
+//! ```text
+//! "hello rabbit"           → {"intent":"cruise","target_speed_mps":5}
+//! "hello parker"           → {"intent":"cruise","target_speed_mps":10}
+//! "what do you see"        → {"intent":"route_to","x_m":120,"y_m":40}
+//! "drive forward one meter"→ {"intent":"go_to","x_m":1,"y_m":0}      (correct)
+//! ```
+//!
+//! The stub model here returns motion json for EVERY prompt, so a fence
+//! regression cannot hide: it would latch a cruise intent and fail these
+//! assertions rather than quietly passing.
+
+use std::cell::Cell;
+use std::rc::Rc;
+
+use kirra_planner::{LlmBrain, ModelClient, ModelError};
+use kirra_sidecars::mick::{IntentOutcome, IntentRequest, IntentService};
+
+/// The wire body `POST /intent` returns for a deterministically non-motion
+/// utterance — mirrors the `IntentOutcome::NonMotion` arm in `mick_service`.
+const NON_MOTION_BODY: &str = r#"{"ok":true,"intent":null}"#;
+
+struct AlwaysMotion {
+    reply: String,
+    calls: Rc<Cell<u32>>,
+}
+
+impl ModelClient for AlwaysMotion {
+    fn complete(&self, _prompt: &str) -> Result<String, ModelError> {
+        self.calls.set(self.calls.get() + 1);
+        Ok(self.reply.clone())
+    }
+}
+
+fn service(reply: &str) -> (IntentService<AlwaysMotion>, Rc<Cell<u32>>) {
+    let calls = Rc::new(Cell::new(0));
+    let svc = IntentService::new(LlmBrain::new(AlwaysMotion {
+        reply: reply.to_string(),
+        calls: Rc::clone(&calls),
+    }));
+    (svc, calls)
+}
+
+fn text(t: &str) -> IntentRequest {
+    IntentRequest {
+        text: t.to_string(),
+        context: None,
+    }
+}
+
+/// The body `POST /intent` would return, and the body `GET /intent/last` would
+/// return afterwards — rendered exactly as `mick_service` renders them.
+fn post_and_last(svc: &mut IntentService<AlwaysMotion>, t: &str, now_ms: u64) -> (String, String) {
+    let post = match svc.handle_text(&text(t), now_ms) {
+        Ok(IntentOutcome::Accepted(_, accepted)) => accepted.to_post_wire(),
+        Ok(IntentOutcome::NonMotion(_)) => NON_MOTION_BODY.to_string(),
+        Err(code) => format!(r#"{{"ok":false,"error":"{code}"}}"#),
+    };
+    let last = match svc.last() {
+        Some(a) => a.to_wire(),
+        None => r#"{"intent":null}"#.to_string(),
+    };
+    (post, last)
+}
+
+#[test]
+fn the_three_misclassified_utterances_return_no_intent_and_call_no_model() {
+    for utterance in ["hello rabbit", "hello parker", "what do you see"] {
+        // The stub replies with the cruise json gemma3:4b actually produced.
+        let (mut svc, calls) = service(r#"{"intent":"cruise","target_speed_mps":5.0}"#);
+        let (post, last) = post_and_last(&mut svc, utterance, 10_000);
+
+        assert_eq!(post, NON_MOTION_BODY, "POST body for {utterance:?}");
+        assert_eq!(
+            last, r#"{"intent":null}"#,
+            "GET /intent/last after {utterance:?} must still be empty"
+        );
+        assert_eq!(calls.get(), 0, "{utterance:?} reached the LLM");
+    }
+}
+
+#[test]
+fn an_explicit_motion_request_is_unaffected() {
+    let (mut svc, calls) = service(r#"{"intent":"go_to","x_m":1.0,"y_m":0.0}"#);
+    let (post, last) = post_and_last(&mut svc, "drive forward one meter", 10_000);
+
+    assert_eq!(
+        post,
+        r#"{"ok":true,"intent":{"intent":"go_to","x_m":1.0,"y_m":0.0},"seq":1,"at_ms":10000}"#
+    );
+    assert_eq!(
+        last,
+        r#"{"intent":{"intent":"go_to","x_m":1.0,"y_m":0.0},"seq":1,"at_ms":10000}"#
+    );
+    assert_eq!(calls.get(), 1, "a real request must reach the model");
+}
+
+#[test]
+fn a_greeting_does_not_re_present_an_earlier_drive_command() {
+    // The state rule, at the wire. After a real command is latched and
+    // consumed, a greeting must leave `GET /intent/last` byte-identical —
+    // same payload AND same seq — so the doer's apply-once check keeps
+    // ignoring it. A bumped seq here would make the robot drive on a hello.
+    let (mut svc, calls) = service(r#"{"intent":"go_to","x_m":12.0,"y_m":-2.0}"#);
+    let (_, after_command) = post_and_last(&mut svc, "take me to the dock", 10_000);
+    assert!(after_command.contains(r#""seq":1"#));
+
+    for (i, greeting) in ["hello rabbit", "thanks", "what do you see"]
+        .iter()
+        .enumerate()
+    {
+        let (post, last) = post_and_last(&mut svc, greeting, 12_000 + i as u64 * 2_000);
+        assert_eq!(post, NON_MOTION_BODY, "{greeting:?}");
+        assert_eq!(
+            last, after_command,
+            "{greeting:?} altered GET /intent/last — a consumer could re-read the drive command"
+        );
+    }
+    assert_eq!(calls.get(), 1, "only the real command called the model");
+}
+
+#[test]
+fn a_command_after_a_greeting_still_advances_the_sequence() {
+    // The fence must not stall the real path: seq has to keep moving, or the
+    // doer would ignore the next genuine intent as already-consumed.
+    let (mut svc, _calls) = service(r#"{"intent":"go_to","x_m":3.0,"y_m":0.0}"#);
+    post_and_last(&mut svc, "take me to the dock", 10_000);
+    post_and_last(&mut svc, "hello rabbit", 12_000);
+    let (post, _) = post_and_last(&mut svc, "take me to the dock", 14_000);
+    assert!(
+        post.contains(r#""seq":2"#),
+        "the next real intent must advance seq: {post}"
+    );
+}
+
+#[test]
+fn a_wake_prefix_carrying_a_command_reaches_the_model() {
+    // "hello rabbit" alone is fenced; the same prefix followed by an explicit
+    // request is not — otherwise the fence would swallow real commands.
+    let (mut svc, calls) = service(r#"{"intent":"go_to","x_m":1.0,"y_m":0.0}"#);
+    let (post, _) = post_and_last(&mut svc, "hello rabbit, drive forward one meter", 10_000);
+    assert!(
+        post.contains(r#""ok":true"#) && post.contains("go_to"),
+        "{post}"
+    );
+    assert_eq!(calls.get(), 1);
+}


### PR DESCRIPTION
## The problem

The deployed `gemma3:4b` returns valid-looking **motion** JSON for plainly conversational text. Observed live against `POST /intent`:

| text | model reply |
|---|---|
| `hello rabbit` | `{"intent":"cruise","target_speed_mps":5}` |
| `hello parker` | `{"intent":"cruise","target_speed_mps":10}` |
| `what do you see` | `{"intent":"route_to","x_m":120,"y_m":40}` |
| `drive forward one meter` | `{"intent":"go_to","x_m":1,"y_m":0}` ✅ |

Each of the first three is well-formed, in-schema and finite, so `MickIntent::parse_llm_json` admits it — **correctly**. The parse checks *shape*, not whether the utterance asked for motion at all. The gap is upstream of the parse.

### Why the model volunteers motion

`chauffeur_prompt` opens with *"Choose the SINGLE best high-level driving intent"* and lists eight forms — **all eight are motion decisions**, including `hold` ("stop and hold"). `INTENT_SCHEMA` is passed to Ollama's `format`, so constrained decoding makes an out-of-vocabulary answer literally unsamplable: the model *cannot* emit "this isn't a driving request". Worse, the worked example `open road, no objects, goal far ahead → cruise 10` matches the situation a greeting arrives in, and the observed speeds of 5 and 10 are the two numbers printed in the prompt's own examples.

**No prompt change here.** After the fence those utterances never reach the model, and a prompt edit is an unverifiable behavioral change to a swappable component — per the model-swap discipline the checker must not depend on prompt wording. If pursued, the minimal fix is a `not_a_driving_request` tag in both the prose contract and `INTENT_SCHEMA`; separate PR, own live matrix.

## The fix

A deterministic, pure, allowlist fence (`crates/kirra-sidecars/src/mick_fence.rs`) classifying obvious non-motion speech **before** the model runs. Matching is **exact against the whole normalized utterance**, never a substring — that single decision buys both directions:

- `drive to the hello sign` contains "hello" and is **not** fenced;
- `hello rabbit, drive forward one meter` isn't an exact match either, so a wake prefix carrying a command still reaches the model.

No regex, no substring matching. Three allowlists: bare wake phrases, greetings, read-only status questions.

### Response and state semantics

`POST /intent` → **`200 {"ok":true,"intent":null}`** — composed from the two shapes already on the wire (the existing `ok:true` success form, and the `{"intent":null}` that `GET /intent/last` already publishes), so consumers parse one null form, not a new one. Deliberately **not** `MickIntent::Hold`: hold clears the doer's goal, which is itself a motion decision.

**Nothing mutates** — not `last`, not `seq`. The unchanged `seq` is load-bearing: the doer applies an intent at most once by tracking the last `seq` it consumed, so a stalled `seq` is a no-op *by construction*, not by timing. A greeting after a consumed drive command cannot re-present it; a real command afterwards still advances normally.

Ordering: rate-limit → context validation → fence → model. After the limiter so the fence can't dodge shedding, after context validation so a malformed context still surfaces, before the LLM — the only thing this needs to prevent.

Observability: a `non_motion_fenced` counter plus **one log line per episode** (latched on kind, cleared by a real accept) — greetings arrive at voice rate. **No transcript is logged.**

## Defense in depth, not a safety boundary

Occy grounds, KIRRA bounds, the verifying consumer enforces — all unchanged, all still authoritative. A greeting that slipped through would still be clamped. This stops it becoming an intent in the first place, which is cheaper and far easier to explain to an operator than a governor clamp. **The fence can only ever remove motion, never create or alter it.**

## Changed files

| File | Change |
|---|---|
| `crates/kirra-sidecars/src/mick_fence.rs` | new — `NonMotionKind`, `normalize`, `classify_non_motion`, allowlists, 10 tests |
| `crates/kirra-sidecars/src/mick.rs` | `IntentOutcome` enum; `handle_text` returns it; fence call; counter + episode latch; 5 tests |
| `crates/kirra-sidecars/src/lib.rs` | `pub mod mick_fence;` |
| `crates/kirra-sidecars/src/bin/mick_service.rs` | `NonMotion` arm → `200 {"ok":true,"intent":null}` |
| `crates/kirra-sidecars/tests/mick_non_motion_endpoint.rs` | new — 5 endpoint tests rendering the exact wire strings the route returns |
| `crates/kirra-actuation-consumer/tests/spoken_governed_loop.rs` | its `handle_text` mirror updated for the new arm |

## Tests

- `cargo test -p kirra-sidecars` — **99 lib + 5 endpoint passed** (15 new)
- `cargo test -p kirra-actuation-consumer` — 17 + 3 + 3 + 1 passed
- `cargo test --workspace --no-run` — clean; this is how the `spoken_governed_loop` caller was caught
- clippy `-D warnings`, `cargo fmt --check`, `git diff --check` — clean

The stub models return the cruise JSON `gemma3:4b` actually produced, for **every** prompt. A fence regression therefore latches a cruise intent and fails loudly — it cannot pass on a coincidence.

### Live matrix

```
hello rabbit            | POST {"ok":true,"intent":null}  | LAST {"intent":null}  llm_calls=0
hello parker            | POST {"ok":true,"intent":null}  | LAST {"intent":null}  llm_calls=0
what do you see         | POST {"ok":true,"intent":null}  | LAST {"intent":null}  llm_calls=0
drive forward one meter | POST {"ok":true,"intent":{"intent":"go_to","x_m":1.0,"y_m":0.0},"seq":1,"at_ms":10000}
                        | LAST {"intent":{...},"seq":1,"at_ms":10000}             llm_calls=1
```

## Left to the model, intentionally

`stop` and `wait` (real motion requests), `can you get to the dock`, `okay`/`yes`/`no`, `go` alone, `is the path clear` — anything genuinely ambiguous stays on the model path. Growing the allowlist to chase these trades false negatives for false positives, and the governor still bounds whatever gets through.

## Notes for the reviewer

- `robot/rabbit_model_smoketest.py gemma3:4b` **was not run** — no Ollama in the dev container, and it has no offline mode. It touches zero Python and zero Rabbit router code, but worth running on the robot.
- **Merge this before #(the Rabbit follow-up)** — that branch fixes how Rabbit *reads* the new `intent:null` reply and its docs describe the fenced behaviour.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjDFKPcBVHURDZpXsvnYhC)_