### PR TITLE
fix(voice): order Rabbit services and keep Gemma resident

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1344,6 +1344,21 @@ jobs:
           # rabbit_wake control matcher incl. non-overlap with the OTA/diag/
           # drive matchers. See docs/hardware/RABBIT_AUDIO_STACK.md §3b.
           python3 robot/wake_word_test.py
+          # Shipped systemd units, structurally. ORDERING IS NOT A DEPENDENCY:
+          # mick and the Rabbit voice listener are ordered AFTER ollama (and mick),
+          # but must never Requires=/BindsTo= them — a hard dep would mean that
+          # stopping Ollama for thirty seconds to swap a model also STOPS THE WAKE
+          # LISTENER, leaving the operator with a deaf robot and no way to ask why.
+          # Also pins the restart policies, exactly one ExecStart per unit, and
+          # that the installer's sed only renders the user placeholder.
+          python3 robot/service_units_test.py
+          # Model residency actually reaches Ollama. KIRRA_RABBIT_KEEP_ALIVE=-1
+          # must serialize as the JSON NUMBER -1 (the string "-1" would be
+          # rejected) and must appear on EVERY request body including the
+          # streaming router path — a config value that never reaches the wire
+          # buys nothing and fails invisibly (everything works, just slowly, and
+          # only after an idle gap).
+          python3 robot/rabbit_keepalive_test.py
           # Turn-state re-arm gate (Slice R, pure, no audio): the cross-process
           # "turn in progress" signal (fail-safe parse, active/done round-trip,
           # seq monotonicity) and the bounded rearm_decision that fixes the wake

--- a/deploy/systemd/kirra-mick.service
+++ b/deploy/systemd/kirra-mick.service
@@ -15,6 +15,25 @@ Documentation=https://github.com/kirra-systems/kirra-runtime-sdk
 After=network-online.target
 Wants=network-online.target
 PartOf=kirra.target
+# Mick's model backend. Wants+After, deliberately NOT Requires/BindsTo:
+#
+#   ORDERING IS NOT READINESS. `After=` only says "start Mick later in the boot
+#   ordering"; it does not wait for Ollama to be LISTENING, and no systemd
+#   directive would. Mick must therefore still tolerate a backend that is not up
+#   yet — and it does: a request while Ollama is unreachable fails CLOSED (no
+#   intent, no motion, a bounded connection error), which is the correct answer
+#   at any time, not just during boot.
+#
+#   `Wants=` pulls Ollama in but does not couple lifecycles. If it were
+#   `Requires=`, restarting or momentarily stopping Ollama would take Mick down
+#   with it — turning a recoverable "the model is briefly away" into "the intent
+#   door has vanished", which is strictly worse for an operator.
+#
+# On a box with no ollama.service installed both lines are inert (systemd logs
+# the missing Wants and proceeds), so this stays correct for a remote-model or
+# model-less deployment.
+Wants=ollama.service
+After=ollama.service
 
 [Service]
 Type=simple

--- a/docs/hardware/RABBIT_BRINGUP_RUNBOOK.md
+++ b/docs/hardware/RABBIT_BRINGUP_RUNBOOK.md
@@ -121,6 +121,92 @@ In its own terminal, alongside any of the above:
 Put an obstacle in front → the checker refuses → Rabbit: *"I've had to refuse a
 command. …"*. Force a lockout → *"I'm locking out and holding a safe stop."*
 
