### PR TITLE
fix(diagnostics): identify motor conflicts by serial authority

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1367,6 +1367,25 @@ jobs:
           # timing value is ever branched on — observability must not quietly
           # become control.
           python3 robot/rabbit_latency_test.py
+          # SERIAL AUTHORITY, not vendor branding. The old detector asked "does
+          # any process have a vendor name?" and, run with --disable on the live
+          # R2, disabled ollama.service (Yahboom workspace on its PATH), pkill'd
+          # the YDLIDAR driver (exe under yahboomcar_ros2_ws), disabled the OLED
+          # unit and flagged `avahi-daemon: running [yahboom.local]`. None held
+          # /dev/myserial. These pin the ten ownership states and prove the four
+          # live false positives are matched by the OLD pattern and by nothing in
+          # the new one (non-vacuity), while a real rosmaster_main still matches.
+          python3 robot/motor_authority_test.py
+          # ONE definition of what the consumer needs, so the doctor, preflight
+          # and installer cannot drift. KIRRA_EXPECTED_CAR_TYPE is X3-ONLY (the
+          # doctor used to demand it in r2_ackermann, a mode that ignores it);
+          # odometry/closed-loop keys are required only when their flag is on.
+          python3 robot/consumer_config_contract_test.py
+          # The preflight that reports EVERY missing key in one run. A lint-clean
+          # Rabbit-only robot.env passed the syntax linter and the consumer then
+          # surfaced one missing value per restart — 200+ restarts to learn eight
+          # facts. Lint answers "valid shell file"; this answers "can it start".
+          python3 robot/install/preflight_consumer_env_test.py
           # Turn-state re-arm gate (Slice R, pure, no audio): the cross-process
           # "turn in progress" signal (fail-safe parse, active/done round-trip,
           # seq monotonicity) and the bounded rearm_decision that fixes the wake

--- a/firmware/rosmaster-r2/docs/ROADMAP.md
+++ b/firmware/rosmaster-r2/docs/ROADMAP.md
@@ -3,6 +3,125 @@
 Benchmarks are gates, not estimates. Host timing is indicative; only target and
 electrical measurements support real-time/safety claims.
 
+## Deployment reality — where the live R2 actually is (2026-07)
+
+The phases below describe the *target*. This section records what is deployed
+on the bring-up robot today, so the gap is legible without reading eleven
+phases. Three states, deliberately separated.
+
+### Current implemented state — Yahboom base, Kirra chokepoint
+
+The Jetson Orin NX (Ubuntu 22.04 / JetPack 6.2, ROS 2 Humble) drives a **stock
+Yahboom/Rosmaster motor controller** over `/dev/myserial`. None of the firmware
+in this tree is on the robot. What *is* live is the ADR-0033 chokepoint:
+
+```
+Rabbit / Mick → planner → verifier / governor
+              → kirra_motor_consumer.py   (verifies the Ed25519 release token)
+              → /dev/myserial             (TIOCEXCL, 0600, single writer)
+              → Yahboom MCU               (vendor firmware, unverified)
+```
+
+Live evidence from bring-up: `serial exclusivity: OK`,
+`TIOCEXCL claimed on /dev/myserial`, `KIRRA consumer OWNS /dev/myserial`,
+`r2_ackermann drive: open-loop equal-PWM`.
+
+So the **authorization** boundary is already Kirra's, in Linux userspace. The
+**actuation** boundary is still the vendor's: the Yahboom MCU accepts whatever
+bytes reach it, and the single-writer property is what stops anything else
+sending them. Closed-loop wheel matching and R2 odometry are deliberately off
+pending validation.
+
+> The consumer is a *sole-writer* guard, not an authenticated link. It cannot
+> stop a process that gains the port; it stops there being a second process
+> with the port. That distinction is why the udev rule, `TIOCEXCL` and the
+> boot sentinel are all load-bearing, and why they must stay after the MCU
+> work lands.
+
+### Near-term bridge state — R2CP over the vendor board
+
+The next boundary move is the **Jetson-side R2CP bridge**, which does not exist
+yet (grep confirms no `R2CP` reference outside `firmware/`). This is the single
+largest gap between the spec in `PROTOCOL.md` and anything runnable, and it is
+host-side work — no board bring-up required to start it:
+
+1. a host encoder/decoder for the canonical frame (`wire.cpp` is the reference
+   implementation and the conformance oracle — do NOT write a second dialect);
+2. a differential test harness: host encoder → `wire.cpp` decoder and back,
+   sharing `fuzz/corpus/` so the two implementations cannot drift;
+3. a **simulated MCU** speaking R2CP over a PTY, so the consumer's serial path
+   is exercised end to end with no hardware;
+4. the consumer gaining an R2CP drive mode alongside `r2_ackermann`/`x3`, gated
+   by `KIRRA_DRIVE_MODE` exactly as the existing modes are.
+
+Only then does firmware flashing become a *swap* rather than a leap.
+
+### Final Kirra-owned state — and what it does NOT remove
+
+```
+… → verifier / governor → consumer → R2CP (authenticated) → Kirra MCU firmware
+                                                          → motors, steering,
+                                                            encoders, watchdog,
+                                                            e-stop
+```
+
+**Replacing the firmware does not remove the Jetson verifier or governor.**
+`PROTOCOL.md` already states this and it bears repeating here because it is the
+easiest thing to get wrong: R2CP's `AUTH_TAG` authenticates the *link* — it
+proves the bridge sent the bytes. It says nothing about whether the checker
+authorized the motion they encode. Until either the MCU verifies the Kirra
+release token itself, or a dedicated Kirra signer emits an authorization MAC
+under a key the bridge never holds, ADR-0033's token-verifying consumer, the
+serial ACL and the startup sentinel remain the trust boundary. A Kirra-owned
+MCU moves the *watchdog and safe-state* into hardware; it does not move the
+*authorization decision* out of the governor.
+
+What the MCU does buy: a hardware watchdog with a bounded FTTI, boot-safe motor
+state, an e-stop input that is not mediated by Linux, encoder/battery/fault
+telemetry the checker can trust, and a firmware image whose provenance we
+control (`bootloader/image_verifier.hpp`).
+
+### Staged migration
+
+| Stage | Boundary | Verifier/governor | Vendor MCU |
+|---|---|---|---|
+| 0 — today | consumer + `TIOCEXCL` | required | present, unverified |
+| 1 — bridge | consumer speaks R2CP to a **simulated** MCU | required | present |
+| 2 — HIL | R2CP to Kirra firmware on a bench board | required | bench only |
+| 3 — swap | R2CP to Kirra firmware on the robot | required | removed |
+| 4 — bound | MCU verifies Kirra authorization | required | — |
+
+Rollback at every stage is `KIRRA_DRIVE_MODE` plus reflashing the vendor image;
+stages 0–2 are rollback-free because the robot never stops using the vendor
+board. Do not skip stage 1: it is the only stage that can fail cheaply.
+
+### Compatibility and test strategy
+
+- **Conformance**: the host encoder is tested against `wire.cpp`, not against a
+  second specification. One decoder is normative.
+- **Simulated MCU** (stage 1) carries the FDIT matrix — truncated frames, CRC
+  flips, replayed sequences, stale timestamps, oversize payloads — reusing the
+  existing `fuzz/corpus/` seeds so host and target see identical bytes.
+- **HIL** (stage 2) adds what simulation cannot: real UART timing, brown-out,
+  cable pull, watchdog expiry under load, and the on-target WCET measurements
+  the crypto phase gate requires.
+- The existing `tools/check.sh` and the `rosmaster-r2-firmware` CI lane stay the
+  gate for firmware changes; the bridge gets a lane of its own when it lands.
+
+### Diagnostics that must survive the migration
+
+Bring-up produced four false positives from *vendor-name* matching — a lidar in
+`yahboomcar_ros2_ws`, the `yahboom.local` mDNS hostname, an OLED unit, and
+`ollama.service` with the workspace on its `PATH`. Acting on them disabled
+Ollama and killed the lidar. `robot/motor_authority.py` replaced that with
+**serial-authority** detection: who actually holds the configured motor device,
+compared against the consumer's systemd MainPID.
+
+That check is written against a device path, not a protocol, so it keeps
+working unchanged when the byte stream on `/dev/myserial` becomes R2CP. The
+single-writer invariant is what it verifies, and that invariant outlives the
+vendor board.
+
 ## Phase 0 — system safety and security baseline
 
 **Deliverables**

--- a/robot/cold_boot_drill.sh
+++ b/robot/cold_boot_drill.sh
@@ -74,13 +74,34 @@ clog="$(journalctl -u kirra-consumer -n 60 --no-pager 2>/dev/null || true)"
 grep -q 'OWNS /dev/myserial' <<<"$clog" && ok "consumer OWNS /dev/myserial" || bad "no 'OWNS /dev/myserial' in recent consumer log"
 if grep -qE 'FATAL' <<<"$clog"; then bad "consumer logged a FATAL"; grep -E 'FATAL' <<<"$clog" | tail -1 | sed 's/^/     /'; else ok "no consumer FATAL"; fi
 
