### PR TITLE
feat(voice): report Rabbit turn latency stages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1359,6 +1359,14 @@ jobs:
           # buys nothing and fails invisibly (everything works, just slowly, and
           # only after an idle gap).
           python3 robot/rabbit_keepalive_test.py
+          # Opt-in per-turn latency staging. Injected clock only — no sleeps, so
+          # it cannot flake on a loaded runner. Pins that it is OFF by default and
+          # inert when off, that the summary carries stage names + integers and
+          # NEVER speech, that a broken clock or timer is swallowed rather than
+          # raised into the turn, and (via an ast walk, not a grep) that no
+          # timing value is ever branched on — observability must not quietly
+          # become control.
+          python3 robot/rabbit_latency_test.py
           # Turn-state re-arm gate (Slice R, pure, no audio): the cross-process
           # "turn in progress" signal (fail-safe parse, active/done round-trip,
           # seq monotonicity) and the bounded rearm_decision that fixes the wake

--- a/docs/hardware/RABBIT_BRINGUP_RUNBOOK.md
+++ b/docs/hardware/RABBIT_BRINGUP_RUNBOOK.md
@@ -206,6 +206,41 @@ conflate them: the **configured** residency, whether the model is **loaded right
 now**, and whether the **server is unreachable**. A model that has legitimately
 unloaded on a healthy server with a finite keep-alive is normal, and is never a
 failure on its own.
+## 5d. Where did the time go? (latency staging)
+
+"Rabbit feels slow" is not actionable. Turn on staging and each turn reports one
+line per process:
+
+```bash
+# /etc/kirra/robot.env
+KIRRA_RABBIT_LATENCY_LOG=1
+sudo systemctl restart kirra-rabbit-voice
+journalctl -u kirra-rabbit-voice -f | grep rabbit_latency
+```
+
+```
+rabbit_latency: wake 40ms (wake_ack 40)
+rabbit_latency: capture 1520ms (record 1340, stt 180)
+rabbit_latency: reply 4520ms (llm 4100, door 120, tts 300)
+```
+
+Three lines because a turn spans three processes (`wake_word.py` →
+`rabbit_voice.sh` → `rabbit_converse.py`). The wake trigger is one bare newline
+with no payload — that is load-bearing for the wake fence — so there is no
+timestamp to thread through and **no end-to-end total is fabricated**. Add the
+three numbers yourself; a guessed total would be the one figure here worth
+distrusting.
+
+Reading it: `record` still at ~4000 ms means VAD is not enabled (§4/§1a of
+`RABBIT_AUDIO_STACK.md`). `llm` spiking on the first turn after an idle gap but
+not afterwards is the cold-reload stall — pin residency (§5c). `tts` dominating
+means the reply is too long; consider `KIRRA_RABBIT_STREAM_TTS=1`.
+
+Observability only: no timing value gates a turn, changes routing, touches the
+fenced `/intent` door, or affects actuation, and a timing failure is swallowed
+rather than raised. Privacy is unchanged — stage names and durations, never
+audio, transcripts or reply text. Off by default; unset it and the path is
+byte-identical.
 
 ## 6. The Rabbit experience (all together)
 

--- a/robot/install/rabbit.env.example
+++ b/robot/install/rabbit.env.example
@@ -201,6 +201,19 @@ KIRRA_RABBIT_MODEL="gemma3:4b"
 # falls back). Off → byte-identical. See RABBIT_BRINGUP_RUNBOOK.md ("Speed").
 #KIRRA_RABBIT_STREAM_TTS=1
 
+# LATENCY STAGING (opt-in, default off). One concise line per turn showing where
+# the time actually went, so a tuning change can be MEASURED instead of assumed:
+#   rabbit_latency: wake 40ms (wake_ack 40)                 [wake_word.py]
+#   rabbit_latency: capture 1520ms (record 1340, stt 180)   [rabbit_voice.sh]
+#   rabbit_latency: reply 4520ms (llm 4100, door 120, tts 300)  [rabbit_converse]
+# Observability ONLY — nothing here gates a turn, changes routing, touches the
+# fenced /intent door, or affects actuation, and a timing failure is swallowed.
+# Privacy is unchanged: stage NAMES and durations only, never audio, transcripts
+# or reply text. The three lines are adjacent in the journal because a turn spans
+# three processes; add them for the end-to-end number (the wake trigger carries no
+# payload to thread a start time through, so no total is fabricated).
+#KIRRA_RABBIT_LATENCY_LOG=1
+
 # ── Speed & responsiveness (Slice S) — the proven levers, in one place ─────────
 # The Rabbit felt slow to reply mostly from LLM cold-reload + long capture. The
 # fixes, all persisted here (none touch the checker / the fence):

