### PR TITLE
fix(voice): use bounded VAD for Rabbit turns

### DIFF
--- a/docs/hardware/R2_VOICE_AUDIO_SETUP.md
+++ b/docs/hardware/R2_VOICE_AUDIO_SETUP.md
@@ -96,8 +96,24 @@ KIRRA_RECORD_CMD="arecord -D plughw:CARD=Device,DEV=0 -d 4 -f S16_LE -r 16000 -c
 # KIRRA_MICK_AUDITOR_TOKEN="<auditor principal token>"
 ```
 Only the two `-D plughw:CARD=…` values and the real paths differ from
-`robot/install/rabbit.env.example`. `-d 4` is the record window (drop to `-d 3`
-for snappier turns).
+`robot/install/rabbit.env.example`. `-d 4` is the record window — but prefer
+**VAD endpointing**, which stops on trailing silence instead of always waiting
+the full window (~1.3 s for a short command vs a flat 4 s):
+
+```bash
+KIRRA_RECORD_CMD="python3 /opt/kirra/robot/vad_record.py"
+KIRRA_VAD_DEVICE="plughw:CARD=Device,DEV=0"   # REQUIRED — there is NO default
+KIRRA_VAD_SILENCE_MS=650
+KIRRA_VAD_MIN_SPEECH_MS=250
+KIRRA_VAD_MAX_MS=6000
+KIRRA_VAD_START_TIMEOUT_MS=3000
+```
+
+The device moves from the `arecord -D` flag to `KIRRA_VAD_DEVICE`, and it is
+**required**: unset, `vad_record.py` refuses before opening anything rather than
+falling back to ALSA's default (which is not the mic, and fails silently). Still
+a bounded mic — `KIRRA_VAD_MAX_MS` is a hard ceiling and a wedged device is
+bounded by a wall clock. Details + tuning: `RABBIT_AUDIO_STACK.md` §1a.
 
 ## 5. PTT button (GPIO) — the Orin gotchas
 ```bash

--- a/docs/hardware/RABBIT_AUDIO_STACK.md
+++ b/docs/hardware/RABBIT_AUDIO_STACK.md
@@ -28,8 +28,9 @@ recipe below). The two dominant terms are the **fixed record window** and the
 
 | Stage | Typical | Notes |
 |---|---|---|
-| record (`arecord -d 4`) | **4.0 s fixed** | it waits the whole window — the biggest lever (see tuning) |
-| STT (whisper `base.en`) | ~0.5–2 s | for a 4 s clip; CUDA build << CPU build |
+| record (`arecord -d 4`) | **4.0 s fixed** | it waits the whole window, however short the command |
+| record (`vad_record.py`) | **~1.3 s** for a short command | stops on trailing silence; §1a — the biggest lever |
+| STT (whisper `base.en`) | ~0.5–2 s | for a 4 s clip; shorter clip → less STT too; CUDA build << CPU build |
 | LLM (`gemma3:4b`) | ~2–5 s | the conversational cost; local, no cloud |
 | TTS (piper `medium`) | ~0.3–1 s | faster than real-time for a sentence |
 
@@ -67,31 +68,76 @@ KIRRA_RECORD_CMD="arecord -d 4 -f S16_LE -r 16000 -c 1"   # 4 s, 16 kHz mono, th
 The `-d 4` bound is the single biggest latency lever. To make Rabbit feel snappier,
 either shorten it (`-d 2` for terse commands) or use **VAD endpointing** (below).
 
-### 1a. VAD endpointing (`vad_record.py`) — opt-in, stop on silence
+### 1a. VAD endpointing (`vad_record.py`) — RECOMMENDED, stop on silence
 
 `robot/vad_record.py` is a **drop-in replacement** for the `arecord` line: it
 records ONE utterance that ends on trailing silence instead of always waiting the
-full window, so a terse "check yourself" returns in ~1 s while a longer sentence
-still gets its time — up to a hard ceiling. It writes the appended WAV path (the
-same `$KIRRA_RECORD_CMD "$wav"` contract), so nothing else in the pipeline
-changes:
+full window, so a short command returns in ~1.3 s while a longer sentence still
+gets its time — up to a hard ceiling. It writes the appended WAV path (the same
+`$KIRRA_RECORD_CMD "$wav"` contract), so nothing else in the pipeline changes:
 
 ```bash
-KIRRA_RECORD_CMD="python3 /opt/kirra/robot/vad_record.py"    # opt in
-#   (left as the arecord line above → byte-identical prior behaviour)
+KIRRA_RECORD_CMD="python3 /opt/kirra/robot/vad_record.py"
+KIRRA_VAD_DEVICE="plughw:CARD=<YOUR_CARD>,DEV=0"   # REQUIRED — `arecord -l`
+KIRRA_VAD_SILENCE_MS=650      # trailing silence that ends the utterance
+KIRRA_VAD_MIN_SPEECH_MS=250   # min ACTUAL speech before an endpoint is honored
+KIRRA_VAD_MAX_MS=6000         # HARD ceiling
+KIRRA_VAD_START_TIMEOUT_MS=3000
 ```
 