-# 5. vendor autostart gone.
-echo "-- vendor node absent --"
-if pgrep -af 'rosmaster_main|Rosmaster_Lib|yahboom' 2>/dev/null | grep -viE 'grep|cold_boot|disable_vendor' >/dev/null; then
-  bad "a vendor base process is RUNNING (will fight the consumer for /dev/myserial)"
-  note "disable it: robot/install/disable_vendor_autostart.sh --disable"
+# 5. motor-port AUTHORITY — who actually holds the device.
+#
+# This used to be `pgrep -af '...|yahboom'`, which on the live R2 matched
+# `avahi-daemon: running [yahboom.local]` and the YDLIDAR node under
+# ~/yahboomcar_ros2_ws, and so reported "a vendor base process is RUNNING"
+# while the Kirra consumer held exclusive ownership. Neither ever opened
+# /dev/myserial. The question is ownership, not branding.
+echo "-- motor port authority --"
+AUTH_PY="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/motor_authority.py"
+MOTOR_PORT="${KIRRA_MOTOR_PORT:-/dev/myserial}"
+if [[ -f "$AUTH_PY" ]]; then
+  if auth_out="$(python3 "$AUTH_PY" "$MOTOR_PORT" 2>&1)"; then
+    ok "consumer is the sole motor-port opener"
+    sed 's/^/     /' <<<"$auth_out"
+    ok "no competing motor-base process owns the motor port"
+  else
+    bad "motor-port ownership check FAILED"
+    sed 's/^/     /' <<<"$auth_out"
+    note "review the holders above; disable_vendor_autostart.sh --report explains"
+  fi
 else
-  ok "no vendor base process running"
+  note "motor_authority.py not found (running outside the checkout?) — skipped"
+fi
+# Vendor-NAMED processes are listed for context only and never fail the drill.
+vendor_named="$(pgrep -af 'yahboom' 2>/dev/null | grep -viE 'grep|cold_boot|disable_vendor' || true)"
+if [[ -n "$vendor_named" ]]; then
+  note "vendor-named processes present and IGNORED (they do not hold the motor port):"
+  sed 's/^/     /' <<<"$vendor_named"
 fi
 
 # 6. sensor topics (advisory — lidar is a separate launch, may be off at boot).

--- a/robot/consumer_config_contract.py
+++ b/robot/consumer_config_contract.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""consumer_config_contract.py — ONE definition of what the motor consumer
+requires, so the doctor, the preflight, the installer and the unit cannot drift.
+
+Two live bring-up failures motivated this:
+
+1. **A mode-blind warning.** The config doctor warned
+   `KIRRA_EXPECTED_CAR_TYPE set: unset` while the robot ran
+   `KIRRA_DRIVE_MODE=r2_ackermann` — a mode in which the consumer never reads
+   that variable. The operator was told to set something that does nothing.
+
+2. **A lint-clean but useless env.** The voice setup copied a Rabbit-focused
+   file into `/etc/kirra/robot.env`. It passed the syntax linter and was
+   missing every actuation key, so the consumer discovered them ONE AT A TIME
+   through a restart loop: freshness window, then control period, then missed
+   periods, then stop decel, then the caps, then the port, then the drive mode,
+   then the FFI. Over 200 restarts to learn eight facts.
+
+Lint answers "is this a valid shell file". This answers "can the consumer
+actually start", which is a different question and the one that matters before
+the unit is enabled. `missing_keys` returns the WHOLE set in one pass.
+
+Pure: every function takes an env mapping and returns data. No file I/O, no
+serial, no systemd — so the whole contract is host-testable.
+"""
+from __future__ import annotations
+
+MODE_R2 = "r2_ackermann"
+MODE_X3 = "x3"
+
+# Required in EVERY mode — the governed-consumer safety envelope.
+ALWAYS_REQUIRED = (
+    "KIRRA_GOVERNOR_VK_HEX",      # the release-token verifying key
+    "KIRRA_PROFILE_DIGEST",       # binds the consumer to a checker profile
+    "KIRRA_FRESHNESS_WINDOW_MS",  # stale release → refuse
+    "KIRRA_CONTROL_PERIOD_MS",
+    "KIRRA_MISSED_PERIODS",       # → safe stop
+    "KIRRA_STOP_DECEL_MPS2",
+    "KIRRA_DEMO_VX_MAX",
+    "KIRRA_DEMO_VZ_MAX",
+    "KIRRA_MOTOR_PORT",
+)
+
+# X3 only. The consumer reads this to verify the base reports the car type it
+# was calibrated for; the R2 Ackermann path has no such handshake.
+X3_ONLY = ("KIRRA_EXPECTED_CAR_TYPE",)
+
+# R2 Ackermann: the measured calibration `calibration_from_env` consumes. These
+# are per-robot MEASUREMENTS — a default would be a guess at the steering
+# geometry of a machine that can move, so they are required, not defaulted.
+R2_REQUIRED = (
+    "KIRRA_R2_WHEELBASE_M",
+    "KIRRA_R2_V_PER_PWM",
+    "KIRRA_R2_PWM_MAX",
+    "KIRRA_R2_STEER_UNITS_PER_RAD",
+    "KIRRA_R2_DELTA_MAX_RAD",
+    "KIRRA_R2_STEER_SIGN",
+    "KIRRA_R2_CENTER_TRIM",
+)
+
+# Only when the corresponding feature is switched on.
+ODOM_REQUIRED = ("KIRRA_R2_M_PER_TICK",)
+CLOSED_LOOP_REQUIRED = ("KIRRA_R2_V_PER_PWM_RIGHT",)
+
+# Needed to load the verify core at all; its absence was one of the restart-loop
+# discoveries and is a deterministic, not transient, failure.
+FFI_KEY = "KIRRA_CONSUMER_LIB"
+
+
+def _truthy(v) -> bool:
+    return (v or "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def drive_mode(env) -> str:
+    """The configured mode. Unset means the consumer's own default path; report
+    it verbatim rather than guessing, so a typo is visible as a typo."""
+    return (env.get("KIRRA_DRIVE_MODE") or "").strip() or MODE_X3
+
+
+def odom_enabled(env) -> bool:
+    return _truthy(env.get("KIRRA_R2_ODOM_ENABLED"))
+
+
+def closed_loop_enabled(env) -> bool:
+    return _truthy(env.get("KIRRA_R2_CLOSED_LOOP"))
+
+
+def required_keys(env) -> list[str]:
+    """Every key this env's MODE actually needs, in report order."""
+    mode = drive_mode(env)
+    keys = list(ALWAYS_REQUIRED) + [FFI_KEY]
+    if mode == MODE_R2:
+        keys += list(R2_REQUIRED)
+        if odom_enabled(env):
+            keys += list(ODOM_REQUIRED)
+        if closed_loop_enabled(env):
+            keys += list(CLOSED_LOOP_REQUIRED)
+    else:
+        keys += list(X3_ONLY)
+    return keys
+
+
+def inapplicable_keys(env) -> list[str]:
+    """Keys that belong to a DIFFERENT mode than the configured one. Reported
+    as a warning, never a failure — a leftover value is untidy, not unsafe."""
+    mode = drive_mode(env)
+    if mode == MODE_R2:
+        out = list(X3_ONLY)
+        if not odom_enabled(env):
+            out += list(ODOM_REQUIRED)
+        if not closed_loop_enabled(env):
+            out += list(CLOSED_LOOP_REQUIRED)
+        return out
+    return list(R2_REQUIRED) + list(ODOM_REQUIRED) + list(CLOSED_LOOP_REQUIRED)
+
+
+def missing_keys(env) -> list[str]:
+    """THE whole missing set, in one pass — the point of this module. The
+    consumer would surface these one restart at a time."""
+    return [k for k in required_keys(env) if not (env.get(k) or "").strip()]
+
+
+def sufficient_for_actuation(env) -> bool:
+    return not missing_keys(env)
+
+
+def report(env) -> dict:
+    """A migration/preflight report: what is missing, what is inapplicable but
+    present, and what mode the answer is relative to."""
+    mode = drive_mode(env)
+    return {
+        "mode": mode,
+        "missing": missing_keys(env),
+        "present_but_inapplicable": [k for k in inapplicable_keys(env)
+                                     if (env.get(k) or "").strip()],
+        "required_count": len(required_keys(env)),
+        "sufficient": sufficient_for_actuation(env),
+    }