--- a/robot/rabbit_converse.py
+++ b/robot/rabbit_converse.py
@@ -56,6 +56,7 @@ import skill_registry  # noqa: E402 — opt-in named-skill router (motion → th
 import world_model  # noqa: E402 — opt-in situation report (read-only TTL'd projection)
 import mission  # noqa: E402 — opt-in multi-step Executive (each step → the SAME /intent fence)
 import rabbit_stream  # noqa: E402 — opt-in first-clause streaming of the reply to TTS
+import rabbit_latency  # noqa: E402 — opt-in per-turn stage timing (observability only)
 from rabbit_persona import name_slot, operator_name  # noqa: E402
 
 MAX_TURNS = 10  # rolling conversation memory (user+assistant pairs kept)
@@ -353,7 +354,16 @@ def route_stream(messages, on_clause, cancelled):
     return plan
 
 
+# The timer for the turn in flight. Module-level because handle_turn has many
+# early returns (the deterministic OTA / diag / wake / sitrep commands), and
+# _run_turn's finally is the one place that sees EVERY completed turn. Safe as
+# a single slot: rabbit_converse handles one utterance at a time (the stdin
+# loop is serial), the same assumption turn_state already relies on.
+_TURN_TIMER = rabbit_latency.TurnTimer("reply")
+
+
 def handle_turn(history, utterance):
+    timer = _TURN_TIMER
     # System commands (OTA "check/apply update") are matched DETERMINISTICALLY and
     # handled BEFORE the LLM/movement path — they run local kirra-ota-ctl, never
     # the fenced mick /intent door, and a movement utterance never reaches here.
@@ -469,6 +479,7 @@ def handle_turn(history, utterance):
             already_spoken = bool(plan.get("streamed")) and directive is None
     if say is None and directive is None and not already_spoken:
         say, directive = ask_llm(history, context, utterance)   # non-streaming / fallback
+    timer.mark(rabbit_latency.LLM)
 
     if say is None:
         say = "My voice module is offline for a moment."
@@ -476,6 +487,7 @@ def handle_turn(history, utterance):
 
     if directive:
         result = offer_to_door(directive)
+        timer.mark(rabbit_latency.DOOR)
         if result == "ok":
             spoken = say or f"On our way{name_slot()} — the governor will keep us honest."
         elif result == "reject":
@@ -490,6 +502,7 @@ def handle_turn(history, utterance):
 
     if not already_spoken:
         _speak_reply(spoken)
+    timer.mark(rabbit_latency.TTS)
     # rolling memory (store the spoken reply, not the raw grounding)
     history.append({"role": "user", "content": utterance})
     history.append({"role": "assistant", "content": spoken})
@@ -501,11 +514,22 @@ def _run_turn(history, utterance):
     listener re-arms its mic the instant the reply finishes (Slice R) instead of
     on a blind timer. mark_active spans exactly the LLM+TTS stretch the listener
     can't see; mark_done runs in a finally so a mid-turn error still re-arms."""
+    global _TURN_TIMER
+    # Stage timing for THIS turn. This process owns transcript→spoken; the
+    # capture stages belong to rabbit_voice.sh, which reports its own span (the
+    # trigger carries no payload to thread a start time through, and an invented
+    # end-to-end total would be the one number here worth distrusting).
+    _TURN_TIMER = rabbit_latency.TurnTimer("reply")
     turn_state.mark_active()
     try:
         handle_turn(history, utterance)
     finally:
         turn_state.mark_done()
+        # ONE line per completed turn — stage names + durations only, never the
+        # transcript or the reply. In `finally`, so a deterministic command (OTA
+        # / diagnostics / sitrep) and a mid-turn error are reported too. Off
+        # unless KIRRA_RABBIT_LATENCY_LOG=1.
+        rabbit_latency.log_summary(_TURN_TIMER)
 
 
 def main():

