### PR TITLE
test(rabbit): preserve greetings across the Mick motion fence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1387,6 +1387,16 @@ jobs:
           # routing guardrails, and parse_reply (the fail-closed directive authority)
           # is order-agnostic. See robot/rabbit_converse.py.
           python3 robot/rabbit_stream_integration_test.py
+          # Rabbit's conversation channel across mick's non-motion fence (skips
+          # where requests is absent, e.g. this lane): a greeting/question still
+          # gets a SPOKEN reply and makes NO /intent call at all, a drive request
+          # still sends exactly one directive, and mick's second 200 shape
+          # ({"ok":true,"intent":null} — fenced, nothing latched) is read as
+          # 'reject', never as a successful drive. Keying on the `ok` flag alone
+          # would have Rabbit announce motion that never happened and would
+          # ADVANCE a mission past a step that never ran. See
+          # robot/rabbit_converse.py::offer_to_door.
+          python3 robot/rabbit_converse_test.py
           # Lidar orientation check (pure geometry, no ROS/hardware): the scan
           # angle→direction labelling (0°=FRONT, +90°=LEFT), in-band return
           # filtering, per-direction nearest, and the forward-aligned verdict — the

--- a/docs/hardware/RABBIT_BRINGUP_RUNBOOK.md
+++ b/docs/hardware/RABBIT_BRINGUP_RUNBOOK.md
@@ -132,6 +132,80 @@ Press the button, ask *"what's ahead?"* → it looks and answers. Say *"take us
 that way"* → it routes the directive through the door; the checker bounds it;
 Rabbit confirms. Approach an obstacle → it warns, unprompted. That's Rabbit.
 
+## 7. Greeting check — speech vs motion (read-only, wheels up)
+
+Four utterances that prove the conversation channel still talks after mick's
+non-motion fence, and that only the fourth asks for motion. **Wheels raised or
+motion disabled** for the whole sequence (§0) — you should not need the floor,
+and step 4 is the only one that can move anything.
+
+Two terminals to watch first:
+
+```bash
+# T1 — Rabbit's voice stack. Under the unit it logs to the JOURNAL, not a file
+# (kirra-rabbit-voice.service is `wake_word.py | rabbit_voice.sh`, no redirect):
+journalctl -u kirra-rabbit-voice -f
+# Running it by hand instead? Nothing writes /tmp/rabbit.log on its own — tee it:
+python3 robot/wake_word.py | ./robot/rabbit_voice.sh 2>&1 | tee /tmp/rabbit.log
+
+# T2 — mick's motion door. The ONLY thing that moves is a new `seq`.
+watch -n1 'curl -s http://localhost:8102/intent/last'
+```
+
+Baseline the door before you speak, so "unchanged" is a fact and not an
+impression:
+
+```bash
+curl -s http://localhost:8102/intent/last     # note `seq` (or {"intent":null})
+```
+
+| # | Say | Expect to hear | `/intent/last` |
+|---|---|---|---|
+| 1 | "Hello Rabbit" | **"Yes?"**, then it listens | **unchanged** |
+| 2 | "How are you?" | a conversational answer | **unchanged** |
+| 3 | "What do you see?" | a grounded answer, or a truthful *"I can't see that right now"* | **unchanged** |
+| 4 | "Drive forward one meter" | a confirmation | **`seq` +1**, `intent` present |
+
+Steps 1–3 must leave `seq` **exactly** where the baseline was. A bump on 1–3 means
+a conversational turn reached the motion door — stop and report it.
+
+What each step is really checking:
+
+1. **Wake ack.** `wake_word.py` matched the phrase and fired **one** trigger; the
+   `"Yes?"` comes from its `_ack` (`KIRRA_WAKE_ACK_CMD`, else `KIRRA_TTS_CMD`).
+   The phrase itself is discarded — `rabbit_voice.sh` records a *new* clip for
+   your next sentence. Log line: `wake_word: wake: "hello rabbit"`.
+   Silent instead? `KIRRA_WAKE_ACK_CMD`/`KIRRA_TTS_CMD` are unset — the listener
+   logs `wake ack (… — silent)` and the trigger still fires.
+2. **Chat.** Channel A end to end: Ollama → TTS. No `/intent` call is made at
+   all for a `directive: null` turn.
+3. **Read-only grounding.** Same channel, plus the perception grab. An
+   unreachable sensor must produce a truthful *unavailable* line, never a
+   confident guess and never motion.
+4. **The motion door.** The one directive-bearing turn. `seq` advances and
+   `intent` is non-null; the checker/governor then bound whatever it grounds to.
+
+Distinguishing speech from motion at the topics, if you want it belt-and-braces
+(read-only subscribes, run alongside):
+
+```bash
+ros2 topic echo /cmd_vel_raw --once   # occy_doer's PROPOSAL — silent on steps 1-3
+ros2 topic echo /cmd_vel --once       # the governed output after the interceptor
+```
+
+Say "Hello Rabbit" straight into mick instead, and you should see the fence
+answer — this is the boundary, not a fault:
+
+```bash
+curl -s localhost:8102/intent -XPOST -H 'content-type: application/json' \
+     -d '{"text":"hello rabbit"}'
+# {"ok":true,"intent":null}    ← no intent, no latch, seq unchanged
+curl -s localhost:8102/intent/last          # still the baseline
+```
+
+That is mick behaving correctly: it is the motion door, not the conversation
+channel. Rabbit answers greetings; mick does not.
+
 ---
 
 ## Speed — making Rabbit reply fast