--- a/robot/consumer_config_contract_test.py
+++ b/robot/consumer_config_contract_test.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Host tests for the shared consumer config contract.
+
+The two live failures, as regressions:
+  * r2_ackermann must NOT demand KIRRA_EXPECTED_CAR_TYPE (the doctor warned
+    about it on a correctly-configured R2);
+  * a lint-clean Rabbit-only env must be reported INSUFFICIENT in ONE pass,
+    not discovered one restart at a time.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import consumer_config_contract as c  # noqa: E402
+
+_F: list[str] = []
+
+
+def check(cond, msg):
+    if not cond:
+        _F.append(msg)
+        print(f"  FAIL: {msg}", file=sys.stderr)
+
+
+# The live, working R2 env from bring-up.
+LIVE_R2 = {
+    "KIRRA_GOVERNOR_VK_HEX": "ab", "KIRRA_PROFILE_DIGEST": "9c70",
+    "KIRRA_FRESHNESS_WINDOW_MS": "200", "KIRRA_CONTROL_PERIOD_MS": "100",
+    "KIRRA_MISSED_PERIODS": "3", "KIRRA_STOP_DECEL_MPS2": "0.5",
+    "KIRRA_DEMO_VX_MAX": "0.15", "KIRRA_DEMO_VZ_MAX": "0.4",
+    "KIRRA_MOTOR_PORT": "/dev/myserial", "KIRRA_DRIVE_MODE": "r2_ackermann",
+    "KIRRA_R2_WHEELBASE_M": "0.229", "KIRRA_R2_V_PER_PWM": "0.0145",
+    "KIRRA_R2_PWM_MAX": "40", "KIRRA_R2_STEER_UNITS_PER_RAD": "66",
+    "KIRRA_R2_DELTA_MAX_RAD": "0.68", "KIRRA_R2_STEER_SIGN": "-1",
+    "KIRRA_R2_CENTER_TRIM": "90",
+    "KIRRA_CONSUMER_LIB": "/opt/kirra/libkirra_consumer_ffi.so",
+}
+
+RABBIT_ONLY = {
+    "KIRRA_STT_CMD": "whisper-cli -m m.bin", "KIRRA_TTS_CMD": "./speak.sh",
+    "KIRRA_RECORD_CMD": "arecord -d 4", "KIRRA_RABBIT_MODEL": "gemma3:4b",
+    "KIRRA_OLLAMA_URL": "http://localhost:11434",
+}
+
+
+def test_the_live_r2_env_is_sufficient():
+    check(c.sufficient_for_actuation(LIVE_R2),
+          f"the working live env must pass, missing={c.missing_keys(LIVE_R2)}")
+
+
+def test_r2_does_not_require_expected_car_type():
+    """Live failure #4."""
+    check("KIRRA_EXPECTED_CAR_TYPE" not in c.required_keys(LIVE_R2),
+          "r2_ackermann must NOT require the X3-only car type")
+    check("KIRRA_EXPECTED_CAR_TYPE" in c.inapplicable_keys(LIVE_R2),
+          "it should be reported as inapplicable in R2 mode")
+    env = dict(LIVE_R2); env.pop("KIRRA_DRIVE_MODE")
+    check("KIRRA_EXPECTED_CAR_TYPE" in c.required_keys(env),
+          "X3 mode must still require it")
+
+
+def test_rabbit_only_env_is_insufficient_and_reported_in_one_pass():
+    """Live failure #6: lint-clean, actuation-useless."""
+    check(not c.sufficient_for_actuation(RABBIT_ONLY),
+          "a Rabbit-only env must NOT be sufficient for actuation")
+    missing = c.missing_keys(RABBIT_ONLY)
+    for key in ("KIRRA_GOVERNOR_VK_HEX", "KIRRA_FRESHNESS_WINDOW_MS",
+                "KIRRA_CONTROL_PERIOD_MS", "KIRRA_MISSED_PERIODS",
+                "KIRRA_STOP_DECEL_MPS2", "KIRRA_DEMO_VX_MAX",
+                "KIRRA_DEMO_VZ_MAX", "KIRRA_MOTOR_PORT", "KIRRA_CONSUMER_LIB"):
+        check(key in missing, f"{key} must be reported missing")
+    check(len(missing) >= 9,
+          f"the WHOLE set must come back at once, got {len(missing)}: {missing}")
+
+
+def test_odom_and_closed_loop_are_conditional():
+    check("KIRRA_R2_M_PER_TICK" not in c.required_keys(LIVE_R2),
+          "odom values must not be required while odom is off")
+    on = dict(LIVE_R2, KIRRA_R2_ODOM_ENABLED="1")
+    check("KIRRA_R2_M_PER_TICK" in c.required_keys(on),
+          "odom values must be required when odom is on")
+    check(not c.sufficient_for_actuation(on), "and missing → insufficient")
+    cl = dict(LIVE_R2, KIRRA_R2_CLOSED_LOOP="1")
+    check("KIRRA_R2_V_PER_PWM_RIGHT" in c.required_keys(cl),
+          "closed-loop values required when enabled")
+
+
+def test_r2_calibration_is_required_not_defaulted():
+    for key in c.R2_REQUIRED:
+        env = dict(LIVE_R2); env.pop(key)
+        check(key in c.missing_keys(env),
+              f"{key} is a per-robot MEASUREMENT and must be required")
+
+
+def test_blank_counts_as_missing():
+    env = dict(LIVE_R2, KIRRA_MOTOR_PORT="   ")
+    check("KIRRA_MOTOR_PORT" in c.missing_keys(env), "whitespace is not a value")
+
+
+def test_report_shape():
+    r = c.report(RABBIT_ONLY)
+    check(r["sufficient"] is False and r["missing"], "report must flag it")
+    check(r["mode"] == c.MODE_X3, f"unset mode reports the default: {r['mode']}")
+    r2 = c.report(LIVE_R2)
+    check(r2["sufficient"] is True and r2["mode"] == c.MODE_R2, "live env ok")
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    print("consumer_config_contract_test:")
+    for t in tests:
+        b = len(_F); t()
+        print(f"  {'ok  ' if len(_F) == b else 'FAIL'} {t.__name__}")
+    if _F:
+        print(f"\n{len(_F)} check(s) FAILED", file=sys.stderr)
+        return 1
+    print(f"\nall {len(tests)} tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())

--- a/robot/doctor/modules/config.py
+++ b/robot/doctor/modules/config.py
@@ -24,12 +24,38 @@ def run(ctx):
         return {"details": details}
 
     env = ctx["robot_env"]
-    for key in ("KIRRA_MOTOR_PORT", "KIRRA_EXPECTED_CAR_TYPE"):
-        if env.get(key):
-            details.append(detail(f"{key} set", "PASS", env[key]))
+    # MODE-AWARE. KIRRA_EXPECTED_CAR_TYPE is an X3-ONLY guard (the consumer
+    # reads it only on the X3 path); warning about it in r2_ackermann told the
+    # operator to set a variable that mode ignores. Requirements come from the
+    # one shared contract so the doctor, preflight and installer cannot drift.
+    import sys as _sys
+    _sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(
+        os.path.abspath(__file__)))))
+    try:
+        import consumer_config_contract as contract
+        missing = contract.missing_keys(env)
+        mode = contract.drive_mode(env)
+        details.append(detail("drive mode", "PASS", mode))
+        for key in contract.required_keys(env):
+            if env.get(key):
+                details.append(detail(f"{key} set", "PASS", env[key]))
+        if missing:
+            details.append(detail(
+                "required actuation config", "FAIL",
+                f"{len(missing)} missing for mode {mode}: " + ", ".join(missing),
+                fix="robot/install/preflight_consumer_env.py lists the full set "
+                    "in one run — see robot/install/env.template"))
         else:
-            details.append(detail(f"{key} set", "WARN", "unset",
-                                  fix="see robot/install/env.template"))
+            details.append(detail("required actuation config", "PASS",
+                                  f"complete for mode {mode}"))
+        for key in contract.inapplicable_keys(env):
+            if env.get(key):
+                details.append(detail(f"{key} set", "WARN",
+                                      f"set but not used in mode {mode}",
+                                      fix=f"remove it, or switch modes"))
+    except Exception as e:  # noqa: BLE001 — never crash the doctor
+        details.append(detail("required actuation config", "UNKNOWN",
+                              f"contract unavailable: {e}"))
     placeholders = [k for k, v in env.items() if "__FILLED" in v]
     if placeholders:
         details.append(detail("placeholder values", "FAIL", ", ".join(placeholders),

--- a/robot/doctor/modules/config.py
+++ b/robot/doctor/modules/config.py
@@ -52,7 +52,7 @@ def run(ctx):
             if env.get(key):
                 details.append(detail(f"{key} set", "WARN",
                                       f"set but not used in mode {mode}",
-                                      fix=f"remove it, or switch modes"))
+                                      fix="remove it, or switch drive mode"))
     except Exception as e:  # noqa: BLE001 — never crash the doctor
         details.append(detail("required actuation config", "UNKNOWN",
                               f"contract unavailable: {e}"))

--- a/robot/doctor/modules/devices.py
+++ b/robot/doctor/modules/devices.py
@@ -39,21 +39,46 @@ def run(ctx):
         import sys as _sys
         _sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(
             os.path.abspath(__file__)))))
+        # AUTHORITY, not "is anyone holding it". serial_exclusivity.preflight()
+        # is the CONSUMER'S STARTUP sentinel, where any holder is a violation
+        # because the consumer has not opened the port yet. Reusing it here
+        # inverted the meaning: at diagnostic time the running consumer IS the
+        # holder, so a correctly-owned port reported
+        #   "/dev/myserial is already open in pid <consumer> — FAIL"
+        # i.e. the healthy state read as the failure. motor_authority compares
+        # holders against the unit's MainPID, so sole-consumer is PASS and any
+        # OTHER opener is still strictly FAIL.
         try:
-            import serial_exclusivity
-            violations = serial_exclusivity.preflight(motor)
+            import motor_authority
+            auth = motor_authority.collect(motor)
+            mode_v = []
+            try:
+                import serial_exclusivity
+                st = os.stat(motor)
+                mode_v = serial_exclusivity.mode_violations(
+                    st.st_mode, st.st_uid, os.geteuid(), motor)
+            except Exception:  # noqa: BLE001 — perms are a separate concern
+                pass
         except Exception as e:  # noqa: BLE001 — census must never crash the doctor
-            violations = [f"exclusivity check errored: {e}"]
-        if violations:
+            auth, mode_v = None, [f"authority check errored: {e}"]
+
+        if auth is None:
+            details.append(detail("motor serial exclusivity", "UNKNOWN",
+                                  "; ".join(mode_v)[:200]))
+        elif auth["verdict"] != motor_authority.PASS or mode_v:
+            why = auth["summary"] + ("; " + "; ".join(mode_v) if mode_v else "")
             details.append(detail(
-                "motor serial exclusivity", "FAIL",
-                f"{motor}: " + "; ".join(violations)[:200],
+                "motor serial exclusivity", "FAIL", why[:240],
                 fix="install robot/install/99-kirra-serial-exclusivity.rules "
                     "(owner=<consumer user>, MODE=0600) + udevadm trigger; "
-                    "stop other openers (disable_vendor_autostart.sh)"))
+                    "stop other openers (disable_vendor_autostart.sh --report)"))
         else:
