### PR TITLE
fix(deploy): verify installed Kirra artifact compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1386,6 +1386,17 @@ jobs:
           # surfaced one missing value per restart — 200+ restarts to learn eight
           # facts. Lint answers "valid shell file"; this answers "can it start".
           python3 robot/install/preflight_consumer_env_test.py
+          # Deployment verification + env migration. The live R2 ran STALE
+          # /opt/kirra artifacts against a newer checkout and everything looked
+          # fine: units active, /health "ok", consumer started — the installed
+          # taj_service was simply an older build with no frame_id. These pin the
+          # three-state contract classification (unavailable / current / LEGACY,
+          # where "healthy but old" is its own state), that the FFI is dlopen'd
+          # explicitly rather than inferred from a successful startup, that both
+          # tools are read-only (ast-checked, so a `fix=` hint that mentions sudo
+          # is not mistaken for running it), and that the migration report never
+          # prints the governor verifying key.
+          python3 robot/install/deployment_verify_test.py
           # Turn-state re-arm gate (Slice R, pure, no audio): the cross-process
           # "turn in progress" signal (fail-safe parse, active/done round-trip,
           # seq monotonicity) and the bounded rearm_decision that fixes the wake

--- a/crates/kirra-sidecars/src/bin/taj_service.rs
+++ b/crates/kirra-sidecars/src/bin/taj_service.rs
@@ -5,13 +5,15 @@
 //! perception.
 //!
 //!   POST /perception  → {"healthy":..,"speed_cap_mps":..,"left":..,...}
-//!   GET  /health      → {"status":"ok"}
+//!   GET  /health      → {"status":"ok","service":"taj","contract":N}
+//!   GET  /capabilities → {"service":"taj","contract":N,"capabilities":[…]}
 //!
 //! Config: `KIRRA_TAJ_ADDR` (default 127.0.0.1:8101);
 //! `KIRRA_SIDECAR_ALLOW_NONLOCAL=1` to permit a routable bind.
 
 use std::net::{TcpListener, TcpStream};
 
+use kirra_sidecars::capabilities::Capabilities;
 use kirra_sidecars::http::{read_request, respond, respond_error};
 use kirra_sidecars::net::{allow_nonlocal_from_env, enforce_bind_policy};
 use kirra_sidecars::taj::{handle_perception_tracked, PerceptionRequest, TrackedPerceptionState};