--- a/robot/rabbit_latency.py
+++ b/robot/rabbit_latency.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""rabbit_latency.py — opt-in per-turn latency staging for the Rabbit voice loop.
+
+"Rabbit feels slow" is not actionable; "the LLM took 4.1 s of a 6.3 s turn" is.
+This records the stage boundaries the loop ALREADY passes through and prints one
+concise line per completed turn, so a tuning change (VAD endpointing, model
+residency, streaming TTS) can be MEASURED instead of assumed.
+
+    KIRRA_RABBIT_LATENCY_LOG=1      # off by default; unset → completely inert
+
+🔴 It observes, it never decides. Nothing here gates a turn, changes routing,
+touches the fenced /intent door, or affects actuation. A timing failure is
+swallowed — measurement must never be able to break the thing it measures.
+
+PRIVACY — the existing policy is unchanged and this does not widen it: no audio,
+no transcript, no reply text. Only stage NAMES and durations. Rabbit's speech
+already goes through `speak()`, which prints the line; nothing new is logged here.
+
+CLOCK: `time.monotonic_ns` by default — never wall clock, which can step under
+NTP mid-turn and produce a negative stage. Injectable, so tests are deterministic
+and never sleep.
+
+CROSS-PROCESS HONESTY. A voice turn spans three processes:
+
+    wake_word.py  ──trigger──▶  rabbit_voice.sh  ──transcript──▶  rabbit_converse.py
+    (wake→ack)                  (record, stt)                     (llm, door, tts)
+
+The trigger carries no payload (one bare newline — that is load-bearing for the
+wake fence), so there is no timestamp to thread through, and this module does NOT
+invent an end-to-end total by guessing. Each process reports the span it actually
+owns; the journal shows them adjacent, and the operator adds them. A fabricated
+"total" would be the one number here worth distrusting.
+
+Usage:
+
+    t = TurnTimer("turn")
+    t.mark("record")     # ends the 'record' stage
+    t.mark("stt")
+    log_summary(t)       # "rabbit_latency: turn 1520ms (record 1340, stt 180)"
+"""
+from __future__ import annotations
+
+import os
+import sys
+import time
+
+ENV_FLAG = "KIRRA_RABBIT_LATENCY_LOG"
+
+# Stage names, so the three processes emit a consistent vocabulary.
+WAKE_ACK = "wake_ack"     # wake detected → acknowledgement started
+RECORD = "record"         # capture started → capture complete
+STT = "stt"               # capture complete → transcript available
+LLM = "llm"               # request sent → model response available
+DOOR = "door"             # directive offered → mick answered
+TTS = "tts"               # reply available → speech started
+
+
+def enabled(env=None) -> bool:
+    """Is latency logging on? Off unless explicitly enabled, so a normal
+    deployment is byte-identical and the journal stays quiet."""
+    env = os.environ if env is None else env
+    return (env.get(ENV_FLAG) or "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def _default_clock() -> int:
+    return time.monotonic_ns()
+
+
+class TurnTimer:
+    """Accumulates stage durations for ONE turn.
+
+    `mark(stage)` closes the current span and attributes it to `stage`; the next
+    span starts immediately. Marking the same stage twice ADDS to it (the door
+    can be called once per mission step), so a summary never silently drops a
+    repeat.
+
+    Pure and clock-injected: `clock()` returns nanoseconds, monotonic.
+    """
+
+    def __init__(self, name: str = "turn", clock=None):
+        self.name = name
+        self._clock = clock or _default_clock
+        # Defensive from the very first read: constructing a timer must never be
+        # able to raise into the turn. A clock that misbehaves degrades to a
+        # frozen one (all stages 0 ms) — useless numbers, but a live robot.
+        self._start = self._now()
+        self._last = self._start
+        self.stages: list[tuple[str, int]] = []   # ordered (stage, ms)
+
+    def _now(self) -> int:
+        try:
+            return int(self._clock())
+        except Exception:  # noqa: BLE001 — measurement is never load-bearing
+            return getattr(self, "_last", 0)
+
+    def mark(self, stage: str) -> int:
+        """Close the current span as `stage`; return its duration in ms."""
+        now = self._now()
+        ms = max(0, (now - self._last) // 1_000_000)   # never negative
+        self._last = now
+        for i, (name, prev) in enumerate(self.stages):
+            if name == stage:
+                self.stages[i] = (name, prev + ms)
+                return ms
+        self.stages.append((stage, ms))
+        return ms
+
+    def skip(self) -> None:
+        """Discard the current span without attributing it — for idle time
+        between stages that belongs to nobody (e.g. waiting on the next
+        trigger)."""
+        self._last = self._now()
+
+    def total_ms(self) -> int:
+        return max(0, (self._now() - self._start) // 1_000_000)
+
+    def summary(self) -> str:
+        """One line. Total first (the number an operator actually feels), then
+        the stages in the order they happened."""
+        parts = ", ".join(f"{name} {ms}" for name, ms in self.stages)
+        body = f"{self.name} {self.total_ms()}ms"
+        return f"{body} ({parts})" if parts else body
+
+    def slowest(self) -> tuple[str, int] | None:
+        """The stage that dominated the turn — the one worth tuning."""
+        return max(self.stages, key=lambda s: s[1]) if self.stages else None
+
+
+def log_summary(timer: TurnTimer, out=None, env=None) -> str | None:
+    """Emit ONE summary line to stderr if enabled; return what was written (or
+    None). Never raises: observability must not be able to break a turn."""
+    try:
+        if not enabled(env):
+            return None
+        line = f"rabbit_latency: {timer.summary()}"
+        print(line, file=out or sys.stderr, flush=True)
+        return line
+    except Exception:  # noqa: BLE001 — measurement is never load-bearing
+        return None

--- a/robot/rabbit_latency_test.py
+++ b/robot/rabbit_latency_test.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""Host tests for the opt-in Rabbit latency staging.
+
+Every timing assertion uses an INJECTED clock — no sleeps, no wall clock, so
+nothing here can flake on a loaded CI box. The one real-clock test only checks
+that the default clock is monotonic in TYPE, not in value.
+
+What matters and is pinned:
+  * off by default, and inert when off (no output, no cost);
+  * one concise line per turn, stage names + durations only;
+  * NO transcript, reply text, or audio ever reaches the log;
+  * a timing failure can never break the turn it is measuring.
+"""
+from __future__ import annotations
+
+import io
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import rabbit_latency as rl  # noqa: E402
+
+_FAILURES: list[str] = []
+
+
+def check(cond, msg):
+    if not cond:
+        _FAILURES.append(msg)
+        print(f"  FAIL: {msg}", file=sys.stderr)
+
+
+class FakeClock:
+    """A clock the test drives. `advance(ms)` moves it; `__call__` returns ns."""
+
+    def __init__(self):
+        self.ns = 1_000_000_000        # arbitrary non-zero start
+
+    def __call__(self):
+        return self.ns
+
+    def advance(self, ms):
+        self.ns += ms * 1_000_000
+        return self
+
+
+ON = {"KIRRA_RABBIT_LATENCY_LOG": "1"}
+OFF: dict[str, str] = {}
+
+
+# ── the gate ─────────────────────────────────────────────────────────────────
+
+def test_disabled_by_default():
+    check(rl.enabled({}) is False, "must be OFF with the var unset")
+    for falsy in ("", "0", "no", "off", "false", "  "):
+        check(rl.enabled({rl.ENV_FLAG: falsy}) is False, f"{falsy!r} must not enable")
+
+
+def test_truthy_spellings_enable():
+    for truthy in ("1", "true", "TRUE", "yes", "on", " On "):
+        check(rl.enabled({rl.ENV_FLAG: truthy}) is True, f"{truthy!r} must enable")
+
+
+def test_nothing_is_written_when_disabled():
+    clock = FakeClock()
+    t = rl.TurnTimer("reply", clock=clock)
+    clock.advance(1234)
+    t.mark(rl.LLM)
+    out = io.StringIO()
+    check(rl.log_summary(t, out=out, env=OFF) is None, "must return None when off")
+    check(out.getvalue() == "", f"must write nothing when off, got {out.getvalue()!r}")
+
+
+# ── staging arithmetic ───────────────────────────────────────────────────────
+
+def test_stages_record_their_own_spans_in_order():
+    clock = FakeClock()
+    t = rl.TurnTimer("reply", clock=clock)
+    check(t.mark(rl.LLM) == 0, "a zero-length span is 0 ms, not negative")
+    clock.advance(4100)
+    t.mark(rl.LLM)
+    clock.advance(120)
+    t.mark(rl.DOOR)
+    clock.advance(300)
+    t.mark(rl.TTS)
+    check(t.stages == [(rl.LLM, 4100), (rl.DOOR, 120), (rl.TTS, 300)],
+          f"stages wrong: {t.stages}")
+    check(t.total_ms() == 4520, f"total wrong: {t.total_ms()}")
+
+
+def test_a_repeated_stage_accumulates_rather_than_being_dropped():
+    # A mission calls the door once per motion step. Overwriting would under-
+    # report; appending twice would read as two different stages.
+    clock = FakeClock()
+    t = rl.TurnTimer("reply", clock=clock)
+    clock.advance(100)
+    t.mark(rl.DOOR)
+    clock.advance(250)
+    t.mark(rl.DOOR)
+    check(t.stages == [(rl.DOOR, 350)], f"repeat must accumulate: {t.stages}")
+
+
+def test_skip_discards_a_span_without_attributing_it():
+    clock = FakeClock()
+    t = rl.TurnTimer("reply", clock=clock)
+    clock.advance(9000)      # idle, belongs to nobody
+    t.skip()
+    clock.advance(200)
+    t.mark(rl.TTS)
+    check(t.stages == [(rl.TTS, 200)], f"skip must not attribute: {t.stages}")
+
+
+def test_the_slowest_stage_is_identified():
+    clock = FakeClock()
+    t = rl.TurnTimer("reply", clock=clock)
+    clock.advance(1340)
+    t.mark(rl.RECORD)
+    clock.advance(4100)
+    t.mark(rl.LLM)
+    clock.advance(300)
+    t.mark(rl.TTS)
+    check(t.slowest() == (rl.LLM, 4100), f"slowest wrong: {t.slowest()}")
+    check(rl.TurnTimer("x", clock=FakeClock()).slowest() is None,
+          "no stages → no slowest, not a crash")
+
+
+def test_a_backwards_clock_never_produces_a_negative_stage():
+    """Defensive: monotonic_ns should never go backwards, but a stage rendered
+    as '-3ms' would make the whole summary untrustworthy."""
+    class Backwards:
+        def __init__(self):
+            self.ns = 5_000_000_000
+
+        def __call__(self):
+            self.ns -= 1_000_000
+            return self.ns
+
+    t = rl.TurnTimer("reply", clock=Backwards())
+    check(t.mark(rl.LLM) >= 0, "a stage duration must never be negative")
+    check(t.total_ms() >= 0, "a total must never be negative")
+
+
+# ── the emitted line ─────────────────────────────────────────────────────────
+
+def test_the_summary_is_one_line_total_first_then_stages():
+    clock = FakeClock()
+    t = rl.TurnTimer("reply", clock=clock)
+    clock.advance(1340)
+    t.mark(rl.RECORD)
+    clock.advance(4100)
+    t.mark(rl.LLM)
+    out = io.StringIO()
+    line = rl.log_summary(t, out=out, env=ON)
+    check(line == "rabbit_latency: reply 5440ms (record 1340, llm 4100)", f"got {line!r}")
+    check(out.getvalue().count("\n") == 1, "exactly one line per turn")
+    check(out.getvalue().rstrip("\n") == line, "the returned line is what was written")
+
+
+def test_a_turn_with_no_stages_still_reports_a_total():
+    clock = FakeClock()
+    t = rl.TurnTimer("reply", clock=clock)
+    clock.advance(80)
+    out = io.StringIO()
+    line = rl.log_summary(t, out=out, env=ON)
+    check(line == "rabbit_latency: reply 80ms", f"got {line!r}")
+
+
+def test_the_summary_never_carries_speech():
+    """The privacy rule, as an assertion. Only stage names and integers may
+    appear — a stage name is a fixed constant, so nothing operator-spoken can
+    reach the journal through this path."""
+    clock = FakeClock()
+    t = rl.TurnTimer("reply", clock=clock)
+    for stage in (rl.WAKE_ACK, rl.RECORD, rl.STT, rl.LLM, rl.DOOR, rl.TTS):
+        clock.advance(10)
+        t.mark(stage)
+    line = rl.log_summary(t, out=io.StringIO(), env=ON)
+    allowed = set("abcdefghijklmnopqrstuvwxyz_0123456789 :(),m")
+    check(set(line) <= allowed, f"unexpected characters in the summary: {line!r}")
+    for stage, _ in t.stages:
+        check(stage in (rl.WAKE_ACK, rl.RECORD, rl.STT, rl.LLM, rl.DOOR, rl.TTS),
+              f"unknown stage name reached the log: {stage!r}")
+
+
+def test_a_timing_failure_never_breaks_the_turn():
+    """Measurement must not be able to break the thing it measures."""
+    class Exploding:
+        def summary(self):
+            raise RuntimeError("boom")
+
+    check(rl.log_summary(Exploding(), out=io.StringIO(), env=ON) is None,
+          "a broken timer must be swallowed, not raised")
+
+    class ExplodingClock:
+        def __call__(self):
+            raise RuntimeError("boom")
+
+    try:
+        rl.log_summary(rl.TurnTimer("x", clock=ExplodingClock()),
+                       out=io.StringIO(), env=ON)
+    except Exception as e:  # noqa: BLE001
+        check(False, f"a broken clock escaped log_summary: {e!r}")
+
+
+def test_the_default_clock_is_monotonic_not_wall_clock():
+    """Wall clock can STEP under NTP mid-turn and yield a negative stage."""
+    src = (Path(__file__).resolve().parent / "rabbit_latency.py").read_text()
+    check("monotonic_ns" in src, "the default clock must be time.monotonic_ns")
+    check("time.time(" not in src, "wall clock must not be used for staging")
+    a = rl._default_clock()
+    b = rl._default_clock()
+    check(isinstance(a, int) and b >= a, "the default clock must not go backwards")
+
+
+# ── wiring: opt-in, observability-only, no new authority ─────────────────────
+
+def test_the_wiring_is_opt_in_everywhere():
+    here = Path(__file__).resolve().parent
+    for name in ("rabbit_voice.sh", "rabbit_converse.py", "wake_word.py"):
+        text = (here / name).read_text()
+        check(rl.ENV_FLAG in text or "rabbit_latency" in text,
+              f"{name} should participate in staging")
+    # The shell gate defaults to 0 (off) rather than on.
+    voice = (here / "rabbit_voice.sh").read_text()
+    check("LATENCY=0" in voice, "the shell timing gate must default OFF")
+
+
+def test_timing_calls_cannot_affect_routing_or_actuation():
+    """Every latency reference is a bare mark/log statement or an assignment —
+    NEVER a condition, an argument, or a return value. If a timing number could
+    gate a turn, observability would have quietly become control.
+
+    Parsed with `ast`, not grepped: prose in a docstring must not read as code
+    (and did, on the first attempt — "…on a blind timer. mark_active spans…").
+    """
+    import ast
+    NAMES = ("timer", "_TURN_TIMER", "rabbit_latency")
+    # Statement kinds in which a latency reference cannot influence anything:
+    # a bare call, an assignment of a fresh timer, an import, a global decl.
+    INERT = (ast.Expr, ast.Assign, ast.Import, ast.ImportFrom, ast.Global)
+
+    def own_refs(stmt):
+        """Names referenced by THIS statement, not by statements nested in it —
+        otherwise every enclosing FunctionDef would match its own body."""
+        found, stack = [], list(ast.iter_child_nodes(stmt))
+        while stack:
+            node = stack.pop()
+            if isinstance(node, ast.stmt):
+                continue                      # a nested statement is its own case
+            if isinstance(node, ast.Name) and node.id in NAMES:
+                found.append(node)
+            stack.extend(ast.iter_child_nodes(node))
+        return found
+
+    here = Path(__file__).resolve().parent
+    for name in ("rabbit_converse.py", "wake_word.py"):
+        tree = ast.parse((here / name).read_text())
+        seen = 0
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.stmt) or not own_refs(node):
+                continue
+            seen += 1
+            check(isinstance(node, INERT),
+                  f"{name}:{node.lineno} uses timing data in a "
+                  f"{type(node).__name__} — it must never gate a turn")
+        check(seen > 0, f"{name} has no latency wiring at all (did it get dropped?)")
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items())
+             if k.startswith("test_") and callable(v)]
+    print("rabbit_latency_test:")
+    for t in tests:
+        before = len(_FAILURES)
+        t()
+        print(f"  {'ok  ' if len(_FAILURES) == before else 'FAIL'} {t.__name__}")
+    if _FAILURES:
+        print(f"\n{len(_FAILURES)} check(s) FAILED", file=sys.stderr)
+        return 1
+    print(f"\nall {len(tests)} tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())

--- a/robot/rabbit_voice.sh
+++ b/robot/rabbit_voice.sh
@@ -46,16 +46,31 @@ if [ -z "${KIRRA_STT_CMD:-}" ]; then
 fi
 : "${KIRRA_RECORD_CMD:=arecord -d 4 -f S16_LE -r 16000 -c 1}"
 
+# Opt-in stage timing (KIRRA_RABBIT_LATENCY_LOG=1). Monotonic ms; a shell
+# without EPOCHREALTIME degrades to no timing rather than to wrong timing.
+# Off → `now_ms` is never called and the loop is byte-identical.
+LATENCY=0
+case "${KIRRA_RABBIT_LATENCY_LOG:-}" in 1|true|yes|on|TRUE|YES|ON) LATENCY=1 ;; esac
+now_ms() { date +%s%3N 2>/dev/null || echo 0; }
+
 # Producer: one transcript line per trigger. STT/RECORD are word-split command
 # lists (the house convention: the WAV path is APPENDED as the last argument).
 transcribe() {
-  local wav text
+  local wav text t0 t1 t2
   while IFS= read -r _; do
     wav="$(mktemp --suffix=.wav)"
+    [ "$LATENCY" = 1 ] && t0="$(now_ms)"
     # shellcheck disable=SC2086
     if $KIRRA_RECORD_CMD "$wav" >/dev/null 2>&1; then
+      [ "$LATENCY" = 1 ] && t1="$(now_ms)"
       # shellcheck disable=SC2086
       text="$($KIRRA_STT_CMD "$wav" 2>/dev/null | tr '\r\n' '  ' | sed 's/  */ /g;s/^ //;s/ $//')"
+      if [ "$LATENCY" = 1 ]; then
+        t2="$(now_ms)"
+        # Stage NAMES and durations only — never the transcript (the privacy
+        # policy is transcribe-and-discard and this must not widen it).
+        echo "rabbit_latency: capture $((t2 - t0))ms (record $((t1 - t0)), stt $((t2 - t1)))" >&2
+      fi
       [ -n "${text// /}" ] && printf '%s\n' "$text"
     else
       echo "rabbit_voice: recorder failed — nothing captured" >&2

--- a/robot/wake_word.py
+++ b/robot/wake_word.py
@@ -76,6 +76,7 @@ import wave
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import turn_state  # noqa: E402 — cross-process "turn in progress" signal (Slice R)
+import rabbit_latency  # noqa: E402 — opt-in stage timing (observability only)
 
 # ---------------------------------------------------------------------------
 # Pure logic (host-tested in robot/wake_word_test.py — no audio, no GPIO)
@@ -244,10 +245,15 @@ def _fire_trigger_and_wait(turn_state_file, rearm_mode, holdoff_s,
     the wake path and the follow-up path so both re-arm identically. The mic is
     already CLOSED by the caller before this runs (release-before-trigger)."""
     baseline_seq = turn_state.read_state(turn_state_file)[1]
+    timer = rabbit_latency.TurnTimer("wake")
     sys.stdout.write("\n")   # THE TRIGGER — sole stdout writer
     sys.stdout.flush()
     if after_fire is not None:
         after_fire()
+    # How long the operator waited between being heard and hearing "Yes?".
+    # Stage name + duration only — never the phrase (transcribe-and-discard).
+    timer.mark(rabbit_latency.WAKE_ACK)
+    rabbit_latency.log_summary(timer)
     if rearm_mode == "timer":
         time.sleep(holdoff_s)   # legacy: blind fixed hold-off
     else:


### PR DESCRIPTION
**Stack position: 3 of 3. Merge last, after #1200 and #1201.** This one has **two known conflicts on rebase** — both pure union, both listed below with the resolution already worked out.

Instrumentation belongs after the behaviour is settled, which is why it is last.

## What it does

"Rabbit feels slow" is not actionable; "the LLM took 4.1 s of a 6.3 s turn" is. This records the stage boundaries the loop **already** passes through and prints one concise line per completed turn, so #1200 and #1201 can be *measured* rather than assumed.

```bash
KIRRA_RABBIT_LATENCY_LOG=1      # off by default; unset → completely inert
```

```
rabbit_latency: wake 40ms (wake_ack 40)                     [wake_word.py]
rabbit_latency: capture 1520ms (record 1340, stt 180)       [rabbit_voice.sh]
rabbit_latency: reply 4520ms (llm 4100, door 120, tts 300)  [rabbit_converse.py]
```

## Three lines, not one total

A turn spans three processes, and the wake trigger is **one bare newline with no payload** — that emptiness is load-bearing for the wake fence (it is why a wake phrase can never become an utterance). So there is no timestamp to thread through, and this module does **not** invent an end-to-end total by guessing. Each process reports the span it actually owns; the journal shows them adjacent and the operator adds them.

A fabricated "total" would be the one number here worth distrusting.

## Observability that cannot become control

The summary is emitted from `_run_turn`'s `finally`, so **every** completed turn is reported — including the deterministic OTA / diagnostics / sitrep commands (which return early) and a mid-turn error.

No timing value is ever branched on, and that is enforced rather than asserted in prose: a test walks the **AST** of both wired modules and fails if a latency reference appears anywhere but a bare call, an assignment, an import or a global. Grepping for this was tried first and false-positived on a docstring reading *"…on a blind timer. mark_active spans…"* — which is exactly why it is parsed now.

Fail-soft by construction: `log_summary` swallows everything, and `TurnTimer` reads its clock through a guard so even the **constructor** cannot raise into a turn. A misbehaving clock degrades to useless numbers, never a dead robot. Durations clamp at 0, so a backwards clock cannot render `-3ms` and make the whole summary untrustworthy. `monotonic_ns`, never wall clock — which can step under NTP mid-turn.

## Privacy

Unchanged and **not widened**: stage NAMES and integers only — no audio, no transcript, no reply text. A test asserts the emitted line contains nothing outside that alphabet, and that every stage name is one of six fixed constants.

## Reading it

| Symptom | Meaning |
|---|---|
| `record` still ~4000 ms | VAD not enabled — see #1200 / `RABBIT_AUDIO_STACK.md` §1a |
| `llm` spikes on the first turn after idle, not after | cold-reload stall — pin residency, #1201 |
| `tts` dominating | reply too long; consider `KIRRA_RABBIT_STREAM_TTS=1` |

## Changed files

| File | Change |
|---|---|
| `robot/rabbit_latency.py` | new — `TurnTimer`, `log_summary`, stage constants, injected clock |
| `robot/rabbit_latency_test.py` | new — 15 tests |
| `robot/rabbit_converse.py` | timer marks for `llm`/`door`/`tts`; summary in `_run_turn`'s `finally` |
| `robot/wake_word.py` | `wake_ack` span |
| `robot/rabbit_voice.sh` | `record`/`stt` spans, shell gate defaults **off** |
| `robot/install/rabbit.env.example`, `docs/hardware/RABBIT_BRINGUP_RUNBOOK.md` §5d | |

## Tests

**15**, registered in CI. Every timing assertion uses an **injected clock** — no sleeps, nothing to flake on a loaded runner. The one real-clock test only checks the default clock's type and non-regression.

Verified non-vacuous: injecting `if timer.total_ms() > 5000: return` into the turn path reds the AST guard with *"uses timing data in an If — it must never gate a turn"*.

All 23 robot suites exit 0 · `cargo test -p kirra-sidecars` 83 passed · `cargo fmt --check` · `compileall` · `bash -n` · `ruff` clean on touched files · `git diff --check` clean.

Verified end to end that the wiring actually emits (`rabbit_latency: reply 0ms (llm 0, tts 0)` with stubs) and emits **nothing** with the flag unset.

## 🔧 Known rebase conflicts — resolution

Rebasing onto `main` after #1200 and #1201 land produces **exactly two conflicts**, both insert-vs-insert, both resolved as a **union — neither side replaces the other**:

| File | Conflict | Resolution |
|---|---|---|
| `.github/workflows/ci.yml` | this PR and #1201 both insert test registrations after `python3 robot/wake_word_test.py` | keep both blocks; all of `service_units`, `rabbit_keepalive`, `rabbit_latency` must survive |
| `docs/hardware/RABBIT_BRINGUP_RUNBOOK.md` | #1201 adds §5b/§5c, this PR adds §5d, both before `## 6.` | keep both, in section-number order: 5b, 5c, 5d |

`robot/install/rabbit.env.example` merges cleanly despite all three branches editing it.

This was dry-run against a simulated `main` with **#1198, #1199, #1200 and #1201 all merged** — the full five-PR queue. Result: #1200 and #1201 rebase clean; only this PR conflicts, with exactly the two files above. The resolved five-way tree was then validated: all 23 robot suites pass, every CI registration present, and all five features coexist (the Mick fence, #1199's `offer_to_door` intent check, #1200's VAD device fail-closed path, #1201's residency reporting, and this PR's timer marks).

Worth noting `robot/rabbit_converse.py` is edited by both #1199 (`offer_to_door`) and this PR (imports + timer marks) and does **not** conflict — disjoint regions.

## Stacking

1. #1200 — bounded VAD
2. #1201 — service ordering + residency (rebase; no conflicts)
3. **this PR** — rebase; the two union conflicts above

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjDFKPcBVHURDZpXsvnYhC)_