-            details.append(detail("motor serial exclusivity", "PASS",
-                                  f"{motor} (owner+mode 0600, no other holder)"))
+            dev = auth["port"] if auth["port"] == auth["resolved"] \
+                else f"{auth['port']} → {auth['resolved']}"
+            details.append(detail(
+                "motor serial exclusivity", "PASS",
+                f"{dev} held only by {motor_authority.CONSUMER_UNIT} "
+                f"pid={auth['consumer_pid']} (owner+mode 0600)"))
     else:
         details.append(detail("motor serial", "FAIL", f"{motor} missing",
                               fix="check the USB lead + vendor udev rules (capture_from_robot.sh)"))

--- a/robot/install/disable_vendor_autostart.sh
+++ b/robot/install/disable_vendor_autostart.sh
@@ -22,9 +22,20 @@ DISABLE=0
 [[ "${1:-}" == "--disable" ]] && DISABLE=1
 [[ "${1:-}" == "--report" || -z "${1:-}" ]] || { [[ $DISABLE -eq 1 ]] || { echo "usage: $0 [--disable]"; exit 2; }; }
 
-# Vendor signatures — what a Yahboom base autostart looks like. Deliberately does
-# NOT match 'kirra' (our own units must never be caught).
-PAT='rosmaster_main|Rosmaster_Lib|yahboom|Yahboom|ros_robot_controller|handsfree|bringup.*rosmaster|start_ros\.sh'
+# 🔴 MOTOR-BASE signatures. These name PROGRAMS, never a vendor, a workspace or
+# a hostname. The previous pattern included a bare 'yahboom|Yahboom' and, run
+# with --disable on the live R2, it:
+#   * disabled ollama.service          (a Yahboom workspace was on its PATH)
+#   * pkill'd the YDLIDAR driver       (its exe lived under yahboomcar_ros2_ws)
+#   * disabled the OLED display unit
+#   * flagged 'avahi-daemon: running [yahboom.local]' as a motor base
+# None of them ever opened /dev/myserial. Ollama and the lidar had to be
+# restored by hand. A vendor's NAME is evidence of nothing; owning the motor
+# serial device is the invariant, so that is what this script acts on.
+PAT='rosmaster_main|Rosmaster_Lib|ros_robot_controller|yahboomcar_bringup|yahboomcar_base_node'
+# Never act on these, whatever else matches — each is a real thing that lives in
+# or is named after the vendor workspace and is NOT a motor base.
+EXCLUDE='ydlidar|lidar|avahi|ollama|oled|astra|usb_cam|camera|kirra'
 found=0
 acted=0
 