@@ -22,7 +24,22 @@ fn serve(mut stream: TcpStream, perception_state: &mut TrackedPerceptionState) {
         Err(status) => return respond_error(&mut stream, status),
     };
     match (req.method.as_str(), req.path.as_str()) {
-        ("GET", "/health") => respond(&mut stream, "200 OK", "{\"status\":\"ok\"}"),
+        // Liveness AND capability in one place: a stale binary is ALIVE, so
+        // {"status":"ok"} alone can never distinguish current from legacy —
+        // which is exactly how an installed pre-frame_id taj_service read as
+        // healthy during R2 bring-up.
+        ("GET", "/health") => {
+            let caps = Capabilities::taj();
+            respond(
+                &mut stream,
+                "200 OK",
+                &format!(
+                    "{{\"status\":\"ok\",\"service\":\"taj\",\"contract\":{}}}",
+                    caps.contract
+                ),
+            )
+        }
+        ("GET", "/capabilities") => respond(&mut stream, "200 OK", &Capabilities::taj().to_json()),
         ("POST", "/perception") => match serde_json::from_slice::<PerceptionRequest>(&req.body) {
             Ok(p) => respond(
                 &mut stream,

--- a/crates/kirra-sidecars/src/capabilities.rs
+++ b/crates/kirra-sidecars/src/capabilities.rs
@@ -1,0 +1,211 @@
+//! Sidecar capability advertisement — "healthy" is not "compatible".
+//!
+//! During R2 bring-up the installed `/opt/kirra/taj_service` answered
+//! `GET /health` with `{"status":"ok"}` while returning the LEGACY perception
+//! shape: no `frame_id`, so no `profile_digest` and no `evidence_digest`. The
+//! diagnostics read the 200 and reported Taj healthy. It was healthy — and
+//! incompatible with the checked-out consumer, which needs the evidence-bound
+//! V2 chain. The operator lost time to a service that was working perfectly at
+//! answering the wrong question.
+//!
+//! A liveness probe cannot detect a stale binary, because a stale binary is
+//! alive. So every separately-installed Kirra artifact advertises WHAT IT CAN
+//! DO, not merely that it is up:
+//!
+//! ```text
+//! GET /capabilities → {"service":"taj","contract":2,"capabilities":["perception.v2",…],
+//!                      "pkg_version":"…","git_describe":"…"}
+//! ```
+//!
+//! `contract` is the load-bearing field: a single integer the consumer and the
+//! doctor compare against what they require. It changes ONLY when the wire
+//! contract changes, so it is meaningful across rebuilds in a way a version
+//! string is not.
+//!
+//! Deliberately NOT `strings` on the binary — the task called that out and it
+//! is right: it reads bytes that were never a promise, and it cannot
+//! distinguish "this symbol exists" from "this code path is reachable".
+
+use serde::{Deserialize, Serialize};
+
+/// The perception wire contract this build speaks.
+///
+/// * `1` — legacy: `{"healthy","speed_cap_mps","left",…}`, no `frame_id`.
+/// * `2` — evidence-bound: adds `frame_id{profile_digest,evidence_digest}`,
+///   which is what binds a perception frame to the profile that produced it.
+///
+/// BUMP ONLY on a wire-contract change. A version bump that does not change
+/// what a peer must understand must NOT touch this, or it becomes noise and
+/// gets ignored — which is how the legacy binary survived in the first place.
+pub const TAJ_CONTRACT: u32 = 2;
+
+/// The minimum Taj contract a current consumer/doctor can work with.
+pub const TAJ_MIN_SUPPORTED_CONTRACT: u32 = 2;
+
+/// Capability tokens. Additive and never renamed: a peer matches on presence,
+/// so removing one is a breaking change and reusing one for a different meaning
+/// is worse.
+pub const CAP_PERCEPTION_V2: &str = "perception.v2";
+pub const CAP_FRAME_ID: &str = "frame_id";
+pub const CAP_EVIDENCE_DIGEST: &str = "evidence_digest";
+
+/// What a service advertises about itself.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Capabilities {
+    pub service: String,
+    pub contract: u32,
+    pub capabilities: Vec<String>,
+    pub pkg_version: String,
+}
+
+impl Capabilities {
+    /// This build's Taj advertisement.
+    #[must_use]
+    pub fn taj() -> Self {
+        Self {
+            service: "taj".to_string(),
+            contract: TAJ_CONTRACT,
+            capabilities: vec![
+                CAP_PERCEPTION_V2.to_string(),
+                CAP_FRAME_ID.to_string(),
+                CAP_EVIDENCE_DIGEST.to_string(),
+            ],
+            pkg_version: env!("CARGO_PKG_VERSION").to_string(),
+        }
+    }
+
+    #[must_use]
+    pub fn to_json(&self) -> String {
+        serde_json::to_string(self).unwrap_or_else(|_| "{}".into())
+    }
+
+    #[must_use]
+    pub fn has(&self, cap: &str) -> bool {
+        self.capabilities.iter().any(|c| c == cap)
+    }
+}
+
+/// What a probe concluded about an installed peer. Three states, deliberately
+/// distinct — collapsing the middle one is the bug this module exists for.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Compatibility {
+    /// Nothing answered — not running, wrong port, crashed.
+    Unavailable,
+    /// Alive and speaking a contract we support.
+    Current { contract: u32 },
+    /// Alive, healthy, and TOO OLD. The live failure.
+    Legacy { contract: u32, required: u32 },
+}
+
+impl Compatibility {
+    #[must_use]
+    pub fn is_usable(&self) -> bool {
+        matches!(self, Self::Current { .. })
+    }
+
+    #[must_use]
+    pub fn summary(&self) -> String {
+        match self {
+            Self::Unavailable => "service unavailable (nothing answered)".into(),
+            Self::Current { contract } => format!("healthy and contract v{contract} — current"),
+            Self::Legacy { contract, required } => format!(
+                "healthy but LEGACY: speaks contract v{contract}, this build needs \
+                 v{required} — rebuild and reinstall the binary"
+            ),
+        }
+    }
+}
+
+/// Classify a peer from its `/capabilities` reply, if it gave one.
+///
+/// `None` means the endpoint was absent (404) or unparseable — which is itself
+/// evidence of a pre-capability build, so it classifies as `Legacy` at contract
+/// 1 rather than `Unavailable`. That distinction matters: "did not answer at
+/// all" and "answered, but is old" call for different operator actions.
+#[must_use]
+pub fn classify(reply: Option<&str>, reachable: bool, required: u32) -> Compatibility {
+    if !reachable {
+        return Compatibility::Unavailable;
+    }
+    let contract = reply
+        .and_then(|r| serde_json::from_str::<Capabilities>(r).ok())
+        .map_or(1, |c| c.contract); // reachable but no/!parseable caps ⇒ pre-capability build
+    if contract >= required {
+        Compatibility::Current { contract }
+    } else {
+        Compatibility::Legacy { contract, required }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn this_build_advertises_the_v2_perception_contract() {
+        let c = Capabilities::taj();
+        assert_eq!(c.contract, TAJ_CONTRACT);
+        assert!(c.has(CAP_FRAME_ID) && c.has(CAP_EVIDENCE_DIGEST) && c.has(CAP_PERCEPTION_V2));
+        assert!(c.to_json().contains("\"contract\":2"));
+    }
+
+    #[test]
+    fn a_healthy_legacy_taj_is_reported_incompatible_not_current() {
+        // THE live failure: /health said ok, the perception reply had no
+        // frame_id, and diagnostics called it healthy. A pre-capability build
+        // has no /capabilities either — reachable, unparseable, contract 1.
+        let v = classify(None, true, TAJ_MIN_SUPPORTED_CONTRACT);
+        assert_eq!(
+            v,
+            Compatibility::Legacy {
+                contract: 1,
+                required: 2
+            }
+        );
+        assert!(!v.is_usable(), "a legacy peer must not read as usable");
+        assert!(v.summary().contains("LEGACY"), "{}", v.summary());
+        assert!(v.summary().contains("rebuild"), "must name the action");
+    }
+
+    #[test]
+    fn a_current_taj_is_usable() {
+        let v = classify(
+            Some(&Capabilities::taj().to_json()),
+            true,
+            TAJ_MIN_SUPPORTED_CONTRACT,
+        );
+        assert_eq!(v, Compatibility::Current { contract: 2 });
+        assert!(v.is_usable());
+    }
+
+    #[test]
+    fn unreachable_is_its_own_state_not_legacy() {
+        let v = classify(None, false, TAJ_MIN_SUPPORTED_CONTRACT);
+        assert_eq!(v, Compatibility::Unavailable);
+        assert!(!v.is_usable());
+        assert!(v.summary().contains("unavailable"));
+    }
+
+    #[test]
+    fn a_future_contract_is_usable_not_a_failure() {
+        // Forward compatibility: a NEWER peer still satisfies our minimum.
+        let newer = r#"{"service":"taj","contract":9,"capabilities":[],"pkg_version":"x"}"#;
+        assert!(classify(Some(newer), true, TAJ_MIN_SUPPORTED_CONTRACT).is_usable());
+    }
+
+    #[test]
+    fn garbage_from_a_reachable_peer_is_legacy_not_a_crash() {
+        for junk in ["", "not json", "{}", "{\"contract\":\"two\"}"] {
+            let v = classify(Some(junk), true, TAJ_MIN_SUPPORTED_CONTRACT);
+            assert!(!v.is_usable(), "junk {junk:?} must not read as current");
+        }
+    }
+
+    #[test]
+    fn the_minimum_never_exceeds_what_this_build_advertises() {
+        assert!(
+            TAJ_MIN_SUPPORTED_CONTRACT <= TAJ_CONTRACT,
+            "this build could not satisfy its own requirement"
+        );
+    }
+}

--- a/crates/kirra-sidecars/src/lib.rs
+++ b/crates/kirra-sidecars/src/lib.rs
@@ -21,6 +21,7 @@
 
 #![forbid(unsafe_code)]
 
+pub mod capabilities;
 pub mod http;
 pub mod mick;
 pub mod mick_fence;

--- a/robot/consumer_config_contract_test.py
+++ b/robot/consumer_config_contract_test.py
@@ -56,7 +56,8 @@ def test_r2_does_not_require_expected_car_type():
           "r2_ackermann must NOT require the X3-only car type")
     check("KIRRA_EXPECTED_CAR_TYPE" in c.inapplicable_keys(LIVE_R2),
           "it should be reported as inapplicable in R2 mode")
-    env = dict(LIVE_R2); env.pop("KIRRA_DRIVE_MODE")
+    env = dict(LIVE_R2)
+    env.pop("KIRRA_DRIVE_MODE")
     check("KIRRA_EXPECTED_CAR_TYPE" in c.required_keys(env),
           "X3 mode must still require it")
 
@@ -89,7 +90,8 @@ def test_odom_and_closed_loop_are_conditional():
 
 def test_r2_calibration_is_required_not_defaulted():
     for key in c.R2_REQUIRED:
-        env = dict(LIVE_R2); env.pop(key)
+        env = dict(LIVE_R2)
+        env.pop(key)
         check(key in c.missing_keys(env),
               f"{key} is a per-robot MEASUREMENT and must be required")
 
@@ -111,7 +113,8 @@ def _run_all() -> int:
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
     print("consumer_config_contract_test:")
     for t in tests:
-        b = len(_F); t()
+        b = len(_F)
+        t()
         print(f"  {'ok  ' if len(_F) == b else 'FAIL'} {t.__name__}")
     if _F:
         print(f"\n{len(_F)} check(s) FAILED", file=sys.stderr)

--- a/robot/install/deployment_verify_test.py
+++ b/robot/install/deployment_verify_test.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Host tests for deployment verification + the env migration report.
+
+Both exist because the live R2 ran stale /opt/kirra artifacts against a newer
+checkout and everything LOOKED fine: units active, /health ok, consumer started.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+sys.path.insert(0, str(HERE.parent))
+import env_migration_report as mig  # noqa: E402
+import verify_deployment as vd  # noqa: E402
+
+_F: list[str] = []
+
+
+def check(cond, msg):
+    if not cond:
+        _F.append(msg)
+        print(f"  FAIL: {msg}", file=sys.stderr)
+
+
+VK = "aa11bb22cc33dd44ee55ff6677889900aa11bb22cc33dd44ee55ff6677889900"
+LIVE_R2 = f"""
+KIRRA_GOVERNOR_VK_HEX={VK}
+KIRRA_PROFILE_DIGEST=9c70086efe
+KIRRA_FRESHNESS_WINDOW_MS=200
+KIRRA_CONTROL_PERIOD_MS=100
+KIRRA_MISSED_PERIODS=3
+KIRRA_STOP_DECEL_MPS2=0.5
+KIRRA_DEMO_VX_MAX=0.15
+KIRRA_DEMO_VZ_MAX=0.4
+KIRRA_MOTOR_PORT=/dev/myserial
+KIRRA_DRIVE_MODE=r2_ackermann
+KIRRA_R2_WHEELBASE_M=0.229
+KIRRA_R2_V_PER_PWM=0.0145
+KIRRA_R2_PWM_MAX=40
+KIRRA_R2_STEER_UNITS_PER_RAD=66
+KIRRA_R2_DELTA_MAX_RAD=0.68
+KIRRA_R2_STEER_SIGN=-1
+KIRRA_R2_CENTER_TRIM=90
+KIRRA_CONSUMER_LIB=/opt/kirra/libkirra_consumer_ffi.so
+"""
+
+
+def _report(text):
+    with tempfile.NamedTemporaryFile("w", suffix=".env", delete=False) as f:
+        f.write(text)
+        p = f.name
+    try:
+        d = subprocess.run([sys.executable, str(HERE / "env_migration_report.py"), p],
+                           capture_output=True, text=True, timeout=30)
+        return d.returncode, d.stdout, p
+    finally:
+        Path(p).unlink()
+
+
+# ── the three-state capability classification (mirrors the Rust side) ────────
+
+def test_a_healthy_legacy_service_is_legacy_not_current():
+    """THE live failure: /health said ok, the binary was old."""
+    state, v = vd.classify_contract(True, '{"status":"ok"}', 2)
+    check(state == "legacy" and v == 1, f"pre-capability build → legacy, got {state} v{v}")
+
+
+def test_a_current_service_is_current():
+    state, v = vd.classify_contract(True, '{"status":"ok","contract":2}', 2)
+    check(state == "current" and v == 2, f"got {state} v{v}")
+
+
+def test_unreachable_is_its_own_state():
+    state, _ = vd.classify_contract(False, "", 2)
+    check(state == "unavailable", f"got {state}")
+
+
+def test_a_service_with_no_declared_requirement_is_not_failed_on_contract():
+    state, _ = vd.classify_contract(True, '{"status":"ok"}', None)
+    check(state == "current", "a service with no contract requirement must not FAIL")
+
+
+def test_ffi_is_probed_explicitly_not_inferred_from_startup():
+    src = (HERE / "verify_deployment.py").read_text()
+    check("ctypes.CDLL" in src, "the FFI must be dlopen'd, not inferred")
+    check("systemctl start" not in src and "systemctl restart" not in src,
+          "verification must never start a service to prove anything")
+
+
+def test_verification_is_read_only():
+    """It must OBSERVE the installed system, never change it.
+
+    Parsed, not grepped: a `fix=` hint may legitimately TELL the operator to run
+    `sudo chmod +x`, which is advice, not an action. What matters is what the
+    tool itself executes and writes."""
+    import ast
+    src = (HERE / "verify_deployment.py").read_text()
+    tree = ast.parse(src)
+    mutating = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        name = ast.unparse(node.func)
+        if name in ("os.remove", "os.rename", "os.replace", "shutil.copy",
+                    "shutil.move", "os.chmod", "os.unlink"):
+            mutating.append(f"{name} at line {node.lineno}")
+        if name == "open":
+            mode = node.args[1].value if len(node.args) > 1 and \
+                isinstance(node.args[1], ast.Constant) else "r"
+            if "w" in str(mode) or "a" in str(mode):
+                mutating.append(f"open(mode={mode}) at line {node.lineno}")
+        # what it SPAWNS — sudo/systemctl-mutation must never be executed
+        if name in ("subprocess.run", "subprocess.Popen", "subprocess.call"):
+            argv = ast.unparse(node.args[0]) if node.args else ""
+            for verb in ("sudo", "systemctl start", "systemctl stop",
+                         "systemctl disable", "systemctl enable", "pkill"):
+                if verb in argv:
+                    mutating.append(f"spawns {verb!r} at line {node.lineno}")
+    check(not mutating, f"verification must be read-only, found: {mutating}")
+
+
+# ── the migration report ─────────────────────────────────────────────────────
+
+def test_the_report_never_prints_a_secret():
+    """A migration report pasted into a ticket must not disclose the governor
+    verifying key."""
+    rc, out, _ = _report(LIVE_R2)
+    check(VK not in out, "the governor key LEAKED into the report")
+    check("fp=" in out and "64 chars" in out,
+          f"it must report presence + a fingerprint instead: {out}")
+    check(VK not in json.dumps(mig.redact("KIRRA_GOVERNOR_VK_HEX", VK)),
+          "redact() must not return the value")
+    check(mig.redact("KIRRA_MOTOR_PORT", "/dev/myserial") == "/dev/myserial",
+          "a non-secret must be shown verbatim")
+
+
+def test_all_six_sections_are_always_present_and_ordered():
+    rc, out, _ = _report(LIVE_R2)
+    order = ["REQUIRED MISSING", "INVALID VALUES", "MODE-INAPPLICABLE",
+             "OBSOLETE", "PRESERVED", "OPERATOR ACTION REQUIRED"]
+    pos = [out.find(s) for s in order]
+    check(all(p >= 0 for p in pos), f"a section is missing: {list(zip(order, pos))}")
+    check(pos == sorted(pos), "sections must appear in the documented order")
+    check("(none)" in out, "an empty section must say (none), not vanish")
+
+
+def test_a_sufficient_env_needs_no_operator_action():
+    rc, out, _ = _report(LIVE_R2)
+    check(rc == 0, f"a complete env must exit 0: {out}")
+    check("none — this file is sufficient" in out, out)
+
+
+def test_missing_keys_are_listed_and_require_action():
+    rc, out, _ = _report("KIRRA_STT_CMD=x\nKIRRA_TTS_CMD=y\n")
+    check(rc != 0, "an insufficient env must exit non-zero")
+    check("KIRRA_GOVERNOR_VK_HEX" in out and "KIRRA_MOTOR_PORT" in out,
+          "the missing keys must be listed")
+
+
+def test_invalid_values_are_caught_separately_from_missing():
+    rc, out, _ = _report(LIVE_R2.replace("KIRRA_CONTROL_PERIOD_MS=100",
+                                         "KIRRA_CONTROL_PERIOD_MS=fast"))
+    check(rc != 0 and "not a number" in out, f"a non-numeric value must be INVALID: {out}")
+    bad_vk = LIVE_R2.replace(VK, "abcd")
+    rc, out, _ = _report(bad_vk)
+    check("64" in out, f"a short verifying key must be flagged: {out}")
+
+
+def test_obsolete_keys_are_reported_but_are_not_a_failure():
+    rc, out, _ = _report(LIVE_R2 + "\nKIRRA_MOTOR_BAUD=115200\n")
+    check("KIRRA_MOTOR_BAUD" in out, "an obsolete key must be reported")
+    check(rc == 0, "a stale key is inert — reporting it must not fail the run")
+
+
+def test_the_report_never_writes():
+    src = (HERE / "env_migration_report.py").read_text()
+    for bad in ('open(path, "w"', "'w')", "shutil", "os.replace", "os.rename"):
+        check(bad not in src, f"the migration report must not {bad!r}")
+    # And the file is byte-identical after a run.
+    import hashlib
+    with tempfile.NamedTemporaryFile("w", suffix=".env", delete=False) as f:
+        f.write(LIVE_R2)
+        p = f.name
+    try:
+        before = hashlib.sha256(Path(p).read_bytes()).hexdigest()
+        subprocess.run([sys.executable, str(HERE / "env_migration_report.py"), p],
+                       capture_output=True, timeout=30)
+        check(hashlib.sha256(Path(p).read_bytes()).hexdigest() == before,
+              "the env file was MODIFIED by a read-only report")
+    finally:
+        Path(p).unlink()
+
+
+def _run_all() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    print("deployment_verify_test:")
+    for t in tests:
+        b = len(_F)
+        t()
+        print(f"  {'ok  ' if len(_F) == b else 'FAIL'} {t.__name__}")
+    if _F:
+        print(f"\n{len(_F)} check(s) FAILED", file=sys.stderr)
+        return 1
+    print(f"\nall {len(tests)} tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())

--- a/robot/install/env_migration_report.py
+++ b/robot/install/env_migration_report.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""env_migration_report.py — what does THIS robot.env need, without touching it?
+
+`/etc/kirra/robot.env` is hand-tuned per robot: measured R2 calibration, the
+governor verifying key, the profile digest. An installer that overwrites it
+destroys measurements someone took with a ruler and a stopwatch. So this tool
+NEVER writes — it reports, and the operator decides.
+
+It also never prints a secret. `KIRRA_GOVERNOR_VK_HEX` is the key the consumer
+verifies release tokens against; a migration report that echoes it turns a
+support paste into a key disclosure. Secrets are reported as
+present/valid/fingerprint only.
+
+    robot/install/env_migration_report.py [path]
+    robot/install/env_migration_report.py --json
+
+Six stable sections, always in this order and always present (an empty section
+prints "(none)", so a reader can tell "nothing to do" from "not checked"):
+
+    REQUIRED MISSING · INVALID VALUES · MODE-INAPPLICABLE
+    OBSOLETE · PRESERVED · OPERATOR ACTION REQUIRED
+
+Exit 0 iff nothing requires operator action.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import consumer_config_contract as contract  # noqa: E402
+from preflight_consumer_env import parse_env_file  # noqa: E402
+
+DEFAULT_ENV = "/etc/kirra/robot.env"
+
+# Never echoed. Reported as presence + a short fingerprint so two robots can be
+# compared, or a rotation confirmed, without the value leaving the machine.
+SECRET_KEYS = ("KIRRA_GOVERNOR_VK_HEX", "KIRRA_ADMIN_TOKEN",
+               "KIRRA_MICK_AUDITOR_TOKEN", "KIRRA_SUPERVISOR_RESET_KEY")
+
+# Renamed/withdrawn keys. Present → the file predates a rename and the operator
+# should know, but it is never a failure: a stale key is inert.
+OBSOLETE_KEYS = {
+    "KIRRA_R2_CLOSED_LOOP_KP": "superseded by the measured calibration profile",
+    "KIRRA_MOTOR_BAUD": "the consumer fixes the baud rate for the R2 base",
+    "KIRRA_VENDOR_CAR_TYPE": "renamed KIRRA_EXPECTED_CAR_TYPE (X3 only)",
+}
+
+# Values that must parse as a number for the consumer to start.
+NUMERIC_KEYS = ("KIRRA_FRESHNESS_WINDOW_MS", "KIRRA_CONTROL_PERIOD_MS",
+                "KIRRA_MISSED_PERIODS", "KIRRA_STOP_DECEL_MPS2",
+                "KIRRA_DEMO_VX_MAX", "KIRRA_DEMO_VZ_MAX",
+                "KIRRA_R2_WHEELBASE_M", "KIRRA_R2_V_PER_PWM", "KIRRA_R2_PWM_MAX",
+                "KIRRA_R2_STEER_UNITS_PER_RAD", "KIRRA_R2_DELTA_MAX_RAD",
+                "KIRRA_R2_STEER_SIGN", "KIRRA_R2_CENTER_TRIM",
+                "KIRRA_R2_M_PER_TICK", "KIRRA_R2_V_PER_PWM_RIGHT")
+
+
+def fingerprint(value: str) -> str:
+    """A short, stable, non-reversible tag for a secret."""
+    return hashlib.sha256(value.encode()).hexdigest()[:12]
+
+
+def redact(key: str, value: str) -> str:
+    if key in SECRET_KEYS:
+        return f"<set, {len(value)} chars, fp={fingerprint(value)}>"
+    return value
+
+
+def invalid_values(env: dict) -> list[tuple[str, str]]:
+    out = []
+    for key in NUMERIC_KEYS:
+        v = (env.get(key) or "").strip()
+        if not v:
+            continue
+        try:
+            float(v)
+        except ValueError:
+            out.append((key, f"{v!r} is not a number"))
+    vk = (env.get("KIRRA_GOVERNOR_VK_HEX") or "").strip()
+    if vk:
+        if len(vk) % 2 or any(c not in "0123456789abcdefABCDEF" for c in vk):
+            out.append(("KIRRA_GOVERNOR_VK_HEX", "not valid hex"))
+        elif len(vk) != 64:
+            out.append(("KIRRA_GOVERNOR_VK_HEX",
+                        f"{len(vk)} hex chars — an Ed25519 key is 64"))
+    return out
+
+
+def build(env: dict) -> dict:
+    r = contract.report(env)
+    invalid = invalid_values(env)
+    obsolete = [(k, why) for k, why in OBSOLETE_KEYS.items() if env.get(k)]
+    required = set(contract.required_keys(env))
+    preserved = sorted(k for k in env if k in required and (env.get(k) or "").strip())
+    action = []
+    if r["missing"]:
+        action.append(f"set {len(r['missing'])} required key(s) — see REQUIRED MISSING")
+    if invalid:
+        action.append(f"correct {len(invalid)} invalid value(s)")
+    if not r["missing"] and not invalid:
+        action.append("none — this file is sufficient for the configured mode")
+    return {"mode": r["mode"], "missing": r["missing"], "invalid": invalid,
+            "inapplicable": r["present_but_inapplicable"], "obsolete": obsolete,
+            "preserved": preserved, "action": action,
+            "ok": not r["missing"] and not invalid}
+
+
+def render(path: str, env: dict, rep: dict) -> str:
+    out = ["== robot.env migration report ==",
+           f"  file: {path}   (READ-ONLY — nothing was modified)",
+           f"  drive mode: {rep['mode']}", ""]
+
+    def section(title, rows):
+        out.append(f"-- {title} --")
+        out.extend(f"     {r}" for r in rows) if rows else out.append("     (none)")
+        out.append("")
+
+    section("REQUIRED MISSING", rep["missing"])
+    section("INVALID VALUES", [f"{k}: {why}" for k, why in rep["invalid"]])
+    section(f"MODE-INAPPLICABLE (set, unused in {rep['mode']})", rep["inapplicable"])
+    section("OBSOLETE", [f"{k}: {why}" for k, why in rep["obsolete"]])
+    section("PRESERVED", [f"{k}={redact(k, env.get(k, ''))}" for k in rep["preserved"]])
+    section("OPERATOR ACTION REQUIRED", rep["action"])
+    return "\n".join(out)
+
+
+def main(argv) -> int:
+    as_json = "--json" in argv
+    positional = [a for a in argv if not a.startswith("-")]
+    path = positional[0] if positional else os.environ.get("KIRRA_ROBOT_ENV", DEFAULT_ENV)
+    if not os.path.isfile(path):
+        msg = f"{path} does not exist — nothing to migrate; the installer will create it"
+        print(json.dumps({"file": path, "exists": False}) if as_json else msg)
+        return 1
+    env = parse_env_file(path)
+    rep = build(env)
+    if as_json:
+        rep["file"] = path
+        # Redact before serialising — the json form is the one most likely to be
+        # pasted into a ticket.
+        rep["preserved"] = [{"key": k, "value": redact(k, env.get(k, ""))}
+                            for k in rep["preserved"]]
+        print(json.dumps(rep, indent=2))
+    else:
+        print(render(path, env, rep))
+    return 0 if rep["ok"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/robot/install/preflight_consumer_env_test.py
+++ b/robot/install/preflight_consumer_env_test.py
@@ -142,7 +142,8 @@ def _run_all() -> int:
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
     print("preflight_consumer_env_test:")
     for t in tests:
-        b = len(_F); t()
+        b = len(_F)
+        t()
         print(f"  {'ok  ' if len(_F) == b else 'FAIL'} {t.__name__}")
     if _F:
         print(f"\n{len(_F)} check(s) FAILED", file=sys.stderr)

--- a/robot/install/systemd/kirra-consumer.service
+++ b/robot/install/systemd/kirra-consumer.service
@@ -12,6 +12,11 @@
 # the installer checks and warns. Confirm on the unit: groups <user>.
 
 [Unit]
+# A transient crash-loop is bounded so a genuinely flapping RUNTIME fault
+# surfaces as `failed` instead of spinning forever. These belong in [Unit] —
+# systemd >= 229 ignores them under [Service].
+StartLimitIntervalSec=300
+StartLimitBurst=10
 Description=KIRRA verifying motor consumer (ADR-0033 chokepoint — sole /dev/myserial writer)
 # No After=multi-user.target: combined with WantedBy=multi-user.target it
 # forms an ordering cycle (review #906). DDS/serial are local; no ordering
@@ -25,10 +30,25 @@ EnvironmentFile=/etc/kirra/robot.env
 # SIGTERM reaches the consumer's signal handler (safe stop before shutdown,
 # robot/kirra_motor_consumer.py:228-235).
 ExecStart=/bin/bash -c 'source /opt/kirra/robot/ros_env.sh && kirra_source_ros && exec python3 /opt/kirra/robot/kirra_motor_consumer.py'
-# on-failure only: a fail-closed config abort (exit 2 — missing env, car-type
-# mismatch) must NOT hot-loop the board opener.
+# on-failure only: a TRANSIENT fault (a serial glitch, a lost ROS peer) should
+# come back on its own.
 Restart=on-failure
 RestartSec=5
+# ...but exit 2 is the DETERMINISTIC config abort — a missing required env var,
+# a non-numeric value, an unloadable FFI, a car-type mismatch. Restarting into
+# it just reproduces it. The comment above always said this "must NOT hot-loop
+# the board opener"; Restart=on-failure restarts on ANY non-zero status, so the
+# intent was stated but never enforced, and R2 bring-up reached 200+ restarts
+# discovering ONE missing variable per cycle. The churn buried the real cause.
+#
+# RestartPreventExitStatus makes exit 2 terminal: the unit stops in `failed`,
+# `systemctl status` shows the FATAL line as the last log, and the fix is
+# `preflight_consumer_env.py` (which reports the WHOLE missing set at once)
+# followed by `systemctl start`. This does NOT weaken fail-closed startup —
+# the consumer still refuses to run misconfigured, it just stops re-announcing
+# it every five seconds.
+RestartPreventExitStatus=2
+
 
 [Install]
 WantedBy=multi-user.target

--- a/robot/install/verify_deployment.py
+++ b/robot/install/verify_deployment.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""verify_deployment.py — is the INSTALLED system what we think it is?
+
+The live R2 ran stale `/opt/kirra` artifacts against a newer checkout for an
+entire bring-up session. Everything looked fine: the units were active, `/health`
+answered `ok`, and the consumer started. The installed `taj_service` was simply
+an older build returning the legacy perception shape, and nothing checked.
+
+`cargo test` proves the CHECKOUT is good. This proves the ROBOT is, which is a
+different claim and the one that was wrong:
+
+  1. expected installed paths exist and are executable
+  2. installed hashes / build IDs recorded (so drift is detectable next time)
+  3. Taj reports a CURRENT capability contract, not merely 200 OK
+  4. other sidecars report compatible contracts where they advertise one
+  5. the consumer FFI LOADS — probed explicitly, not inferred from startup
+  6. systemd units reference the expected installed paths
+  7. the consumer environment satisfies consumer_config_contract
+  8. services reach the expected healthy/current state
+
+Read-only. Nothing is installed, started, stopped or written.
+
+    robot/install/verify_deployment.py            # human report
+    robot/install/verify_deployment.py --json     # machine-readable
+
+Exit 0 iff every check passes.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import consumer_config_contract as contract  # noqa: E402
+
+OPT = os.environ.get("KIRRA_OPT_DIR", "/opt/kirra")
+ROBOT_ENV = os.environ.get("KIRRA_ROBOT_ENV", "/etc/kirra/robot.env")
+
+# (path, must_be_executable) — the artifacts a governed robot actually runs.
+EXPECTED_ARTIFACTS = [
+    (f"{OPT}/robot/kirra_motor_consumer.py", True),
+    (f"{OPT}/robot/serial_exclusivity.py", False),
+    (f"{OPT}/robot/motor_authority.py", False),
+    (f"{OPT}/libkirra_consumer_ffi.so", False),
+    (f"{OPT}/taj_service", True),
+    (f"{OPT}/mick_service", True),
+]
+
+# service → (url, minimum contract). A service with no advertised contract yet
+# is probed for liveness only; `None` means "no contract requirement declared".
+EXPECTED_SERVICES = [
+    ("taj", os.environ.get("KIRRA_TAJ_URL", "http://127.0.0.1:8101"), 2),
+    ("mick", os.environ.get("KIRRA_MICK_URL", "http://127.0.0.1:8102"), None),
+]
+
+PASS, FAIL, WARN = "PASS", "FAIL", "WARN"
+
+
+class Report:
+    def __init__(self):
+        self.rows: list[dict] = []
+
+    def add(self, check, status, detail, fix=None):
+        self.rows.append({"check": check, "status": status,
+                          "detail": detail, "fix": fix})
+
+    @property
+    def failed(self) -> int:
+        return sum(1 for r in self.rows if r["status"] == FAIL)
+
+
+def sha256_file(path: str) -> str:
+    h = hashlib.sha256()
+    try:
+        with open(path, "rb") as f:
+            for chunk in iter(lambda: f.read(65536), b""):
+                h.update(chunk)
+        return h.hexdigest()
+    except OSError:
+        return ""
+
+
+def http_get(url: str, timeout: float = 3.0):
+    """(reachable, body). No requests dependency — urllib is stdlib."""
+    import urllib.error
+    import urllib.request
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as r:
+            return True, r.read().decode("utf-8", "replace")
+    except urllib.error.HTTPError as e:
+        return True, f"__HTTP_{e.code}__"      # answered, just not with a body
+    except Exception:  # noqa: BLE001
+        return False, ""
+
+
+def classify_contract(reachable, body, required):
+    """Mirrors kirra_sidecars::capabilities::classify — three distinct states.
+    A reachable peer with no parseable capabilities is a PRE-CAPABILITY build
+    (legacy), not 'unavailable': the operator actions differ."""
+    if not reachable:
+        return "unavailable", None
+    contract_v = 1
+    try:
+        j = json.loads(body)
+        if isinstance(j.get("contract"), int):
+            contract_v = j["contract"]
+    except Exception:  # noqa: BLE001
+        pass
+    if required is None:
+        return "current", contract_v
+    return ("current" if contract_v >= required else "legacy"), contract_v
+
+
+def check_artifacts(rep: Report) -> dict:
+    digests = {}
+    for path, must_exec in EXPECTED_ARTIFACTS:
+        if not os.path.exists(path):
+            rep.add(f"artifact {os.path.basename(path)}", FAIL, f"{path} missing",
+                    fix="re-run the installer (install_robot_units.sh / install_kirra.sh)")
+            continue
+        if must_exec and not os.access(path, os.X_OK):
+            rep.add(f"artifact {os.path.basename(path)}", FAIL,
+                    f"{path} not executable", fix=f"sudo chmod +x {path}")
+            continue
+        d = sha256_file(path)
+        digests[path] = d
+        rep.add(f"artifact {os.path.basename(path)}", PASS,
+                f"{path} sha256={d[:12]}…")
+    return digests
+
+
+def probe_ffi(rep: Report, env: dict) -> None:
+    """Load the consumer FFI EXPLICITLY.
+
+    Deliberately not "the consumer started, so the library must be fine": that
+    conflates a config abort, a missing ROS environment and a broken .so into
+    one restart, which is exactly how the live FFI failure hid inside a restart
+    loop. A dlopen either works or names its own error.
+    """
+    lib = (env.get("KIRRA_CONSUMER_LIB") or "").strip() or f"{OPT}/libkirra_consumer_ffi.so"
+    if not os.path.exists(lib):
+        rep.add("consumer FFI loads", FAIL, f"{lib} missing",
+                fix="build + install libkirra_consumer_ffi.so")
+        return
+    code = ("import ctypes,sys\n"
+            "try:\n"
+            "    ctypes.CDLL(sys.argv[1])\n"
+            "    print('OK')\n"
+            "except OSError as e:\n"
+            "    print('ERR', e); sys.exit(1)\n")
+    try:
+        d = subprocess.run([sys.executable, "-c", code, lib],
+                           capture_output=True, text=True, timeout=20)
+        if d.returncode == 0:
+            rep.add("consumer FFI loads", PASS, f"dlopen({lib}) OK")
+        else:
+            rep.add("consumer FFI loads", FAIL,
+                    f"dlopen({lib}) failed: {d.stdout.strip()[:160]}",
+                    fix="rebuild the FFI for THIS architecture; check ldd for "
+                        "missing shared objects")
+    except Exception as e:  # noqa: BLE001
+        rep.add("consumer FFI loads", FAIL, f"probe errored: {e}")
+
+
+def check_services(rep: Report) -> None:
+    for name, base, required in EXPECTED_SERVICES:
+        reachable, body = http_get(f"{base}/capabilities")
+        if not reachable:                      # fall back to /health for liveness
+            reachable, body = http_get(f"{base}/health")
+        state, contract_v = classify_contract(reachable, body, required)
+        if state == "unavailable":
+            rep.add(f"{name} service", FAIL, f"{base} unavailable",
+                    fix=f"systemctl status kirra-{name}")
+        elif state == "legacy":
+            rep.add(f"{name} capability contract", FAIL,
+                    f"healthy but LEGACY: contract v{contract_v}, need v{required} "
+                    "— an OLD binary is installed",
+                    fix=f"rebuild and reinstall {OPT}/{name}_service, then restart it")
+        else:
+            v = f" (contract v{contract_v})" if contract_v else ""
+            rep.add(f"{name} service", PASS, f"{base} healthy and current{v}")
+
+
+def check_units(rep: Report) -> None:
+    for unit, expect in (("kirra-consumer.service", f"{OPT}/robot/kirra_motor_consumer.py"),):
+        try:
+            out = subprocess.run(["systemctl", "cat", unit],
+                                 capture_output=True, text=True, timeout=5).stdout
+        except Exception:  # noqa: BLE001
+            rep.add(f"unit {unit}", WARN, "systemctl unavailable (not the robot?)")
+            continue
+        if not out:
+            rep.add(f"unit {unit}", FAIL, "not installed",
+                    fix="robot/install/install_robot_units.sh")
+        elif expect not in out:
+            rep.add(f"unit {unit}", FAIL,
+                    f"does not reference the installed path {expect}",
+                    fix="re-run the installer — the unit points somewhere else")
+        else:
+            rep.add(f"unit {unit}", PASS, f"references {expect}")
+
+
+def check_env(rep: Report, env: dict) -> None:
+    r = contract.report(env)
+    if r["missing"]:
+        rep.add("consumer env complete", FAIL,
+                f"{len(r['missing'])} required key(s) missing for mode {r['mode']}: "
+                + ", ".join(r["missing"]),
+                fix="robot/install/preflight_consumer_env.py")
+    else:
+        rep.add("consumer env complete", PASS,
+                f"all {r['required_count']} required key(s) set for mode {r['mode']}")
+
+
+def run() -> Report:
+    rep = Report()
+    from preflight_consumer_env import parse_env_file
+    env = parse_env_file(ROBOT_ENV) if os.path.isfile(ROBOT_ENV) else {}
+    if not env:
+        rep.add("robot.env readable", FAIL, f"{ROBOT_ENV} missing or empty")
+    check_artifacts(rep)
+    check_env(rep, env)
+    probe_ffi(rep, env)
+    check_units(rep)
+    check_services(rep)
+    return rep
+
+
+def main(argv) -> int:
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+    rep = run()
+    if "--json" in argv:
+        print(json.dumps({"rows": rep.rows, "failed": rep.failed}, indent=2))
+        return 1 if rep.failed else 0
+    print("== deployment verification ==")
+    for r in rep.rows:
+        mark = {"PASS": "✔", "FAIL": "❌", "WARN": "⚠"}[r["status"]]
+        print(f"  {mark} {r['check']}: {r['detail']}")
+        if r["fix"] and r["status"] != PASS:
+            print(f"       ↳ fix: {r['fix']}")
+    print(f"\n{'❌ ' + str(rep.failed) + ' check(s) FAILED' if rep.failed else '✔ deployment verified'}")
+    return 1 if rep.failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/robot/service_units_test.py
+++ b/robot/service_units_test.py
@@ -32,6 +32,7 @@ REPO = Path(__file__).resolve().parent.parent
 MICK = REPO / "deploy" / "systemd" / "kirra-mick.service"
 VOICE = REPO / "robot" / "install" / "systemd" / "kirra-rabbit-voice.service"
 INSTALLER = REPO / "robot" / "install" / "install_robot_units.sh"
+CONSUMER = REPO / "robot" / "install" / "systemd" / "kirra-consumer.service"
 
 # Directives that couple LIFECYCLES rather than just ordering.
 HARD_DEPS = ("Requires", "Requisite", "BindsTo", "PartOf")
@@ -184,6 +185,58 @@ def test_no_stale_dropin_shipped_for_these_units():
         text = tuning.read_text()
         check("ExecStart" not in text,
               "the Ollama tuning drop-in must set Environment only, never ExecStart")
+
+
+# ── the consumer: permanent config abort vs transient fault ─────────────────
+
+def _section_of(text, key):
+    """Which [Section] a directive is declared under (systemd cares)."""
+    sec = None
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("["):
+            sec = line
+        elif line.startswith(key + "="):
+            return sec
+    return None
+
+
+def test_a_deterministic_config_abort_does_not_restart_forever():
+    """Exit 2 is the consumer's fail-closed config abort (missing env var,
+    non-numeric value, unloadable FFI). Restart=on-failure restarts on ANY
+    non-zero status, so R2 bring-up reached 200+ restarts surfacing ONE missing
+    variable per cycle and the churn buried the cause."""
+    text = _unit(CONSUMER)
+    check("2" in directive(text, "RestartPreventExitStatus"),
+          "exit 2 must be terminal — RestartPreventExitStatus=2")
+    check(_section_of(text, "RestartPreventExitStatus") == "[Service]",
+          "RestartPreventExitStatus belongs in [Service]")
+
+
+def test_transient_failures_still_restart():
+    """The other half: a serial glitch or a lost ROS peer must still recover
+    on its own. Weakening that would trade one problem for a worse one."""
+    text = _unit(CONSUMER)
+    check(directive(text, "Restart") == ["on-failure"],
+          f"transient restart must survive: {directive(text, 'Restart')}")
+    check(directive(text, "RestartSec"), "RestartSec must stay set")
+
+
+def test_the_crash_loop_is_bounded_and_the_limits_are_where_systemd_reads_them():
+    text = _unit(CONSUMER)
+    for key in ("StartLimitIntervalSec", "StartLimitBurst"):
+        check(directive(text, key), f"{key} must be set (bound a flapping fault)")
+        check(_section_of(text, key) == "[Unit]",
+              f"{key} must be in [Unit] — systemd >= 229 IGNORES it under [Service]")
+
+
+def test_fail_closed_startup_is_not_weakened():
+    """The consumer must still REFUSE to run misconfigured — this change only
+    stops it re-announcing the refusal every five seconds."""
+    src = (REPO / "robot" / "kirra_motor_consumer.py").read_text()
+    check("sys.exit(2)" in src, "the config abort must still exit non-zero")
+    check("FATAL: required env var" in src,
+          "a missing required env var must still be fatal, not defaulted")
 
 
 def _run_all() -> int:


### PR DESCRIPTION
#1203 has merged and this branch is rebased onto the new `main`. The diff is now exactly the two commits below — the stacked-review caveat no longer applies.

```
70152e58  fix(deploy): verify installed Kirra artifact compatibility
4633c4b5  fix(deploy): verify installed artifacts and report env migration
```

## The live incidents this prevents

| Incident | Cause |
|---|---|
| **Stale Taj reported healthy** | installed `/opt/kirra/taj_service` answered `GET /health` → `{"status":"ok"}` while returning the *legacy* perception shape — no `frame_id`, so no `profile_digest`, no `evidence_digest`. Diagnostics read the 200 and called it healthy. It **was** healthy, and incompatible with the checked-out consumer. |
| **200+ deterministic restart attempts** | the consumer fail-closed on missing config, systemd restarted it, it fail-closed on the *next* missing value — eight facts learned over eight restart cycles, with the real cause buried in the churn. |

A liveness probe cannot detect a stale binary, because **a stale binary is alive**.

## Taj capability contracts — legacy is distinct from unavailable

New `crates/kirra-sidecars/src/capabilities.rs`. Taj now serves `GET /capabilities` and echoes the contract integer in `/health`, so one probe answers liveness *and* compatibility:

```
GET /health       → {"status":"ok","service":"taj","contract":2}
GET /capabilities → {"service":"taj","contract":2,"capabilities":["perception.v2","frame_id","evidence_digest"],…}
```

`classify()` returns **three** states that must not collapse:

| state | meaning | operator action |
|---|---|---|
| `Unavailable` | nothing answered | check the unit is running |
| `Current` | alive, contract ≥ required | none |
| `Legacy` | **alive, healthy, too old** | rebuild + reinstall the binary |

A reachable peer with **no parseable `/capabilities`** classifies as `Legacy` contract 1 — a pre-capability build — *not* `Unavailable`. "Didn't answer" and "answered, but is old" call for different actions.

`contract` is deliberately a single integer that changes **only** on a wire-contract change, so it stays meaningful across rebuilds in a way a version string is not. Explicitly **not** `strings` on the binary: that reads bytes that were never a promise.

## `RestartPreventExitStatus=2`

The find here: `kirra-consumer.service` **already carried the comment** *"a fail-closed config abort (exit 2 — missing env, car-type mismatch) must NOT hot-loop the board opener"* — while `Restart=on-failure` restarts on **any** non-zero status. The intent was written down and never enforced. That is the restart storm.

Exit 2 was already the consumer's dedicated deterministic-config code (missing required env var, non-numeric value, unloadable FFI, car-type mismatch), so the fix is the directive matching the existing semantics.

- **Fail-closed startup is unchanged** — the consumer still refuses to run misconfigured. It stops re-announcing the refusal every five seconds and stops in `failed`, with the `FATAL` line last in `systemctl status`.
- **Transient faults still restart** (`Restart=on-failure`, `RestartSec=5`) — a serial glitch or a lost ROS peer recovers on its own.
- A flapping *runtime* fault is bounded by `StartLimitIntervalSec`/`StartLimitBurst`, placed in **`[Unit]`** — systemd ≥ 229 silently ignores them under `[Service]`, which I got wrong first and the test now pins by section, not just presence.

## Explicit FFI dlopen

`verify_deployment.py` probes the consumer FFI with an actual `ctypes.CDLL`, rather than inferring it from a successful service start. A consumer start conflates a config abort, a missing ROS environment and a broken `.so` into one restart — exactly how the live FFI failure hid inside the loop. A dlopen either works or names its own error.

## Deployment verification

`cargo test` proves the **checkout** is good; this proves the **robot** is:

1. expected installed paths exist and are executable
2. sha256 of each recorded, so drift is detectable next time
3. Taj reports a current capability contract
4. other sidecars checked where they advertise one
5. consumer FFI loads (explicit dlopen)
6. systemd units reference the expected installed paths
7. environment satisfies `consumer_config_contract` (landed in #1203)
8. services reach the expected healthy/current state

## Read-only env migration reporting, with redacted fingerprints

`robot.env` is hand-tuned per robot — measured R2 calibration someone took with a ruler, the governor key, the profile digest. An installer that overwrites it destroys measurements. `env_migration_report.py` **never writes**. Six stable sections, always present and ordered, each printing `(none)` when empty so "nothing to do" is distinguishable from "not checked":

```
REQUIRED MISSING · INVALID VALUES · MODE-INAPPLICABLE
OBSOLETE · PRESERVED · OPERATOR ACTION REQUIRED
```

**No secret is ever printed.** `KIRRA_GOVERNOR_VK_HEX` is the key the consumer verifies release tokens against; a report pasted into a support ticket must not disclose it:

```
KIRRA_GOVERNOR_VK_HEX=<set, 64 chars, fp=3f9a1c7e2b04>
KIRRA_MOTOR_PORT=/dev/myserial
```

Presence, length and a 12-char SHA-256 fingerprint — enough to compare two robots or confirm a rotation, without the value leaving the machine. Invalid values are a **separate section** from missing ones: a non-numeric period and an unset period need different fixes.

Both tools' read-only claims are asserted by an **AST walk**, not a grep — my first attempt flagged a `fix=` hint that *tells* the operator to run `sudo chmod +x` as though the tool ran it. The migration report additionally hashes the env file before and after a run.

## Changed files

| File | Change |
|---|---|
| `crates/kirra-sidecars/src/capabilities.rs` | new — contract + 3-state classification |
| `crates/kirra-sidecars/src/bin/taj_service.rs` | `/capabilities`, contract in `/health` |
| `crates/kirra-sidecars/src/lib.rs` | `pub mod capabilities;` |
| `robot/install/systemd/kirra-consumer.service` | `RestartPreventExitStatus=2`, `StartLimit*` in `[Unit]` |
| `robot/install/verify_deployment.py` | new — installed-system verification |
| `robot/install/env_migration_report.py` | new — read-only migration report |
| `robot/install/deployment_verify_test.py` | new — 13 tests |
| `robot/service_units_test.py` | +4 consumer restart-policy tests |
| `.github/workflows/ci.yml` | registers the new test file |

## Tests — 20 new

7 capability (106 total in `kirra-sidecars`), 4 service (14 in `service_units_test`), 13 deployment/migration.

**Non-vacuity:** a health-only probe returns `{"status":"ok"}` for the legacy binary and would report healthy — the new classifier calls it `legacy contract v1`. Removing `RestartPreventExitStatus` reds the suite, as does moving `StartLimit*` back to `[Service]`.

`cargo test -p kirra-sidecars` · `cargo fmt --check` · workspace build · all robot suites · `compileall` · `ruff` (touched files) · `git diff --check` clean. **shellcheck is not installed in this environment.**

Re-verified after the rebase: `git diff` against the new `main` is byte-identical to the pre-rebase two-commit diff, and all four robot suites plus `cargo test -p kirra-sidecars` pass.

## Remaining work

Before Yahboom motor-controller removal: the **Jetson-side R2CP bridge** (host codec + **PTY-simulated MCU** now in progress), the consumer's R2CP drive mode, then **HIL**. Before safe floor driving: **odometry** and **closed-loop** wheel matching remain deliberately disabled pending validation, and the live `KIRRA_GOVERNOR_VK_HEX` is a bench/dev key.

Scoped deliberately: this is capability, restart policy, verification and migration **reporting** — not an installer redesign.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjDFKPcBVHURDZpXsvnYhC)_