+## 5b. Service ordering and downstream resilience
+
+The voice stack talks to two backends: **Ollama** (the persona/router model) and
+**mick** (the fenced `/intent` door). Both are ordered-before, neither is a hard
+dependency:
+
+| Unit | Declares | Deliberately NOT |
+|---|---|---|
+| `kirra-mick.service` | `Wants=`/`After=ollama.service` | `Requires=`/`BindsTo=` |
+| `kirra-rabbit-voice.service` | `After=… ollama.service kirra-mick.service`, `Wants=ollama.service` | any hard dep on either |
+
+**Ordering is not readiness.** `After=` only places a unit later in the boot
+ordering — it does not wait for Ollama to be *listening*, and no systemd
+directive would. Both services therefore still tolerate an absent backend at
+runtime, which is the property that actually matters:
+
+- Ollama down → Rabbit says *"My voice module is offline for a moment."*
+- mick down → *"I can't reach my driving control right now, so I'm staying put."*
+- mick with Ollama down → a fail-closed 422: no intent, no motion.
+
+**Why not `Requires=`.** A hard dependency would mean that stopping Ollama for
+thirty seconds to swap a model also **stops the wake listener** — the robot goes
+deaf, and the operator loses the very channel they would use to ask what is
+wrong. Losing the answers is recoverable; losing the ears is not. `Restart=` is
+unchanged for the same reason: an unreachable HTTP endpoint is handled
+in-process and never exits, so a downstream outage cannot cause a restart storm.
+(`kirra-rabbit-voice` keeps `Restart=on-failure`, not `always`, so a listener
+disabled via `KIRRA_WAKE_ENABLED` exits 0 and rests inactive instead of
+restart-looping.)
+
+Structural regression: `python3 robot/service_units_test.py`.
+
+Verify what is actually installed:
+
+```bash
+systemctl show kirra-mick        -p After -p Wants -p Requires -p BindsTo
+systemctl show kirra-rabbit-voice -p After -p Wants -p Requires -p BindsTo
+systemctl list-dependencies --reverse ollama.service    # who would follow it down
+systemctl cat kirra-rabbit-voice | grep -c '^ExecStart' # exactly 1, no stale drop-in
+```
+
+## 5c. Model residency — pin Gemma on a dedicated robot
+
+Without residency Ollama unloads `gemma3:4b` after ~5 minutes idle and the next
+turn pays a multi-second cold reload — the single worst "why is it slow *this*
+time" effect. `KIRRA_RABBIT_KEEP_ALIVE` is sent as `keep_alive` on **every**
+Rabbit request (normal and streaming); it is residency only and cannot change
+what the model says.
+
+```bash
+# /etc/kirra/robot.env — on a DEDICATED Rabbit robot:
+KIRRA_RABBIT_KEEP_ALIVE=-1      # pin indefinitely
+# on a SHARED or development host, keep a finite hold instead:
+# KIRRA_RABBIT_KEEP_ALIVE=30m
+```
+
+There is deliberately **no global `-1`**: pinning holds the weights + KV cache
+for the life of the Ollama server, which is comfortable on a 16 GB Orin NX
+alongside the ROS stack and is not on an 8 GB board or with a second model
+loaded. It is a per-robot decision — so **verify, don't assume**:
+
+```bash
+# 1. baseline BEFORE the turn
+curl -s http://127.0.0.1:11434/api/ps | python3 -m json.tool
+free -h
+timeout 5 tegrastats
+
+# 2. trigger ONE Rabbit turn (say "Hello Rabbit", then "How are you?")
+
+# 3. after ~10 minutes idle — well past the old ~5 min unload:
+curl -s http://127.0.0.1:11434/api/ps | python3 -m json.tool   # gemma3:4b STILL listed?
+free -h                                                        # headroom still comfortable?
+timeout 5 tegrastats
+```
+
+`gemma3:4b` still listed after the idle gap = pinned and working. If `free -h`
+shows the box under memory pressure, **revert to a finite value** (`30m`) and
+restart the Rabbit units — a resident model is a latency optimization, never
+worth swapping.
+
+`robot/kirra_voice_doctor.sh` reports the three states separately and does not
+conflate them: the **configured** residency, whether the model is **loaded right
+now**, and whether the **server is unreachable**. A model that has legitimately
+unloaded on a healthy server with a finite keep-alive is normal, and is never a
+failure on its own.
+
 ## 6. The Rabbit experience (all together)
 
 Three terminals + the loop:

--- a/robot/install/rabbit.env.example
+++ b/robot/install/rabbit.env.example
@@ -153,11 +153,32 @@ KIRRA_OLLAMA_URL="http://localhost:11434"
 KIRRA_RABBIT_MODEL="gemma3:4b"
 # Keep the model RESIDENT between turns (Slice S) — the biggest per-turn latency
 # win on the Orin: without it Ollama unloads after ~5 min idle and the next turn
-# eats a multi-second cold reload. "30m" holds it after each request, "-1" pins
-# it indefinitely (best on a dedicated robot), "0" unloads at once. Residency
-# only — never changes the model's output, so it cannot affect the router or the
-# checker. Default "30m".
-#KIRRA_RABBIT_KEEP_ALIVE=-1
+# eats a multi-second cold reload. Sent as `keep_alive` on every Rabbit request
+# (both the normal and the streaming router path); residency ONLY, so it can
+# never change what the model says, and therefore cannot affect the router
+# decision or anything downstream of the fence.
+#
+#   "-1"   pin indefinitely — RECOMMENDED ON A DEDICATED RABBIT ROBOT, where
+#          nothing else competes for memory and the first word after an hour
+#          idle should be as fast as the second word in a conversation.
+#   "30m"  (the default) hold for 30 minutes after each request — the right
+#          choice on a SHARED or development host, where another workload may
+#          need the memory back.
+#   "0"    unload immediately — lowest memory, worst latency.
+#
+# MEMORY TRADEOFF, stated plainly: "-1" means gemma3:4b's weights + KV cache stay
+# resident for the life of the Ollama server. On an Orin NX 16 GB that is
+# comfortable alongside the ROS stack; on an 8 GB board, or with a second model
+# loaded, it is not. There is deliberately no global default of "-1" — pick it
+# per robot, and VERIFY rather than assume:
+#
+#   curl -s http://127.0.0.1:11434/api/ps | python3 -m json.tool   # still listed?
+#   free -h                                                        # headroom left?
+#
+# Revert to a finite value if the platform becomes memory constrained. See
+# RABBIT_BRINGUP_RUNBOOK.md ("Speed") for the wheels-up residency check.
+#KIRRA_RABBIT_KEEP_ALIVE=-1      # dedicated robot
+#KIRRA_RABBIT_KEEP_ALIVE=30m     # shared / development host (also the default)
 # Reply-length cap (OPT-IN, default unset). The router emits a {say, directive}
 # JSON object; a too-tight cap TRUNCATES it and parse_reply fail-closes to
 # directive=null — a silently DROPPED drive command. Leave unset unless you have