@@ -40,7 +51,14 @@ mapfile -t UNITS < <(
 for u in "${UNITS[@]}"; do
   frag="$(systemctl cat "$u" 2>/dev/null || true)"
   [[ -z "$frag" ]] && continue
-  if grep -qiE "$PAT" <<<"$frag"; then
+  # Match ONLY the ExecStart line — a vendor path in Environment=, PATH=,
+  # WorkingDirectory= or a comment is not a motor base. This is what saved
+  # ollama.service, whose unit merely carried the workspace on PATH.
+  exec_lines="$(grep -iE '^\s*ExecStart' <<<"$frag" || true)"
+  if grep -qiE "$EXCLUDE" <<<"$u $exec_lines"; then
+    continue
+  fi
+  if grep -qiE "$PAT" <<<"$exec_lines"; then
     state="$(systemctl is-enabled "$u" 2>/dev/null || echo '?')"
     active="$(systemctl is-active "$u" 2>/dev/null || echo '?')"
     echo "  ⚠ ${u}  (enabled=${state} active=${active})"
@@ -70,7 +88,7 @@ echo "== 3. rc.local / autostart scripts =="
 r=0
 for f in /etc/rc.local "$HOME/.bashrc" "$HOME/.profile" "$HOME/.config/autostart"/*.desktop; do
   [[ -e "$f" ]] || continue
-  if grep -qiE "$PAT" "$f" 2>/dev/null; then
+  if grep -qiE "$PAT" "$f" 2>/dev/null && ! grep -qiE "$EXCLUDE" "$f" 2>/dev/null; then
     echo "  ⚠ $f references the vendor bringup:"
     grep -niE "$PAT" "$f" | sed 's/^/       /' | head -3
     r=$((r + 1)); found=$((found + 1))
@@ -86,14 +104,28 @@ done
 [[ $r -eq 0 ]] && echo "  (none found)"
 
 # ---- 4. currently-running process (advisory) ------------------------------
-echo "== 4. running now? =="
-if pgrep -af "$PAT" 2>/dev/null | grep -viE 'disable_vendor_autostart|grep'; then
-  echo "  ⚠ a vendor process is running NOW."
-  [[ $DISABLE -eq 1 ]] && { sudo pkill -f "$PAT" 2>/dev/null && echo "  ✔ pkill sent" || true; }
-  echo "  (a running process is separate from the boot autostart above — disable both.)"
+echo "== 4. who actually OWNS the motor port? =="
+# THE authoritative check. A process is a conflict because it holds the
+# configured motor device, not because of what it is called. `pkill -f` on a
+# name is gone: that is the line that killed the lidar.
+AUTH="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/motor_authority.py"
+if [[ -f "$AUTH" ]]; then
+  python3 "$AUTH" "${KIRRA_MOTOR_PORT:-/dev/myserial}" 2>&1 | sed 's/^/  /' || true
 else
-  echo "  (no vendor process running)"
+  echo "  (motor_authority.py not found — run from the repo checkout)"
 fi
+echo
+echo "  Processes matching a motor-base signature (secondary evidence only —"
+echo "  never acted on unless they hold the motor port above):"
+if pgrep -af "$PAT" 2>/dev/null | grep -viE "disable_vendor_autostart|grep|$EXCLUDE"; then
+  echo "  ⚠ review the list above against the port owner."
+else
+  echo "  (none)"
+fi
+echo "  NOTE: this script never kills a process by name. If one of the above"
+echo "  owns the motor port, stop its SERVICE deliberately after reading the"
+echo "  ownership evidence."
+
 
 hr
 if [[ $found -eq 0 ]]; then

--- a/robot/install/preflight_consumer_env.py
+++ b/robot/install/preflight_consumer_env.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""preflight_consumer_env.py — can the motor consumer actually START?
+
+Answers, in ONE run, the question that cost 200+ restarts during R2 bring-up:
+*which required settings are missing?* The consumer discovers them one at a
+time — it reads a value, fails closed, systemd restarts it, it reads the next
+value, fails closed — so learning eight facts took eight restart cycles and the
+real cause was buried in the churn.
+
+This is deliberately NOT the syntax linter. `lint_robot_env.sh` answers "is this
+a valid shell file", which the Rabbit-only env that triggered the loop passed
+cleanly while missing every actuation key. Two different questions; both matter;
+only this one gates starting the service.
+
+    robot/install/preflight_consumer_env.py                  # /etc/kirra/robot.env
+    robot/install/preflight_consumer_env.py path/to/env      # any file
+    robot/install/preflight_consumer_env.py --format=json    # for scripts
+
+Exit 0 iff the file is sufficient for the configured drive mode. Read-only:
+nothing is written, no device is opened, no service is touched — safe to run at
+any time, including before the unit is enabled (which is the point).
+"""
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import consumer_config_contract as contract  # noqa: E402
+
+DEFAULT_ENV = "/etc/kirra/robot.env"
+
+
+def parse_env_file(path: str) -> dict:
+    """Read `KEY=value` / `export KEY=value` lines, honouring shell quoting.
+
+    Tolerant on purpose: a line this cannot parse is skipped rather than fatal,
+    because a partial parse still lets us report the missing keys — and the
+    syntax linter is the tool that owns malformed-file complaints.
+    """
+    env: dict[str, str] = {}
+    with open(path, encoding="utf-8", errors="replace") as f:
+        for raw in f:
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            if line.startswith("export "):
+                line = line[len("export "):].strip()
+            if "=" not in line:
+                continue
+            key, _, value = line.partition("=")
+            key = key.strip()
+            if not key or not key.replace("_", "").isalnum():
+                continue
+            try:
+                parts = shlex.split(value, comments=True)
+                env[key] = parts[0] if parts else ""
+            except ValueError:
+                env[key] = value.strip().strip("\"'")
+    return env
+
+
+def render(path: str, env: dict) -> tuple[str, int]:
+    r = contract.report(env)
+    out = ["== consumer config preflight ==",
+           f"  file: {path}",
+           f"  drive mode: {r['mode']}",
+           f"  required for this mode: {r['required_count']} key(s)"]
+
+    if r["missing"]:
+        out.append("")
+        out.append(f"  ❌ {len(r['missing'])} REQUIRED key(s) missing — the consumer "
+                   "would fail closed on each, one restart at a time:")
+        out += [f"       {k}" for k in r["missing"]]
+        out.append("")
+        out.append("     fix them ALL before starting kirra-consumer.service; see")
+        out.append("     robot/install/rabbit.env.example and env.template.")
+    else:
+        out.append(f"  ✔ every required key is set for mode {r['mode']}")
+
+    if r["present_but_inapplicable"]:
+        out.append("")
+        out.append(f"  ⚠ set but NOT USED in mode {r['mode']} (harmless, but it will "
+                   "mislead the next reader):")
+        for k in r["present_but_inapplicable"]:
+            why = "X3-only" if k in contract.X3_ONLY else \
+                  "needs KIRRA_R2_ODOM_ENABLED=1" if k in contract.ODOM_REQUIRED else \
+                  "needs KIRRA_R2_CLOSED_LOOP=1" if k in contract.CLOSED_LOOP_REQUIRED else \
+                  "belongs to another drive mode"
+            out.append(f"       {k}  ({why})")
+
+    out.append("")
+    out.append("  VERDICT: " + ("READY — the consumer has what it needs to start"
+                                if r["sufficient"] else
+                                "NOT READY — do not enable kirra-consumer.service yet"))
+    return "\n".join(out), (0 if r["sufficient"] else 1)
+
+
+def main(argv: list[str]) -> int:
+    as_json = "--format=json" in argv
+    positional = [a for a in argv if not a.startswith("-")]
+    path = positional[0] if positional else os.environ.get("KIRRA_ROBOT_ENV", DEFAULT_ENV)
+
+    if not os.path.isfile(path) or not os.access(path, os.R_OK):
+        if as_json:
+            print(json.dumps({"file": path, "readable": False, "sufficient": False,
+                              "missing": list(contract.ALWAYS_REQUIRED)}, indent=2))
+        else:
+            print(f"== consumer config preflight ==\n  ❌ {path} is not readable\n"
+                  "     create it — docs/hardware/R2_VOICE_AUDIO_SETUP.md §4")
+        return 1
+
+    env = parse_env_file(path)
+    if as_json:
+        report = contract.report(env)
+        report["file"] = path
+        report["readable"] = True
+        print(json.dumps(report, indent=2))
+        return 0 if report["sufficient"] else 1
+    text, code = render(path, env)
+    print(text)
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/robot/install/preflight_consumer_env_test.py
+++ b/robot/install/preflight_consumer_env_test.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Host tests for the consumer-config preflight entry point.
+
+The regression it exists for: a lint-clean, Rabbit-only /etc/kirra/robot.env
+that the consumer could not start from, and that surfaced ONE missing key per
+restart (200+ restarts to learn eight facts). One command must now report the
+whole set, before the service is enabled.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+SCRIPT = HERE / "preflight_consumer_env.py"
+sys.path.insert(0, str(HERE.parent))
+
+_F: list[str] = []
+
+
+def check(cond, msg):
+    if not cond:
+        _F.append(msg)
+        print(f"  FAIL: {msg}", file=sys.stderr)
+
+
+RABBIT_ONLY = """
+# voice setup copied this in — syntactically valid, actuation-useless
+KIRRA_STT_CMD="whisper-cli -m models/ggml-base.en.bin -np -nt -f"
+KIRRA_TTS_CMD="./speak.sh"
+KIRRA_RECORD_CMD="arecord -d 4 -f S16_LE -r 16000 -c 1"
+KIRRA_RABBIT_MODEL="gemma3:4b"
+"""
+
+LIVE_R2 = """
+KIRRA_GOVERNOR_VK_HEX=abcd
+KIRRA_PROFILE_DIGEST=9c70086efe
+KIRRA_FRESHNESS_WINDOW_MS=200
+KIRRA_CONTROL_PERIOD_MS=100
+KIRRA_MISSED_PERIODS=3
+KIRRA_STOP_DECEL_MPS2=0.5
+KIRRA_DEMO_VX_MAX=0.15
+KIRRA_DEMO_VZ_MAX=0.4
+KIRRA_MOTOR_PORT=/dev/myserial
+KIRRA_DRIVE_MODE=r2_ackermann
+KIRRA_R2_WHEELBASE_M=0.229
+KIRRA_R2_V_PER_PWM=0.0145
+KIRRA_R2_PWM_MAX=40
+KIRRA_R2_STEER_UNITS_PER_RAD=66
+KIRRA_R2_DELTA_MAX_RAD=0.68
+KIRRA_R2_STEER_SIGN=-1
+KIRRA_R2_CENTER_TRIM=90
+export KIRRA_CONSUMER_LIB=/opt/kirra/libkirra_consumer_ffi.so
+"""
+
+
+def _run(text, *args):
+    with tempfile.NamedTemporaryFile("w", suffix=".env", delete=False) as f:
+        f.write(text)
+        path = f.name
+    try:
+        d = subprocess.run([sys.executable, str(SCRIPT), path, *args],
+                           capture_output=True, text=True, timeout=30)
+        return d.returncode, d.stdout
+    finally:
+        Path(path).unlink()
+
+
+def test_rabbit_only_env_is_not_ready_and_lists_every_key_at_once():
+    rc, out = _run(RABBIT_ONLY)
+    check(rc != 0, "a Rabbit-only env must exit non-zero")
+    check("NOT READY" in out, f"and say NOT READY: {out}")
+    for key in ("KIRRA_GOVERNOR_VK_HEX", "KIRRA_FRESHNESS_WINDOW_MS",
+                "KIRRA_CONTROL_PERIOD_MS", "KIRRA_MISSED_PERIODS",
+                "KIRRA_STOP_DECEL_MPS2", "KIRRA_DEMO_VX_MAX", "KIRRA_DEMO_VZ_MAX",
+                "KIRRA_MOTOR_PORT", "KIRRA_CONSUMER_LIB"):
+        check(key in out, f"{key} must appear in the ONE report")
+
+
+def test_live_r2_env_is_ready():
+    rc, out = _run(LIVE_R2)
+    check(rc == 0, f"the live working env must be READY (rc={rc}):\n{out}")
+    check("READY" in out and "NOT READY" not in out, f"verdict: {out}")
+    check("r2_ackermann" in out, "the mode must be reported")
+
+
+def test_r2_marks_expected_car_type_not_applicable():
+    rc, out = _run(LIVE_R2 + "\nKIRRA_EXPECTED_CAR_TYPE=1\n")
+    check(rc == 0, "an X3-only key set in R2 mode is not a failure")
+    check("KIRRA_EXPECTED_CAR_TYPE" in out and "X3-only" in out,
+          f"it must be marked not-applicable, not demanded: {out}")
+    check("REQUIRED key(s) missing" not in out,
+          "and must never appear in the missing list in R2 mode")
+
+
+def test_odom_and_closed_loop_only_required_when_enabled():
+    rc, out = _run(LIVE_R2)
+    check("KIRRA_R2_M_PER_TICK" not in out.split("VERDICT")[0].split("NOT USED")[0],
+          "odom keys must not be demanded while odom is off")
+    rc, out = _run(LIVE_R2 + "\nKIRRA_R2_ODOM_ENABLED=1\n")
+    check(rc != 0 and "KIRRA_R2_M_PER_TICK" in out,
+          f"enabling odom must require its key: {out}")
+    rc, out = _run(LIVE_R2 + "\nKIRRA_R2_CLOSED_LOOP=1\n")
+    check(rc != 0 and "KIRRA_R2_V_PER_PWM_RIGHT" in out,
+          f"enabling closed loop must require its key: {out}")
+
+
+def test_quoting_and_export_are_handled():
+    rc, out = _run(LIVE_R2.replace("KIRRA_MOTOR_PORT=/dev/myserial",
+                                   'export KIRRA_MOTOR_PORT="/dev/myserial"'))
+    check(rc == 0, f"export + quotes must parse: {out}")
+
+
+def test_unreadable_file_fails_closed():
+    d = subprocess.run([sys.executable, str(SCRIPT), "/nope/robot.env"],
+                       capture_output=True, text=True, timeout=30)
+    check(d.returncode != 0, "a missing env file must fail closed")
+    check("not readable" in d.stdout, f"and say so: {d.stdout}")
+
+
+def test_json_form_is_machine_readable():
+    import json
+    rc, out = _run(RABBIT_ONLY, "--format=json")
+    check(rc != 0, "json form keeps the exit code")
+    j = json.loads(out)
+    check(j["sufficient"] is False and len(j["missing"]) >= 9,
+          f"json must carry the whole missing set: {j}")
+
+
+def test_it_is_read_only():
+    """It gates STARTING the service, so it must be safe to run any time."""
+    src = SCRIPT.read_text()
+    for forbidden in ("systemctl", "subprocess", "open(.*'w'", "os.remove", "pkill"):
+        check(forbidden not in src or forbidden == "subprocess",
+              f"the preflight must not {forbidden}")
+    check("subprocess" not in src, "the preflight must spawn nothing")
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    print("preflight_consumer_env_test:")
+    for t in tests:
+        b = len(_F); t()
+        print(f"  {'ok  ' if len(_F) == b else 'FAIL'} {t.__name__}")
+    if _F:
+        print(f"\n{len(_F)} check(s) FAILED", file=sys.stderr)
+        return 1
+    print(f"\nall {len(tests)} tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())

--- a/robot/motor_authority.py
+++ b/robot/motor_authority.py
@@ -35,7 +35,6 @@ robot, no serial port and no systemd. Only `collect()` touches the system.
 from __future__ import annotations
 
 import os
-import re
 import subprocess
 
 # Verdicts. PASS/FAIL follow the doctor's vocabulary; UNKNOWN is used only when

--- a/robot/motor_authority.py
+++ b/robot/motor_authority.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""motor_authority.py — who actually owns the motor serial port?
+
+**The invariant is serial authority, not vendor branding.**
+
+The ADR-0033 chokepoint says exactly one process may hold the configured motor
+device. Everything downstream of that — the release-token verify, TIOCEXCL, the
+0600 udev rule — assumes it. So the question a diagnostic must answer is
+"*which PIDs hold this device, and is the consumer the only one?*"
+
+It is NOT "does any process anywhere have a vendor name in its path?" That
+question produced four live false positives during R2 bring-up, and acting on
+them did real damage:
+
+| Matched | What it actually was | Damage |
+|---|---|---|
+| `yahboom` in `PATH` | `ollama.service` | **disabled** — had to be restored by hand |
+| `yahboomcar_ros2_ws` in exe path | the YDLIDAR driver | **killed** — lidar down |
+| `yahboom` in the unit | the OLED display service | **disabled** |
+| `avahi-daemon: running [yahboom.local]` | the mDNS hostname | reported as a motor base |
+
+None of them had `/dev/myserial` open. A lidar in a vendor-named workspace is a
+lidar. A hostname is a string. The vendor's *name* is evidence of nothing.
+
+So: resolve the configured port through its symlinks, find the PIDs actually
+holding that device, and compare against the consumer's systemd MainPID. Vendor
+name matching survives only as SECONDARY evidence for *dormant* autostart units
+(a unit that is enabled but not running holds no fd to inspect) — and it may
+never, on its own, justify stopping or disabling anything.
+
+Pure where it matters: `classify`, `verdict_for` and the parsing helpers take
+injected data and do no I/O, so every state below is host-testable with no
+robot, no serial port and no systemd. Only `collect()` touches the system.
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+
+# Verdicts. PASS/FAIL follow the doctor's vocabulary; UNKNOWN is used only when
+# the evidence is genuinely unavailable, never to soften a real conflict.
+PASS = "PASS"
+FAIL = "FAIL"
+UNKNOWN = "UNKNOWN"
+
+CONSUMER_UNIT = "kirra-consumer.service"
+DEFAULT_MOTOR_PORT = "/dev/myserial"
+
+# Executables/commands that ARE a Rosmaster motor base. Deliberately narrow:
+# every entry names a motor-base program, not a vendor, a workspace or a host.
+# Used only as secondary evidence for dormant units — never to kill a process
+# that does not hold the motor device.
+MOTOR_BASE_SIGNATURES = (
+    "rosmaster_main",          # the vendor bringup node
+    "Rosmaster_Lib",           # the vendor driver library entry point
+    "ros_robot_controller",    # the alternate vendor base node
+    "yahboomcar_bringup",      # the base bringup package (NOT the workspace name)
+    "yahboomcar_base_node",
+)
+
+# Things that live in a vendor workspace, or carry the vendor's name, and are
+# NOT a motor base. Present so the intent is executable, not just documented.
+NOT_A_MOTOR_BASE = (
+    "ydlidar",       # a sensor
+    "avahi-daemon",  # the mDNS hostname yahboom.local
+    "ollama",        # an unrelated service that merely had the ws on PATH
+    "oled",          # the display
+    "astra",         # the camera
+    "usb_cam",
+)
+
+
+def resolve_device(path: str) -> str:
+    """Follow `/dev/myserial → /dev/ttyUSB1` so the symlink and the underlying
+    tty compare equal. A dangling/absent link returns the path unchanged — the
+    caller reports "missing", which is a different failure from "contended"."""
+    try:
+        return os.path.realpath(path)
+    except OSError:
+        return path
+
+
+def parse_mainpid(show_output: str) -> int | None:
+    """MainPID from `systemctl show -p MainPID -p ActiveState`. 0 means the
+    unit is not running, which is not the same as "no such unit"."""
+    for line in (show_output or "").splitlines():
+        if line.startswith("MainPID="):
+            try:
+                pid = int(line.split("=", 1)[1].strip())
+            except ValueError:
+                return None
+            return pid or None
+    return None
+
+
+def parse_active_state(show_output: str) -> str:
+    for line in (show_output or "").splitlines():
+        if line.startswith("ActiveState="):
+            return line.split("=", 1)[1].strip()
+    return "unknown"
+
+
+def parse_lsof_pids(lsof_output: str) -> list[int]:
+    """PIDs from `lsof -t <dev>` (one per line). Tolerates blank/garbage lines
+    so a partial read never invents a holder."""
+    pids = []
+    for line in (lsof_output or "").splitlines():
+        line = line.strip()
+        if line.isdigit():
+            pids.append(int(line))
+    return pids
+
+
+def is_motor_base(exe: str, cmdline: str) -> bool:
+    """Does this process look like a Rosmaster MOTOR BASE?
+
+    Requires a signature from `MOTOR_BASE_SIGNATURES` — a program name, not a
+    directory. An explicit exclusion list wins first, so a lidar node whose exe
+    lives under `~/yahboomcar_ros2_ws` can never match on the path alone.
+    """
+    hay = f"{exe} {cmdline}"
+    low = hay.lower()
+    if any(x in low for x in NOT_A_MOTOR_BASE):
+        return False
+    return any(sig.lower() in low for sig in MOTOR_BASE_SIGNATURES)
+
+
+class Holder:
+    """One process holding the motor device."""
+
+    def __init__(self, pid: int, exe: str = "", cmdline: str = "", comm: str = ""):
+        self.pid = pid
+        self.exe = exe
+        self.cmdline = cmdline
+        self.comm = comm
+
+    def label(self) -> str:
+        return self.comm or os.path.basename(self.exe) or self.cmdline[:40] or f"pid {self.pid}"
+
+    def __repr__(self):
+        return f"Holder(pid={self.pid}, exe={self.exe!r})"
+
+
+def classify(holders, consumer_pid, consumer_active):
+    """The whole decision, as pure data → (verdict, summary, evidence lines).
+
+    | holders | consumer | verdict |
+    |---|---|---|
+    | exactly the consumer pid | active | PASS — sole opener |
+    | consumer + others | active | FAIL — contended |
+    | others only | active | FAIL — consumer does not own its port |
+    | others only | inactive | FAIL — something else owns the actuation boundary |
+    | none | inactive | PASS (reported) — nothing owns it, nothing claims to |
+    | none | active | FAIL — the consumer claims active but holds no fd |
+    """
+    others = [h for h in holders if h.pid != consumer_pid]
+    has_consumer = consumer_pid is not None and any(h.pid == consumer_pid for h in holders)
+    ev = [f"holder pid={h.pid} ({h.label()}) exe={h.exe or '?'}" for h in holders] or ["no holders"]
+
+    if not holders:
+        if consumer_active:
+            return (FAIL,
+                    f"{CONSUMER_UNIT} is active (pid {consumer_pid}) but holds no handle "
+                    "on the motor port — it is not the writer it claims to be",
+                    ev)
+        return (PASS, "no process holds the motor port and the consumer is not active", ev)
+
+    if has_consumer and not others:
+        return (PASS,
+                f"held only by {CONSUMER_UNIT} pid={consumer_pid}",
+                ev)
+
+    if has_consumer and others:
+        names = ", ".join(f"pid {h.pid} ({h.label()})" for h in others)
+        return (FAIL,
+                f"{CONSUMER_UNIT} pid={consumer_pid} shares the motor port with {names} "
+                "— the single-writer chokepoint is broken",
+                ev)
+
+    names = ", ".join(f"pid {h.pid} ({h.label()})" for h in others)
+    return (FAIL,
+            f"the motor port is held by {names} and NOT by {CONSUMER_UNIT}"
+            + (f" (pid {consumer_pid})" if consumer_pid else " (not running)"),
+            ev)
+
+
+def verdict_for(port, resolved, holders, consumer_pid, consumer_active, exists=True):
+    """`classify` plus the device-missing case, as one dict a caller renders."""
+    if not exists:
+        return {"verdict": FAIL, "port": port, "resolved": resolved,
+                "summary": f"{port} does not exist", "evidence": [],
+                "holders": [], "consumer_pid": consumer_pid,
+                "consumer_active": consumer_active}
+    v, summary, ev = classify(holders, consumer_pid, consumer_active)
+    return {"verdict": v, "port": port, "resolved": resolved, "summary": summary,
+            "evidence": ev, "holders": list(holders), "consumer_pid": consumer_pid,
+            "consumer_active": consumer_active}
+
+
+# ── system probes (the only I/O in this module) ──────────────────────────────
+
+def _read(path: str) -> str:
+    try:
+        with open(path, encoding="utf-8", errors="replace") as f:
+            return f.read()
+    except OSError:
+        return ""
+
+
+def proc_exe(pid: int) -> str:
+    try:
+        return os.readlink(f"/proc/{pid}/exe")
+    except OSError:
+        return ""
+
+
+def proc_cmdline(pid: int) -> str:
+    return _read(f"/proc/{pid}/cmdline").replace("\0", " ").strip()
+
+
+def proc_comm(pid: int) -> str:
+    return _read(f"/proc/{pid}/comm").strip()
+
+
+def find_holder_pids(resolved: str) -> list[int]:
+    """PIDs holding `resolved`, from /proc/<pid>/fd. Same-uid visibility only,
+    which is what the consumer's own sentinel already relies on; `lsof` is used
+    as a fallback when available because it can see other uids."""
+    pids = []
+    for entry in os.listdir("/proc"):
+        if not entry.isdigit():
+            continue
+        pid = int(entry)
+        fd_dir = f"/proc/{pid}/fd"
+        try:
+            fds = os.listdir(fd_dir)
+        except OSError:
+            continue
+        for fd in fds:
+            try:
+                if os.path.realpath(os.path.join(fd_dir, fd)) == resolved:
+                    pids.append(pid)
+                    break
+            except OSError:
+                continue
+    try:
+        out = subprocess.run(["lsof", "-t", resolved], capture_output=True,
+                             text=True, timeout=5).stdout
+        for pid in parse_lsof_pids(out):
+            if pid not in pids:
+                pids.append(pid)
+    except Exception:  # noqa: BLE001 — lsof absent/denied is fine, /proc stands
+        pass
+    return sorted(pids)
+
+
+def consumer_state(unit: str = CONSUMER_UNIT):
+    """(MainPID|None, ActiveState) for the consumer unit."""
+    try:
+        out = subprocess.run(
+            ["systemctl", "show", unit, "-p", "MainPID", "-p", "ActiveState"],
+            capture_output=True, text=True, timeout=5).stdout
+    except Exception:  # noqa: BLE001 — no systemd (container/CI)
+        return None, "unknown"
+    return parse_mainpid(out), parse_active_state(out)
+
+
+def collect(port: str | None = None, unit: str = CONSUMER_UNIT) -> dict:
+    """The live authority answer for `port` (default `KIRRA_MOTOR_PORT`)."""
+    port = port or os.environ.get("KIRRA_MOTOR_PORT") or DEFAULT_MOTOR_PORT
+    resolved = resolve_device(port)
+    exists = os.path.exists(port)
+    pid, state = consumer_state(unit)
+    active = state == "active"
+    holders = []
+    if exists:
+        holders = [Holder(p, proc_exe(p), proc_cmdline(p), proc_comm(p))
+                   for p in find_holder_pids(resolved)]
+    return verdict_for(port, resolved, holders, pid, active, exists)
+
+
+def render(result: dict) -> list[str]:
+    """Operator-facing lines: what was checked, what holds it, what follows."""
+    port, resolved = result["port"], result["resolved"]
+    dev = port if port == resolved else f"{port} → {resolved}"
+    lines = [f"motor port: {dev}",
+             f"consumer:   {CONSUMER_UNIT} "
+             f"{'active' if result['consumer_active'] else 'not active'}"
+             + (f" (MainPID {result['consumer_pid']})" if result["consumer_pid"] else ""),
+             f"verdict:    {result['verdict']} — {result['summary']}"]
+    lines += [f"  · {e}" for e in result["evidence"]]
+    return lines
+
+
+if __name__ == "__main__":
+    import sys
+    r = collect(sys.argv[1] if len(sys.argv) > 1 else None)
+    print("\n".join(render(r)))
+    raise SystemExit(0 if r["verdict"] == PASS else 1)

--- a/robot/motor_authority_test.py
+++ b/robot/motor_authority_test.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Host tests for serial-authority detection (`motor_authority.py`).
+
+Every case below is a real state observed or reachable on the live R2, driven
+through the PURE decision functions with injected data — no serial port, no
+systemd, no /proc, no robot.
+
+The ten required states plus the four live false positives that motivated the
+rewrite. Cases 7-10 are the important ones: each is a process that the OLD
+name-based matcher flagged as a vendor motor base and that the new logic must
+ignore, because none of them holds the motor device.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from motor_authority import (  # noqa: E402
+    FAIL, MOTOR_BASE_SIGNATURES, PASS, Holder, classify, is_motor_base,
+    parse_active_state, parse_lsof_pids, parse_mainpid, resolve_device,
+    verdict_for,
+)
+
+_FAILURES: list[str] = []
+
+
+def check(cond, msg):
+    if not cond:
+        _FAILURES.append(msg)
+        print(f"  FAIL: {msg}", file=sys.stderr)
+
+
+CONSUMER = 4242
+VENDOR = 9001
+
+
+def _consumer(pid=CONSUMER):
+    return Holder(pid, "/usr/bin/python3",
+                  "python3 /opt/kirra/robot/kirra_motor_consumer.py", "python3")
+
+
+def _vendor(pid=VENDOR):
+    return Holder(pid, "/usr/bin/python3",
+                  "python3 /home/jetson/yahboomcar_ros2_ws/rosmaster_main.py", "python3")
+
+
+# ── the ten required states ──────────────────────────────────────────────────
+
+def test_1_consumer_is_sole_opener_passes():
+    v, summary, _ = classify([_consumer()], CONSUMER, True)
+    check(v == PASS, f"sole consumer must PASS, got {v}: {summary}")
+    check(str(CONSUMER) in summary, f"the summary must name the pid: {summary}")
+
+
+def test_2_consumer_plus_vendor_both_open_fails():
+    v, summary, ev = classify([_consumer(), _vendor()], CONSUMER, True)
+    check(v == FAIL, f"a shared port must FAIL, got {v}")
+    check(str(VENDOR) in summary, f"the summary must name the intruder: {summary}")
+    check(any(str(VENDOR) in e for e in ev), "the evidence must list the intruder")
+
+
+def test_3_vendor_is_sole_opener_fails():
+    v, summary, _ = classify([_vendor()], CONSUMER, True)
+    check(v == FAIL, f"vendor-only must FAIL, got {v}")
+    check("NOT" in summary or "not" in summary,
+          f"the summary must say the consumer does not hold it: {summary}")
+
+
+def test_4_no_opener_and_consumer_inactive_is_reported_pass():
+    v, summary, _ = classify([], None, False)
+    check(v == PASS, f"nothing running, nothing held → PASS, got {v}")
+    check("not active" in summary, f"and it must SAY so: {summary}")
+
+
+def test_5_no_opener_while_consumer_claims_active_fails():
+    """The dangerous silent state: systemd says active, but the process holds
+    no fd — so the chokepoint everyone assumes is simply not there."""
+    v, summary, _ = classify([], CONSUMER, True)
+    check(v == FAIL, f"active-but-holding-nothing must FAIL, got {v}")
+    check("holds no handle" in summary, f"and be actionable: {summary}")
+
+
+def test_6_symlink_and_underlying_tty_resolve_to_one_device(tmp=None):
+    import os
+    import tempfile
+    with tempfile.TemporaryDirectory() as d:
+        tty = os.path.join(d, "ttyUSB1")
+        link = os.path.join(d, "myserial")
+        open(tty, "w").close()
+        os.symlink(tty, link)
+        check(resolve_device(link) == resolve_device(tty),
+              "the symlink and its target must resolve equal")
+        check(resolve_device(link) == os.path.realpath(tty), "resolve to the real tty")
+
+
+def test_7_lidar_in_a_vendor_workspace_is_ignored():
+    """The live kill. The YDLIDAR driver lives under ~/yahboomcar_ros2_ws and
+    was killed by the old matcher. It is a SENSOR."""
+    exe = "/home/jetson/yahboomcar_ros2_ws/install/ydlidar_ros2_driver/lib/ydlidar_ros2_driver_node"
+    check(not is_motor_base(exe, "ydlidar_ros2_driver_node --ros-args"),
+          "a lidar in a vendor workspace must NOT be a motor base")
+
+
+def test_8_avahi_hostname_is_ignored():
+    """`avahi-daemon: running [yahboom.local]` — a hostname, not a process."""
+    check(not is_motor_base("/usr/sbin/avahi-daemon",
+                            "avahi-daemon: running [yahboom.local]"),
+          "the mDNS hostname must NOT be a motor base")
+
+
+def test_9_ollama_with_a_vendor_path_is_ignored():
+    """The live disable. ollama.service merely had the workspace on PATH."""
+    check(not is_motor_base("/usr/local/bin/ollama", "ollama serve"),
+          "ollama must NOT be a motor base")
+    check(not is_motor_base(
+        "/usr/local/bin/ollama",
+        "PATH=/home/jetson/yahboomcar_ros2_ws/install/bin:/usr/bin ollama serve"),
+        "a vendor workspace on PATH must NOT make ollama a motor base")
+
+
+def test_10_oled_service_is_ignored():
+    check(not is_motor_base("/home/jetson/yahboomcar_ros2_ws/oled_node",
+                            "python3 oled_display.py"),
+          "the OLED display must NOT be a motor base")
+
+
+# ── the positive control: a real motor base IS still recognised ──────────────
+
+def test_a_real_rosmaster_base_is_still_recognised():
+    check(is_motor_base("/usr/bin/python3",
+                        "python3 /home/jetson/yahboomcar_ros2_ws/rosmaster_main.py"),
+          "rosmaster_main.py must still match")
+    check(is_motor_base("/usr/bin/python3", "python3 -m Rosmaster_Lib.driver"),
+          "Rosmaster_Lib must still match")
+    check(is_motor_base("/opt/ros/humble/lib/ros_robot_controller/node", "ros_robot_controller"),
+          "ros_robot_controller must still match")
+
+
+def test_every_signature_names_a_program_not_a_vendor_or_workspace():
+    """The rule that keeps this from regressing: a bare vendor name is not a
+    signature. `yahboom` alone matched a hostname, a lidar, an OLED and a PATH."""
+    for sig in MOTOR_BASE_SIGNATURES:
+        check(sig.lower() not in ("yahboom", "yahboomcar", "rosmaster"),
+              f"{sig!r} is a vendor/workspace name, not a program — too broad")
+        check(len(sig) >= 8, f"{sig!r} is short enough to match incidentally")
+
+
+def test_non_vacuity_the_old_broad_pattern_would_have_matched_all_four():
+    """Proof the new logic actually changed something: the OLD pattern matches
+    every one of the four live false positives; the NEW one matches none."""
+    import re
+    old = re.compile(
+        r"rosmaster_main|Rosmaster_Lib|yahboom|Yahboom|ros_robot_controller"
+        r"|handsfree|bringup.*rosmaster|start_ros\.sh")
+    live_false_positives = [
+        ("/usr/local/bin/ollama",
+         "PATH=/home/jetson/yahboomcar_ros2_ws/install/bin ollama serve"),
+        ("/home/jetson/yahboomcar_ros2_ws/install/ydlidar_ros2_driver/lib/ydlidar_ros2_driver_node",
+         "ydlidar_ros2_driver_node --ros-args"),
+        ("/home/jetson/yahboomcar_ros2_ws/oled_node", "python3 oled_display.py"),
+        ("/usr/sbin/avahi-daemon", "avahi-daemon: running [yahboom.local]"),
+    ]
+    for exe, cmd in live_false_positives:
+        check(bool(old.search(f"{exe} {cmd}")),
+              f"the OLD pattern should have matched (non-vacuity): {exe}")
+        check(not is_motor_base(exe, cmd),
+              f"the NEW check must NOT match: {exe}")
+
+
+# ── systemd / lsof parsing ───────────────────────────────────────────────────
+
+def test_mainpid_and_active_state_parse():
+    out = "MainPID=4242\nActiveState=active\n"
+    check(parse_mainpid(out) == 4242, "MainPID must parse")
+    check(parse_active_state(out) == "active", "ActiveState must parse")
+    check(parse_mainpid("MainPID=0\nActiveState=inactive\n") is None,
+          "MainPID=0 means not running → None, not pid 0")
+    check(parse_active_state("MainPID=0\nActiveState=inactive\n") == "inactive", "inactive")
+    check(parse_mainpid("") is None, "empty output → None, not a crash")
+    check(parse_mainpid("MainPID=garbage\n") is None, "garbage → None")
+
+
+def test_lsof_pid_parsing_is_tolerant():
+    check(parse_lsof_pids("4242\n9001\n") == [4242, 9001], "two pids")
+    check(parse_lsof_pids("") == [], "no output → no holders")
+    check(parse_lsof_pids("lsof: WARNING\n4242\n") == [4242],
+          "a warning line must not invent a holder")
+
+
+# ── the rendered result ──────────────────────────────────────────────────────
+
+def test_missing_device_is_its_own_failure():
+    r = verdict_for("/dev/myserial", "/dev/myserial", [], CONSUMER, True, exists=False)
+    check(r["verdict"] == FAIL, "a missing device must FAIL")
+    check("does not exist" in r["summary"], f"and say why: {r['summary']}")
+
+
+def test_verdict_carries_the_evidence_a_operator_needs():
+    r = verdict_for("/dev/myserial", "/dev/ttyUSB1", [_consumer()], CONSUMER, True)
+    check(r["verdict"] == PASS, "the live good state must PASS")
+    check(r["resolved"] == "/dev/ttyUSB1", "the resolved device must be carried")
+    check(r["consumer_pid"] == CONSUMER, "the consumer pid must be carried")
+    check(any("4242" in e for e in r["evidence"]), "evidence must name the holder")
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items())
+             if k.startswith("test_") and callable(v)]
+    print("motor_authority_test:")
+    for t in tests:
+        before = len(_FAILURES)
+        t()
+        print(f"  {'ok  ' if len(_FAILURES) == before else 'FAIL'} {t.__name__}")
+    if _FAILURES:
+        print(f"\n{len(_FAILURES)} check(s) FAILED", file=sys.stderr)
+        return 1
+    print(f"\nall {len(tests)} tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
**Stack 1 of 2. Merge this first.** #(Branch 2) is stacked on this branch.

## The live incidents this prevents

R2 bring-up produced four diagnostics failures. Two of them did real damage when acted on:

| Incident | Cause | Damage |
|---|---|---|
| **`ollama.service` disabled** | its unit carried a Yahboom workspace on `PATH` | restored by hand |
| **YDLIDAR driver killed** | its exe lived under `~/yahboomcar_ros2_ws` | lidar down, restored by hand |
| **OLED unit disabled** | vendor-named | — |
| **Avahi flagged as a motor base** | `avahi-daemon: running [yahboom.local]` — a *hostname* | — |
| **The intended consumer reported as a conflict** | `/dev/myserial is already open in pid <kirra-consumer>` | the healthy state read as `FAIL` |
| **`KIRRA_EXPECTED_CAR_TYPE` warned in R2 mode** | X3-only key checked unconditionally | operator told to set a variable that mode ignores |

None of the four processes had `/dev/myserial` open.

## Root causes, exactly

1. `PAT='...|yahboom|Yahboom|...'` was matched against the **whole `systemctl cat` output**, so a vendor path in `Environment=`/`PATH=`/`WorkingDirectory=`/a comment triggered `sudo systemctl disable --now`. And `sudo pkill -f "$PAT"` killed by executable path — that is the line that killed the lidar.
2. `cold_boot_drill.sh` used `pgrep -af '...|yahboom'`, which matched the Avahi hostname string and the lidar.
3. `devices.py` called `serial_exclusivity.preflight()` — the **consumer's startup sentinel**, where *any* holder is a violation because the consumer has not opened the port yet. At diagnostic time the running consumer *is* the holder.
4. `config.py` warned on `KIRRA_EXPECTED_CAR_TYPE` regardless of mode.

## Authority-based ownership replaces vendor-name matching

**The invariant is serial authority, not vendor branding.** New `robot/motor_authority.py` resolves the configured port through its symlinks (`/dev/myserial → /dev/ttyUSB1`), finds the PIDs actually holding that device via `/proc/*/fd` + `lsof`, and compares against `kirra-consumer.service`'s systemd **MainPID**.

| holders | consumer | verdict |
|---|---|---|
| exactly the consumer pid | active | **PASS** — sole opener |
| consumer + others | active | FAIL — chokepoint broken |
| others only | any | FAIL |
| none | inactive | PASS (reported) |
| none | **active** | FAIL — claims active, holds no fd |

That last row is the silent state worth naming: systemd says active, but the chokepoint everyone assumes is simply not there.

Name matching survives **only** as secondary evidence for *dormant* autostart units, and can never alone justify stopping or disabling anything. `disable_vendor_autostart.sh` now matches program names (`rosmaster_main`, `Rosmaster_Lib`, `ros_robot_controller`, `yahboomcar_bringup`/`_base_node`) **against `ExecStart` only**, with an explicit exclusion list winning first. **`pkill -f` on a name is removed outright** — zero live kill paths remain.

## Full mode-aware consumer config preflight

New `robot/consumer_config_contract.py` is the single definition the doctor, preflight and installer share, so they cannot drift. `KIRRA_EXPECTED_CAR_TYPE` is **X3-only**; R2 requires the measured calibration profile; odometry and closed-loop keys are required **only** when `KIRRA_R2_ODOM_ENABLED=1` / `KIRRA_R2_CLOSED_LOOP=1`.

New `robot/install/preflight_consumer_env.py` reports **every** missing key in one run:

```
$ robot/install/preflight_consumer_env.py rabbit_only.env
  ❌ 11 REQUIRED key(s) missing — the consumer would fail closed on each,
     one restart at a time:
       KIRRA_GOVERNOR_VK_HEX · KIRRA_PROFILE_DIGEST · KIRRA_FRESHNESS_WINDOW_MS
       KIRRA_CONTROL_PERIOD_MS · KIRRA_MISSED_PERIODS · KIRRA_STOP_DECEL_MPS2
       KIRRA_DEMO_VX_MAX · KIRRA_DEMO_VZ_MAX · KIRRA_MOTOR_PORT
       KIRRA_CONSUMER_LIB · KIRRA_EXPECTED_CAR_TYPE
  VERDICT: NOT READY — do not enable kirra-consumer.service yet
```

This is deliberately **not** the syntax linter: `lint_robot_env.sh` answers "is this a valid shell file", which the Rabbit-only env that caused the restart loop passed cleanly while missing every actuation key.

## Roadmap

`firmware/rosmaster-r2/docs/ROADMAP.md` extended in place — **no competing architecture document**. R2CP v1, the 11-phase roadmap and `ARCHITECTURE.md` already exist and are coherent. What was missing was a statement of where the robot *is*, separating current / near-term bridge / final Kirra-owned state, and making explicit that **Kirra currently owns authorization and sole-writer enforcement, but not yet the authenticated MCU link** — so `TIOCEXCL` is not read as stronger security than it is.

## Changed files

| File | Change |
|---|---|
| `robot/motor_authority.py` | new — authority detection, pure decision core |
| `robot/consumer_config_contract.py` | new — the one shared requirement definition |
| `robot/install/preflight_consumer_env.py` | new — whole-set preflight |
| `robot/install/disable_vendor_autostart.sh` | ExecStart-only matching, exclusions, no `pkill` |
| `robot/cold_boot_drill.sh` | authority check; vendor-named processes listed as ignored |
| `robot/doctor/modules/devices.py` | MainPID-aware exclusivity |
| `robot/doctor/modules/config.py` | mode-aware requirements via the contract |
| `firmware/rosmaster-r2/docs/ROADMAP.md` | deployment-reality section |
| `.github/workflows/ci.yml` | registers all three new test files |

## Tests — 32 new

`motor_authority_test.py` (17), `consumer_config_contract_test.py` (7), `preflight_consumer_env_test.py` (8). All 25 robot suites pass.

**Non-vacuity:**

```
victim                              OLD  NEW
ollama.service                      ACT  --
ydlidar node (yahboomcar_ros2_ws)   ACT  --
OLED service                        ACT  --
avahi-daemon [yahboom.local]        ACT  --
positive control: rosmaster_main    ACT  ACT
live pkill paths remaining: 0
```

`compileall` · `bash -n` · `ruff` (touched files) · `ci.yml` · `git diff --check` clean. **shellcheck is not installed in this environment** — shell files checked with `bash -n` only.

## Live verification (wheels raised, all read-only)

```bash
robot/install/preflight_consumer_env.py                 # → READY
python3 robot/motor_authority.py /dev/myserial          # → PASS, sole opener
python3 robot/kirra_doctor.py --module config --module devices
bash robot/cold_boot_drill.sh                           # lidar/avahi ignored
bash robot/install/disable_vendor_autostart.sh --report # no confirmed conflict
systemctl is-active ollama kirra-lidar kirra-consumer   # all active
```

Nothing above starts, stops or kills anything.

## Remaining work

Before Yahboom motor-controller removal: the **Jetson-side R2CP bridge** (no `R2CP` reference exists outside `firmware/`), a **PTY-simulated MCU**, the consumer's R2CP drive mode, then **HIL**. Before safe floor driving: **odometry** and **closed-loop** wheel matching remain deliberately disabled pending validation, and the live `KIRRA_GOVERNOR_VK_HEX` is a bench/dev key.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjDFKPcBVHURDZpXsvnYhC)_