-It stays a **bounded** mic, not an open one: `KIRRA_VAD_MAX_MS` (default 8 s) is a
-hard ceiling the endpointer always stops at, exactly like arecord's `-d` bound,
-and a silence-only capture ends at `KIRRA_VAD_START_TIMEOUT_MS` with an empty clip
-→ the fenced parser latches nothing → no motion. It emits only a WAV the existing
-STT transcribes — **no new authority**. The default backend is `energy` (RMS vs
-`KIRRA_VAD_RMS_FLOOR`, zero new deps — the same idea as `wake_word.py`'s pre-gate);
-`KIRRA_VAD_BACKEND` is a fail-closed seam for a future Silero/webrtc detector (an
-unimplemented value is refused, never silently ignored). The endpoint state
-machine (min actual speech + trailing-silence + hard cap) is host-tested in
-`robot/vad_record_test.py`; the capture loop is the hardware seam. Full env set:
+**The device is required.** There is deliberately no default: ALSA's default is
+whichever card the kernel enumerated first, which on the R2 is not the
+microphone, and the failure is *silent* — near-silence arrives, every turn
+endpoints as "no speech", and the robot simply appears not to hear you. Unset →
+`vad_record.py` refuses at startup, **before opening anything**. This is the same
+rule the wake listener already enforces on `KIRRA_WAKE_RECORD_CMD`, and for the
+same reason; the two remain separate variables and separate contracts.
+
+What the ~2.6 s saving looks like on a short command ("how are you?", ~690 ms of
+speech):
+
+| | capture | note |
+|---|---|---|
+| `arecord -d 4` | **4000 ms** | every turn, however short |
+| VAD (`silence 650`) | **~1340 ms** | 690 ms speech + 650 ms trailing silence |
+
+It stays a **bounded** mic, not an open one, and there are now three bounds, not
+one:
+
+- `KIRRA_VAD_MAX_MS` — the hard sample-time ceiling the endpointer always stops
+  at, exactly like arecord's `-d`. It is itself capped at `VAD_ABSOLUTE_MAX_MS`
+  (30 s), so a config typo cannot quietly turn a 6-second recorder into a
+  ten-minute one.
+- A **wall-clock deadline** (`max_ms + 2 s`). The endpointer counts *samples*; a
+  wedged capture device delivers none, so sample-time stops advancing and a plain
+  blocking read would hold the mic open forever. The deadline is what actually
+  bounds that case — it exits non-zero with `capture stalled`.
+- `KIRRA_VAD_START_TIMEOUT_MS` — silence-only ends here with an empty clip → the
+  fenced parser latches nothing → no motion.
+
+**Exit status is part of the contract.** Non-zero means "no usable clip"
+(unconfigured device, wedged card, capture program died), and `rabbit_voice.sh`
+logs `recorder failed — nothing captured` and drops the turn — no transcript, no
+intent, no motion. A dead microphone therefore reports itself instead of looking
+like a mishearing.
+
+It emits only a WAV the existing STT transcribes — **no new authority**. The
+default backend is `energy` (RMS vs `KIRRA_VAD_RMS_FLOOR`, zero new deps — the
+same idea as `wake_word.py`'s pre-gate); `KIRRA_VAD_BACKEND` is a fail-closed seam
+for a future Silero/webrtc detector (an unimplemented value is refused, never
+silently ignored). A non-arecord `KIRRA_VAD_CAPTURE_CMD` is used verbatim and gets
+no ALSA-specific validation — a custom backend has its own device convention.
+
+The endpoint state machine, the config validators and the capture seam are all
+tested in `robot/vad_record_test.py`; `robot/kirra_voice_doctor.sh` reports the
+effective settings and flags a missing device, a drifted card, an out-of-range
+bound, or the two recorder contracts being swapped. Full env set:
 `robot/install/rabbit.env.example`.
+
+> **Deployment:** an already-provisioned robot keeps its existing
+> `/etc/kirra/robot.env` — the installer never rewrites it. Adopting VAD is a
+> manual edit of that file plus a restart of the voice units. Until then the
+> fixed 4 s window stands.
 
 ## 2. TTS — piper
 

--- a/docs/hardware/RABBIT_BRINGUP_RUNBOOK.md
+++ b/docs/hardware/RABBIT_BRINGUP_RUNBOOK.md
@@ -159,8 +159,11 @@ tuned. In order of impact:
    ```
 3. **tiny.en for the wake listener** (`KIRRA_WAKE_STT_CMD`) so the always-on
    detector sips CPU; keep `base.en` on `KIRRA_STT_CMD` for turn transcription.
-4. **VAD endpointing** for the turn recorder (`KIRRA_RECORD_CMD=…vad_record.py`)
-   so a terse command returns in ~1 s instead of the fixed `-d 4` window.
+4. **VAD endpointing** for the turn recorder (`KIRRA_RECORD_CMD=…vad_record.py`
+   plus the REQUIRED `KIRRA_VAD_DEVICE`) so a short command's capture costs
+   ~1.3 s instead of the flat 4 s `-d 4` window — a ~2.6 s saving on every terse
+   turn, and less STT work on the shorter clip. Still a bounded mic (hard
+   ceiling + a wall-clock stall bound); see `RABBIT_AUDIO_STACK.md` §1a.
 5. **Event-driven re-arm + follow-up mode** (Slices R/F) so back-to-back
    questions need neither a dead-window wait nor a fresh wake word.
 6. **First-clause streaming to TTS** (Slice T, `KIRRA_RABBIT_STREAM_TTS=1`,

--- a/robot/install/rabbit.env.example
+++ b/robot/install/rabbit.env.example
@@ -47,20 +47,46 @@ KIRRA_TTS_CMD="./speak.sh"
 # continue); a barge-in (Slice 2) cancels. Takes precedence over KIRRA_SKILLS_
 # ENABLED. Default off → the single-turn router. See robot/mission.py.
 #KIRRA_MISSIONS_ENABLED=1
-# Bounded push-to-talk recorder (the -d bound = no open mic). WAV path appended.
+# ── The TURN recorder (ONE bounded clip per trigger; WAV path APPENDED) ───────
+# Fixed-window fallback: every turn costs the full -d seconds, however short the
+# command. The -d bound is what makes it a bounded mic, not an open one.
 KIRRA_RECORD_CMD="arecord -d 4 -f S16_LE -r 16000 -c 1"
-# VAD ENDPOINTING (opt-in): stop on trailing silence instead of the fixed -d window
-# → a terse command returns in ~1 s, not always 4 s. Drop-in replacement (writes
-# the appended WAV path, same contract). Default = the arecord line above (off).
-# vad_record.py is still a BOUNDED mic (KIRRA_VAD_MAX_MS is a hard ceiling) and
-# only produces a clip the existing pipeline transcribes — no new authority.
+#
+# VAD ENDPOINTING (RECOMMENDED) — stop on trailing SILENCE instead of the fixed
+# -d window, so a short command ("how are you?") finishes in ~1.3 s instead of
+# always 4 s. Drop-in: same contract (writes the appended WAV path), and still a
+# BOUNDED mic — KIRRA_VAD_MAX_MS is a HARD ceiling, and a wedged capture device
+# is bounded by a wall clock rather than held open. It only produces a clip the
+# existing pipeline transcribes: no new authority, and an empty/garbled clip
+# still dead-ends at the fenced /intent door (no intent, no motion).
+#
+# 🔴 KIRRA_VAD_DEVICE is REQUIRED (there is deliberately NO default) — same rule
+# as KIRRA_WAKE_RECORD_CMD below, for the same reason: ALSA's default device is
+# whichever card the kernel enumerated first, which on the R2 is not the mic, and
+# the failure is SILENT (near-silence arrives and every turn reads as "no
+# speech"). Unset → vad_record.py refuses at startup, BEFORE opening anything.
+# Run `arecord -l` and use the by-NAME form; it survives USB re-enumeration.
 #KIRRA_RECORD_CMD="python3 /opt/kirra/robot/vad_record.py"
+#KIRRA_VAD_DEVICE="plughw:CARD=<YOUR_CARD>,DEV=0"   # REQUIRED — `arecord -l`
 #KIRRA_VAD_BACKEND=energy         # 'energy' (RMS, zero deps); silero/webrtc = later slice
 #KIRRA_VAD_RMS_FLOOR=300          # speech energy threshold (16-bit FS = 32767)
-#KIRRA_VAD_SILENCE_MS=800         # trailing silence that ends the utterance
-#KIRRA_VAD_MIN_SPEECH_MS=300      # min actual speech before an endpoint is honored
-#KIRRA_VAD_MAX_MS=8000            # HARD ceiling (the bounded-mic guarantee)
+#KIRRA_VAD_SILENCE_MS=650         # trailing silence that ends the utterance
+#KIRRA_VAD_MIN_SPEECH_MS=250      # min actual speech before an endpoint is honored
+#KIRRA_VAD_MAX_MS=6000            # HARD ceiling (the bounded-mic guarantee; <= 30000)
 #KIRRA_VAD_START_TIMEOUT_MS=3000  # if speech never starts, give up (empty clip → no-op)
+# A non-arecord capture backend instead? Give the whole command; it is used
+# verbatim and gets NO ALSA-specific validation (it has its own convention).
+#KIRRA_VAD_CAPTURE_CMD="my-capture --raw --rate 16000"
+#
+# ⚠ MIGRATION: an already-deployed robot keeps its existing /etc/kirra/robot.env
+# — the installer never rewrites it. To adopt VAD you must edit that file by hand
+# (uncomment the two KIRRA_RECORD_CMD/KIRRA_VAD_DEVICE lines above, fill in your
+# card) and restart the voice units. Until you do, the fixed 4 s window stands.
+#
+# Tuning: raise KIRRA_VAD_SILENCE_MS if it cuts you off mid-sentence; lower it
+# (to ~500) for snappier turns in a quiet room. Raise KIRRA_VAD_RMS_FLOOR if a
+# noisy room keeps the clip open to the cap; check with
+# `robot/kirra_voice_doctor.sh`, which reports the effective settings.
 
 # ── Wake word (W1, OPT-IN — off by default; PTT stays the recommended default) ─
 # "hello rabbit" / "hey rabbit" / "yo rabbit" as a hands-free trigger. It is a

--- a/robot/kirra_voice_doctor.sh
+++ b/robot/kirra_voice_doctor.sh
@@ -34,6 +34,8 @@ RENV="${KIRRA_ROBOT_ENV:-/etc/kirra/robot.env}"
 
 # first token of a command string (the binary/script it invokes)
 first_tok() { set -- $1; printf '%s' "${1:-}"; }
+# nth (1-based) token of a command string, or ""
+nth_tok() { local n="$1"; shift; set -- $1; shift $((n - 1)) 2>/dev/null || return 0; printf '%s' "${1:-}"; }
 # value following <flag> in a command string, or "" (e.g. opt_val -m "$KIRRA_STT_CMD")
 opt_val() { local f="$1"; shift; set -- $1; while [ "$#" -gt 0 ]; do [ "$1" = "$f" ] && { printf '%s' "${2:-}"; return; }; shift; done; }
 # ALSA card reference from a device spec: plughw:N,0 / hw:N,0 (numeric) or
@@ -84,17 +86,117 @@ else
   warn "KIRRA_TTS_CMD unset — Rabbit will PRINT, not speak"
 fi
 
-# 4. MIC device present in arecord -l  (the drift check)
-mic_spec="$(opt_val -D "${KIRRA_RECORD_CMD:-}")"
-mc="$(card_ref "$mic_spec")"
-if [ -n "${mc#*:}" ]; then
-  if command -v arecord >/dev/null 2>&1 && card_present arecord "$mc"; then
-    ok "mic device present: -D $mic_spec"
-  else
-    bad "mic device NOT in arecord -l (card drifted?): -D $mic_spec"; fix "arecord -l → update KIRRA_RECORD_CMD -D plughw:<N>,0 (or the more robust plughw:CARD=<name>,DEV=0) — §0"
-  fi
-else
-  warn "KIRRA_RECORD_CMD has no -D plughw:N,0 (mic device not pinned)"
+# 4. TURN recorder: which mode, and is its mic pinned + present?
+#    Two shapes are valid and their device lives in DIFFERENT places:
+#      arecord -d N …                 → the device is this command's -D
+#      python3 …/vad_record.py        → the device is KIRRA_VAD_DEVICE
+#    Reading -D off the vad_record.py line would find nothing and wrongly report
+#    "not pinned" on a correctly configured VAD robot.
+# The VAD form is "python3 <path>/vad_record.py", so the FIRST token is the
+# interpreter — classify on the script it runs, not on argv[0].
+turn_prog="$(basename "$(first_tok "${KIRRA_RECORD_CMD:-}")")"
+case "${KIRRA_RECORD_CMD:-}" in
+  *vad_record.py*) turn_prog="vad_record.py" ;;
+esac
+case "$turn_prog" in
+  vad_record.py)
+    # 4a. the recorder must actually be installed and runnable.
+    # the command is "python3 <script>" — the script is the 2nd token.
+    # nth_tok, not `set --`: this runs at top level, where `set --` would
+    # clobber the doctor's own arguments.
+    turn_script="$(nth_tok 2 "${KIRRA_RECORD_CMD}")"
+    case "$turn_script" in *vad_record.py) : ;; *) turn_script="$(first_tok "${KIRRA_RECORD_CMD}")" ;; esac
+    if [ -z "$turn_script" ] || [ ! -f "$turn_script" ]; then
+      bad "KIRRA_RECORD_CMD points at vad_record.py but ${turn_script:-<none>} is missing"
+      fix "re-run robot/install/install_robot_units.sh (it stages /opt/kirra/robot/vad_record.py)"
+    elif [ ! -r "$turn_script" ]; then
+      bad "turn VAD recorder not readable: $turn_script"; fix "sudo chmod 0755 $turn_script"
+    else
+      ok "turn recorder: VAD endpointing ($turn_script)"
+    fi
+    # 4b. the VAD mic — REQUIRED, and it must not have drifted.
+    if [ -n "${KIRRA_VAD_CAPTURE_CMD:-}" ]; then
+      vcp="$(basename "$(first_tok "$KIRRA_VAD_CAPTURE_CMD")")"
+      if [ "$vcp" = "arecord" ]; then
+        vdev="$(opt_val -D "$KIRRA_VAD_CAPTURE_CMD")"
+        [ -n "$vdev" ] || vdev="$(opt_val --device "$KIRRA_VAD_CAPTURE_CMD")"
+        if [ -z "$vdev" ]; then
+          bad "KIRRA_VAD_CAPTURE_CMD uses arecord with no -D/--device (ALSA DEFAULT — every turn would record near-silence)"
+          fix 'arecord -l → add -D plughw:CARD=<name>,DEV=0'
+        else
+          ok "VAD capture command pins its device: -D $vdev"
+        fi
+      else
+        ok "VAD uses a custom capture backend ($vcp) — no ALSA rule applied"
+      fi
+    elif [ -z "${KIRRA_VAD_DEVICE:-}" ]; then
+      bad "KIRRA_RECORD_CMD is vad_record.py but KIRRA_VAD_DEVICE is unset (it will REFUSE to start — there is no ALSA default)"
+      fix 'arecord -l → KIRRA_VAD_DEVICE="plughw:CARD=<name>,DEV=0" — §0'
+    else
+      vc="$(card_ref "$KIRRA_VAD_DEVICE")"
+      if command -v arecord >/dev/null 2>&1 && card_present arecord "$vc"; then
+        ok "VAD mic device present: $KIRRA_VAD_DEVICE"
+      else
+        bad "VAD mic device NOT in arecord -l (card drifted?): $KIRRA_VAD_DEVICE"
+        fix "arecord -l → update KIRRA_VAD_DEVICE to plughw:CARD=<name>,DEV=0 — §0"
+      fi
+    fi
+    # 4c. the bounds must be positive and actually bounded (the no-open-mic claim).
+    vmax="${KIRRA_VAD_MAX_MS:-8000}"; vsto="${KIRRA_VAD_START_TIMEOUT_MS:-3000}"
+    vabs=30000
+    if ! printf '%s' "$vmax" | grep -qE '^[0-9]+$' || [ "$vmax" -le 0 ]; then
+      bad "KIRRA_VAD_MAX_MS='$vmax' is not a positive integer"; fix "set e.g. KIRRA_VAD_MAX_MS=6000"
+    elif [ "$vmax" -gt "$vabs" ]; then
+      bad "KIRRA_VAD_MAX_MS=$vmax exceeds the ${vabs}ms absolute ceiling (vad_record.py will refuse)"; fix "set KIRRA_VAD_MAX_MS <= $vabs"
+    elif ! printf '%s' "$vsto" | grep -qE '^[0-9]+$' || [ "$vsto" -le 0 ]; then
+      bad "KIRRA_VAD_START_TIMEOUT_MS='$vsto' is not a positive integer"; fix "set e.g. KIRRA_VAD_START_TIMEOUT_MS=3000"
+    elif [ "$vsto" -gt "$vmax" ]; then
+      bad "KIRRA_VAD_START_TIMEOUT_MS=$vsto exceeds KIRRA_VAD_MAX_MS=$vmax (it could never fire)"; fix "set the start timeout below the ceiling"
+    else
+      ok "VAD bounds sane: max ${vmax}ms, start timeout ${vsto}ms, silence ${KIRRA_VAD_SILENCE_MS:-800}ms"
+    fi
+    ;;
+  arecord)
+    mic_spec="$(opt_val -D "${KIRRA_RECORD_CMD:-}")"
+    mc="$(card_ref "$mic_spec")"
+    if [ -n "${mc#*:}" ]; then
+      if command -v arecord >/dev/null 2>&1 && card_present arecord "$mc"; then
+        ok "mic device present: -D $mic_spec"
+      else
+        bad "mic device NOT in arecord -l (card drifted?): -D $mic_spec"; fix "arecord -l → update KIRRA_RECORD_CMD -D plughw:<N>,0 (or the more robust plughw:CARD=<name>,DEV=0) — §0"
+      fi
+    else
+      warn "KIRRA_RECORD_CMD has no -D plughw:N,0 (mic device not pinned)"
+    fi
+    rdb="$(opt_val -d "${KIRRA_RECORD_CMD}")"
+    if [ -n "$rdb" ]; then
+      warn "turn recorder is the FIXED ${rdb}s window — every turn costs ${rdb}s however short"
+      fix "switch to VAD endpointing: KIRRA_RECORD_CMD=\"python3 /opt/kirra/robot/vad_record.py\" + KIRRA_VAD_DEVICE — see rabbit.env.example"
+    else
+      bad "KIRRA_RECORD_CMD uses arecord with no -d bound — that is an UNBOUNDED microphone"; fix "add -d 4, or switch to vad_record.py"
+    fi
+    ;;
+  "")
+    warn "KIRRA_RECORD_CMD unset — the turn recorder defaults to a fixed arecord window"
+    ;;
+  *)
+    ok "turn recorder: custom backend ($turn_prog) — no ALSA rule applied"
+    ;;
+esac
+
+# 4d. the two recorder contracts must not be swapped. KIRRA_WAKE_RECORD_CMD is
+# the always-on RAW stream (-t raw, no -d); KIRRA_RECORD_CMD is the one-turn WAV
+# recorder. Swap them and the turn recorder never terminates, or the listener
+# stops after one window — both fail in confusing, intermittent ways.
+if [ -n "${KIRRA_RECORD_CMD:-}" ] && [ "$turn_prog" = "arecord" ]; then
+  case " ${KIRRA_RECORD_CMD} " in
+    *" -t raw "*|*" -t raw") bad "KIRRA_RECORD_CMD is a RAW stream (-t raw) — that is the WAKE recorder's contract, not the turn recorder's"; fix "the turn recorder must write a bounded WAV: \"arecord -D <dev> -d 4 -f S16_LE -r 16000 -c 1\" (or vad_record.py)" ;;
+  esac
+fi
+if [ -n "${KIRRA_WAKE_RECORD_CMD:-}" ]; then
+  case " ${KIRRA_WAKE_RECORD_CMD} " in
+    *" -d "*) bad "KIRRA_WAKE_RECORD_CMD has a -d bound — that is the TURN recorder's contract; the wake listener needs an UNBOUNDED raw stream"; fix "drop -d and add -t raw" ;;
+  esac
 fi
 
 # 5. SPEAKER device present in aplay -l (parse the plughw from the TTS wrapper file)
@@ -189,7 +291,13 @@ sys.exit(0 if parse_phrases(os.environ.get('KIRRA_WAKE_PHRASES', DEFAULT_PHRASES
     # 8c. hold-off must cover the turn recorder's -d bound (mic contention:
     # the listener releases the device for holdoff; a short holdoff steals it
     # back mid-turn and the turn recorder fails SILENTLY).
-    rd="$(opt_val -d "${KIRRA_RECORD_CMD:-arecord -d 4}")"
+    # The turn recorder's WORST-CASE seconds: -d for the fixed window, the VAD
+    # hard ceiling for the endpointing recorder (that is what the mic can hold).
+    if [ "$turn_prog" = "vad_record.py" ]; then
+      rd=$(( ${KIRRA_VAD_MAX_MS:-8000} / 1000 ))
+    else
+      rd="$(opt_val -d "${KIRRA_RECORD_CMD:-arecord -d 4}")"
+    fi
     ho="${KIRRA_WAKE_HOLDOFF_S:-10}"
     if [ -n "$rd" ] && awk "BEGIN{exit !($ho >= $rd + 3)}" 2>/dev/null; then
       ok "wake holdoff ${ho}s covers the ${rd}s turn recording (+STT/TTS)"

--- a/robot/vad_record.py
+++ b/robot/vad_record.py
@@ -30,27 +30,60 @@ Backends (`KIRRA_VAD_BACKEND`):
   * anything else → FATAL exit (fail-closed seam; a Silero/webrtc backend is a
     later slice — no silent fallback to an unimplemented detector).
 
-Env (all optional):
+Env:
+  KIRRA_VAD_DEVICE         REQUIRED for the built-in arecord backend — the ALSA
+                           capture device, e.g. "plughw:CARD=Device,DEV=0".
+                           There is deliberately NO default: ALSA's default is
+                           whichever card the kernel enumerated first, which on
+                           the R2 is not the microphone, and the failure is
+                           SILENT (the stream opens and delivers near-silence, so
+                           every turn endpoints as "no speech"). Same rule the
+                           wake listener already enforces on
+                           KIRRA_WAKE_RECORD_CMD.
+  KIRRA_VAD_CAPTURE_CMD    full raw-PCM-to-stdout capture command, overriding the
+                           built-in arecord line. A custom (non-arecord) backend
+                           is left alone — it has its own device convention and
+                           this module has no business guessing it.
   KIRRA_VAD_BACKEND        'energy' (default); other → refuse
-  KIRRA_VAD_CAPTURE_CMD    raw-PCM capture to stdout
-                           (default "arecord -f S16_LE -r 16000 -c 1 -t raw")
   KIRRA_VAD_RMS_FLOOR      speech energy threshold (default 300; 16-bit FS=32767)
   KIRRA_VAD_FRAME_MS       analysis frame (default 30 ms)
   KIRRA_VAD_MIN_SPEECH_MS  min speech before an endpoint is honored (default 300)
   KIRRA_VAD_SILENCE_MS     trailing silence that ends the utterance (default 800)
-  KIRRA_VAD_MAX_MS         HARD ceiling — always stop by here (default 8000)
+  KIRRA_VAD_MAX_MS         HARD ceiling — always stop by here (default 8000;
+                           must be positive and <= VAD_ABSOLUTE_MAX_MS)
   KIRRA_VAD_START_TIMEOUT_MS  if speech never starts, give up (default 3000)
   KIRRA_VAD_SAMPLE_RATE    Hz (default 16000, whisper-native)
 
-The pure core (`rms_energy`, `Endpointer`) is host-tested in vad_record_test.py;
-the capture loop is the thin hardware seam.
+Contract with the caller (`rabbit_voice.sh`): the WAV path is APPENDED as the
+last argument, and a NONZERO exit means "no usable clip" — the caller logs
+"recorder failed — nothing captured" and the turn dead-ends with no transcript,
+no intent and no motion.
+
+The pure core (`rms_energy`, `Endpointer`, `validate_capture_cmd`,
+`resolve_capture_argv`, `validate_bounds`) is host-tested in vad_record_test.py;
+only the read loop is the hardware seam.
 """
 import os
+import selectors
+import shlex
 import subprocess
 import sys
+import time
 import wave
 
 SAMPLE_WIDTH_BYTES = 2  # S16_LE
+
+# An absolute ceiling on KIRRA_VAD_MAX_MS. The per-turn bound is operator
+# tunable, but not without limit: this module's whole safety claim is "a BOUNDED
+# mic, never an open one", and a config typo (`KIRRA_VAD_MAX_MS=600000`) must not
+# be able to quietly turn a 6-second recorder into a ten-minute one.
+VAD_ABSOLUTE_MAX_MS = 30_000
+
+# How long the read loop waits past the hard ceiling before declaring the capture
+# STALLED. The endpointer counts SAMPLES; if the device wedges, samples stop
+# arriving and sample-time stops advancing, so a wall clock is what actually
+# bounds the mic. Generous enough not to trip on ordinary scheduling jitter.
+CAPTURE_STALL_GRACE_MS = 2_000
 
 
 def log(msg):
@@ -132,6 +165,109 @@ class Endpointer:
         return CONTINUE
 
 
+# ── pure configuration resolution (host-tested; no spawning, no probing) ─────
+
+def validate_capture_cmd(raw):
+    """Parse and check an explicit `KIRRA_VAD_CAPTURE_CMD`.
+
+    Returns `(argv, "")` or `(None, reason)`. Pure: nothing is spawned and no
+    device is probed, so a misconfigured turn recorder fails BEFORE a microphone
+    is opened.
+
+    Same two rules the wake listener applies to `KIRRA_WAKE_RECORD_CMD`
+    (`wake_word.validate_record_cmd`) — deliberately identical, because the
+    failure mode is identical:
+
+      - the command must parse and name a program;
+      - if that program is `arecord`, it must select a device explicitly
+        (`-D`/`--device`). A bare `arecord` takes ALSA's default — the first card
+        the kernel enumerated, which on the R2 is not the mic — and the failure
+        is SILENT: near-silence arrives, every turn endpoints as "no speech",
+        and the operator sees a robot that never hears them.
+
+    A non-`arecord` program is LEFT ALONE. A custom capture backend has its own
+    device-selection convention and this module has no business guessing it.
+    """
+    if not raw or not raw.strip():
+        return None, "KIRRA_VAD_CAPTURE_CMD is blank"
+    try:
+        argv = shlex.split(raw)
+    except ValueError as exc:
+        return None, f"KIRRA_VAD_CAPTURE_CMD is not parseable as a command: {exc}"
+    if not argv:
+        return None, "KIRRA_VAD_CAPTURE_CMD parsed to an empty command"
+    if os.path.basename(argv[0]) == "arecord" and \
+            not any(a in ("-D", "--device") for a in argv[1:]):
+        return None, ("KIRRA_VAD_CAPTURE_CMD uses arecord without -D/--device, so it "
+                      "would capture from ALSA's DEFAULT device — on this platform "
+                      "that is not the microphone, and every turn would record "
+                      "near-silence without erroring. Name the device, e.g. "
+                      '"arecord -D plughw:CARD=Device,DEV=0 -f S16_LE -r 16000 '
+                      '-c 1 -t raw"')
+    return argv, ""
+
+
+def resolve_capture_argv(device, capture_cmd, sample_rate):
+    """Decide what to run for capture. Returns `(argv, "")` or `(None, reason)`.
+
+    Precedence, both fail-closed:
+      1. an explicit `KIRRA_VAD_CAPTURE_CMD` wins (validated as above) — this is
+         the escape hatch for a non-arecord backend;
+      2. otherwise the built-in arecord line, which REQUIRES `KIRRA_VAD_DEVICE`.
+
+    There is no third case. With neither set we refuse rather than fall back to
+    ALSA's default device, for exactly the reason above.
+    """
+    if capture_cmd and capture_cmd.strip():
+        return validate_capture_cmd(capture_cmd)
+    if not device or not device.strip():
+        return None, ("KIRRA_VAD_DEVICE is unset and no KIRRA_VAD_CAPTURE_CMD was "
+                      "given, so there is no microphone to open. Set an EXPLICIT "
+                      'ALSA device, e.g. KIRRA_VAD_DEVICE="plughw:CARD=Device,DEV=0" '
+                      "(`arecord -l` lists the cards). There is no default: ALSA's "
+                      "default device is not the microphone on this platform.")
+    return ["arecord", "-D", device.strip(), "-f", "S16_LE",
+            "-r", str(sample_rate), "-c", "1", "-t", "raw"], ""
+
+
+def capture_device(argv):
+    """The ALSA device `argv` selects, or "" if it names none. Diagnostics only —
+    reporting WHICH mic was opened is the difference between "VAD is on" and
+    "VAD is on and listening to the right thing"."""
+    for flag, value in zip(argv, argv[1:]):
+        if flag in ("-D", "--device"):
+            return value
+    return ""
+
+
+def validate_bounds(max_ms, start_timeout_ms, silence_ms, min_speech_ms, frame_ms):
+    """Check the timing configuration. Returns "" if usable, else the reason.
+
+    The bounded-mic guarantee is only as good as these numbers, so a nonsense
+    value is REFUSED rather than silently defaulted: a non-positive ceiling would
+    stop the clip before a single frame (a recorder that records nothing), and an
+    absurdly large one would defeat the bound this module exists to provide.
+    """
+    if max_ms <= 0:
+        return f"KIRRA_VAD_MAX_MS must be positive (got {max_ms})"
+    if max_ms > VAD_ABSOLUTE_MAX_MS:
+        return (f"KIRRA_VAD_MAX_MS={max_ms} exceeds the absolute ceiling "
+                f"{VAD_ABSOLUTE_MAX_MS} ms — this is a bounded recorder, not an "
+                "open microphone")
+    if start_timeout_ms <= 0:
+        return f"KIRRA_VAD_START_TIMEOUT_MS must be positive (got {start_timeout_ms})"
+    if start_timeout_ms > max_ms:
+        return (f"KIRRA_VAD_START_TIMEOUT_MS={start_timeout_ms} exceeds "
+                f"KIRRA_VAD_MAX_MS={max_ms} — the start timeout could never fire")
+    if silence_ms <= 0:
+        return f"KIRRA_VAD_SILENCE_MS must be positive (got {silence_ms})"
+    if min_speech_ms < 0:
+        return f"KIRRA_VAD_MIN_SPEECH_MS must not be negative (got {min_speech_ms})"
+    if frame_ms <= 0:
+        return f"KIRRA_VAD_FRAME_MS must be positive (got {frame_ms})"
+    return ""
+
+
 # ── hardware seam (thin; not unit-tested) ────────────────────────────────────
 
 def _env_int(key, default):
@@ -169,21 +305,35 @@ def main(argv):
     sample_rate = _env_int("KIRRA_VAD_SAMPLE_RATE", 16000)
     frame_ms = _env_int("KIRRA_VAD_FRAME_MS", 30)
     floor = _env_int("KIRRA_VAD_RMS_FLOOR", 300)
-    endpointer = Endpointer(
-        min_speech_ms=_env_int("KIRRA_VAD_MIN_SPEECH_MS", 300),
-        silence_ms=_env_int("KIRRA_VAD_SILENCE_MS", 800),
-        max_ms=_env_int("KIRRA_VAD_MAX_MS", 8000),
-        start_timeout_ms=_env_int("KIRRA_VAD_START_TIMEOUT_MS", 3000),
-    )
+    min_speech_ms = _env_int("KIRRA_VAD_MIN_SPEECH_MS", 300)
+    silence_ms = _env_int("KIRRA_VAD_SILENCE_MS", 800)
+    max_ms = _env_int("KIRRA_VAD_MAX_MS", 8000)
+    start_timeout_ms = _env_int("KIRRA_VAD_START_TIMEOUT_MS", 3000)
+
+    # Every check below runs BEFORE a microphone is opened (nothing is spawned
+    # until the Popen further down), so a misconfigured recorder fails without
+    # ever touching the device.
+    bad_bounds = validate_bounds(max_ms, start_timeout_ms, silence_ms,
+                                 min_speech_ms, frame_ms)
+    if bad_bounds:
+        log(f"FATAL: {bad_bounds}")
+        return 2
+
+    capture_argv, why = resolve_capture_argv(
+        os.environ.get("KIRRA_VAD_DEVICE"),
+        os.environ.get("KIRRA_VAD_CAPTURE_CMD"),
+        sample_rate)
+    if capture_argv is None:
+        log(f"FATAL: {why}")
+        return 2
+
+    endpointer = Endpointer(min_speech_ms=min_speech_ms, silence_ms=silence_ms,
+                            max_ms=max_ms, start_timeout_ms=start_timeout_ms)
     frame_bytes = max(1, (sample_rate * frame_ms) // 1000) * SAMPLE_WIDTH_BYTES
 
-    import shlex
-    capture_cmd = os.environ.get("KIRRA_VAD_CAPTURE_CMD") \
-        or f"arecord -f S16_LE -r {sample_rate} -c 1 -t raw"
-    capture_argv = shlex.split(capture_cmd)
-
-    log(f"endpointing capture ({backend}, floor={floor}, silence="
-        f"{endpointer.silence_ms}ms, max={endpointer.max_ms}ms) → {out_path}")
+    device = capture_device(capture_argv) or f"{os.path.basename(capture_argv[0])} (custom backend)"
+    log(f"endpointing capture ({backend}, device={device}, floor={floor}, "
+        f"silence={silence_ms}ms, max={max_ms}ms) → {out_path}")
 
     pcm = bytearray()
     proc = None
@@ -194,14 +344,35 @@ def main(argv):
         log(f"FATAL: capture command failed to start ({e})")
         return 2
 
+    # The WALL-CLOCK bound. The endpointer counts SAMPLES, which only bounds the
+    # mic while samples keep arriving at the expected rate — a wedged device
+    # delivers none, sample-time stops advancing, and a plain blocking read would
+    # wait forever with the mic held open. So the loop is driven by a selector
+    # with a deadline, and a stall is a hard stop like any other.
+    deadline = time.monotonic() + (max_ms + CAPTURE_STALL_GRACE_MS) / 1000.0
+    stalled = False
     reason = STOP_MAX
     t_ms = 0
+    pending = bytearray()
+    sel = selectors.DefaultSelector()
+    sel.register(proc.stdout, selectors.EVENT_READ)
     try:
         while True:
-            chunk = proc.stdout.read(frame_bytes)
-            if not chunk or len(chunk) < frame_bytes:
-                # Stream ended / underran — stop with whatever we have (fail-soft).
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                stalled = True
                 break
+            if not sel.select(timeout=remaining):
+                stalled = True     # nothing readable before the deadline
+                break
+            data = os.read(proc.stdout.fileno(), frame_bytes)
+            if not data:
+                break              # EOF — the capture process ended on its own
+            pending += data
+            if len(pending) < frame_bytes:
+                continue           # partial frame; wait for the rest
+            chunk = bytes(pending[:frame_bytes])
+            del pending[:frame_bytes]
             t_ms += frame_ms
             is_speech = rms_energy(chunk) >= floor
             decision = endpointer.feed(is_speech, t_ms)
@@ -211,12 +382,31 @@ def main(argv):
                 reason = decision
                 break
     finally:
+        sel.close()
         if proc:
             proc.terminate()
             try:
                 proc.wait(timeout=1)
             except Exception:  # noqa: BLE001
                 proc.kill()
+
+    if stalled:
+        # A held-open, silent device. Never a hang and never a stale clip.
+        log(f"FATAL: capture stalled — no audio for {max_ms}+{CAPTURE_STALL_GRACE_MS} ms "
+            f"from {device}. Is the mic in use by another process?")
+        return 2
+
+    # A capture process that exited on its own with a nonzero status never gave
+    # us a usable clip (a bad device, a busy card, wrong format). Report it: the
+    # caller then logs "recorder failed" and the turn dead-ends, instead of
+    # transcribing a silent stub and looking like a mishearing.
+    # rc is negative when WE terminated it (the normal endpointed path), so only
+    # a genuine self-exit with a positive status counts.
+    rc = proc.returncode if proc else None
+    if t_ms == 0 and rc is not None and rc > 0:
+        log(f"FATAL: capture command exited {rc} without producing audio "
+            f"(device={device}).")
+        return 2
 
     # Fail-closed: no speech → write an (empty) clip so the turn dead-ends cleanly
     # in the parser rather than reusing a stale file.

--- a/robot/vad_record_test.py
+++ b/robot/vad_record_test.py
@@ -15,13 +15,16 @@ and speech→silence→speech re-arming the trailing-silence window.
 """
 from __future__ import annotations
 
+import re
 import struct
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from vad_record import (  # noqa: E402
-    CONTINUE, STOP_ENDPOINTED, STOP_MAX, STOP_NO_SPEECH, Endpointer, rms_energy,
+    CONTINUE, STOP_ENDPOINTED, STOP_MAX, STOP_NO_SPEECH, VAD_ABSOLUTE_MAX_MS,
+    Endpointer, capture_device, resolve_capture_argv, rms_energy,
+    validate_bounds, validate_capture_cmd,
 )
 
 _FAILURES: list[str] = []
@@ -113,6 +116,374 @@ def test_hard_cap_wins_even_during_speech():
     # At exactly max_ms the endpointer stops regardless of speech state.
     ep = Endpointer(min_speech_ms=0, silence_ms=800, max_ms=300, start_timeout_ms=3000)
     check(ep.feed(True, 300) == STOP_MAX, "max_ms boundary must stop even mid-speech")
+
+
+# ── exact threshold boundaries ───────────────────────────────────────────────
+
+def test_min_speech_boundary_is_inclusive():
+    # Exactly min_speech_ms of accumulated speech DOES qualify; one frame less
+    # does not. The endpoint rule is `>=`, and which side of it a real utterance
+    # lands on decides whether the operator's short command is kept or dropped.
+    for frames, want_endpoint in ((10, True), (9, False)):
+        ep = Endpointer(min_speech_ms=300, silence_ms=300, max_ms=8000,
+                        start_timeout_ms=5000)
+        reason, _ = _run(ep, [True] * frames + [False] * 20)
+        got = reason == STOP_ENDPOINTED
+        check(got == want_endpoint,
+              f"{frames} speech frames (={frames * 30} ms) vs min 300: "
+              f"expected endpoint={want_endpoint}, got {reason}")
+
+
+def test_trailing_silence_boundary_is_inclusive():
+    # Endpoint fires on the frame where trailing silence REACHES silence_ms,
+    # not one frame later — that difference is pure added latency per turn.
+    ep = Endpointer(min_speech_ms=60, silence_ms=300, max_ms=8000,
+                    start_timeout_ms=5000)
+    for _ in range(4):                       # 120 ms speech, ends at t=120
+        ep.feed(True, ep.prev_t_ms + 30)
+    t = 120
+    for _i in range(1, 20):                  # silence frames
+        t += 30
+        d = ep.feed(False, t)
+        if d == STOP_ENDPOINTED:
+            check(t - 120 == 300, f"endpoint at {t - 120} ms of silence, want exactly 300")
+            return
+    check(False, "trailing silence never endpointed")
+
+
+def test_start_timeout_boundary():
+    # At exactly start_timeout_ms with no speech, give up.
+    ep = Endpointer(min_speech_ms=300, silence_ms=800, max_ms=8000,
+                    start_timeout_ms=1000)
+    check(ep.feed(False, 970) == CONTINUE, "before the timeout must continue")
+    check(ep.feed(False, 1000) == STOP_NO_SPEECH, "at the timeout must give up")
+
+
+# ── the latency claim, in the simulated timing model ─────────────────────────
+
+def test_a_short_command_endpoints_well_before_the_old_fixed_window():
+    """The whole point of the change.
+
+    The deployed recorder was `arecord -d 4` — EVERY turn cost 4000 ms of
+    capture, however short. With the deployed VAD settings a ~700 ms command
+    ("how are you?") must finish far sooner. Same frame clock as the real loop
+    (30 ms), so this is the recorder's own timing model, not wall clock.
+    """
+    OLD_FIXED_MS = 4000
+    ep = Endpointer(min_speech_ms=250, silence_ms=650, max_ms=6000,
+                    start_timeout_ms=3000)     # the deployed settings
+    speech_frames = 23                          # ~690 ms of speech
+    reason, t = _run(ep, [True] * speech_frames + [False] * 100)
+    check(reason == STOP_ENDPOINTED, f"a normal short command must endpoint, got {reason}")
+    check(t < OLD_FIXED_MS,
+          f"VAD took {t} ms — no better than the fixed {OLD_FIXED_MS} ms window")
+    # Speech ends at 690 ms; +650 ms silence ⇒ ~1340 ms, a ~2.6 s saving.
+    check(1300 <= t <= 1400, f"expected ~1340 ms, got {t}")
+    check(OLD_FIXED_MS - t > 2000, f"saving only {OLD_FIXED_MS - t} ms; expected > 2 s")
+
+
+def test_a_long_utterance_still_gets_its_time_up_to_the_cap():
+    # The flip side: VAD must not truncate someone speaking a full sentence.
+    ep = Endpointer(min_speech_ms=250, silence_ms=650, max_ms=6000,
+                    start_timeout_ms=3000)
+    reason, t = _run(ep, [True] * 150 + [False] * 40)   # 4.5 s of speech
+    check(reason == STOP_ENDPOINTED, f"expected endpoint, got {reason}")
+    check(t > 4500, f"a 4.5 s utterance was cut at {t} ms")
+    check(t <= 6000, f"must never exceed the hard cap, got {t} ms")
+
+
+# ── explicit capture device required (fail-closed, before any mic opens) ─────
+
+_GOOD_CMD = "arecord -D plughw:CARD=Device,DEV=0 -f S16_LE -r 16000 -c 1 -t raw"
+
+
+def test_bare_arecord_capture_cmd_is_refused():
+    argv, why = validate_capture_cmd("arecord -f S16_LE -r 16000 -c 1 -t raw")
+    check(argv is None, "bare arecord must be refused (it takes ALSA's default)")
+    check("default" in why.lower(), f"the reason must name the failure: {why}")
+
+
+def test_arecord_with_an_explicit_device_is_accepted():
+    for cmd in (_GOOD_CMD, "arecord --device plughw:1,0 -t raw",
+                "/usr/bin/arecord -D hw:2,0 -t raw"):
+        argv, why = validate_capture_cmd(cmd)
+        check(argv is not None, f"must be accepted: {cmd} ({why})")
+
+
+def test_a_custom_capture_backend_is_left_alone():
+    # Not arecord → no ALSA-specific rule. A custom backend picks its device
+    # however it likes and this module has no business guessing the convention.
+    argv, why = validate_capture_cmd("my-capture --raw --rate 16000")
+    check(argv is not None, f"a custom backend must not get the arecord rule: {why}")
+    check(argv[0] == "my-capture", f"argv preserved verbatim: {argv}")
+
+
+def test_blank_and_unparseable_capture_cmds_are_refused():
+    for raw in ("", "   ", None, 'arecord -D "unterminated'):
+        argv, _ = validate_capture_cmd(raw)
+        check(argv is None, f"must be refused: {raw!r}")
+
+
+def test_device_is_required_when_no_capture_cmd_is_given():
+    argv, why = resolve_capture_argv(None, None, 16000)
+    check(argv is None, "no device and no capture command must refuse, not default")
+    check("KIRRA_VAD_DEVICE" in why, f"the reason must name the fix: {why}")
+    argv, why = resolve_capture_argv("   ", "", 16000)
+    check(argv is None, "a blank device is still no device")
+
+
+def test_device_builds_the_arecord_line_with_the_right_rate():
+    argv, why = resolve_capture_argv("plughw:CARD=Device,DEV=0", None, 16000)
+    check(argv is not None, f"a named device must resolve: {why}")
+    check(capture_device(argv) == "plughw:CARD=Device,DEV=0", f"device not carried: {argv}")
+    check("-t" in argv and argv[argv.index("-t") + 1] == "raw", f"must be a RAW stream: {argv}")
+    check(argv[argv.index("-r") + 1] == "16000", f"sample rate not honored: {argv}")
+    argv, _ = resolve_capture_argv("hw:1,0", None, 8000)
+    check(argv[argv.index("-r") + 1] == "8000", f"sample rate not honored: {argv}")
+
+
+def test_an_explicit_capture_cmd_wins_over_the_device():
+    argv, _ = resolve_capture_argv("plughw:CARD=Ignored,DEV=0", _GOOD_CMD, 16000)
+    check(capture_device(argv) == "plughw:CARD=Device,DEV=0",
+          f"KIRRA_VAD_CAPTURE_CMD must take precedence: {argv}")
+
+
+def test_capture_device_reports_none_for_a_custom_backend():
+    check(capture_device(["my-capture", "--raw"]) == "", "no -D → no device reported")
+
+
+def test_validation_never_spawns_anything():
+    # The point of validating first: no microphone is opened and no process is
+    # started while deciding whether the configuration is usable.
+    import subprocess
+    spawned = []
+    saved = {}
+    for name in ("Popen", "run", "call", "check_call", "check_output"):
+        saved[name] = getattr(subprocess, name)
+        setattr(subprocess, name,
+                lambda *a, _n=name, **k: spawned.append(_n))
+    try:
+        for cmd in ("", "   ", "arecord -f S16_LE", _GOOD_CMD, "my-capture --raw"):
+            validate_capture_cmd(cmd)
+            resolve_capture_argv("plughw:CARD=Device,DEV=0", cmd, 16000)
+        validate_bounds(6000, 3000, 650, 250, 30)
+    finally:
+        for name, fn in saved.items():
+            setattr(subprocess, name, fn)
+    check(spawned == [], f"validation spawned: {spawned}")
+
+
+# ── bounds are validated, so the mic stays bounded ───────────────────────────
+
+def test_sane_bounds_are_accepted():
+    check(validate_bounds(6000, 3000, 650, 250, 30) == "", "the deployed settings must pass")
+
+
+def test_non_positive_and_absurd_bounds_are_refused():
+    check(validate_bounds(0, 3000, 650, 250, 30) != "", "max_ms=0 must be refused")
+    check(validate_bounds(-1, 3000, 650, 250, 30) != "", "negative max_ms must be refused")
+    check(validate_bounds(6000, 0, 650, 250, 30) != "", "start_timeout=0 must be refused")
+    check(validate_bounds(6000, 3000, 0, 250, 30) != "", "silence_ms=0 must be refused")
+    check(validate_bounds(6000, 3000, 650, -1, 30) != "", "negative min_speech must be refused")
+    check(validate_bounds(6000, 3000, 650, 250, 0) != "", "frame_ms=0 must be refused")
+
+
+def test_an_absurd_ceiling_cannot_turn_this_into_an_open_mic():
+    check(validate_bounds(VAD_ABSOLUTE_MAX_MS, 3000, 650, 250, 30) == "",
+          "the absolute ceiling itself must be allowed")
+    why = validate_bounds(VAD_ABSOLUTE_MAX_MS + 1, 3000, 650, 250, 30)
+    check(why != "", "past the absolute ceiling must be refused")
+    check("open microphone" in why, f"the reason must say why: {why}")
+    check(validate_bounds(600_000, 3000, 650, 250, 30) != "",
+          "a 10-minute ceiling (a plausible typo) must be refused")
+
+
+def test_a_start_timeout_past_the_cap_is_refused():
+    # It could never fire — the ceiling would always win, so the "speech never
+    # started" path would silently become "record the full window".
+    check(validate_bounds(3000, 6000, 650, 250, 30) != "",
+          "start_timeout > max_ms must be refused")
+
+
+# ── the two recorder contracts stay independent ──────────────────────────────
+
+def test_wake_and_turn_recorder_contracts_are_separate():
+    """`KIRRA_WAKE_RECORD_CMD` is the always-on RAW stream; `KIRRA_RECORD_CMD` is
+    the one-turn WAV recorder. Swapping them is a real deployment mistake — the
+    turn recorder would never terminate, or the wake listener would stop after
+    one bounded window — so the two live in different modules with different
+    validators and neither reads the other's variable."""
+    import wake_word
+    src = Path(__file__).resolve().parent
+
+    def env_reads(module_name):
+        """Env vars a module actually READS (mentions in prose don't count —
+        the two files reference each other's variables on purpose, to explain
+        why they are different contracts)."""
+        text = (src / module_name).read_text()
+        return set(re.findall(r'environ\.get\(\s*"([A-Z0-9_]+)"', text)) | \
+            set(re.findall(r'environ\[\s*"([A-Z0-9_]+)"', text))
+
+    vad_reads, wake_reads = env_reads("vad_record.py"), env_reads("wake_word.py")
+    check("KIRRA_WAKE_RECORD_CMD" not in vad_reads,
+          f"vad_record must not READ the wake recorder's variable: {vad_reads}")
+    check("KIRRA_RECORD_CMD" not in wake_reads,
+          f"wake_word must not READ the turn recorder's variable: {wake_reads}")
+    check("KIRRA_VAD_DEVICE" not in wake_reads,
+          "wake_word must not read the turn recorder's device")
+    check("KIRRA_VAD_DEVICE" in vad_reads, f"sanity: vad_record reads its own device: {vad_reads}")
+    # Same rule, independently implemented — a bare arecord is refused by both.
+    check(wake_word.validate_record_cmd("arecord -t raw")[0] is None,
+          "wake validator must still refuse a bare arecord")
+    check(validate_capture_cmd("arecord -t raw")[0] is None,
+          "vad validator must refuse a bare arecord")
+
+
+# ── the capture seam, end to end (a scripted backend — no mic, no arecord) ───
+#
+# These drive the REAL main() with KIRRA_VAD_CAPTURE_CMD pointed at a scripted
+# PCM producer, so the WAV shape, the exit-code contract and the bounded-mic
+# guarantee are checked against the actual read loop rather than argued about.
+# Deterministic: every stop is driven by the scripted audio or a bound.
+
+_BACKEND_SPEECH = (
+    "import sys,struct,time\n"
+    "f=480\n"
+    "loud=struct.pack('<%dh'%f,*([6000]*f))\n"
+    "quiet=struct.pack('<%dh'%f,*([0]*f))\n"
+    "n=0\n"
+    "while True:\n"
+    "    sys.stdout.buffer.write(loud if n<{speech_frames} else quiet)\n"
+    "    sys.stdout.buffer.flush()\n"
+    "    n+=1\n"
+    "    time.sleep(0.005)\n"
+)
+_BACKEND_STALL = "import time\ntime.sleep(600)\n"
+_BACKEND_FAIL = "import sys\nsys.exit(3)\n"
+
+_VAD = None
+
+
+def _vad_path():
+    global _VAD
+    if _VAD is None:
+        _VAD = str(Path(__file__).resolve().parent / "vad_record.py")
+    return _VAD
+
+
+def _record(backend_src, out_path, **env_extra):
+    """Run vad_record.py in a child with a scripted capture backend.
+    Returns (exit_code, stderr)."""
+    import os
+    import subprocess
+    import tempfile
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as f:
+        f.write(backend_src)
+        backend = f.name
+    env = {k: v for k, v in os.environ.items() if not k.startswith("KIRRA_VAD_")}
+    env["KIRRA_VAD_CAPTURE_CMD"] = f"{sys.executable} {backend}"
+    env.update({k: str(v) for k, v in env_extra.items()})
+    try:
+        done = subprocess.run([sys.executable, _vad_path(), out_path],
+                              env=env, capture_output=True, text=True, timeout=60)
+        return done.returncode, done.stderr
+    finally:
+        os.unlink(backend)
+
+
+def _wav_ms(path):
+    import wave
+    with wave.open(path) as w:
+        check(w.getnchannels() == 1, f"must be mono, got {w.getnchannels()}")
+        check(w.getsampwidth() == 2, f"must be S16, got {w.getsampwidth()}")
+        check(w.getframerate() == 16000, f"must be 16 kHz, got {w.getframerate()}")
+        return round(1000 * w.getnframes() / w.getframerate())
+
+
+def test_seam_writes_a_valid_bounded_wav_at_the_given_path():
+    import tempfile
+    with tempfile.TemporaryDirectory() as d:
+        out = str(Path(d) / "turn.wav")
+        rc, err = _record(_BACKEND_SPEECH.format(speech_frames=10), out,
+                          KIRRA_VAD_SILENCE_MS=300, KIRRA_VAD_MIN_SPEECH_MS=250,
+                          KIRRA_VAD_MAX_MS=6000)
+        check(rc == 0, f"a normal turn must succeed, got {rc}: {err}")
+        check(Path(out).exists(), "the WAV must be written to the path we passed")
+        ms = _wav_ms(out)
+        # 300 ms speech + 300 ms trailing silence — well under the old fixed 4 s.
+        check(500 <= ms <= 800, f"expected ~600 ms of audio, got {ms} ms")
+        check("endpointed" in err, f"must stop by ENDPOINT, not a bound: {err}")
+
+
+def test_seam_never_exceeds_the_hard_cap():
+    import tempfile
+    with tempfile.TemporaryDirectory() as d:
+        out = str(Path(d) / "turn.wav")
+        rc, err = _record(_BACKEND_SPEECH.format(speech_frames=10000), out,
+                          KIRRA_VAD_SILENCE_MS=300, KIRRA_VAD_MIN_SPEECH_MS=250,
+                          KIRRA_VAD_MAX_MS=900, KIRRA_VAD_START_TIMEOUT_MS=800)
+        check(rc == 0, f"hitting the cap is not an error, got {rc}: {err}")
+        ms = _wav_ms(out)
+        check(ms <= 960, f"the bounded-mic ceiling leaked: {ms} ms for a 900 ms cap")
+        check("stopped: max" in err, f"must stop on the cap: {err}")
+
+
+def test_seam_bounds_a_stalled_device_instead_of_hanging():
+    """The no-open-mic guarantee under the failure that actually threatens it.
+
+    The endpointer counts SAMPLES; a wedged capture device delivers none, so
+    sample-time never advances and a plain blocking read would hold the mic open
+    forever. The wall-clock deadline is what bounds this."""
+    import tempfile
+    import time as _time
+    with tempfile.TemporaryDirectory() as d:
+        out = str(Path(d) / "turn.wav")
+        t0 = _time.monotonic()
+        rc, err = _record(_BACKEND_STALL, out, KIRRA_VAD_MAX_MS=500,
+                          KIRRA_VAD_START_TIMEOUT_MS=400)
+        elapsed = _time.monotonic() - t0
+        check(rc != 0, "a stalled capture must report failure, not a silent empty clip")
+        check("stalled" in err, f"the reason must name the stall: {err}")
+        # max_ms + the stall grace, with generous room for a slow CI box.
+        check(elapsed < 20, f"a stalled device was not bounded: took {elapsed:.1f} s")
+
+
+def test_seam_returns_nonzero_when_the_recorder_fails():
+    """rabbit_voice.sh keys on the exit status: nonzero -> "recorder failed --
+    nothing captured" -> no transcript, no intent, no motion. A dead device must
+    NOT look like a successful silent turn."""
+    import tempfile
+    with tempfile.TemporaryDirectory() as d:
+        out = str(Path(d) / "turn.wav")
+        rc, err = _record(_BACKEND_FAIL, out)
+        check(rc != 0, f"a capture command that exits nonzero must fail the run (got {rc})")
+        check("exited 3" in err, f"the reason must carry the child status: {err}")
+
+
+def test_seam_requires_an_output_path():
+    import os
+    import subprocess
+    env = dict(os.environ)
+    env["KIRRA_VAD_DEVICE"] = "plughw:CARD=Device,DEV=0"
+    done = subprocess.run([sys.executable, _vad_path()],
+                          env=env, capture_output=True, text=True, timeout=30)
+    check(done.returncode != 0, "no output path must be refused")
+    check("output WAV path" in done.stderr, f"reason: {done.stderr}")
+
+
+def test_seam_refuses_to_open_a_mic_without_an_explicit_device():
+    import os
+    import subprocess
+    import tempfile
+    env = {k: v for k, v in os.environ.items() if not k.startswith("KIRRA_VAD_")}
+    with tempfile.TemporaryDirectory() as d:
+        out = str(Path(d) / "turn.wav")
+        done = subprocess.run([sys.executable, _vad_path(), out],
+                              env=env, capture_output=True, text=True, timeout=30)
+        check(done.returncode != 0, "an unconfigured device must fail closed")
+        check("KIRRA_VAD_DEVICE" in done.stderr, f"reason must name the fix: {done.stderr}")
+        check(not Path(out).exists(),
+              "nothing may be written when the configuration is refused")
 
 
 def main():


### PR DESCRIPTION
**Stack position: 1 of 3 (voice responsiveness). Merge this first.** See *Stacking* at the bottom.

## The problem

The deployed turn recorder is `arecord -d 4`: every turn costs the full four seconds however short the command. `robot/vad_record.py` already existed and already endpointed on trailing silence — but it was not deployable as-is. Three gaps, two of them safety-relevant rather than performance polish.

### 1. No explicit capture device (silent wrong-microphone)

The default capture line was bare `arecord -f S16_LE -r 16000 -c 1 -t raw` — **no `-D`**, i.e. ALSA's default device, which on the R2 is not the microphone. The failure mode is the dangerous kind: near-silence arrives, every turn endpoints as "no speech", the unit looks healthy, and the robot simply appears not to hear you.

This is the same hazard `wake_word.validate_record_cmd` was hardened against for `KIRRA_WAKE_RECORD_CMD`, so it gets the same rule. New `KIRRA_VAD_DEVICE`, **no default**, refused *before anything is spawned*. A non-`arecord` `KIRRA_VAD_CAPTURE_CMD` is used verbatim and gets no ALSA-specific validation — a custom backend has its own device convention.

### 2. The hard ceiling was sample-time only (bounded-mic guarantee defeated)

The endpointer counts frames. A wedged capture device delivers none, so sample-time stops advancing and the blocking `read` would have held the microphone open **forever** — precisely the "never an open mic" claim failing in the one case that threatens it.

The read loop is now driven by a `selectors` deadline against a **wall clock** (`max_ms + 2 s` grace); a stall exits non-zero with `capture stalled`. Measured: bounded at **3.03 s** for a 1 s cap. `KIRRA_VAD_MAX_MS` is itself capped at `VAD_ABSOLUTE_MAX_MS` (30 s) so a config typo cannot turn a 6-second recorder into a ten-minute one, and non-positive or unfireable bounds are refused rather than silently defaulted.

### 3. A dead device returned 0

If the capture program exited immediately the loop saw EOF, wrote an empty WAV and reported **success** — indistinguishable from a genuinely silent turn. `rabbit_voice.sh` keys on the exit status, so this now returns non-zero and the operator sees `recorder failed — nothing captured` instead of a mystery mishearing.

## Measured latency

In the recorder's own 30 ms frame model, with the deployed settings:

| | capture | note |
|---|---|---|
| `arecord -d 4` | **4000 ms** | every turn, however short |
| VAD (`silence 650`) | **~1340 ms** | 690 ms speech + 650 ms trailing silence |

**~2.6 s saved** per terse turn, plus less STT work on the shorter clip. A 4.5 s sentence still gets its time, capped at 6 s. Confirmed against the real loop with a scripted PCM backend (600 ms of audio for a 300 ms utterance, `stopped: endpointed`).

## Fail-closed behaviour

| Condition | Result |
|---|---|
| `KIRRA_VAD_DEVICE` unset, no capture cmd | refuse, exit 2, **nothing written**, no mic opened |
| bare `arecord` capture cmd | refuse, exit 2, before spawning |
| `KIRRA_VAD_MAX_MS` non-positive / above 30 s / start-timeout above the ceiling | refuse, exit 2 |
| capture device wedged | `capture stalled`, exit 2, wall-clock bounded |
| capture program exits non-zero | exit 2, reason carries the child status |
| no speech | empty clip, **exit 0** → turn dead-ends at the fenced `/intent` door |

## Changed files

| File | Change |
|---|---|
| `robot/vad_record.py` | `KIRRA_VAD_DEVICE` + pure validators; wall-clock deadline; non-zero on capture failure |
| `robot/vad_record_test.py` | **7 → 32 tests** |
| `robot/kirra_voice_doctor.sh` | §4 rewritten: VAD vs fixed-window modes, device presence, bound sanity, swapped-contract detection |
| `robot/install/rabbit.env.example` | VAD block with the required device + a `YOUR_CARD` placeholder |
| `docs/hardware/{RABBIT_AUDIO_STACK,R2_VOICE_AUDIO_SETUP,RABBIT_BRINGUP_RUNBOOK}.md` | |

The env template uses a **placeholder**, not this robot's `CARD=Device` — the card name varies by microphone.

## Tests

`vad_record_test.py` **32 passed** — exact threshold boundaries (min-speech and trailing-silence inclusivity, start timeout), the latency claim in the simulated model, device validation, bounds validation, and a scripted-backend **capture seam** covering WAV shape/duration, the hard cap, a stalled device, the exit-code contract and the output-path contract. Plus a test that neither module reads the other's env var, so the wake and turn recorder contracts stay independent.

All 23 robot suites exit 0 · `compileall` · `bash -n` · `ruff` clean on touched files · `git diff --check` clean.

## Deployment consequence

An already-provisioned robot keeps its `/etc/kirra/robot.env` — **the installer never rewrites it** — so adopting VAD is a deliberate manual edit plus a restart of the voice units. Until then the fixed 4 s window stands, unchanged. Called out in the env template and in `RABBIT_AUDIO_STACK.md` §1a.

Conservative first deployment (substitute your own card name from `arecord -l`):

```bash
KIRRA_RECORD_CMD="python3 /opt/kirra/robot/vad_record.py"
KIRRA_VAD_DEVICE="plughw:CARD=YOUR_CARD,DEV=0"   # arecord -l
KIRRA_VAD_BACKEND=energy
KIRRA_VAD_RMS_FLOOR=300
KIRRA_VAD_SILENCE_MS=650
KIRRA_VAD_MIN_SPEECH_MS=300     # conservative; 250 only if short words linger
KIRRA_VAD_MAX_MS=6000
KIRRA_VAD_START_TIMEOUT_MS=3000
```

**Validating VAD needs a spoken turn** — `echo "how are you" | python3 robot/rabbit_converse.py` exercises Ollama and TTS but **not the recorder**:

```bash
journalctl -u kirra-rabbit-voice.service -f -o cat | grep -E 'vad_record|endpoint|capture|recorder'
# say "Hello Rabbit", then "How are you?"
# want: `stopped: endpointed` WELL BEFORE the 6 s ceiling.
# `stopped: max` instead means the endpointer never fired — usually
# KIRRA_VAD_RMS_FLOOR too low for the room, holding the clip open.
```

Remaining hardware-only tuning: `KIRRA_VAD_RMS_FLOOR` in a noisy bay, `KIRRA_VAD_SILENCE_MS` vs being cut off mid-sentence, and whether `KIRRA_WAKE_HOLDOFF_S` still covers the now-shorter turn. The doctor reports all three.

## Stacking

Three branches, all cut from `main`, merge in order:

1. **this PR** — safety hardening + the largest perceived-latency win
2. #1201 (service ordering + residency) — rebase onto updated `main`; **verified: no conflicts**
3. #1202 (latency observability) — rebase; **two known union conflicts**, listed in that PR

Dry-run of the whole chain (including #1198/#1199 already in the queue): branches 1 and 2 auto-merge **cleanly**, including `kirra_voice_doctor.sh`, which #1200 and #1201 both edit. A clean auto-merge is the risk here, not a conflict — nothing prompts a reviewer to check — so the combined tree was verified behaviourally, not just by exit code: this PR's device fail-closed path and #1201's residency reporting both still fire.