--- a/docs/hardware/RABBIT_CONVERSATION_DESIGN.md
+++ b/docs/hardware/RABBIT_CONVERSATION_DESIGN.md
@@ -147,6 +147,49 @@ directive at worst becomes a checker-APPROVED bounded motion; an unparseable tur
 drives nothing. The only actuation-adjacent call in the whole script is the
 text-to-`/intent` POST — no publisher, no serial, no release token.
 
+#### Reading mick's reply: two 200 shapes, one of which moves nothing
+
+mick's deterministic non-motion fence (`crates/kirra-sidecars/src/mick_fence.rs`)
+answers plainly conversational text — a bare wake phrase, a greeting, a read-only
+question — **without calling the model and without latching anything**. So
+`POST /intent` now has two success shapes:
+
+| reply | meaning | `offer_to_door` |
+|---|---|---|
+| `{"ok":true,"intent":{…},"seq":n,"at_ms":t}` | an intent was latched; `seq` advanced | `ok` |
+| `{"ok":true,"intent":null}` | deterministically non-motion: no intent, no latch, **`seq` unchanged** | `reject` |
+
+**`ok` means an intent EXISTS, not merely that the request was well-formed.**
+Keying on the `ok` flag alone would report the second shape as a successful
+drive — Rabbit would say *"On our way"* while standing still, and in mission mode
+the Executive would **advance past a step that never ran**. `offer_to_door`
+therefore requires a non-null `intent`; every caller's existing non-`ok` arm then
+does the right thing (converse re-asks, `mission._decide` halts, skills say the
+governor wouldn't clear it). `intent` is present and non-null on every accepted
+reply both before and after the fence existed, so this reads correctly against
+either mick build — no coordinated deploy.
+
+This is a *reply-reading* rule, not a new route. Regression:
+`robot/rabbit_converse_test.py`.
+
+#### The fence does not touch the conversation channel
+
+A greeting never reaches mick at all. Rabbit routes it as `directive: null`
+(Channel A), which makes **no `/intent` call whatsoever** — the fence is not even
+on that path. The wake phrase itself is likewise never an utterance: `wake_word.py`
+emits **one bare newline** as its trigger (`_fire_trigger_and_wait`) and
+`rabbit_voice.sh` reads it with `read -r _`, discarding the payload by
+construction, then records a **separate** clip for the actual turn. The heard
+phrase is transcribed, matched and thrown away inside the listener process.
+
+So the two channels stay disjoint on the same words: `"hello rabbit"` sent
+*directly* to mick yields no intent (correct — mick is the motion door), while the
+same conversational turn through Rabbit produces a spoken reply and touches
+nothing actuation-adjacent. Both halves are pinned —
+`test_the_same_words_are_conversation_to_rabbit_and_nothing_to_mick`
+(`robot/rabbit_converse_test.py`) and the Rust fence tests
+(`crates/kirra-sidecars/tests/mick_non_motion_endpoint.rs`).
+
 ### Stage 3 — how to run (`robot/rabbit_watch.py`)
 
 ```bash

--- a/robot/rabbit_converse.py
+++ b/robot/rabbit_converse.py
@@ -240,11 +240,32 @@ def parse_reply(raw):
 def offer_to_door(directive_text):
     """Hand the directive TEXT to the ONE fail-closed door (mick POST /intent).
     Returns 'ok' | 'reject' | 'error'. This is the sole actuation-adjacent call —
-    it is text-to-the-door, exactly what a human typing does."""
+    it is text-to-the-door, exactly what a human typing does.
+
+    'ok' means AN INTENT EXISTS, not merely that the request was well-formed.
+    mick has two 200 shapes and only one of them moves anything:
+
+        {"ok":true,"intent":{...},"seq":n,"at_ms":t}   an intent was latched
+        {"ok":true,"intent":null}                      deterministically non-motion
+                                                       (mick's greeting/read-only
+                                                       fence): no intent, no latch,
+                                                       seq UNCHANGED — nothing moves
+
+    Keying 'ok' on the `ok` flag alone would report the second shape as a
+    successful drive, and Rabbit would say "On our way" while standing still —
+    a false success acknowledgement, and worse in mission mode, where 'ok'
+    ADVANCES to the next step. So an absent or null `intent` is 'reject': the
+    door declined to produce motion, which is exactly what every caller's
+    non-'ok' arm already handles (converse re-asks, mission halts, skills say so).
+
+    `intent` is present and non-null on every accepted reply, before and after
+    the fence existed, so this reads correctly against either mick build — no
+    coordinated deploy."""
     try:
         r = requests.post(f"{MICK}/intent", timeout=60.0, json={"text": directive_text})
         j = r.json() if r.content else {}
-        if r.status_code == 200 and isinstance(j, dict) and j.get("ok"):
+        if (r.status_code == 200 and isinstance(j, dict) and j.get("ok")
+                and j.get("intent") is not None):
             return "ok"
         return "reject"
     except Exception:  # noqa: BLE001

--- a/robot/rabbit_converse_test.py
+++ b/robot/rabbit_converse_test.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python3
+"""rabbit_converse_test — the Rabbit conversation channel still TALKS, and the
+motion door still only opens for motion, after mick's non-motion fence.
+
+mick now answers a deterministically non-motion utterance with a 200 carrying
+NO intent (`{"ok":true,"intent":null}`) instead of calling the LLM. That is
+correct for the motion door — mick is not the conversation channel. The
+question this file answers is the OTHER half: does Rabbit still greet, chat and
+answer questions, and can the new reply shape mislead anyone?
+
+The two channels, and why they cannot be confused (design doc §Channels):
+
+    wake word ──▶ wake_word.py ──▶ ONE newline (no text!) ──▶ rabbit_voice.sh
+                                                                  │ records a
+                                                                  │ NEW clip
+                                                                  ▼
+                            transcript ──▶ rabbit_converse.handle_turn
+                                              │
+                        ┌─────────────────────┴──────────────────────┐
+                   say (Channel A)                        directive (Channel B)
+                   speak() → TTS sink                      offer_to_door()
+                   NO /intent, no ROS,                     → mick POST /intent
+                   no serial, no token                     → Occy → the checker
+
+`directive: null` is the overwhelmingly common case — every greeting, question
+and chat turn — and it makes NO call to mick at all. So the fence is not even
+on the path for a greeting: Rabbit answers from Ollama and speaks.
+
+Everything external is stubbed: Ollama, TTS, mick, and the telemetry GETs. No
+network, no model, no audio.
+
+`rabbit_converse` (and `rabbit_ask` under it) do `import requests` at module load
+and `sys.exit` without it, and the CI robot lane does not install it. Rather than
+skip there — which would leave the false-success regression ungated on the only
+lane that runs automatically — we install a MINIMAL stub module first. Its
+`get`/`post` raise unless a test has replaced them, so a genuine network attempt
+is a loud failure, never a silent pass. When the real library is present (the
+robot, a dev box) it is used unchanged.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+
+def _install_requests_stub() -> None:
+    """Make `import requests` succeed with a surface that cannot reach the
+    network. Only `get`/`post` are ever touched by the code under test."""
+    def _refuse(*_a, **_k):
+        raise AssertionError(
+            "the test tried to make a REAL HTTP call — a seam is unstubbed")
+
+    stub = types.ModuleType("requests")
+    stub.get = _refuse
+    stub.post = _refuse
+    stub.RequestException = type("RequestException", (Exception,), {})
+    stub.exceptions = types.SimpleNamespace(RequestException=stub.RequestException)
+    stub.__kirra_stub__ = True
+    sys.modules["requests"] = stub
+
+
+try:
+    import requests  # noqa: F401 — rabbit_converse needs it at import
+except ImportError:
+    _install_requests_stub()
+
+# The two mick 200 shapes, verbatim from crates/kirra-sidecars/src/mick.rs
+# (`AcceptedIntent::to_post_wire` and mick_service's non-motion arm).
+MICK_ACCEPTED = '{"ok":true,"intent":{"intent":"go_to","x_m":1.0,"y_m":0.0},"seq":1,"at_ms":10000}'
+MICK_NON_MOTION = '{"ok":true,"intent":null}'
+
+
+class _Resp:
+    """Minimal stand-in for a requests.Response (status_code/content/json)."""
+
+    def __init__(self, status_code: int, body: str):
+        self.status_code = status_code
+        self._body = body
+        self.content = body.encode()
+
+    def json(self):
+        return json.loads(self._body)
+
+
+class Harness:
+    """Rabbit with every external seam replaced by a recorder.
+
+    Records what was SPOKEN and what was POSTed to mick, so 'it talked' and
+    'it asked for motion' are separate, checkable facts rather than one blur.
+    """
+
+    def __init__(self, rc, router_reply: str, mick_body: str = MICK_ACCEPTED,
+                 mick_status: int = 200):
+        self.rc = rc
+        self.router_reply = router_reply
+        self.mick_body = mick_body
+        self.mick_status = mick_status
+        self.spoken: list[str] = []
+        self.mick_posts: list[dict] = []
+        self.ollama_posts: list[dict] = []
+        self._saved: dict = {}
+
+    # -- seams ----------------------------------------------------------
+    def _post(self, url, **kw):
+        payload = kw.get("json") or {}
+        if "/intent" in url:
+            self.mick_posts.append(payload)
+            return _Resp(self.mick_status, self.mick_body)
+        if "/api/chat" in url:
+            self.ollama_posts.append(payload)
+            return _Resp(200, json.dumps(
+                {"message": {"content": self.router_reply}}))
+        raise AssertionError(f"unexpected POST to {url}")
+
+    def __enter__(self):
+        rc = self.rc
+        self._saved = {
+            "post": rc.requests.post,
+            "speak": rc.speak,
+            "gather_posture": rc.gather_posture,
+            "gather_stop_reason": rc.gather_stop_reason,
+            "gather_perception": rc.gather_perception,
+        }
+        rc.requests.post = self._post
+        rc.speak = lambda text: self.spoken.append(text)   # the TTS sink
+        rc.gather_posture = lambda: "posture: NOMINAL"
+        rc.gather_stop_reason = lambda: "last verdict: none"
+        rc.gather_perception = lambda: "perception: nearest object 2.0 m ahead"
+        return self
+
+    def __exit__(self, *exc):
+        rc = self.rc
+        rc.requests.post = self._saved["post"]
+        rc.speak = self._saved["speak"]
+        rc.gather_posture = self._saved["gather_posture"]
+        rc.gather_stop_reason = self._saved["gather_stop_reason"]
+        rc.gather_perception = self._saved["gather_perception"]
+        return False
+
+    # -- convenience ----------------------------------------------------
+    def turn(self, utterance: str) -> None:
+        self.rc.handle_turn([], utterance)
+
+    @property
+    def said(self) -> str:
+        return " ".join(self.spoken)
+
+
+def _rc():
+    import rabbit_converse
+    return rabbit_converse
+
+
+# ---------------------------------------------------------------------------
+# Channel A — conversation still works
+# ---------------------------------------------------------------------------
+
+def test_hello_produces_a_spoken_reply_and_no_mick_call() -> None:
+    """The headline claim: a greeting still gets a spoken answer, and the
+    motion door is never even contacted."""
+    rc = _rc()
+    reply = '{"say": "Hello! All nominal here.", "directive": null}'
+    with Harness(rc, reply) as h:
+        h.turn("hello")
+        assert h.spoken == ["Hello! All nominal here."], h.spoken
+        assert h.mick_posts == [], f"a greeting reached the motion door: {h.mick_posts}"
+        assert len(h.ollama_posts) == 1, "the greeting must reach the conversation model"
+
+
+def test_how_are_you_produces_a_spoken_reply_and_no_mick_call() -> None:
+    rc = _rc()
+    reply = '{"say": "Running well — governor is nominal.", "directive": null}'
+    with Harness(rc, reply) as h:
+        h.turn("how are you")
+        assert h.spoken == ["Running well — governor is nominal."], h.spoken
+        assert h.mick_posts == []
+
+
+def test_what_do_you_see_uses_the_readonly_grounding_and_speaks() -> None:
+    """A perception question takes the READ-ONLY grounding path (gather_perception
+    is folded into the prompt) and produces speech — never motion."""
+    rc = _rc()
+    assert rc.perception_relevant("what do you see"), \
+        "the perception grab must be armed for this utterance"
+    reply = '{"say": "Nearest object is about two meters ahead.", "directive": null}'
+    with Harness(rc, reply) as h:
+        h.turn("what do you see")
+        assert h.spoken == ["Nearest object is about two meters ahead."], h.spoken
+        assert h.mick_posts == [], "a perception question must not reach the motion door"
+        # The read-only telemetry really reached the model.
+        sent = json.dumps(h.ollama_posts[0])
+        assert "nearest object 2.0 m ahead" in sent, \
+            "the read-only perception grounding must be in the prompt"
+
+
+def test_no_mick_request_is_made_for_a_null_directive() -> None:
+    """Stated as its own invariant over a spread of conversational turns:
+    `directive: null` means the /intent door is not called AT ALL."""
+    rc = _rc()
+    for utterance in ("hello", "hey rabbit", "how are you", "what do you see",
+                      "thanks", "what's our status"):
+        with Harness(rc, '{"say": "Sure thing.", "directive": null}') as h:
+            h.turn(utterance)
+            assert h.spoken, f"{utterance!r} produced no speech"
+            assert h.mick_posts == [], f"{utterance!r} contacted mick"
+
+
+# ---------------------------------------------------------------------------
+# Channel B — motion still routes, exactly once
+# ---------------------------------------------------------------------------
+
+def test_drive_forward_sends_exactly_one_directive_to_mick() -> None:
+    rc = _rc()
+    reply = ('{"say": "Creeping forward a meter.", '
+             '"directive": "drive forward one meter"}')
+    with Harness(rc, reply) as h:
+        h.turn("drive forward one meter")
+        assert len(h.mick_posts) == 1, f"expected exactly one door call: {h.mick_posts}"
+        assert h.mick_posts[0] == {"text": "drive forward one meter"}, h.mick_posts[0]
+        assert h.spoken == ["Creeping forward a meter."], h.spoken
+
+
+def test_wake_prefix_plus_command_in_one_transcript_still_routes() -> None:
+    """A single-turn transcript that carries the wake words AND a command:
+    Rabbit extracts the movement request, and what reaches mick is the
+    directive — which mick's fence does not catch (it is not a bare wake
+    phrase). Supported end to end."""
+    rc = _rc()
+    reply = ('{"say": "On our way.", "directive": "drive forward one meter"}')
+    with Harness(rc, reply) as h:
+        h.turn("hello rabbit, drive forward one meter")
+        assert len(h.mick_posts) == 1, h.mick_posts
+        assert h.mick_posts[0]["text"] == "drive forward one meter"
+        assert h.spoken == ["On our way."]
+
+
+# ---------------------------------------------------------------------------
+# 🔴 The regression this file exists for: no false success acknowledgement
+# ---------------------------------------------------------------------------
+
+def test_offer_to_door_rejects_a_200_that_carries_no_intent() -> None:
+    """mick's non-motion 200 is NOT a successful drive.
+
+    Before the fence, `{"ok":true,...}` always carried an intent, so keying on
+    `ok` alone was sound. The fence added a second 200 shape that moves
+    nothing; reading it as success would make Rabbit announce motion that never
+    happens — and would ADVANCE a mission past a step that never ran."""
+    rc = _rc()
+    with Harness(rc, "unused", mick_body=MICK_NON_MOTION):
+        assert rc.offer_to_door("hello rabbit") == "reject"
+    with Harness(rc, "unused", mick_body='{"ok":true}'):
+        assert rc.offer_to_door("hello rabbit") == "reject", \
+            "an absent `intent` field must not read as success either"
+    # Positive control: a real accepted intent is still 'ok'.
+    with Harness(rc, "unused", mick_body=MICK_ACCEPTED):
+        assert rc.offer_to_door("drive forward one meter") == "ok"
+
+
+def test_a_fenced_directive_never_claims_the_robot_is_moving() -> None:
+    """End to end at the spoken layer. If the router ever emits a directive
+    that mick's fence absorbs, Rabbit must NOT say the on-our-way line."""
+    rc = _rc()
+    reply = '{"say": "On our way — heading off now.", "directive": "hello rabbit"}'
+    with Harness(rc, reply, mick_body=MICK_NON_MOTION) as h:
+        h.turn("hello rabbit")
+        assert len(h.mick_posts) == 1, "the directive was offered to the door"
+        said = h.said.lower()
+        assert "on our way" not in said, \
+            f"false success acknowledgement — nothing moved but Rabbit said: {h.said!r}"
+        assert said, "Rabbit must still say something"
+        # The truthful arm: it asks the operator to rephrase.
+        assert "another way" in said or "couldn't" in said, h.said
+
+
+def test_mission_does_not_advance_on_a_no_intent_reply() -> None:
+    """The second consumer of offer_to_door's verdict. 'ok' would ADVANCE the
+    Executive past a step that never moved; 'reject' halts, fail-closed."""
+    import mission
+    assert mission._decide("ok", 0, 2) == "advance"
+    assert mission._decide("reject", 0, 2) == "halt", \
+        "a door that produced no intent must halt the mission, never advance it"
+
+
+# ---------------------------------------------------------------------------
+# The Rabbit ↔ mick boundary, made explicit
+# ---------------------------------------------------------------------------
+
+def test_the_same_words_are_conversation_to_rabbit_and_nothing_to_mick() -> None:
+    """The separation, in one test.
+
+    "hello rabbit" sent DIRECTLY to mick yields no intent — that is the fence,
+    and it is correct: mick is the motion door. The same conversational turn
+    passed through Rabbit produces a spoken reply and never touches mick. Two
+    channels, one utterance, no overlap."""
+    rc = _rc()
+
+    # Rabbit's side: speech, no door call.
+    with Harness(rc, '{"say": "Hello there!", "directive": null}') as h:
+        h.turn("hello rabbit")
+        assert h.spoken == ["Hello there!"]
+        assert h.mick_posts == []
+
+    # mick's side, at the wire: the fenced body carries no intent, so Rabbit's
+    # door helper reports no motion. (The fence itself is proven in Rust —
+    # crates/kirra-sidecars/src/mick_fence.rs + tests/mick_non_motion_endpoint.rs;
+    # here we pin how Rabbit READS that reply.)
+    with Harness(rc, "unused", mick_body=MICK_NON_MOTION):
+        assert rc.offer_to_door("hello rabbit") == "reject"
+
+
+# ---------------------------------------------------------------------------
+# No authority regression
+# ---------------------------------------------------------------------------
+
+def test_a_conversational_turn_makes_no_actuation_adjacent_call() -> None:
+    """The single-door invariant, as an assertion. A chat turn's only outbound
+    call is the Ollama chat POST; nothing reaches /intent."""
+    rc = _rc()
+    with Harness(rc, '{"say": "All good.", "directive": null}') as h:
+        h.turn("how are you")
+        assert h.mick_posts == []
+        assert len(h.ollama_posts) == 1
+        # Every outbound POST went to Ollama — the harness raises on any other
+        # host, so reaching here means no third endpoint was contacted.
+
+
+def test_offer_to_door_is_the_only_intent_poster_in_the_rabbit_path() -> None:
+    """Source-level: exactly ONE `/intent` POST exists in the conversation
+    path, and it is offer_to_door's. A new route would show up here."""
+    here = Path(__file__).resolve().parent
+    posters = []
+    for name in ("rabbit_converse.py", "rabbit_ask.py", "rabbit_watch.py",
+                 "rabbit_boot.py", "rabbit_diag.py", "rabbit_wake.py",
+                 "rabbit_ota.py", "skill_registry.py", "mission.py",
+                 "world_model.py", "rabbit_persona.py", "barge_in.py",
+                 "rabbit_stream.py", "turn_state.py"):
+        for i, line in enumerate((here / name).read_text().splitlines(), 1):
+            code = line.split("#", 1)[0]
+            if "/intent" in code and ".post(" in code:
+                posters.append(f"{name}:{i}")
+    assert len(posters) == 1 and posters[0].startswith("rabbit_converse.py:"), \
+        f"expected exactly one /intent poster (offer_to_door), found {posters}"
+
+
+def test_tts_is_a_pure_sink() -> None:
+    """speak() prints and pipes to a TTS process. It cannot publish a ROS goal,
+    write the motor serial, or mint a release token — asserted over the source
+    so a future edit that adds one fails here."""
+    src = (Path(__file__).resolve().parent / "rabbit_persona.py").read_text()
+    body = src[src.index("def speak("):]
+    for forbidden in ("requests", "/intent", "rclpy", "publish", "serial",
+                      "ReleaseToken", "signing", "Twist"):
+        assert forbidden not in body, \
+            f"speak() must stay a pure sink; found {forbidden!r}"
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items())
+             if k.startswith("test_") and callable(v)]
+    print("rabbit_converse tests:")
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  ok   {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"  FAIL {t.__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())

--- a/robot/wake_word_test.py
+++ b/robot/wake_word_test.py
@@ -367,6 +367,128 @@ def test_wake_recorder_is_not_inherited_from_the_turn_recorder() -> None:
     assert "KIRRA_WAKE_RECORD_CMD" in done.stderr
 
 
+# --- the trigger + acknowledgement contract ----------------------------------
+#
+# What the wake produces is ONE NEWLINE and a spoken "Yes?" — never the heard
+# words. rabbit_voice.sh reads the trigger with `read -r _` (the payload is
+# discarded by construction) and then records a SEPARATE clip for the actual
+# turn. That is why a wake phrase can never be a motion request: the phrase is
+# transcribed, matched, and thrown away inside this process.
+
+
+def _fire_once(**overrides):
+    """Run the real `_fire_trigger_and_wait` with sleeps stubbed out, and
+    return (what reached stdout, what the ack sink was handed)."""
+    import io
+    import tempfile
+    import wake_word as ww
+
+    spoken: list[str] = []
+    saved_sleep, saved_stdout = ww.time.sleep, sys.stdout
+    ww.time.sleep = lambda _s: None
+    sys.stdout = io.StringIO()
+    try:
+        with tempfile.NamedTemporaryFile(suffix=".json") as state:
+            kwargs = dict(turn_state_file=state.name, rearm_mode="timer",
+                          holdoff_s=0, grace_s=0, max_s=0, cooldown_s=0,
+                          after_fire=lambda: spoken.append("<ack>"))
+            kwargs.update(overrides)
+            ww._fire_trigger_and_wait(**kwargs)
+        return sys.stdout.getvalue(), spoken
+    finally:
+        ww.time.sleep = saved_sleep
+        sys.stdout = saved_stdout
+
+
+def test_a_wake_emits_exactly_one_trigger_newline() -> None:
+    out, _ = _fire_once()
+    assert out == "\n", f"the trigger must be exactly one newline, got {out!r}"
+    assert out.count("\n") == 1, "a double trigger would record two clips per wake"
+
+
+def test_the_trigger_carries_no_text_so_a_wake_phrase_is_never_a_request() -> None:
+    # The heard phrase never leaves this process. rabbit_voice.sh records a NEW
+    # clip per trigger, so "hello rabbit" cannot arrive at rabbit_converse (and
+    # therefore cannot reach mick /intent) as an utterance.
+    out, _ = _fire_once()
+    assert out.strip() == "", f"the trigger payload must be empty, got {out!r}"
+    for phrase in ("hello", "rabbit", "parker", "hey", "yo"):
+        assert phrase not in out.lower(), f"the wake phrase leaked into the trigger: {out!r}"
+
+
+def test_the_ack_fires_once_per_wake() -> None:
+    _, spoken = _fire_once()
+    assert spoken == ["<ack>"], f"exactly one ack per wake, got {spoken}"
+    # A follow-up turn fires with no after_fire — the "Yes?" is the WAKE cue only.
+    _, none_spoken = _fire_once(after_fire=None)
+    assert none_spoken == [], "a follow-up trigger must not re-ack"
+
+
+def test_the_default_acknowledgement_is_yes() -> None:
+    """`_ack` speaks the literal "Yes?" through KIRRA_TTS_CMD when no explicit
+    KIRRA_WAKE_ACK_CMD is configured (voice line W1)."""
+    import subprocess
+    import wake_word as ww
+
+    calls = []
+    saved = subprocess.run
+    subprocess.run = lambda *a, **k: calls.append((a, k)) or None
+    try:
+        ww._ack(None, "piper --model en_GB-alba-medium")
+        assert len(calls) == 1, calls
+        args, kwargs = calls[0]
+        assert kwargs.get("input") == "Yes?", \
+            f'the default wake acknowledgement must be "Yes?", got {kwargs.get("input")!r}'
+        assert args[0][0] == "piper", "it must go through the configured TTS command"
+
+        # An explicit ack command wins, and is run as a command (no stdin text).
+        calls.clear()
+        ww._ack("aplay /opt/kirra/chime.wav", "piper --model x")
+        assert len(calls) == 1 and calls[0][0][0] == ["aplay", "/opt/kirra/chime.wav"]
+        assert "input" not in calls[0][1], "an ack COMMAND takes no spoken text"
+    finally:
+        subprocess.run = saved
+
+
+def test_ack_never_blocks_the_trigger_when_tts_is_broken() -> None:
+    # The trigger is already on stdout by the time the ack runs; a dead TTS must
+    # not raise back into the listener loop.
+    import subprocess
+    import wake_word as ww
+
+    saved = subprocess.run
+
+    def _boom(*a, **k):
+        raise OSError("no audio device")
+
+    subprocess.run = _boom
+    try:
+        ww._ack(None, "piper --model x")   # must not raise
+    finally:
+        subprocess.run = saved
+
+
+# --- a configured second name ("parker") -------------------------------------
+
+def test_a_configured_parker_phrase_wakes() -> None:
+    """"hello parker" is NOT a default phrase — it wakes only when configured
+    via KIRRA_WAKE_PHRASES. Both facts are pinned so a bring-up that expects
+    "hello parker" knows it must set the variable."""
+    assert _hit("hello parker") is None, \
+        "hello parker must NOT wake on the default phrase set"
+
+    configured = parse_phrases("hello rabbit,hey rabbit,yo rabbit,"
+                               "hello parker,hey parker,yo parker")
+    assert wake_hit(transcript_tokens("hello parker"), configured) == "hello parker"
+    assert wake_hit(transcript_tokens("hey parker"), configured) == "hey parker"
+    # Same matcher, so the same guarantees carry over: mid-sentence wakes, a
+    # mishear of the long token is absorbed, and the anchor alone does not.
+    assert wake_hit(transcript_tokens("well hello parker"), configured) == "hello parker"
+    assert wake_hit(transcript_tokens("hello parkers"), configured) == "hello parker"
+    assert wake_hit(transcript_tokens("parker"), configured) is None, \
+        "the name alone must not wake — the phrase needs its anchor"
+
+
 def _run_all() -> int:
     failures = 0
     for name, fn in sorted(globals().items()):


### PR DESCRIPTION
Follow-up to **#1198** (Mick's deterministic non-motion fence). That PR is correct for the motion door — Mick should not treat greetings as motion. This one answers the other half: **does Rabbit still greet, chat and answer questions?**

It does. But verifying it turned up one real bug in how Rabbit *reads* the fence's new reply.

## The bug: `intent:null` read as a successful drive

The fence gives `POST /intent` a **second 200 shape**:

```
{"ok":true,"intent":{...},"seq":n,"at_ms":t}   an intent was latched
{"ok":true,"intent":null}                      fenced: no intent, no latch,
                                               seq unchanged — nothing moves
```

`rabbit_converse.offer_to_door` keyed `'ok'` on the `ok` flag alone. Probed against the real function before changing anything:

```python
offer_to_door("hello rabbit")  →  'ok'      # for {"ok":true,"intent":null}
```

Before the fence that was sound — every 200 carried an intent. Now it is a **false success acknowledgement** in three places:

- `handle_turn` speaks *"On our way — the governor will keep us honest"* while standing still;
- `mission._decide('ok')` → `'advance'` — the Executive **marches past a step that never ran**;
- `skill_registry` stays silent instead of saying the request didn't clear.

**Fix**: one condition in the one responsible layer — `'ok'` now also requires a non-null `intent`. Everything else falls to `'reject'`, which every caller's existing arm already handles correctly (converse re-asks, mission halts fail-closed, skills speak up). `intent` is present and non-null on every accepted reply **both before and after** the fence (`to_post_wire` is byte-identical on `main` and on #1198), so this reads correctly against either Mick build — **no coordinated deploy**, and it is safe to merge in either order.

The fence is not weakened, no route is added, greetings are not sent to Mick, and Occy / Taj / the verifier / governor / consumer are untouched.

## The verified path

```
"hello rabbit"
 → wake_word.py     RMS gate → whisper tiny → wake_hit() token matcher
 → _fire_trigger_and_wait()  writes ONE bare newline, then _ack()
 → rabbit_voice.sh  `while IFS= read -r _`  ← payload DISCARDED by construction
                    records a NEW bounded clip → STT → transcript
 → rabbit_converse.handle_turn(transcript)
      ├─ Channel A  say       → speak() → TTS sink          (no /intent)
      └─ Channel B  directive → offer_to_door() → POST /intent → Occy → checker
```

- **The wake phrase is never sent onward.** The trigger is literally `"\n"`; `rabbit_voice.sh` reads it into `_` and records a *separate* clip. The heard phrase dies inside the listener, so it cannot reach Mick as an utterance.
- **"Yes?" is `wake_word.py:_ack`** — `KIRRA_WAKE_ACK_CMD`, else the literal `"Yes?"` through `KIRRA_TTS_CMD`, else a stderr note. Once per wake, not on follow-ups; a broken TTS can't block an already-emitted trigger.
- **`directive: null` makes no Mick call at all**, so the fence isn't even on a greeting's path.

| Input | Result |
|---|---|
| `hello` / `how are you` | spoken reply, zero Mick calls |
| `what do you see` | read-only `gather_perception()` grounding → spoken answer, zero Mick calls |
| `drive forward one meter` | exactly one `POST {"text":"drive forward one meter"}` |
| `hello rabbit, drive forward one meter` | directive extracted; `drive forward one meter` reaches Mick (not a bare wake phrase, so not fenced) |

No deterministic pre-router (OTA, diag, wake-control, world-model) intercepts any of these — verified by running them.

## Tests

**`robot/rabbit_converse_test.py`** — new, **13 tests**, stubbing Ollama, TTS, Mick and the telemetry GETs: three Channel-A turns; the `directive:null` → no-Mick-call invariant over six utterances; one-directive-to-Mick; wake-prefix-plus-command; the no-intent-200 regression (plus `{"ok":true}` with the field absent, and an accepted-intent positive control); the end-to-end "never claims the robot is moving"; the mission non-advance; the explicit Rabbit↔Mick boundary; and three no-authority-regression checks (single door, exactly one `/intent` poster at source level, `speak()` is a pure sink).

**`robot/wake_word_test.py`** — 34 → **40**: exactly one trigger newline; the trigger carries no text; ack once per wake and not on follow-ups; the default acknowledgement is the literal `"Yes?"`, with an explicit ack command taking precedence; a dead TTS can't block the trigger; and a **configured** `hello parker` wakes — pinning that it does *not* wake on the default set (`hello rabbit,hey rabbit,yo rabbit`), which a bring-up expecting "parker" needs to know.

**Non-vacuity proven**: with the fix reverted, exactly the three regression tests fail — including `false success acknowledgement — nothing moved but Rabbit said: 'On our way — heading off now.'`

**CI gating**: the robot lane has no `requests`, and `rabbit_converse` `sys.exit`s without it — the existing convention is to skip, which would leave this regression ungated on the only lane that runs automatically. The test installs a minimal `requests` stub whose `get`/`post` **raise** unless a test replaced them, so a real network call fails loudly. Verified **13/13 both with the real library and with `requests` blocked**.

## Validation

All 20 robot Python suites exit 0 · `cargo test -p kirra-sidecars` 83 passed · `compileall` OK · `bash -n` OK (shellcheck not installed in the container) · `check_mick_actuation_fence.py` INTACT · `git diff --check` clean · `ci.yml` parses · `ruff` clean on all three touched files (the 6 findings elsewhere in `robot/` are pre-existing — confirmed identical on the stashed baseline).

`rabbit_model_smoketest.py gemma3:4b` **was not run** — no Ollama in the container, no offline mode. **No live model result is claimed.** The change is model-independent (a reply-reading rule, not a prompt or router change), but worth running on the robot.

## Docs

- `RABBIT_CONVERSATION_DESIGN.md` — the two 200 shapes and why `ok` alone is not success; why the fence can't touch the conversation channel.
- `RABBIT_BRINGUP_RUNBOOK.md` §7 — a **wheels-up** 4-utterance Jetson check with a `seq` baseline; steps 1–3 must leave `/intent/last` unchanged.

Two things in the runbook were corrected by checking rather than assuming: **nothing writes `/tmp/rabbit.log`** (under systemd the voice stack logs to the journal — `ExecStart=... wake_word.py | rabbit_voice.sh`, no redirect), so it gives `journalctl -u kirra-rabbit-voice -f` plus a `tee` recipe; and there is no `/kirra/proposal` topic — the doer publishes `/cmd_vel_raw`.

## Changed files

| File | Change |
|---|---|
| `robot/rabbit_converse.py` | `offer_to_door` requires a non-null `intent`; docstring covers both 200 shapes |
| `robot/rabbit_converse_test.py` | new — 13 tests + `requests` stub |
| `robot/wake_word_test.py` | +6 trigger/ack/parker tests |
| `docs/hardware/RABBIT_CONVERSATION_DESIGN.md` | the two shapes; channel separation |
| `docs/hardware/RABBIT_BRINGUP_RUNBOOK.md` | §7 wheels-up greeting check |
| `.github/workflows/ci.yml` | registers the new test |

## Merge order

Branched from `main`, not from #1198, so it stands alone and CI is meaningful either way. **Prefer merging #1198 first** — the docs here describe the fenced behaviour, and the §7 Jetson check expects `{"ok":true,"intent":null}` from a direct `POST /intent`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjDFKPcBVHURDZpXsvnYhC)_