--- a/robot/install/systemd/kirra-rabbit-voice.service
+++ b/robot/install/systemd/kirra-rabbit-voice.service
@@ -33,9 +33,38 @@
 [Unit]
 Description=KIRRA Rabbit voice listener (wake word -> bounded turn -> fenced intent door)
 Documentation=https://github.com/kirra-systems/kirra-runtime-sdk
-# Talks to mick/verifier/Ollama but is fail-soft per turn — no hard dependency.
-After=network-online.target kirra.target
-Wants=network-online.target
+#
+# 🔴 ORDERING ONLY — NEVER A HARD DEPENDENCY.
+#
+# Rabbit talks to Ollama (the persona/router model) and to mick (the fenced
+# intent door), so on a cold boot it should come up AFTER them: the operator's
+# very first "hello rabbit" then lands on a warm stack instead of eating a
+# connection error. That is all `After=` buys, and it is worth having.
+#
+# But every one of those calls is fail-soft PER TURN, and that property is what
+# must survive:
+#
+#   * Ollama down  → ask_llm returns (None, None) → Rabbit SPEAKS
+#                    "My voice module is offline for a moment." It still wakes,
+#                    still acknowledges, still answers truthfully.
+#   * mick down    → offer_to_door returns 'error' → "I can't reach my driving
+#                    control right now, so I'm staying put." No motion, said out
+#                    loud rather than silently dropped.
+#
+# So these are `Wants=`, not `Requires=`/`BindsTo=`/`PartOf=`. With a hard
+# dependency, stopping Ollama for thirty seconds to swap a model would STOP THE
+# WAKE LISTENER — the robot would go deaf, and the operator would have no way to
+# ask it what was wrong. Losing the ears is worse than losing the answers.
+#
+# Restart=on-failure below is likewise unchanged: an unreachable HTTP endpoint is
+# handled IN-PROCESS and never exits, so a downstream outage cannot produce a
+# restart storm. The listener only restarts if the listener itself dies.
+#
+# kirra-mick.service is ordering-ONLY (no Wants): kirra.target already pulls it
+# in on a box running the governor stack, and the voice layer has no business
+# force-starting that stack on a box where the operator installed only Rabbit.
+After=network-online.target kirra.target ollama.service kirra-mick.service
+Wants=network-online.target ollama.service
 
 [Service]
 Type=simple

--- a/robot/kirra_voice_doctor.sh
+++ b/robot/kirra_voice_doctor.sh
@@ -220,6 +220,41 @@ for pair in "8090:verifier" "8102:mick" "11434:ollama"; do
   if ss -tlnH 2>/dev/null | grep -qE ":${p}([[:space:]]|$)"; then ok "$n listening (:$p)"; else warn "$n not listening (:$p)"; fix "bring up the loop — R2_LIVE_LOOP_BRINGUP.md"; fi
 done
 
+# 6b. Rabbit model residency. THREE DISTINCT STATES, deliberately not collapsed:
+#       configured residency — what robot.env asks for
+#       currently loaded     — what Ollama reports right now
+#       server unavailable   — we cannot tell, and must not guess
+#     A model that has legitimately unloaded on a HEALTHY server with a finite
+#     keep-alive is NORMAL, not a fault, so it is never a ❌ on its own.
+ka="${KIRRA_RABBIT_KEEP_ALIVE:-30m}"
+rmodel="${KIRRA_RABBIT_MODEL:-gemma3:4b}"
+case "$ka" in
+  -1)   ok "Rabbit keep-alive: -1 (PINNED RESIDENT — the dedicated-robot setting)" ;;
+  0)    warn "Rabbit keep-alive: 0 (unload immediately — every turn pays a cold reload)"; fix "set KIRRA_RABBIT_KEEP_ALIVE=-1 on a dedicated robot" ;;
+  *)    # A duration string ("30m", "1h") or a positive number of seconds. Empty
+        # already resolved to the 30m default above, exactly as rabbit_ask does.
+        ok "Rabbit keep-alive: $ka (finite hold)" ;;
+esac
+ourl="${KIRRA_OLLAMA_URL:-http://localhost:11434}"
+if ! command -v curl >/dev/null 2>&1; then
+  warn "curl not installed — cannot check whether $rmodel is loaded"
+else
+  ps_json="$(curl -sf --max-time 3 "${ourl}/api/ps" 2>/dev/null)"
+  if [ -z "$ps_json" ]; then
+    # Server unavailable is its own state: it says nothing about residency.
+    warn "Ollama not reachable at $ourl — residency unknown (this is a SERVER state, not a config fault)"
+    fix "systemctl status ollama; then re-run"
+  elif printf '%s' "$ps_json" | grep -q "$rmodel"; then
+    ok "$rmodel is loaded now (resident)"
+  elif [ "$ka" = "-1" ]; then
+    # Pinned but absent = nothing has warmed it since the server started.
+    warn "$rmodel is NOT loaded although keep-alive is -1 — nothing has warmed it since Ollama started"
+    fix "run one Rabbit turn (or: ollama run $rmodel hi >/dev/null) — it then stays pinned"
+  else
+    ok "$rmodel not loaded right now — expected with a finite keep-alive ($ka); it loads on the next turn"
+  fi
+fi
+
 # 7. Jetson.GPIO (PTT button) — WARN (Enter-key path works without it)
 if python3 -c "import Jetson.GPIO" >/dev/null 2>&1; then
   ok "Jetson.GPIO importable (PTT ready)"

--- a/robot/rabbit_keepalive_test.py
+++ b/robot/rabbit_keepalive_test.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""The configured model residency actually reaches Ollama — on EVERY path.
+
+`KIRRA_RABBIT_KEEP_ALIVE` is the biggest per-turn latency lever on the Orin:
+without it Ollama unloads gemma3:4b after ~5 minutes idle and the next turn pays
+a multi-second cold reload. On a dedicated robot the recommended value is `-1`
+(pin indefinitely).
+
+But a config value that never reaches the wire buys nothing, and the failure is
+invisible — everything still works, just slowly, and only after an idle gap. So
+this pins the plumbing: the value must be parsed correctly (`-1` is an INTEGER,
+not the string "-1", which Ollama would reject) and must appear as `keep_alive`
+in every Rabbit request body, including the streaming router path that is easy
+to forget when adding one.
+
+Residency only: `keep_alive` cannot change what the model says, so it cannot
+affect the {say, directive} routing decision or anything downstream of the fence.
+
+Stubs `requests` when it is absent (the CI robot lane) so this RUNS there rather
+than skipping — an unexercised latency guard is not a guard.
+"""
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import sys
+import types
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+
+def _install_requests_stub() -> None:
+    def _refuse(*_a, **_k):
+        raise AssertionError("the test made a REAL HTTP call — a seam is unstubbed")
+
+    stub = types.ModuleType("requests")
+    stub.get = _refuse
+    stub.post = _refuse
+    stub.RequestException = type("RequestException", (Exception,), {})
+    stub.exceptions = types.SimpleNamespace(RequestException=stub.RequestException)
+    sys.modules["requests"] = stub
+
+
+try:
+    import requests  # noqa: F401
+except ImportError:
+    _install_requests_stub()
+
+_FAILURES: list[str] = []
+
+
+def check(cond, msg):
+    if not cond:
+        _FAILURES.append(msg)
+        print(f"  FAIL: {msg}", file=sys.stderr)
+
+
+class _Resp:
+    def __init__(self, body, status=200):
+        self.status_code = status
+        self._body = body
+        self.content = body.encode()
+
+    def json(self):
+        return json.loads(self._body)
+
+    # the streaming path uses the response as a context manager + iter_lines
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def iter_lines(self):
+        yield json.dumps({"message": {"content": self._body}, "done": True}).encode()
+
+
+def _reload_with(keep_alive):
+    """Reload rabbit_ask + rabbit_converse under a given KIRRA_RABBIT_KEEP_ALIVE.
+    Both read it at import time, so a reload is how the value is applied."""
+    prev = os.environ.get("KIRRA_RABBIT_KEEP_ALIVE")
+    if keep_alive is None:
+        os.environ.pop("KIRRA_RABBIT_KEEP_ALIVE", None)
+    else:
+        os.environ["KIRRA_RABBIT_KEEP_ALIVE"] = keep_alive
+    import rabbit_ask
+    import rabbit_converse
+    importlib.reload(rabbit_ask)
+    importlib.reload(rabbit_converse)
+    return rabbit_ask, rabbit_converse, prev
+
+
+def _restore(prev):
+    if prev is None:
+        os.environ.pop("KIRRA_RABBIT_KEEP_ALIVE", None)
+    else:
+        os.environ["KIRRA_RABBIT_KEEP_ALIVE"] = prev
+    import rabbit_ask
+    import rabbit_converse
+    importlib.reload(rabbit_ask)
+    importlib.reload(rabbit_converse)
+
+
+# ── parsing ──────────────────────────────────────────────────────────────────
+
+def test_minus_one_parses_as_an_integer_not_a_string():
+    """`-1` must go on the wire as the JSON number -1. Ollama accepts a duration
+    STRING ("30m") or a NUMBER of seconds; the string "-1" is neither, and the
+    request would be rejected — silently costing exactly the residency this is
+    meant to buy."""
+    ask, _, prev = _reload_with("-1")
+    try:
+        check(ask.KEEP_ALIVE == -1, f"expected int -1, got {ask.KEEP_ALIVE!r}")
+        check(isinstance(ask.KEEP_ALIVE, int), f"must be an int, got {type(ask.KEEP_ALIVE)}")
+        check(json.dumps({"keep_alive": ask.KEEP_ALIVE}) == '{"keep_alive": -1}',
+              "must serialize as a JSON number")
+    finally:
+        _restore(prev)
+
+
+def test_a_duration_string_is_preserved_verbatim():
+    for value in ("30m", "5m", "1h"):
+        ask, _, prev = _reload_with(value)
+        try:
+            check(ask.KEEP_ALIVE == value, f"{value!r} must pass through, got {ask.KEEP_ALIVE!r}")
+        finally:
+            _restore(prev)
+
+
+def test_the_default_is_a_finite_hold_not_pinned():
+    """No global `-1`: pinning a model forever is a per-robot memory decision the
+    operator opts into, not something a fresh checkout does on its own."""
+    ask, _, prev = _reload_with(None)
+    try:
+        check(ask.KEEP_ALIVE == "30m", f"default changed to {ask.KEEP_ALIVE!r}")
+    finally:
+        _restore(prev)
+
+
+def test_zero_unloads_immediately():
+    ask, _, prev = _reload_with("0")
+    try:
+        check(ask.KEEP_ALIVE == 0, f"expected int 0, got {ask.KEEP_ALIVE!r}")
+    finally:
+        _restore(prev)
+
+
+# ── it reaches the wire, on every path ───────────────────────────────────────
+
+def _capture_bodies(rc, call):
+    """Run `call` with rc.requests.post recording every request body."""
+    bodies = []
+
+    def fake_post(url, **kw):
+        bodies.append((url, kw.get("json")))
+        return _Resp('{"say": "ok", "directive": null}')
+
+    saved = rc.requests.post
+    rc.requests.post = fake_post
+    try:
+        call()
+    finally:
+        rc.requests.post = saved
+    return bodies
+
+
+def test_the_normal_router_path_sends_keep_alive():
+    ask, rc, prev = _reload_with("-1")
+    try:
+        ctx = "TELEMETRY: posture NOMINAL"
+        bodies = _capture_bodies(rc, lambda: rc.ask_llm([], ctx, "how are you"))
+        check(len(bodies) == 1, f"expected one Ollama call, got {len(bodies)}")
+        url, body = bodies[0]
+        check("/api/chat" in url, f"unexpected endpoint: {url}")
+        check(body.get("keep_alive") == -1,
+              f"keep_alive missing/wrong on the normal path: {body}")
+    finally:
+        _restore(prev)
+
+
+def test_the_streaming_router_path_sends_keep_alive():
+    """The path most likely to drift: it builds its own request body. A missing
+    keep_alive here would leave streaming users on the cold-reload stall while
+    everyone else was fine."""
+    ask, rc, prev = _reload_with("-1")
+    try:
+        msgs = rc._stream_messages([], "TELEMETRY: posture NOMINAL", "how are you")
+        bodies = _capture_bodies(
+            rc, lambda: rc.route_stream(msgs, lambda _c: None, lambda: False))
+        check(len(bodies) == 1, f"expected one Ollama call, got {len(bodies)}")
+        url, body = bodies[0]
+        check(body.get("stream") is True, f"this must be the STREAMING path: {body}")
+        check(body.get("keep_alive") == -1,
+              f"keep_alive missing/wrong on the streaming path: {body}")
+    finally:
+        _restore(prev)
+
+
+def test_every_ollama_caller_in_the_rabbit_path_sends_keep_alive():
+    """Source-level sweep, so a NEW Ollama call added later cannot quietly skip
+    residency: every `/api/chat` POST must carry keep_alive."""
+    here = Path(__file__).resolve().parent
+    missing = []
+    for name in ("rabbit_converse.py", "rabbit_ask.py"):
+        text = (here / name).read_text()
+        for i, chunk in enumerate(text.split("/api/chat")[1:], 1):
+            window = chunk[:400]
+            if "keep_alive" not in window:
+                missing.append(f"{name} call #{i}")
+    check(not missing, f"Ollama calls without keep_alive: {missing}")
+
+
+def test_the_model_is_unchanged():
+    """Residency work must not become a model swap. gemma3:4b is the vetted
+    router model (rabbit_model_smoketest.py gates it)."""
+    ask, _, prev = _reload_with("-1")
+    try:
+        check(ask.MODEL == "gemma3:4b", f"model default changed to {ask.MODEL!r}")
+    finally:
+        _restore(prev)
+
+
+def test_keep_alive_is_not_a_model_option():
+    """It must be a top-level request field, never folded into `options` —
+    `options` is sampling behaviour, and putting a residency hint there would
+    both fail to work and muddy the "residency cannot change output" claim."""
+    _, rc, prev = _reload_with("-1")
+    try:
+        check("keep_alive" not in rc.ROUTER_LLM_OPTIONS,
+              f"keep_alive leaked into sampling options: {rc.ROUTER_LLM_OPTIONS}")
+    finally:
+        _restore(prev)
+
+
+# ── the documented recommendation matches the code ───────────────────────────
+
+def test_the_example_env_documents_both_choices():
+    example = (Path(__file__).resolve().parent / "install" / "rabbit.env.example").read_text()
+    check("KIRRA_RABBIT_KEEP_ALIVE=-1" in example,
+          "the dedicated-robot recommendation (-1) must be documented")
+    check("KIRRA_RABBIT_KEEP_ALIVE=30m" in example,
+          "the shared-host choice (30m) must be documented")
+    for phrase in ("dedicated", "shared", "memory"):
+        check(phrase.lower() in example.lower(),
+              f"the tradeoff must be explicit — {phrase!r} not mentioned")
+    # And it must stay OPT-IN: no uncommented -1 that a fresh copy would inherit.
+    live = [ln for ln in example.splitlines()
+            if ln.strip().startswith("KIRRA_RABBIT_KEEP_ALIVE")]
+    check(live == [], f"keep-alive must stay commented out in the example: {live}")
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items())
+             if k.startswith("test_") and callable(v)]
+    print("rabbit_keepalive_test:")
+    for t in tests:
+        before = len(_FAILURES)
+        t()
+        print(f"  {'ok  ' if len(_FAILURES) == before else 'FAIL'} {t.__name__}")
+    if _FAILURES:
+        print(f"\n{len(_FAILURES)} check(s) FAILED", file=sys.stderr)
+        return 1
+    print(f"\nall {len(tests)} tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())

--- a/robot/service_units_test.py
+++ b/robot/service_units_test.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Structural tests for the shipped systemd units.
+
+These parse the CHECKED-IN unit files (they are installed verbatim — the robot
+installer only sed-renders `__KIRRA_ROBOT_USER__`, and deploy/systemd/install.sh
+copies its units byte-for-byte), so what is asserted here is what lands in
+/etc/systemd/system.
+
+What they defend is one distinction that is easy to get wrong and expensive when
+you do: **ordering is not a dependency.**
+
+  After=  — "start me later in the boot ordering". Costs nothing at runtime.
+  Wants=  — "also pull that unit in". Still no runtime coupling.
+  Requires= / BindsTo= / PartOf= — a LIFECYCLE coupling: stop or restart the
+            other unit and this one goes down too.
+
+Rabbit talks to Ollama and to mick, and both calls are fail-soft per turn. If
+those relationships were hard dependencies, restarting Ollama for thirty seconds
+to swap a model would STOP THE WAKE LISTENER — the robot would go deaf and the
+operator would have no way to ask it what was wrong. Losing the ears is worse
+than losing the answers, so the coupling must stay soft.
+
+No systemd needed; pure text. Runs standalone, also importable under pytest.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+MICK = REPO / "deploy" / "systemd" / "kirra-mick.service"
+VOICE = REPO / "robot" / "install" / "systemd" / "kirra-rabbit-voice.service"
+INSTALLER = REPO / "robot" / "install" / "install_robot_units.sh"
+
+# Directives that couple LIFECYCLES rather than just ordering.
+HARD_DEPS = ("Requires", "Requisite", "BindsTo", "PartOf")
+
+_FAILURES: list[str] = []
+
+
+def check(cond, msg):
+    if not cond:
+        _FAILURES.append(msg)
+        print(f"  FAIL: {msg}", file=sys.stderr)
+
+
+def directive(text: str, key: str) -> list[str]:
+    """All values of `key=` across the unit, comment lines excluded, split on
+    whitespace (systemd allows several units per directive line)."""
+    out: list[str] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("#") or "=" not in line:
+            continue
+        k, _, v = line.partition("=")
+        if k.strip() == key:
+            out.extend(v.split())
+    return out
+
+
+def directive_lines(text: str, key: str) -> list[str]:
+    """One entry per `key=` LINE, value unsplit — for directives whose value is a
+    single string (ExecStart, Restart) rather than a unit list."""
+    out: list[str] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("#") or "=" not in line:
+            continue
+        k, _, v = line.partition("=")
+        if k.strip() == key:
+            out.append(v.strip())
+    return out
+
+
+def _unit(path: Path) -> str:
+    check(path.is_file(), f"missing unit: {path}")
+    return path.read_text() if path.is_file() else ""
+
+
+# ── Mick: ordered after Ollama, not chained to it ────────────────────────────
+
+def test_mick_is_ordered_after_ollama():
+    text = _unit(MICK)
+    check("ollama.service" in directive(text, "After"),
+          "kirra-mick.service must declare After=ollama.service")
+    check("ollama.service" in directive(text, "Wants"),
+          "kirra-mick.service must declare Wants=ollama.service")
+
+
+def test_mick_does_not_hard_depend_on_ollama():
+    text = _unit(MICK)
+    for key in HARD_DEPS:
+        vals = directive(text, key)
+        check("ollama.service" not in vals,
+              f"kirra-mick.service must not {key}=ollama.service — "
+              "stopping Ollama would take the intent door down with it")
+
+
+def test_mick_keeps_its_restart_policy():
+    text = _unit(MICK)
+    check(directive(text, "Restart") == ["always"],
+          f"mick's restart policy changed: {directive(text, 'Restart')}")
+
+
+# ── Rabbit voice: ordered after both, coupled to neither ─────────────────────
+
+def test_rabbit_voice_is_ordered_after_ollama_and_mick():
+    text = _unit(VOICE)
+    after = directive(text, "After")
+    for unit in ("ollama.service", "kirra-mick.service"):
+        check(unit in after, f"kirra-rabbit-voice.service must declare After={unit}")
+
+
+def test_rabbit_voice_never_hard_depends_on_a_downstream_service():
+    """The load-bearing one. A hard dependency on either backend would make a
+    momentary Ollama or mick outage STOP THE WAKE LISTENER."""
+    text = _unit(VOICE)
+    for key in HARD_DEPS:
+        for unit in directive(text, key):
+            check(unit not in ("ollama.service", "kirra-mick.service", "kirra.target"),
+                  f"kirra-rabbit-voice.service has {key}={unit} — a downstream "
+                  "outage would stop wake listening")
+
+
+def test_rabbit_voice_keeps_its_existing_restart_policy():
+    """`on-failure`, NOT `always`, and deliberately so: with the wake word
+    disabled wake_word.py exits 0 and the unit must rest inactive rather than
+    restart-loop. Changing it to `always` would spin a disabled listener."""
+    text = _unit(VOICE)
+    check(directive(text, "Restart") == ["on-failure"],
+          f"restart policy changed: {directive(text, 'Restart')} (expected on-failure)")
+    check(directive(text, "RestartSec"), "RestartSec must stay set (no tight respawn)")
+
+
+def test_downstream_unavailability_is_handled_in_process_not_by_restarting():
+    """A restart policy cannot fix an unreachable HTTP endpoint — it would just
+    respawn into the same failure. So the handling must live in the code, and it
+    does: both backends have a spoken, fail-soft arm."""
+    converse = (REPO / "robot" / "rabbit_converse.py").read_text()
+    check("voice module is offline" in converse,
+          "the Ollama-unreachable arm must still SAY something truthful")
+    check("can't reach my driving control" in converse,
+          "the mick-unreachable arm must still SAY something truthful")
+    # And neither arm exits the process — the listener keeps listening.
+    check("sys.exit" not in converse.split("def handle_turn", 1)[-1],
+          "a downstream outage must never exit the turn loop")
+
+
+# ── one ExecStart, and the installer preserves what we wrote ─────────────────
+
+def test_each_unit_declares_exactly_one_execstart():
+    """A second ExecStart= in a Type=simple unit is a systemd ERROR (only
+    oneshot may repeat it), and a stale drop-in that re-declares it silently
+    replaces the command. Catch a duplicate in the shipped file at least."""
+    for path in (MICK, VOICE):
+        n = len(directive_lines(_unit(path), "ExecStart"))
+        check(n == 1, f"{path.name} declares {n} ExecStart lines (want exactly 1)")
+
+
+def test_the_installer_copies_the_voice_unit_without_rewriting_its_unit_section():
+    """The robot installer renders ONLY the user placeholder. If it grew a
+    broader sed the ordering lines could be silently dropped on install."""
+    sh = _unit(INSTALLER)
+    check("kirra-rabbit-voice.service" in sh,
+          "the installer must still install the voice unit")
+    seds = re.findall(r'sed\s+"([^"]+)"', sh) + re.findall(r"sed\s+'([^']+)'", sh)
+    for expr in seds:
+        check("__KIRRA_ROBOT_USER__" in expr,
+              f"the installer rewrites more than the user placeholder: sed {expr!r}")
+    check("__KIRRA_ROBOT_USER__" in _unit(VOICE),
+          "the voice unit must still carry the placeholder the installer renders")
+
+
+def test_no_stale_dropin_shipped_for_these_units():
+    """A checked-in `<unit>.service.d/*.conf` would override the file above
+    without showing up in it. There is one legitimate drop-in in the repo
+    (Ollama server tuning); it must not target our units."""
+    for d in REPO.rglob("*.service.d"):
+        check(d.name not in (f"{MICK.name}.d", f"{VOICE.name}.d"),
+              f"unexpected drop-in directory shipped: {d}")
+    tuning = REPO / "robot" / "install" / "kirra-ollama-tuning.conf"
+    if tuning.is_file():
+        text = tuning.read_text()
+        check("ExecStart" not in text,
+              "the Ollama tuning drop-in must set Environment only, never ExecStart")
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items())
+             if k.startswith("test_") and callable(v)]
+    print("service_units_test:")
+    for t in tests:
+        before = len(_FAILURES)
+        t()
+        print(f"  {'ok  ' if len(_FAILURES) == before else 'FAIL'} {t.__name__}")
+    if _FAILURES:
+        print(f"\n{len(_FAILURES)} check(s) FAILED", file=sys.stderr)
+        return 1
+    print(f"\nall {len(tests)} tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
**Stack position: 2 of 3. Merge after #1200.** Rebase onto updated `main` first — dry-run says **no conflicts**, but see *Stacking* for why that needs checking anyway.

Two independent gaps, both in deployment rather than code.

## Service ordering

Neither `kirra-mick.service` nor `kirra-rabbit-voice.service` referenced `ollama.service` **at all**, so on a cold boot either could start before the model backend and the operator's first turn ate a connection error.

- `kirra-mick.service` — `Wants=` + `After=ollama.service`
- `kirra-rabbit-voice.service` — `After=… ollama.service kirra-mick.service`, `Wants=ollama.service`

### Why not `Requires=`

Deliberately **not** `Requires=`/`BindsTo=`/`PartOf=`. A hard dependency would mean that stopping Ollama for thirty seconds to swap a model also **stops the wake listener** — the robot goes deaf, and the operator loses the one channel they would use to ask what is wrong. Losing the answers is recoverable; losing the ears is not.

`kirra-mick.service` is ordering-**only** from the voice unit (no `Wants`): `kirra.target` already pulls it in on a box running the governor stack, and the voice layer has no business force-starting that stack on a box where the operator installed only Rabbit.

### Ordering is not readiness

`After=` does not wait for Ollama to be *listening*, and no systemd directive would. Nothing here pretends otherwise — both services already tolerate an absent backend per request and still do:

| Backend down | Behaviour |
|---|---|
| Ollama | *"My voice module is offline for a moment."* — still wakes, still acknowledges |
| mick | *"I can't reach my driving control right now, so I'm staying put."* — no motion, said aloud |
| mick with Ollama down | fail-closed 422: no intent, no motion |

Restart policies are **untouched** for the same reason: an unreachable HTTP endpoint is handled in-process and never exits, so a restart could only respawn into the same failure. `kirra-rabbit-voice` keeps `Restart=on-failure`, **not** `always` — a listener disabled via `KIRRA_WAKE_ENABLED` exits 0 and must rest inactive rather than restart-loop.

The units are checked in and installed **verbatim** (the robot installer only sed-renders `__KIRRA_ROBOT_USER__`), so what the tests assert is what lands in `/etc/systemd/system`.

## Model residency

The `keep_alive` plumbing already reached all four Ollama call sites **including the streaming router** — what was missing was the operator-facing recommendation and any proof the value survives to the wire.

`rabbit.env.example` now states the choice explicitly: `-1` (pin) on a dedicated robot, `30m` on a shared/dev host, with the memory tradeoff spelled out. **No global default of `-1`** — pinning holds weights + KV cache for the life of the server, which is comfortable on a 16 GB Orin NX alongside the ROS stack and is not on an 8 GB board or with a second model loaded. It stays commented out in the template.

The tests pin what a config value alone cannot tell you:

- `-1` parses to the JSON **number** `-1` — the string `"-1"` would be rejected by Ollama, silently costing exactly the residency it was meant to buy;
- it appears on **both** the normal and the streaming request body;
- a source sweep means no future `/api/chat` call can omit it;
- `keep_alive` is never folded into `options` (sampling behaviour), which would both fail and muddy the "residency cannot change output" claim.

**Model unchanged: `gemma3:4b`.**

### Doctor: three states, not conflated

- **configured** residency (what `robot.env` asks for)
- **loaded right now** (what `/api/ps` reports)
- **server unreachable** (we cannot tell, and must not guess)

A model that has legitimately unloaded on a healthy server with a finite keep-alive is **normal** and is never a FAIL on its own. `-1` reports as *PINNED RESIDENT*, not as malformed.

## Verify on the Jetson

```bash
systemctl show kirra-mick         -p After -p Wants -p Requires -p BindsTo
systemctl show kirra-rabbit-voice -p After -p Wants -p Requires -p BindsTo
systemctl cat kirra-rabbit-voice | grep -c '^ExecStart'      # exactly 1

# residency: baseline, one turn, then AFTER ~10 min idle
curl -s http://127.0.0.1:11434/api/ps | python3 -m json.tool
free -h; timeout 5 tegrastats

# the one that matters — resilience:
sudo systemctl stop ollama
#   "Hello Rabbit" still gets "Yes?"; "How are you?" → "My voice module is offline for a moment."
systemctl is-active kirra-rabbit-voice        # MUST still be `active`
sudo systemctl start ollama                   # next turn recovers, NO restart of the voice unit
```

`active` in that last block is the whole point of `Wants` over `Requires`. Pin `KIRRA_RABBIT_KEEP_ALIVE=-1` only **after** checking `free -h` with the full ROS stack running; revert to `30m` if the board becomes memory constrained.

## Changed files

| File | Change |
|---|---|
| `deploy/systemd/kirra-mick.service` | `Wants=`/`After=ollama.service` + rationale |
| `robot/install/systemd/kirra-rabbit-voice.service` | ordering after Ollama + mick; restart policy unchanged |
| `robot/install/rabbit.env.example` | keep-alive recommendation + memory tradeoff |
| `robot/kirra_voice_doctor.sh` | §6b three-state residency reporting |
| `docs/hardware/RABBIT_BRINGUP_RUNBOOK.md` | §5b ordering/resilience, §5c residency |
| `robot/service_units_test.py`, `robot/rabbit_keepalive_test.py` | new — 10 + 10 tests |
| `.github/workflows/ci.yml` | registers both |

## Tests

**10 + 10**, both registered in CI and both **verified non-vacuous** against injected breakage — `Requires=ollama.service`, `BindsTo=ollama.service`, `Restart=always`, and a dropped `keep_alive` on the streaming path each red the suite.

`rabbit_keepalive_test.py` installs a minimal `requests` stub when the library is absent so it **runs on the CI robot lane** rather than skipping — an unexercised latency guard is not a guard.

All 23 robot suites exit 0 · `cargo test -p kirra-sidecars` 83 passed · `cargo fmt --check` · `compileall` · `bash -n` · `ruff` clean on touched files · `git diff --check` clean.

## Deployment consequence

An existing robot keeps `/etc/kirra/robot.env`, so `KIRRA_RABBIT_KEEP_ALIVE` is a manual opt-in. **Re-run `robot/install/install_robot_units.sh`** to pick up the unit ordering.

## Stacking

1. #1200 — bounded VAD
2. **this PR** — rebase onto updated `main` after #1200 lands; dry-run: **no conflicts**
3. #(latency observability) — two known union conflicts

Note this PR and #1200 both edit `robot/kirra_voice_doctor.sh` and `robot/install/rabbit.env.example` and **still auto-merge cleanly** (disjoint regions: doctor §4 vs §6b). That is the risk worth naming — a clean merge prompts nobody to check. The combined tree was verified behaviourally: #1200's `KIRRA_VAD_DEVICE` fail-closed refusal *and* this PR's `PINNED RESIDENT` reporting both still fire, on the real conservative Jetson config.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjDFKPcBVHURDZpXsvnYhC)_