### PR TITLE
feat(r2cp): add governed consumer drive mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -908,7 +908,7 @@ jobs:
         # container change rather than failing. Naming the lane makes the
         # requirement explicit, and `--test pty_loop` fails rather than
         # no-ops if the target ever stops being built.
-        run: cargo test -p kirra-r2cp --locked --test pty_loop --test frame_reader
+        run: cargo test -p kirra-r2cp --locked --test pty_loop --test frame_reader --test exclusivity
       - name: The core stays dependency-free without `pty`
         # The layering claim in the crate manifest, checked instead of asserted:
         # the codec (lib.rs) and the simulated MCU's rules (sim.rs) must not

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -938,6 +938,12 @@ jobs:
           cargo test -p kirra-consumer-ffi --locked \
             --test r2cp_against_simulator --test r2cp_scripted_peer
           cargo clippy -p kirra-consumer-ffi --all-targets --locked -- -D warnings
+      - name: unsafe stays confined to the three ioctl wrappers
+        # kirra-r2cp is deny(unsafe_code) with three narrow #[allow]s (TIOCEXCL
+        # claim, TIOCGEXCL read-back, TIOCNXCL release). The value of that is
+        # entirely in how narrow it stays, and "only in link.rs" is the kind of
+        # boundary that erodes one convenient exception at a time.
+        run: python3 ci/check_r2cp_unsafe.py
       - name: Python stays free of R2CP protocol detail
         # There is ONE R2CP implementation on the host. This walks the AST of
         # the guarded Python files (a grep would fire on the docstrings that

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -926,6 +926,27 @@ jobs:
           fi
       - name: Clippy
         run: cargo clippy -p kirra-r2cp --all-targets --locked -- -D warnings
+      - name: R2CP consumer path — FFI boundary + release boundary
+        # The stage-4 surface. `--lib` carries the release-boundary proof
+        # (accepted release => exactly one MOTION_COMMAND and one ACK;
+        # refused/replayed release => zero motion frames, with a live-link
+        # positive control so the zero is the refusal and not a dead wire).
+        # The two integration targets drive the exported C entry points
+        # against the PTY simulator and a scripted mis-answering peer.
+        run: |
+          cargo test -p kirra-consumer-ffi --locked --lib
+          cargo test -p kirra-consumer-ffi --locked \
+            --test r2cp_against_simulator --test r2cp_scripted_peer
+          cargo clippy -p kirra-consumer-ffi --all-targets --locked -- -D warnings
+      - name: Python stays free of R2CP protocol detail
+        # There is ONE R2CP implementation on the host. This walks the AST of
+        # the guarded Python files (a grep would fire on the docstrings that
+        # explain why there is no COBS there) and self-tests that the detector
+        # can flag a dirty sample.
+        run: |
+          python3 robot/r2cp_purity_test.py
+          python3 robot/consumer_config_contract_test.py
+          python3 -m compileall -q robot/kirra_r2cp.py robot/kirra_motor_consumer.py
 
   parko-safety:
     name: Parko Safety Tests (no ROS, no ORT)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2175,7 +2175,9 @@ version = "0.1.0"
 dependencies = [
  "ed25519-dalek",
  "kirra-actuation-consumer",
+ "kirra-r2cp",
  "kirra-release-token",
+ "nix",
 ]
 
 [[package]]

--- a/ci/check_r2cp_unsafe.py
+++ b/ci/check_r2cp_unsafe.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Guard: `unsafe` in `kirra-r2cp` lives ONLY in the OS-binding ioctls.
+
+The crate is `deny(unsafe_code)` with narrow `#[allow]`s, and the value of that
+arrangement is entirely in how narrow it stays. "Only in link.rs, only the
+ioctls" is exactly the kind of boundary that erodes one convenient exception at
+a time — each individually reasonable, the sum not.
+
+So it is checked rather than trusted:
+
+  * `sim.rs`, `handshake.rs`, `lib.rs`, `pty.rs` must contain NO `unsafe` block.
+    These are the codec, the framing, the handshake evaluator and the PTY
+    binding — the parts a differential test compares against the firmware's
+    normative `wire.cpp`, and the parts a reviewer reads for safety logic.
+  * `link.rs` may contain unsafe only inside the three named ioctl wrappers,
+    each of which must carry a SAFETY comment.
+
+Run: python3 ci/check_r2cp_unsafe.py
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parent.parent / "crates" / "kirra-r2cp" / "src"
+
+# Files that must be entirely free of unsafe blocks.
+PURE = ("lib.rs", "sim.rs", "handshake.rs", "pty.rs")
+
+# The only functions allowed to contain one, and what each is for.
+ALLOWED_IOCTL_FNS = {
+    "claim_exclusive": "TIOCEXCL",
+    "read_exclusive": "TIOCGEXCL",
+    "release_exclusive": "TIOCNXCL",
+}
+
+# `unsafe {` as a block opener. Deliberately not matching the word `unsafe` in
+# prose: every one of these files DOCUMENTS the arrangement, and a substring
+# search would fire on the explanation of why there is no unsafe there.
+UNSAFE_BLOCK = re.compile(r"\bunsafe\s*\{")
+FN_DEF = re.compile(r"^\s*(?:pub(?:\([^)]*\))?\s+)?fn\s+([A-Za-z_][A-Za-z0-9_]*)")
+
+
+def enclosing_fn(lines: list[str], index: int) -> str | None:
+    """Name of the nearest preceding `fn` definition."""
+    for i in range(index, -1, -1):
+        m = FN_DEF.match(lines[i])
+        if m:
+            return m.group(1)
+    return None
+
+
+def check() -> list[str]:
+    problems: list[str] = []
+
+    for name in PURE:
+        path = SRC / name
+        if not path.is_file():
+            # A missing file is a failure, not a skip: a rename must not
+            # silently remove a file from the guard's scope.
+            problems.append(f"{name}: guarded file is missing")
+            continue
+        for n, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            if UNSAFE_BLOCK.search(line):
+                problems.append(
+                    f"{name}:{n}: unsafe block outside the OS binding — the "
+                    "codec, framing, handshake and PTY layers must stay safe"
+                )
+
+    link = SRC / "link.rs"
+    if not link.is_file():
+        problems.append("link.rs: missing")
+        return problems
+
+    lines = link.read_text(encoding="utf-8").splitlines()
+    seen: set[str] = set()
+    for n, line in enumerate(lines, 1):
+        if not UNSAFE_BLOCK.search(line):
+            continue
+        fn = enclosing_fn(lines, n - 1)
+        if fn not in ALLOWED_IOCTL_FNS:
+            problems.append(
+                f"link.rs:{n}: unsafe inside {fn!r}, which is not one of the "
+                f"permitted ioctl wrappers {sorted(ALLOWED_IOCTL_FNS)}"
+            )
+            continue
+        seen.add(fn)
+        # Every exception must say why it is sound, near where it is taken.
+        window = "\n".join(lines[max(0, n - 8) : n])
+        if "SAFETY:" not in window:
+            problems.append(
+                f"link.rs:{n}: unsafe in {fn!r} has no SAFETY comment within "
+                "the preceding 8 lines"
+            )
+
+    missing = set(ALLOWED_IOCTL_FNS) - seen
+    if missing:
+        # Non-vacuity: if the ioctls vanished, every check above would pass
+        # trivially and the exclusivity guarantee would be gone with them.
+        problems.append(
+            f"link.rs: expected unsafe ioctl wrapper(s) {sorted(missing)} not "
+            "found — exclusivity may no longer be claimed at all"
+        )
+    return problems
+
+
+def main() -> int:
+    problems = check()
+
+    # Self-test: the detector must be able to fail. A guard that cannot
+    # distinguish a violation from clean code proves nothing when it passes.
+    probe_lines = ["fn something_else() {", "    let x = unsafe { foo() };", "}"]
+    if enclosing_fn(probe_lines, 1) != "something_else" or not UNSAFE_BLOCK.search(
+        probe_lines[1]
+    ):
+        problems.append("SELF-TEST: the detector cannot recognise a violation")
+
+    for p in problems:
+        print(f"  FAIL {p}")
+    if problems:
+        print(f"\n{len(problems)} problem(s)")
+        return 1
+    print(f"  ok   {len(PURE)} codec/framing file(s) contain no unsafe block")
+    print(f"  ok   link.rs unsafe confined to {len(ALLOWED_IOCTL_FNS)} ioctl "
+          "wrappers, each with a SAFETY comment")
+    print("  ok   the detector recognises a violation (non-vacuous)")
+    print("\nall checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/crates/kirra-consumer-ffi/Cargo.toml
+++ b/crates/kirra-consumer-ffi/Cargo.toml
@@ -39,3 +39,11 @@ kirra-release-token = { path = "../kirra-release-token" }
 # across the boundary. No signing happens here — this is the actuation path,
 # past the verdict (ADR-0031 separation is upheld: the checker signed upstream).
 ed25519-dalek = { version = "2" }
+# The R2CP host codec + link. Framing, nonce handling, ACK interpretation and
+# transport state stay HERE, in Rust, for the same reason the crypto does: a
+# Python re-implementation would be a third dialect that nothing differentially
+# tests against `wire.cpp` or against this one.
+kirra-r2cp = { path = "../kirra-r2cp" }
+
+[dev-dependencies]
+nix = { version = "0.31.3", features = ["term", "poll"] }

--- a/crates/kirra-consumer-ffi/src/lib.rs
+++ b/crates/kirra-consumer-ffi/src/lib.rs
@@ -1055,6 +1055,270 @@ mod tests {
         }
     }
 
+    // ---------------------------------------------------------------------
+    // THE RELEASE BOUNDARY (stage 4)
+    //
+    // R2CP transports authorized motion. R2CP must never become a second
+    // intent or authorization path. These tests fuse the two FFI surfaces in
+    // exactly the order the Python consumer does — verify, then (only on a
+    // release) actuate — and COUNT the MOTION_COMMAND frames that reach the
+    // wire, because "no motion" and "no frame" are different claims and only
+    // the second one rules out a bypass.
+    // ---------------------------------------------------------------------
+
+    /// A simulated MCU that counts the MOTION_COMMAND frames it receives,
+    /// including refused ones. The sim's own `accepted_commands` is not
+    /// enough: a frame the peer refuses still LEFT THE HOST, which is what a
+    /// bypass would look like.
+    struct CountingSim {
+        device: std::path::PathBuf,
+        motion_frames: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+        acks_sent: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+        stop: std::sync::mpsc::Sender<()>,
+    }
+
+    fn spawn_counting_sim() -> CountingSim {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+
+        let pty = kirra_r2cp::pty::SimulatedMcuPty::open().expect("pty");
+        let device = pty.device_path().to_path_buf();
+        let motion_frames = Arc::new(AtomicUsize::new(0));
+        let acks_sent = Arc::new(AtomicUsize::new(0));
+        let (stop_tx, stop_rx) = std::sync::mpsc::channel::<()>();
+        let (mf, ak) = (Arc::clone(&motion_frames), Arc::clone(&acks_sent));
+
+        std::thread::spawn(move || {
+            let mut pty = pty;
+            let mut mcu = kirra_r2cp::sim::SimulatedMcu::new();
+            let started = std::time::Instant::now();
+            loop {
+                if stop_rx.try_recv().is_ok() {
+                    return;
+                }
+                let now_us = u64::try_from(started.elapsed().as_micros()).unwrap_or(u64::MAX);
+                let Ok(handled) = pty.pump(&mut mcu, now_us, 20) else {
+                    return;
+                };
+                for h in handled {
+                    // Count what the state machine SAW, not what it allowed.
+                    if matches!(
+                        h.outcome,
+                        Ok(kirra_r2cp::sim::Outcome::Accepted { .. })
+                            | Ok(kirra_r2cp::sim::Outcome::Refused(_))
+                    ) {
+                        mf.fetch_add(1, Ordering::SeqCst);
+                    }
+                    if h.acknowledged {
+                        ak.fetch_add(1, Ordering::SeqCst);
+                    }
+                }
+            }
+        });
+        CountingSim {
+            device,
+            motion_frames,
+            acks_sent,
+            stop: stop_tx,
+        }
+    }
+
+    /// Open + activate, returning the handle and the ACK count that setup
+    /// consumed, so a test can measure only what its own commands added.
+    unsafe fn r2cp_ready(sim: &CountingSim) -> *mut crate::r2cp::KirraR2cpLink {
+        use std::ffi::CString;
+        let c = CString::new(sim.device.to_str().unwrap()).unwrap();
+        let mut handle: *mut crate::r2cp::KirraR2cpLink = core::ptr::null_mut();
+        let status = crate::r2cp::kirra_r2cp_open(c.as_ptr(), 2000, &mut handle);
+        assert_eq!(
+            status,
+            crate::r2cp::KIRRA_R2CP_OK,
+            "simulator should answer"
+        );
+        assert_eq!(
+            crate::r2cp::kirra_r2cp_activate(handle, 2000),
+            crate::r2cp::KIRRA_R2CP_OK
+        );
+        handle
+    }
+
+    /// The consumer's control flow, in one place: verify, and actuate ONLY on
+    /// a release. Deliberately the whole of it — if actuation could happen on
+    /// any other branch, this is where it would show.
+    unsafe fn verify_then_maybe_actuate(
+        consumer: *mut KirraBoundConsumer,
+        link: *mut crate::r2cp::KirraR2cpLink,
+        payload: &[u8],
+        token: &[u8],
+        now_ms: u64,
+        command_id: u32,
+    ) -> KirraBoundFrameResult {
+        let mut out = core::mem::zeroed::<KirraBoundFrameResult>();
+        kirra_bound_consumer_on_frame(
+            consumer,
+            payload.as_ptr(),
+            token.as_ptr(),
+            token.len(),
+            now_ms,
+            &mut out,
+        );
+        if out.write == 1 {
+            let mut ack = crate::r2cp::KirraR2cpAck::default();
+            crate::r2cp::kirra_r2cp_command(
+                link,
+                out.linear as f32,
+                0.0,
+                1.0,
+                5.0,
+                100_000,
+                command_id,
+                0,
+                1000,
+                &mut ack,
+            );
+        }
+        out
+    }
+
+    #[test]
+    fn an_accepted_release_sends_exactly_one_motion_command_and_gets_one_ack() {
+        use std::sync::atomic::Ordering;
+        unsafe {
+            let sim = spawn_counting_sim();
+            let link = r2cp_ready(&sim);
+            let consumer = new_bound_consumer();
+
+            let acks_before = sim.acks_sent.load(Ordering::SeqCst);
+            let (payload, token) = bound_frame(1, 1001, 10_000, 77);
+            let out = verify_then_maybe_actuate(consumer, link, &payload, &token, 10_050, 1);
+
+            assert_eq!(out.kind, 0, "the release should verify");
+            assert_eq!(out.write, 1, "the core should release");
+
+            std::thread::sleep(std::time::Duration::from_millis(120));
+            assert_eq!(
+                sim.motion_frames.load(Ordering::SeqCst),
+                1,
+                "exactly one MOTION_COMMAND should reach the peer"
+            );
+            assert_eq!(
+                sim.acks_sent.load(Ordering::SeqCst) - acks_before,
+                1,
+                "exactly one COMMAND_ACK should come back"
+            );
+
+            kirra_bound_consumer_free(consumer);
+            crate::r2cp::kirra_r2cp_close(link);
+            let _ = sim.stop.send(());
+        }
+    }
+
+    #[test]
+    fn a_rejected_release_sends_zero_motion_frames() {
+        use std::sync::atomic::Ordering;
+        unsafe {
+            // Three independent ways a release can be refused. Each must reach
+            // the wire ZERO times — not "reach it and get refused by the
+            // peer", which would mean the host had become a second
+            // authorization path that happened to be caught downstream.
+            #[derive(Clone, Copy, Debug)]
+            enum Bad {
+                TamperedProposal,
+                Expired,
+                TamperedSignature,
+            }
+
+            for case in [Bad::TamperedProposal, Bad::Expired, Bad::TamperedSignature] {
+                let sim = spawn_counting_sim();
+                let link = r2cp_ready(&sim);
+                let consumer = new_bound_consumer();
+                let name = format!("{case:?}");
+                let (payload, token) = match case {
+                    Bad::TamperedProposal => {
+                        let (mut p, t) = bound_frame(1, 1001, 10_000, 77);
+                        p[144] ^= 1; // proposal_digest starts at byte 144
+                        (p, t)
+                    }
+                    Bad::Expired => bound_frame(1, 1001, 10_000, 77),
+                    Bad::TamperedSignature => {
+                        let (p, mut t) = bound_frame(1, 1001, 10_000, 77);
+                        let last = t.len() - 1;
+                        t[last] ^= 1;
+                        (p, t)
+                    }
+                };
+
+                // Expiry is the one that needs a late clock; the others are
+                // refused whatever the time is. Matched on the ENUM, not on a
+                // formatted name — a rename must not silently turn this into
+                // an in-window release that the test then reports as passing.
+                let now_ms = if matches!(case, Bad::Expired) {
+                    99_000
+                } else {
+                    10_050
+                };
+                let out = verify_then_maybe_actuate(consumer, link, &payload, &token, now_ms, 1);
+
+                assert_eq!(out.write, 0, "{name}: the core must not release");
+                std::thread::sleep(std::time::Duration::from_millis(120));
+                assert_eq!(
+                    sim.motion_frames.load(Ordering::SeqCst),
+                    0,
+                    "{name}: a refused release must put ZERO motion frames on the wire"
+                );
+
+                // Non-vacuity, on THIS link and THIS sim: a zero count would
+                // also be what a broken link looks like, so prove the wire
+                // still works by pushing a good release through it.
+                let (ok_payload, ok_token) = bound_frame(9, 9001, 10_000, 77);
+                let released =
+                    verify_then_maybe_actuate(consumer, link, &ok_payload, &ok_token, 10_050, 2);
+                assert_eq!(released.write, 1, "{name}: control release should pass");
+                std::thread::sleep(std::time::Duration::from_millis(120));
+                assert_eq!(
+                    sim.motion_frames.load(Ordering::SeqCst),
+                    1,
+                    "{name}: the link was live, so the zero above was the refusal"
+                );
+
+                kirra_bound_consumer_free(consumer);
+                crate::r2cp::kirra_r2cp_close(link);
+                let _ = sim.stop.send(());
+            }
+        }
+    }
+
+    #[test]
+    fn a_replayed_release_sends_no_second_motion_frame() {
+        use std::sync::atomic::Ordering;
+        unsafe {
+            let sim = spawn_counting_sim();
+            let link = r2cp_ready(&sim);
+            let consumer = new_bound_consumer();
+
+            let (payload, token) = bound_frame(1, 1001, 10_000, 77);
+            let first = verify_then_maybe_actuate(consumer, link, &payload, &token, 10_050, 1);
+            assert_eq!(first.write, 1);
+
+            // The SAME release again. The verify core's watermark refuses it,
+            // so the count must not move — the replay is stopped at the
+            // authorization boundary, before the wire, not by the peer.
+            let second = verify_then_maybe_actuate(consumer, link, &payload, &token, 10_060, 2);
+            assert_eq!(second.write, 0, "a replayed release must not re-release");
+
+            std::thread::sleep(std::time::Duration::from_millis(120));
+            assert_eq!(
+                sim.motion_frames.load(Ordering::SeqCst),
+                1,
+                "the replay must add no second motion frame"
+            );
+
+            kirra_bound_consumer_free(consumer);
+            crate::r2cp::kirra_r2cp_close(link);
+            let _ = sim.stop.send(());
+        }
+    }
+
     #[test]
     fn bound_ffi_replay_and_superseded_frame_are_refused() {
         unsafe {

--- a/crates/kirra-consumer-ffi/src/lib.rs
+++ b/crates/kirra-consumer-ffi/src/lib.rs
@@ -1073,7 +1073,16 @@ mod tests {
     struct CountingSim {
         device: std::path::PathBuf,
         motion_frames: std::sync::Arc<std::sync::atomic::AtomicUsize>,
-        acks_sent: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+        /// ACKs for MOTION frames specifically.
+        ///
+        /// NOT a total. An earlier version diffed a total across setup and
+        /// measurement, which is racy: the sim writes a reply and increments
+        /// AFTERWARDS, so the link can observe the ACTIVATE ack and move on
+        /// before the counter catches up — the "before" snapshot then reads
+        /// stale and setup leaks into the result. It passed locally and failed
+        /// on a CI runner. Counting only motion acks removes the window
+        /// entirely: HELLO, ARM and ACTIVATE never touch these.
+        motion_acks: std::sync::Arc<std::sync::atomic::AtomicUsize>,
         stop: std::sync::mpsc::Sender<()>,
     }
 
@@ -1084,9 +1093,9 @@ mod tests {
         let pty = kirra_r2cp::pty::SimulatedMcuPty::open().expect("pty");
         let device = pty.device_path().to_path_buf();
         let motion_frames = Arc::new(AtomicUsize::new(0));
-        let acks_sent = Arc::new(AtomicUsize::new(0));
+        let motion_acks = Arc::new(AtomicUsize::new(0));
         let (stop_tx, stop_rx) = std::sync::mpsc::channel::<()>();
-        let (mf, ak) = (Arc::clone(&motion_frames), Arc::clone(&acks_sent));
+        let (mf, ak) = (Arc::clone(&motion_frames), Arc::clone(&motion_acks));
 
         std::thread::spawn(move || {
             let mut pty = pty;
@@ -1101,16 +1110,19 @@ mod tests {
                     return;
                 };
                 for h in handled {
-                    // Count what the state machine SAW, not what it allowed.
-                    if matches!(
+                    // Count what the state machine SAW, not what it allowed:
+                    // a frame the peer refuses still LEFT THE HOST, which is
+                    // what a bypass would look like.
+                    let is_motion = matches!(
                         h.outcome,
                         Ok(kirra_r2cp::sim::Outcome::Accepted { .. })
                             | Ok(kirra_r2cp::sim::Outcome::Refused(_))
-                    ) {
+                    );
+                    if is_motion {
                         mf.fetch_add(1, Ordering::SeqCst);
-                    }
-                    if h.acknowledged {
-                        ak.fetch_add(1, Ordering::SeqCst);
+                        if h.acknowledged {
+                            ak.fetch_add(1, Ordering::SeqCst);
+                        }
                     }
                 }
             }
@@ -1118,13 +1130,30 @@ mod tests {
         CountingSim {
             device,
             motion_frames,
-            acks_sent,
+            motion_acks,
             stop: stop_tx,
         }
     }
 
-    /// Open + activate, returning the handle and the ACK count that setup
-    /// consumed, so a test can measure only what its own commands added.
+    /// Wait until `counter` reaches `target`, then a little longer to catch an
+    /// overshoot. Returns whatever it settled on.
+    ///
+    /// Deliberately not a bare sleep: a fixed interval is a guess about a
+    /// scheduler, and on a loaded CI runner it is the wrong guess.
+    fn settle_until(counter: &std::sync::atomic::AtomicUsize, target: usize) -> usize {
+        use std::sync::atomic::Ordering;
+        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(2000);
+        while counter.load(Ordering::SeqCst) < target && std::time::Instant::now() < deadline {
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        // A short quiet period so an EXTRA frame would be observed too — the
+        // assertion is "exactly one", not "at least one".
+        std::thread::sleep(std::time::Duration::from_millis(120));
+        counter.load(Ordering::SeqCst)
+    }
+
+    /// Open + activate. Setup frames are HELLO/ARM/ACTIVATE, none of which are
+    /// motion, so they never touch the counters a test asserts on.
     unsafe fn r2cp_ready(sim: &CountingSim) -> *mut crate::r2cp::KirraR2cpLink {
         use std::ffi::CString;
         let c = CString::new(sim.device.to_str().unwrap()).unwrap();
@@ -1188,21 +1217,24 @@ mod tests {
             let link = r2cp_ready(&sim);
             let consumer = new_bound_consumer();
 
-            let acks_before = sim.acks_sent.load(Ordering::SeqCst);
             let (payload, token) = bound_frame(1, 1001, 10_000, 77);
             let out = verify_then_maybe_actuate(consumer, link, &payload, &token, 10_050, 1);
 
             assert_eq!(out.kind, 0, "the release should verify");
             assert_eq!(out.write, 1, "the core should release");
 
-            std::thread::sleep(std::time::Duration::from_millis(120));
+            // Wait for the count to REACH one rather than sleeping a fixed
+            // interval and hoping, then keep watching to prove it does not go
+            // higher. A bare sleep is both slower and weaker.
+            settle_until(&sim.motion_frames, 1);
             assert_eq!(
                 sim.motion_frames.load(Ordering::SeqCst),
                 1,
                 "exactly one MOTION_COMMAND should reach the peer"
             );
+            settle_until(&sim.motion_acks, 1);
             assert_eq!(
-                sim.acks_sent.load(Ordering::SeqCst) - acks_before,
+                sim.motion_acks.load(Ordering::SeqCst),
                 1,
                 "exactly one COMMAND_ACK should come back"
             );
@@ -1260,7 +1292,9 @@ mod tests {
                 let out = verify_then_maybe_actuate(consumer, link, &payload, &token, now_ms, 1);
 
                 assert_eq!(out.write, 0, "{name}: the core must not release");
-                std::thread::sleep(std::time::Duration::from_millis(120));
+                // Target 0 means "wait the quiet period and confirm nothing
+                // arrived", which is what a zero-claim actually requires.
+                settle_until(&sim.motion_frames, 0);
                 assert_eq!(
                     sim.motion_frames.load(Ordering::SeqCst),
                     0,
@@ -1274,7 +1308,7 @@ mod tests {
                 let released =
                     verify_then_maybe_actuate(consumer, link, &ok_payload, &ok_token, 10_050, 2);
                 assert_eq!(released.write, 1, "{name}: control release should pass");
-                std::thread::sleep(std::time::Duration::from_millis(120));
+                settle_until(&sim.motion_frames, 1);
                 assert_eq!(
                     sim.motion_frames.load(Ordering::SeqCst),
                     1,
@@ -1306,7 +1340,7 @@ mod tests {
             let second = verify_then_maybe_actuate(consumer, link, &payload, &token, 10_060, 2);
             assert_eq!(second.write, 0, "a replayed release must not re-release");
 
-            std::thread::sleep(std::time::Duration::from_millis(120));
+            settle_until(&sim.motion_frames, 1);
             assert_eq!(
                 sim.motion_frames.load(Ordering::SeqCst),
                 1,

--- a/crates/kirra-consumer-ffi/src/lib.rs
+++ b/crates/kirra-consumer-ffi/src/lib.rs
@@ -1335,3 +1335,7 @@ mod tests {
         }
     }
 }
+
+/// The R2CP link surface (stage 4 of the MCU migration). Separate module,
+/// same rule: decisions across the boundary, never wire bytes.
+pub mod r2cp;

--- a/crates/kirra-consumer-ffi/src/r2cp.rs
+++ b/crates/kirra-consumer-ffi/src/r2cp.rs
@@ -1,0 +1,551 @@
+//! C-ABI over the R2CP link — an **opaque handle**, deliberately.
+//!
+//! Same rule as the rest of this crate: the Python consumer never sees a key,
+//! a signature or a watermark, and it must never see a COBS run, a CRC, a
+//! nonce, a sequence watermark or an ACK result code either. Framing lives in
+//! ONE implementation (`kirra-r2cp`, differentially tested against the
+//! normative `wire.cpp`); a Python re-implementation would be a third dialect
+//! that nothing tests against either of the other two.
+//!
+//! So this surface exposes *decisions*, not bytes. Python selects the mode,
+//! passes SI-unit command fields, and reports errors.
+//!
+//! # The handshake is inside `open`
+//!
+//! [`kirra_r2cp_open`] probes the peer and returns a handle ONLY if one
+//! answered acceptably. There is no way to hold a handle to an unidentified
+//! device, so "command a peer we never identified" is not a mistake the caller
+//! can make — it is unrepresentable rather than merely discouraged.
+//!
+//! On the bring-up robot that matters concretely: `/dev/myserial` is a stock
+//! vendor motor board which does not speak R2CP, and writing R2CP frames into
+//! a vendor command parser attached to motors is undefined behaviour.
+//!
+//! # Status classes exist so systemd can behave correctly
+//!
+//! [`kirra_r2cp_status_class`] separates DETERMINISTIC CONFIGURATION failures
+//! from HARDWARE AVAILABILITY ones. This is not cosmetic: the consumer unit
+//! carries `RestartPreventExitStatus=2`, so a fault reported as configuration
+//! stops the unit permanently. An MCU that was merely unplugged at boot must
+//! NOT land there, or reconnecting it would leave the unit dead until someone
+//! runs `systemctl reset-failed`.
+
+use std::ffi::{c_char, CStr};
+use std::path::PathBuf;
+
+use kirra_r2cp::handshake::HandshakeError;
+use kirra_r2cp::link::{LinkError, LinkFault, SerialLink};
+use kirra_r2cp::sim::{MotionCommand, MODE_TRACK};
+
+/// Opaque to C. The identified peer lives INSIDE it, so a reopen starts
+/// unidentified by construction.
+pub struct KirraR2cpLink {
+    link: SerialLink,
+    /// Kept so a caller can be told which device failed without re-deriving it.
+    device: PathBuf,
+}
+
+// ---------------------------------------------------------------- status codes
+
+pub const KIRRA_R2CP_OK: i32 = 0;
+
+// 10..19 — DETERMINISTIC CONFIGURATION. Will not fix itself; restarting only
+// repeats it. These are the ones that deserve the consumer's exit 2.
+pub const KIRRA_R2CP_BAD_PATH: i32 = 10;
+pub const KIRRA_R2CP_DEVICE_NOT_FOUND: i32 = 11;
+pub const KIRRA_R2CP_PERMISSION_DENIED: i32 = 12;
+pub const KIRRA_R2CP_NOT_A_SERIAL_DEVICE: i32 = 13;
+
+// 20..29 — HARDWARE AVAILABILITY. May resolve without a config change (someone
+// plugs the MCU back in, the board finishes booting). Bounded restart is the
+// right response, NOT a permanent stop.
+pub const KIRRA_R2CP_NO_PEER: i32 = 20;
+pub const KIRRA_R2CP_DISCONNECTED: i32 = 21;
+pub const KIRRA_R2CP_FRAMING_LOST: i32 = 22;
+
+// 30..39 — PROTOCOL DISAGREEMENT. A peer answered and we cannot work with it.
+// Deterministic for a given pair of builds, but a firmware update fixes it
+// without touching this robot's configuration, so it is its own class.
+pub const KIRRA_R2CP_VERSION_MISMATCH: i32 = 30;
+pub const KIRRA_R2CP_FRAME_LIMIT: i32 = 31;
+pub const KIRRA_R2CP_BAD_HANDSHAKE_REPLY: i32 = 32;
+pub const KIRRA_R2CP_NOT_ACKNOWLEDGED: i32 = 33;
+pub const KIRRA_R2CP_REFUSED: i32 = 34;
+
+// 40+ — caller/runtime errors.
+pub const KIRRA_R2CP_NULL_ARGUMENT: i32 = 40;
+pub const KIRRA_R2CP_NOT_IDENTIFIED: i32 = 41;
+pub const KIRRA_R2CP_IO: i32 = 42;
+
+/// Status classes. See the module docs — the consumer maps these to exit
+/// codes, and mapping availability to the configuration exit would make an
+/// unplugged MCU unrecoverable.
+pub const KIRRA_R2CP_CLASS_OK: i32 = 0;
+pub const KIRRA_R2CP_CLASS_CONFIG: i32 = 1;
+pub const KIRRA_R2CP_CLASS_AVAILABILITY: i32 = 2;
+pub const KIRRA_R2CP_CLASS_PROTOCOL: i32 = 3;
+pub const KIRRA_R2CP_CLASS_RUNTIME: i32 = 4;
+
+/// Classify a status.
+///
+/// # Note on the one genuinely ambiguous case
+///
+/// [`KIRRA_R2CP_NO_PEER`] is classed as AVAILABILITY even though, on the
+/// bring-up robot, "nothing answered" is *also* exactly what a mis-selected
+/// mode against a vendor board looks like. The link cannot tell those apart —
+/// both are silence — so the classification is a deliberate choice under
+/// uncertainty:
+///
+/// * Calling a recoverable hardware fault permanent leaves a reconnected MCU
+///   dead until someone runs `systemctl reset-failed`.
+/// * Calling a wrong-mode misconfiguration recoverable costs a bounded burst
+///   of restarts that fail loudly and identically, with the cause named in
+///   every one, and `StartLimitBurst` stops the churn.
+///
+/// The second failure is visible and self-limiting; the first is silent and
+/// needs an operator who knows the incantation.
+#[no_mangle]
+pub extern "C" fn kirra_r2cp_status_class(status: i32) -> i32 {
+    match status {
+        KIRRA_R2CP_OK => KIRRA_R2CP_CLASS_OK,
+        10..=19 => KIRRA_R2CP_CLASS_CONFIG,
+        20..=29 => KIRRA_R2CP_CLASS_AVAILABILITY,
+        30..=39 => KIRRA_R2CP_CLASS_PROTOCOL,
+        _ => KIRRA_R2CP_CLASS_RUNTIME,
+    }
+}
+
+/// A static, operator-facing sentence for `status`. Never NULL.
+#[no_mangle]
+pub extern "C" fn kirra_r2cp_status_message(status: i32) -> *const c_char {
+    let s: &CStr = match status {
+        KIRRA_R2CP_OK => c"ok",
+        KIRRA_R2CP_BAD_PATH => c"device path is empty or not valid UTF-8",
+        KIRRA_R2CP_DEVICE_NOT_FOUND => c"device does not exist",
+        KIRRA_R2CP_PERMISSION_DENIED => c"permission denied opening the device",
+        KIRRA_R2CP_NOT_A_SERIAL_DEVICE => {
+            c"device is not a serial device (raw mode could not be set)"
+        }
+        KIRRA_R2CP_NO_PEER => {
+            c"no R2CP peer answered. Either the MCU is not connected/powered, or this \
+              device is a VENDOR motor board, which does not speak R2CP — refusing to \
+              send it frames"
+        }
+        KIRRA_R2CP_DISCONNECTED => c"the device went away (cable, power or MCU reset)",
+        KIRRA_R2CP_FRAMING_LOST => {
+            c"sustained framing failure: the two ends disagree about frame boundaries"
+        }
+        KIRRA_R2CP_VERSION_MISMATCH => c"no overlapping protocol major version with the peer",
+        KIRRA_R2CP_FRAME_LIMIT => c"the peer's advertised maximum frame size is unusable",
+        KIRRA_R2CP_BAD_HANDSHAKE_REPLY => {
+            c"the peer's handshake reply did not match the probe (stale, replayed or malformed)"
+        }
+        KIRRA_R2CP_NOT_ACKNOWLEDGED => c"the peer did not acknowledge a control frame",
+        KIRRA_R2CP_REFUSED => c"the peer refused the command",
+        KIRRA_R2CP_NULL_ARGUMENT => c"a required argument was NULL",
+        KIRRA_R2CP_NOT_IDENTIFIED => {
+            c"the peer is no longer identified; a fresh handshake is required"
+        }
+        _ => c"link I/O error",
+    };
+    s.as_ptr()
+}
+
+fn classify_open_error(e: &std::io::Error) -> i32 {
+    match e.kind() {
+        std::io::ErrorKind::NotFound => KIRRA_R2CP_DEVICE_NOT_FOUND,
+        std::io::ErrorKind::PermissionDenied => KIRRA_R2CP_PERMISSION_DENIED,
+        // ENOTTY from tcgetattr/tcsetattr: the path exists and opened, but it
+        // is not a terminal — a regular file or a socket someone pointed the
+        // config at. That is configuration, not availability.
+        _ if e.raw_os_error() == Some(25) => KIRRA_R2CP_NOT_A_SERIAL_DEVICE,
+        _ => KIRRA_R2CP_IO,
+    }
+}
+
+fn classify_link_error(e: &LinkError) -> i32 {
+    match e {
+        LinkError::Handshake(HandshakeError::NoResponse) => KIRRA_R2CP_NO_PEER,
+        LinkError::Handshake(HandshakeError::VersionMismatch { .. }) => KIRRA_R2CP_VERSION_MISMATCH,
+        LinkError::Handshake(
+            HandshakeError::FrameTooSmall { .. }
+            | HandshakeError::FrameBelowProtocolMinimum { .. }
+            | HandshakeError::FrameAboveProtocolMaximum { .. },
+        ) => KIRRA_R2CP_FRAME_LIMIT,
+        LinkError::Handshake(_) => KIRRA_R2CP_BAD_HANDSHAKE_REPLY,
+        LinkError::NotHandshaken => KIRRA_R2CP_NOT_IDENTIFIED,
+        LinkError::NotAcknowledged(_) => KIRRA_R2CP_NOT_ACKNOWLEDGED,
+        LinkError::Io(io) => classify_open_error(io),
+    }
+}
+
+/// Peer metadata for the caller's log. No wire details.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct KirraR2cpPeerInfo {
+    pub implementation_id: u32,
+    pub firmware_semver: u32,
+    pub maximum_frame: u16,
+    pub agreed_major: u8,
+    /// 1 while the peer is identified; 0 after a disconnect, sustained framing
+    /// failure, or an explicit reset. A caller seeing 0 must re-open.
+    pub identified: u8,
+}
+
+/// The outcome of one command. `result` is the peer's COMMAND_ACK result code.
+///
+/// ⚠ Those numeric values are PROVISIONAL — `PROTOCOL.md` names the results in
+/// prose but binds no wire values. A caller should log `accepted` and treat
+/// `result`/`safety_state` as diagnostics until the firmware adopts them.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct KirraR2cpAck {
+    /// 1 if the peer acknowledged with ACCEPTED. This is the field to branch on.
+    pub accepted: u8,
+    /// Mirrors `safety_manager.hpp` discriminants — NOT provisional.
+    pub safety_state: u8,
+    pub result: u16,
+    /// 1 if no acknowledgement arrived within the timeout.
+    pub timed_out: u8,
+}
+
+/// Open `device`, put it in raw mode, and complete the HELLO handshake.
+///
+/// On success `*out` receives an owned handle the caller must later pass to
+/// [`kirra_r2cp_close`]. On failure `*out` is left NULL and the return value
+/// names the reason — **there is no handle to an unidentified device.**
+///
+/// `nonce` must be 16 unpredictable bytes. It is what ties the peer's reply to
+/// this probe; a constant would let a recorded reply satisfy the gate. The
+/// caller supplies it rather than this layer generating one so the entropy
+/// source stays the caller's explicit choice.
+///
+/// # Safety
+/// - `device` is a NUL-terminated C string.
+/// - `nonce` points to 16 readable bytes.
+/// - `out` points to a writable pointer slot.
+#[no_mangle]
+pub unsafe extern "C" fn kirra_r2cp_open(
+    device: *const c_char,
+    nonce: *const u8,
+    timeout_ms: u16,
+    out: *mut *mut KirraR2cpLink,
+) -> i32 {
+    if device.is_null() || nonce.is_null() || out.is_null() {
+        return KIRRA_R2CP_NULL_ARGUMENT;
+    }
+    // SAFETY: caller guarantees a writable slot.
+    unsafe { *out = std::ptr::null_mut() };
+
+    // SAFETY: caller guarantees a NUL-terminated string.
+    let path = match unsafe { CStr::from_ptr(device) }.to_str() {
+        Ok(s) if !s.is_empty() => PathBuf::from(s),
+        _ => return KIRRA_R2CP_BAD_PATH,
+    };
+    let mut nonce_buf = [0u8; 16];
+    // SAFETY: caller guarantees 16 readable bytes.
+    nonce_buf.copy_from_slice(unsafe { std::slice::from_raw_parts(nonce, 16) });
+
+    let mut link = match SerialLink::open(&path, None) {
+        Ok(l) => l,
+        Err(e) => return classify_open_error(&e),
+    };
+    if let Err(e) = link.handshake(nonce_buf, timeout_ms) {
+        return classify_link_error(&e);
+    }
+    let boxed = Box::new(KirraR2cpLink { link, device: path });
+    // SAFETY: caller guarantees a writable slot.
+    unsafe { *out = Box::into_raw(boxed) };
+    KIRRA_R2CP_OK
+}
+
+/// ARM then ACTIVATE, each requiring an acknowledgement.
+///
+/// # Safety
+/// `h` is a live handle from [`kirra_r2cp_open`].
+#[no_mangle]
+pub unsafe extern "C" fn kirra_r2cp_activate(h: *mut KirraR2cpLink, timeout_ms: u16) -> i32 {
+    let Some(link) = (unsafe { h.as_mut() }) else {
+        return KIRRA_R2CP_NULL_ARGUMENT;
+    };
+    match link.link.arm_and_activate(timeout_ms) {
+        Ok(()) => KIRRA_R2CP_OK,
+        Err(e) => classify_link_error(&e),
+    }
+}
+
+/// Peer metadata, including whether it is still identified.
+///
+/// # Safety
+/// `h` is a live handle; `out` points to a writable [`KirraR2cpPeerInfo`].
+#[no_mangle]
+pub unsafe extern "C" fn kirra_r2cp_peer_info(
+    h: *mut KirraR2cpLink,
+    out: *mut KirraR2cpPeerInfo,
+) -> i32 {
+    let (Some(link), false) = (unsafe { h.as_mut() }, out.is_null()) else {
+        return KIRRA_R2CP_NULL_ARGUMENT;
+    };
+    let info = match link.link.peer() {
+        Some(p) => KirraR2cpPeerInfo {
+            implementation_id: p.implementation_id,
+            firmware_semver: p.firmware_semver,
+            maximum_frame: p.maximum_frame,
+            agreed_major: p.agreed_major,
+            identified: 1,
+        },
+        None => KirraR2cpPeerInfo::default(),
+    };
+    // SAFETY: caller guarantees a writable struct.
+    unsafe { *out = info };
+    if info.identified == 1 {
+        KIRRA_R2CP_OK
+    } else {
+        match link.link.fault() {
+            Some(LinkFault::Disconnected) => KIRRA_R2CP_DISCONNECTED,
+            Some(LinkFault::FramingLost { .. }) => KIRRA_R2CP_FRAMING_LOST,
+            _ => KIRRA_R2CP_NOT_IDENTIFIED,
+        }
+    }
+}
+
+/// Send one motion command and wait for its acknowledgement.
+///
+/// The values are the ones the governor already released — this transports
+/// them, it does not decide them. Nothing here clamps, and nothing here is a
+/// safety authority.
+///
+/// # Safety
+/// `h` is a live handle; `out` points to a writable [`KirraR2cpAck`].
+#[no_mangle]
+pub unsafe extern "C" fn kirra_r2cp_command(
+    h: *mut KirraR2cpLink,
+    velocity_mps: f32,
+    curvature_per_m: f32,
+    acceleration_limit_mps2: f32,
+    jerk_limit_mps3: f32,
+    valid_for_us: u32,
+    command_id: u32,
+    source_time_us: u64,
+    timeout_ms: u16,
+    out: *mut KirraR2cpAck,
+) -> i32 {
+    let (Some(link), false) = (unsafe { h.as_mut() }, out.is_null()) else {
+        return KIRRA_R2CP_NULL_ARGUMENT;
+    };
+    // SAFETY: caller guarantees a writable struct.
+    unsafe { *out = KirraR2cpAck::default() };
+
+    let cmd = MotionCommand {
+        command_id,
+        valid_for_us,
+        velocity_mps,
+        curvature_per_m,
+        acceleration_limit_mps2,
+        jerk_limit_mps3,
+        mode: MODE_TRACK,
+    };
+    let seq = match link.link.send_motion(&cmd, source_time_us) {
+        Ok(s) => s,
+        Err(e) => return classify_link_error(&e),
+    };
+    let received = match link.link.receive(timeout_ms) {
+        Ok(r) => r,
+        Err(e) => return classify_open_error(&e),
+    };
+    let Some(ack) = received
+        .frames
+        .iter()
+        .find(|f| kirra_r2cp::link::ack_received_sequence(f) == Some(seq))
+    else {
+        // SAFETY: caller guarantees a writable struct.
+        unsafe { (*out).timed_out = 1 };
+        return KIRRA_R2CP_NOT_ACKNOWLEDGED;
+    };
+    let result = kirra_r2cp::link::ack_result(ack).unwrap_or(u16::MAX);
+    let accepted = u8::from(result == kirra_r2cp::sim::ack_result::ACCEPTED);
+    // SAFETY: caller guarantees a writable struct.
+    unsafe {
+        *out = KirraR2cpAck {
+            accepted,
+            safety_state: kirra_r2cp::link::ack_safety_state(ack).unwrap_or(0),
+            result,
+            timed_out: 0,
+        }
+    };
+    if accepted == 1 {
+        KIRRA_R2CP_OK
+    } else {
+        KIRRA_R2CP_REFUSED
+    }
+}
+
+/// Send a stop. Works even after the peer has been de-identified.
+///
+/// 🔴 **`KIRRA_R2CP_OK` here means the bytes were written — NOT that anything
+/// stopped.** Nothing is read back, and if the peer was de-identified this may
+/// be writing to a device that is not an R2CP peer at all. The thing that
+/// actually stops a governed robot is the peer's own watchdog: commands cease,
+/// the window lapses, the MCU enters ControlledStop by itself. This makes that
+/// immediate when the peer is real; it is not a substitute for it, and a caller
+/// must log it as "stop sent", never "stopped".
+///
+/// # Safety
+/// `h` is a live handle from [`kirra_r2cp_open`].
+#[no_mangle]
+pub unsafe extern "C" fn kirra_r2cp_stop(
+    h: *mut KirraR2cpLink,
+    valid_for_us: u32,
+    source_time_us: u64,
+) -> i32 {
+    let Some(link) = (unsafe { h.as_mut() }) else {
+        return KIRRA_R2CP_NULL_ARGUMENT;
+    };
+    match link.link.send_stop(valid_for_us, source_time_us) {
+        Ok(_) => KIRRA_R2CP_OK,
+        Err(e) => classify_open_error(&e),
+    }
+}
+
+/// Drop the identified peer, requiring a fresh open before further commands.
+/// The hook for a watchdog-triggered stop.
+///
+/// # Safety
+/// `h` is a live handle from [`kirra_r2cp_open`].
+#[no_mangle]
+pub unsafe extern "C" fn kirra_r2cp_reset(h: *mut KirraR2cpLink) -> i32 {
+    let Some(link) = (unsafe { h.as_mut() }) else {
+        return KIRRA_R2CP_NULL_ARGUMENT;
+    };
+    link.link.reset();
+    KIRRA_R2CP_OK
+}
+
+/// The device path this handle was opened on. Valid until [`kirra_r2cp_close`].
+///
+/// # Safety
+/// `h` is a live handle; the returned pointer must not outlive it.
+#[no_mangle]
+pub unsafe extern "C" fn kirra_r2cp_device_len(h: *mut KirraR2cpLink) -> usize {
+    match unsafe { h.as_ref() } {
+        Some(l) => l.device.as_os_str().len(),
+        None => 0,
+    }
+}
+
+/// Free a handle. Safe with NULL (no-op).
+///
+/// # Safety
+/// `h` must come from [`kirra_r2cp_open`] and not already be freed.
+#[no_mangle]
+pub unsafe extern "C" fn kirra_r2cp_close(h: *mut KirraR2cpLink) {
+    if !h.is_null() {
+        // SAFETY: caller guarantees provenance and single free.
+        drop(unsafe { Box::from_raw(h) });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn availability_and_configuration_are_different_classes() {
+        // The distinction the consumer's exit code rests on. If these ever
+        // collapse, an MCU that was merely unplugged at boot becomes
+        // permanently un-restartable under RestartPreventExitStatus=2.
+        assert_eq!(
+            kirra_r2cp_status_class(KIRRA_R2CP_NO_PEER),
+            KIRRA_R2CP_CLASS_AVAILABILITY
+        );
+        assert_eq!(
+            kirra_r2cp_status_class(KIRRA_R2CP_DISCONNECTED),
+            KIRRA_R2CP_CLASS_AVAILABILITY
+        );
+        assert_eq!(
+            kirra_r2cp_status_class(KIRRA_R2CP_DEVICE_NOT_FOUND),
+            KIRRA_R2CP_CLASS_CONFIG
+        );
+        assert_eq!(
+            kirra_r2cp_status_class(KIRRA_R2CP_PERMISSION_DENIED),
+            KIRRA_R2CP_CLASS_CONFIG
+        );
+        assert_ne!(
+            kirra_r2cp_status_class(KIRRA_R2CP_NO_PEER),
+            kirra_r2cp_status_class(KIRRA_R2CP_DEVICE_NOT_FOUND),
+            "a silent peer must not be classed with a missing device"
+        );
+    }
+
+    #[test]
+    fn every_status_has_a_message_and_a_class() {
+        for status in [
+            KIRRA_R2CP_OK,
+            KIRRA_R2CP_BAD_PATH,
+            KIRRA_R2CP_DEVICE_NOT_FOUND,
+            KIRRA_R2CP_PERMISSION_DENIED,
+            KIRRA_R2CP_NOT_A_SERIAL_DEVICE,
+            KIRRA_R2CP_NO_PEER,
+            KIRRA_R2CP_DISCONNECTED,
+            KIRRA_R2CP_FRAMING_LOST,
+            KIRRA_R2CP_VERSION_MISMATCH,
+            KIRRA_R2CP_FRAME_LIMIT,
+            KIRRA_R2CP_BAD_HANDSHAKE_REPLY,
+            KIRRA_R2CP_NOT_ACKNOWLEDGED,
+            KIRRA_R2CP_REFUSED,
+            KIRRA_R2CP_NULL_ARGUMENT,
+            KIRRA_R2CP_NOT_IDENTIFIED,
+            KIRRA_R2CP_IO,
+        ] {
+            let msg = unsafe { CStr::from_ptr(kirra_r2cp_status_message(status)) };
+            assert!(
+                !msg.to_bytes().is_empty(),
+                "status {status} has no operator message"
+            );
+            let class = kirra_r2cp_status_class(status);
+            assert!((0..=4).contains(&class), "status {status} class {class}");
+        }
+    }
+
+    #[test]
+    fn the_no_peer_message_names_the_vendor_board() {
+        // "no response" alone sends an operator hunting a cable fault; on this
+        // robot the likeliest cause is a mode pointed at the vendor board.
+        let msg = unsafe { CStr::from_ptr(kirra_r2cp_status_message(KIRRA_R2CP_NO_PEER)) }
+            .to_str()
+            .unwrap();
+        assert!(msg.contains("VENDOR"), "got: {msg}");
+        assert!(msg.contains("not connected"), "got: {msg}");
+    }
+
+    #[test]
+    fn null_arguments_are_refused_not_dereferenced() {
+        let mut out: *mut KirraR2cpLink = std::ptr::null_mut();
+        let nonce = [0u8; 16];
+        assert_eq!(
+            unsafe { kirra_r2cp_open(std::ptr::null(), nonce.as_ptr(), 10, &mut out) },
+            KIRRA_R2CP_NULL_ARGUMENT
+        );
+        assert_eq!(
+            unsafe { kirra_r2cp_activate(std::ptr::null_mut(), 10) },
+            KIRRA_R2CP_NULL_ARGUMENT
+        );
+        assert_eq!(
+            unsafe { kirra_r2cp_stop(std::ptr::null_mut(), 100_000, 0) },
+            KIRRA_R2CP_NULL_ARGUMENT
+        );
+        // close(NULL) is a documented no-op, not a crash.
+        unsafe { kirra_r2cp_close(std::ptr::null_mut()) };
+    }
+
+    #[test]
+    fn a_missing_device_is_configuration_not_availability() {
+        let mut out: *mut KirraR2cpLink = std::ptr::null_mut();
+        let nonce = [1u8; 16];
+        let path = c"/dev/definitely-not-a-real-device-kirra";
+        let status = unsafe { kirra_r2cp_open(path.as_ptr(), nonce.as_ptr(), 10, &mut out) };
+        assert_eq!(status, KIRRA_R2CP_DEVICE_NOT_FOUND);
+        assert_eq!(kirra_r2cp_status_class(status), KIRRA_R2CP_CLASS_CONFIG);
+        assert!(out.is_null(), "no handle on failure");
+    }
+}

--- a/crates/kirra-consumer-ffi/src/r2cp.rs
+++ b/crates/kirra-consumer-ffi/src/r2cp.rs
@@ -62,6 +62,11 @@ pub const KIRRA_R2CP_NOT_A_SERIAL_DEVICE: i32 = 13;
 pub const KIRRA_R2CP_NO_PEER: i32 = 20;
 pub const KIRRA_R2CP_DISCONNECTED: i32 = 21;
 pub const KIRRA_R2CP_FRAMING_LOST: i32 = 22;
+/// The port is already held exclusively by another process. AVAILABILITY, not
+/// configuration: the other holder may exit without anything about this
+/// robot's config changing, and a permanent stop would then need a manual
+/// `systemctl reset-failed` to undo.
+pub const KIRRA_R2CP_PORT_BUSY: i32 = 23;
 
 // 30..39 — PROTOCOL DISAGREEMENT. A peer answered and we cannot work with it.
 // Deterministic for a given pair of builds, but a firmware update fixes it
@@ -132,6 +137,10 @@ pub extern "C" fn kirra_r2cp_status_message(status: i32) -> *const c_char {
               send it frames"
         }
         KIRRA_R2CP_DISCONNECTED => c"the device went away (cable, power or MCU reset)",
+        KIRRA_R2CP_PORT_BUSY => {
+            c"the serial port is already held exclusively by another process — \
+              refusing to share the path to the motors (ADR-0033 sole writer)"
+        }
         KIRRA_R2CP_FRAMING_LOST => {
             c"sustained framing failure: the two ends disagree about frame boundaries"
         }
@@ -155,6 +164,9 @@ fn classify_open_error(e: &std::io::Error) -> i32 {
     match e.kind() {
         std::io::ErrorKind::NotFound => KIRRA_R2CP_DEVICE_NOT_FOUND,
         std::io::ErrorKind::PermissionDenied => KIRRA_R2CP_PERMISSION_DENIED,
+        // EBUSY: someone else holds TIOCEXCL on this port. Availability, not
+        // configuration — see KIRRA_R2CP_PORT_BUSY.
+        std::io::ErrorKind::ResourceBusy => KIRRA_R2CP_PORT_BUSY,
         // ENOTTY from tcgetattr/tcsetattr: the path exists and opened, but it
         // is not a terminal — a regular file or a socket someone pointed the
         // config at. That is configuration, not availability.
@@ -190,6 +202,10 @@ pub struct KirraR2cpPeerInfo {
     /// 1 while the peer is identified; 0 after a disconnect, sustained framing
     /// failure, or an explicit reset. A caller seeing 0 must re-open.
     pub identified: u8,
+    /// 1 when the KERNEL CONFIRMS this descriptor holds the tty exclusively
+    /// (read back with TIOCGEXCL, not inferred from the claim returning 0).
+    /// A caller may only tell an operator the port is exclusive when this is 1.
+    pub exclusive: u8,
 }
 
 /// The outcome of one command. `result` is the peer's COMMAND_ACK result code.
@@ -288,8 +304,15 @@ pub unsafe extern "C" fn kirra_r2cp_peer_info(
             maximum_frame: p.maximum_frame,
             agreed_major: p.agreed_major,
             identified: 1,
+            exclusive: u8::from(link.link.is_exclusive()),
         },
-        None => KirraR2cpPeerInfo::default(),
+        None => KirraR2cpPeerInfo {
+            // Exclusivity is a property of the DESCRIPTOR, not of
+            // identification: a de-identified link still holds the port, and
+            // reporting otherwise would understate what is held.
+            exclusive: u8::from(link.link.is_exclusive()),
+            ..KirraR2cpPeerInfo::default()
+        },
     };
     // SAFETY: caller guarantees a writable struct.
     unsafe { *out = info };
@@ -457,6 +480,12 @@ mod tests {
             kirra_r2cp_status_class(KIRRA_R2CP_DISCONNECTED),
             KIRRA_R2CP_CLASS_AVAILABILITY
         );
+        // Another process holding the port may release it without any config
+        // change, so a permanent stop would be wrong here too.
+        assert_eq!(
+            kirra_r2cp_status_class(KIRRA_R2CP_PORT_BUSY),
+            KIRRA_R2CP_CLASS_AVAILABILITY
+        );
         assert_eq!(
             kirra_r2cp_status_class(KIRRA_R2CP_DEVICE_NOT_FOUND),
             KIRRA_R2CP_CLASS_CONFIG
@@ -482,6 +511,7 @@ mod tests {
             KIRRA_R2CP_NOT_A_SERIAL_DEVICE,
             KIRRA_R2CP_NO_PEER,
             KIRRA_R2CP_DISCONNECTED,
+            KIRRA_R2CP_PORT_BUSY,
             KIRRA_R2CP_FRAMING_LOST,
             KIRRA_R2CP_VERSION_MISMATCH,
             KIRRA_R2CP_FRAME_LIMIT,

--- a/crates/kirra-consumer-ffi/src/r2cp.rs
+++ b/crates/kirra-consumer-ffi/src/r2cp.rs
@@ -215,23 +215,22 @@ pub struct KirraR2cpAck {
 /// [`kirra_r2cp_close`]. On failure `*out` is left NULL and the return value
 /// names the reason — **there is no handle to an unidentified device.**
 ///
-/// `nonce` must be 16 unpredictable bytes. It is what ties the peer's reply to
-/// this probe; a constant would let a recorded reply satisfy the gate. The
-/// caller supplies it rather than this layer generating one so the entropy
-/// source stays the caller's explicit choice.
+/// The handshake nonce is drawn from the OS entropy pool INSIDE this call. It
+/// is deliberately not a parameter: the caller is a Python node that must not
+/// hold nonce logic, and a predictable nonce silently converts the gate into
+/// theatre with no visible symptom. One audited entropy source beats a
+/// contract every caller has to honour.
 ///
 /// # Safety
 /// - `device` is a NUL-terminated C string.
-/// - `nonce` points to 16 readable bytes.
 /// - `out` points to a writable pointer slot.
 #[no_mangle]
 pub unsafe extern "C" fn kirra_r2cp_open(
     device: *const c_char,
-    nonce: *const u8,
     timeout_ms: u16,
     out: *mut *mut KirraR2cpLink,
 ) -> i32 {
-    if device.is_null() || nonce.is_null() || out.is_null() {
+    if device.is_null() || out.is_null() {
         return KIRRA_R2CP_NULL_ARGUMENT;
     }
     // SAFETY: caller guarantees a writable slot.
@@ -242,15 +241,11 @@ pub unsafe extern "C" fn kirra_r2cp_open(
         Ok(s) if !s.is_empty() => PathBuf::from(s),
         _ => return KIRRA_R2CP_BAD_PATH,
     };
-    let mut nonce_buf = [0u8; 16];
-    // SAFETY: caller guarantees 16 readable bytes.
-    nonce_buf.copy_from_slice(unsafe { std::slice::from_raw_parts(nonce, 16) });
-
     let mut link = match SerialLink::open(&path, None) {
         Ok(l) => l,
         Err(e) => return classify_open_error(&e),
     };
-    if let Err(e) = link.handshake(nonce_buf, timeout_ms) {
+    if let Err(e) = link.handshake_fresh(timeout_ms) {
         return classify_link_error(&e);
     }
     let boxed = Box::new(KirraR2cpLink { link, device: path });
@@ -521,9 +516,8 @@ mod tests {
     #[test]
     fn null_arguments_are_refused_not_dereferenced() {
         let mut out: *mut KirraR2cpLink = std::ptr::null_mut();
-        let nonce = [0u8; 16];
         assert_eq!(
-            unsafe { kirra_r2cp_open(std::ptr::null(), nonce.as_ptr(), 10, &mut out) },
+            unsafe { kirra_r2cp_open(std::ptr::null(), 10, &mut out) },
             KIRRA_R2CP_NULL_ARGUMENT
         );
         assert_eq!(
@@ -541,9 +535,8 @@ mod tests {
     #[test]
     fn a_missing_device_is_configuration_not_availability() {
         let mut out: *mut KirraR2cpLink = std::ptr::null_mut();
-        let nonce = [1u8; 16];
         let path = c"/dev/definitely-not-a-real-device-kirra";
-        let status = unsafe { kirra_r2cp_open(path.as_ptr(), nonce.as_ptr(), 10, &mut out) };
+        let status = unsafe { kirra_r2cp_open(path.as_ptr(), 10, &mut out) };
         assert_eq!(status, KIRRA_R2CP_DEVICE_NOT_FOUND);
         assert_eq!(kirra_r2cp_status_class(status), KIRRA_R2CP_CLASS_CONFIG);
         assert!(out.is_null(), "no handle on failure");

--- a/crates/kirra-consumer-ffi/tests/r2cp_against_simulator.rs
+++ b/crates/kirra-consumer-ffi/tests/r2cp_against_simulator.rs
@@ -15,8 +15,6 @@ use kirra_consumer_ffi::r2cp::*;
 use kirra_r2cp::pty::SimulatedMcuPty;
 use kirra_r2cp::sim::SimulatedMcu;
 
-const NONCE: [u8; 16] = [0x5A; 16];
-
 struct SimHandle {
     device: PathBuf,
     stop: std::sync::mpsc::Sender<()>,
@@ -69,7 +67,7 @@ impl SilentPeer {
 fn open_link(device: &std::path::Path, timeout_ms: u16) -> (i32, *mut KirraR2cpLink) {
     let c = CString::new(device.to_str().unwrap()).unwrap();
     let mut handle: *mut KirraR2cpLink = std::ptr::null_mut();
-    let status = unsafe { kirra_r2cp_open(c.as_ptr(), NONCE.as_ptr(), timeout_ms, &mut handle) };
+    let status = unsafe { kirra_r2cp_open(c.as_ptr(), timeout_ms, &mut handle) };
     (status, handle)
 }
 

--- a/crates/kirra-consumer-ffi/tests/r2cp_against_simulator.rs
+++ b/crates/kirra-consumer-ffi/tests/r2cp_against_simulator.rs
@@ -1,0 +1,221 @@
+//! The FFI surface driven against the PTY simulator — the same path the Python
+//! consumer will take.
+//!
+//! These go through `kirra_r2cp_open`/`_activate`/`_command`/`_stop`/`_close`
+//! exactly as ctypes will, rather than through the Rust API underneath. A test
+//! that called `SerialLink` directly would leave the C boundary — the pointer
+//! handling, the status mapping, the "no handle on failure" rule — unproven.
+
+use std::ffi::CString;
+use std::io::Write;
+use std::os::fd::AsFd;
+use std::path::PathBuf;
+
+use kirra_consumer_ffi::r2cp::*;
+use kirra_r2cp::pty::SimulatedMcuPty;
+use kirra_r2cp::sim::SimulatedMcu;
+
+const NONCE: [u8; 16] = [0x5A; 16];
+
+struct SimHandle {
+    device: PathBuf,
+    stop: std::sync::mpsc::Sender<()>,
+}
+
+fn spawn_sim() -> SimHandle {
+    let pty = SimulatedMcuPty::open().expect("allocate a pty");
+    let device = pty.device_path().to_path_buf();
+    let (stop_tx, stop_rx) = std::sync::mpsc::channel::<()>();
+    std::thread::spawn(move || {
+        let mut pty = pty;
+        let mut mcu = SimulatedMcu::new();
+        let started = std::time::Instant::now();
+        loop {
+            if stop_rx.try_recv().is_ok() {
+                return;
+            }
+            let now_us = u64::try_from(started.elapsed().as_micros()).unwrap_or(u64::MAX);
+            if pty.pump(&mut mcu, now_us, 20).is_err() {
+                return;
+            }
+        }
+    });
+    SimHandle {
+        device,
+        stop: stop_tx,
+    }
+}
+
+/// A pty nobody services: present, openable, silent in R2CP terms — the shape
+/// of the vendor motor board on the bring-up robot.
+struct SilentPeer {
+    master: std::fs::File,
+    _slave: std::os::fd::OwnedFd,
+    device: PathBuf,
+}
+
+impl SilentPeer {
+    fn open() -> Self {
+        let pair = nix::pty::openpty(None, None).expect("openpty");
+        let device = nix::unistd::ttyname(pair.slave.as_fd()).expect("ttyname");
+        Self {
+            master: std::fs::File::from(pair.master),
+            _slave: pair.slave,
+            device,
+        }
+    }
+}
+
+fn open_link(device: &std::path::Path, timeout_ms: u16) -> (i32, *mut KirraR2cpLink) {
+    let c = CString::new(device.to_str().unwrap()).unwrap();
+    let mut handle: *mut KirraR2cpLink = std::ptr::null_mut();
+    let status = unsafe { kirra_r2cp_open(c.as_ptr(), NONCE.as_ptr(), timeout_ms, &mut handle) };
+    (status, handle)
+}
+
+#[test]
+fn case_1_simulator_present_command_reaches_it_and_an_ack_returns() {
+    let sim = spawn_sim();
+    let (status, handle) = open_link(&sim.device, 1000);
+    assert_eq!(status, KIRRA_R2CP_OK, "the simulator should answer");
+    assert!(!handle.is_null());
+
+    let mut info = KirraR2cpPeerInfo::default();
+    assert_eq!(
+        unsafe { kirra_r2cp_peer_info(handle, &mut info) },
+        KIRRA_R2CP_OK
+    );
+    assert_eq!(info.identified, 1);
+    assert_eq!(info.agreed_major, 1);
+
+    assert_eq!(unsafe { kirra_r2cp_activate(handle, 1000) }, KIRRA_R2CP_OK);
+
+    let mut ack = KirraR2cpAck::default();
+    let status =
+        unsafe { kirra_r2cp_command(handle, 0.4, 0.0, 1.0, 5.0, 100_000, 7, 0, 1000, &mut ack) };
+    assert_eq!(status, KIRRA_R2CP_OK);
+    assert_eq!(ack.accepted, 1);
+    assert_eq!(ack.timed_out, 0);
+    assert_eq!(ack.safety_state, 4, "safety_manager.hpp: active == 4");
+
+    unsafe { kirra_r2cp_close(handle) };
+    let _ = sim.stop.send(());
+}
+
+#[test]
+fn case_2_a_silent_device_refuses_and_is_an_availability_failure() {
+    // 🔴 The vendor-board case. It must refuse — and it must NOT be classed as
+    // deterministic configuration, or `RestartPreventExitStatus=2` would make
+    // a merely-unplugged MCU unrecoverable after someone reconnects it.
+    let quiet = SilentPeer::open();
+    let (status, handle) = open_link(&quiet.device, 150);
+
+    assert_eq!(status, KIRRA_R2CP_NO_PEER);
+    assert_eq!(
+        kirra_r2cp_status_class(status),
+        KIRRA_R2CP_CLASS_AVAILABILITY
+    );
+    assert!(handle.is_null(), "no handle to an unidentified device");
+}
+
+#[test]
+fn case_3_a_device_chattering_a_foreign_protocol_refuses_and_sends_no_command() {
+    let mut noisy = SilentPeer::open();
+    for _ in 0..8 {
+        noisy
+            .master
+            .write_all(&[0xFF, 0xFE, 0x04, 0x01, 0x02, 0x03, 0x00])
+            .expect("vendor-shaped chatter");
+    }
+    noisy.master.flush().unwrap();
+
+    let (status, handle) = open_link(&noisy.device, 150);
+    assert_ne!(status, KIRRA_R2CP_OK);
+    assert!(handle.is_null());
+    // And there is no way to proceed: without a handle there is no call that
+    // can send a motion command. The refusal is structural, not a convention.
+}
+
+#[test]
+fn case_7_a_link_that_disappears_stops_being_identified() {
+    let sim = spawn_sim();
+    let (status, handle) = open_link(&sim.device, 1000);
+    assert_eq!(status, KIRRA_R2CP_OK);
+    assert_eq!(unsafe { kirra_r2cp_activate(handle, 1000) }, KIRRA_R2CP_OK);
+
+    // The peer goes away mid-session.
+    let _ = sim.stop.send(());
+    std::thread::sleep(std::time::Duration::from_millis(100));
+
+    // Commands now fail rather than silently going nowhere, and peer_info
+    // reports the link is no longer identified.
+    let mut ack = KirraR2cpAck::default();
+    let status =
+        unsafe { kirra_r2cp_command(handle, 0.4, 0.0, 1.0, 5.0, 100_000, 8, 0, 200, &mut ack) };
+    assert_ne!(status, KIRRA_R2CP_OK, "a dead link must not report success");
+    assert_eq!(ack.accepted, 0);
+
+    let mut info = KirraR2cpPeerInfo::default();
+    let status = unsafe { kirra_r2cp_peer_info(handle, &mut info) };
+    assert!(
+        info.identified == 0 || status == KIRRA_R2CP_OK,
+        "identification must not survive a link that stopped answering"
+    );
+    unsafe { kirra_r2cp_close(handle) };
+}
+
+#[test]
+fn case_8_a_stop_is_attempted_even_when_the_peer_was_de_identified() {
+    // A shutdown path must not be blocked by the gate that protects startup.
+    let sim = spawn_sim();
+    let (status, handle) = open_link(&sim.device, 1000);
+    assert_eq!(status, KIRRA_R2CP_OK);
+
+    // Explicitly de-identify (the watchdog-reset hook), then stop anyway.
+    assert_eq!(unsafe { kirra_r2cp_reset(handle) }, KIRRA_R2CP_OK);
+    let mut info = KirraR2cpPeerInfo::default();
+    let _ = unsafe { kirra_r2cp_peer_info(handle, &mut info) };
+    assert_eq!(info.identified, 0);
+
+    // A command is refused...
+    let mut ack = KirraR2cpAck::default();
+    assert_eq!(
+        unsafe { kirra_r2cp_command(handle, 0.4, 0.0, 1.0, 5.0, 100_000, 9, 0, 200, &mut ack) },
+        KIRRA_R2CP_NOT_IDENTIFIED
+    );
+    // ...but a stop is still attempted. OK here means BYTES WRITTEN, not
+    // "stopped" — see the kirra_r2cp_stop docs.
+    assert_eq!(
+        unsafe { kirra_r2cp_stop(handle, 100_000, 0) },
+        KIRRA_R2CP_OK
+    );
+
+    unsafe { kirra_r2cp_close(handle) };
+    let _ = sim.stop.send(());
+}
+
+#[test]
+fn a_handle_is_only_ever_produced_for_an_identified_peer() {
+    // The structural claim the whole surface rests on, stated once as a test:
+    // across every failure mode, `out` is left NULL. "Command a peer we never
+    // identified" is therefore unrepresentable, not merely discouraged.
+    let quiet = SilentPeer::open();
+    let cases: Vec<(&str, PathBuf)> = vec![
+        ("missing device", PathBuf::from("/dev/kirra-no-such-device")),
+        ("silent peer", quiet.device.clone()),
+    ];
+    for (name, device) in cases {
+        let (status, handle) = open_link(&device, 100);
+        assert_ne!(status, KIRRA_R2CP_OK, "{name} should not succeed");
+        assert!(handle.is_null(), "{name} produced a handle");
+    }
+
+    // Positive control: a real peer DOES produce one, so the assertion above
+    // is not passing because open never succeeds.
+    let sim = spawn_sim();
+    let (status, handle) = open_link(&sim.device, 1000);
+    assert_eq!(status, KIRRA_R2CP_OK);
+    assert!(!handle.is_null());
+    unsafe { kirra_r2cp_close(handle) };
+    let _ = sim.stop.send(());
+}

--- a/crates/kirra-consumer-ffi/tests/r2cp_against_simulator.rs
+++ b/crates/kirra-consumer-ffi/tests/r2cp_against_simulator.rs
@@ -193,6 +193,76 @@ fn case_8_a_stop_is_attempted_even_when_the_peer_was_de_identified() {
 }
 
 #[test]
+fn case_6_an_exclusivity_failure_maps_to_the_right_class_and_yields_no_handle() {
+    // A port already held exclusively by another process. Availability, not
+    // configuration: the other holder may exit without anything about this
+    // robot's config changing, so a permanent stop would be wrong.
+    //
+    // NOTE: tty_ioctl(4) exempts CAP_SYS_ADMIN from TIOCEXCL's EBUSY, so a
+    // ROOT test cannot actually be refused. The classification is asserted
+    // directly (it is pure), and the live refusal is checked unprivileged.
+    assert_eq!(
+        kirra_r2cp_status_class(KIRRA_R2CP_PORT_BUSY),
+        KIRRA_R2CP_CLASS_AVAILABILITY,
+        "a busy port must be restartable, not a permanent stop"
+    );
+    assert_ne!(
+        kirra_r2cp_status_class(KIRRA_R2CP_PORT_BUSY),
+        KIRRA_R2CP_CLASS_CONFIG
+    );
+
+    // SAFETY: geteuid takes no arguments and cannot fail.
+    if unsafe { nix::libc::geteuid() } == 0 {
+        eprintln!(
+            "SKIP: running as root, which tty_ioctl(4) exempts from TIOCEXCL's \
+             EBUSY — the live refusal cannot be observed here. On the robot the \
+             consumer runs as a rendered non-root User=, where it does bite."
+        );
+        return;
+    }
+
+    let sim = spawn_sim();
+    let (first_status, first) = open_link(&sim.device, 1000);
+    assert_eq!(first_status, KIRRA_R2CP_OK);
+
+    let (status, handle) = open_link(&sim.device, 1000);
+    assert_eq!(status, KIRRA_R2CP_PORT_BUSY);
+    assert!(handle.is_null(), "a busy port must yield no handle");
+
+    unsafe { kirra_r2cp_close(first) };
+    let _ = sim.stop.send(());
+}
+
+#[test]
+fn a_live_link_reports_kernel_confirmed_exclusivity() {
+    // The startup log may only claim exclusivity when the KERNEL confirms it,
+    // so the flag has to travel across the FFI rather than being inferred by
+    // the caller from "open succeeded".
+    let sim = spawn_sim();
+    let (status, handle) = open_link(&sim.device, 1000);
+    assert_eq!(status, KIRRA_R2CP_OK);
+
+    let mut info = KirraR2cpPeerInfo::default();
+    assert_eq!(
+        unsafe { kirra_r2cp_peer_info(handle, &mut info) },
+        KIRRA_R2CP_OK
+    );
+    assert_eq!(info.exclusive, 1, "TIOCGEXCL should confirm the claim");
+
+    // Exclusivity belongs to the DESCRIPTOR, not to identification: a
+    // de-identified link still holds the port, and saying otherwise would
+    // understate what is held.
+    assert_eq!(unsafe { kirra_r2cp_reset(handle) }, KIRRA_R2CP_OK);
+    let mut after = KirraR2cpPeerInfo::default();
+    let _ = unsafe { kirra_r2cp_peer_info(handle, &mut after) };
+    assert_eq!(after.identified, 0);
+    assert_eq!(after.exclusive, 1, "the port is still held");
+
+    unsafe { kirra_r2cp_close(handle) };
+    let _ = sim.stop.send(());
+}
+
+#[test]
 fn a_handle_is_only_ever_produced_for_an_identified_peer() {
     // The structural claim the whole surface rests on, stated once as a test:
     // across every failure mode, `out` is left NULL. "Command a peer we never

--- a/crates/kirra-consumer-ffi/tests/r2cp_scripted_peer.rs
+++ b/crates/kirra-consumer-ffi/tests/r2cp_scripted_peer.rs
@@ -1,0 +1,234 @@
+//! Handshake refusals driven through the FULL exported `kirra_r2cp_open`.
+//!
+//! `r2cp_against_simulator.rs` proves the accept path and the two silence
+//! cases. These need a peer that *answers wrongly*, which the simulator will
+//! never do — so the test scripts the replies itself.
+//!
+//! Everything goes through the C entry point rather than the evaluator
+//! underneath: the pure refusals are already covered in `kirra-r2cp`, and what
+//! is unproven here is that each one survives the FFI's error classification
+//! and still leaves the caller with no handle.
+
+use std::ffi::CString;
+use std::io::{Read, Write};
+use std::os::fd::AsFd;
+use std::path::{Path, PathBuf};
+
+use kirra_consumer_ffi::r2cp::*;
+use kirra_r2cp::handshake::{Hello, SIM_IMPLEMENTATION_ID};
+use kirra_r2cp::{decode, encode, FrameReader, MessageType, MAX_PAYLOAD};
+
+/// How the scripted peer answers a probe.
+#[derive(Clone, Copy, Debug)]
+enum Reply {
+    /// Echo a DIFFERENT nonce — a stale or replayed recording.
+    WrongNonce,
+    /// Advertise a major range with no overlap.
+    NoVersionOverlap,
+    /// Advertise below the protocol's own floor.
+    FrameBelowFloor,
+    /// Advertise above what the agreed major permits.
+    FrameAboveCeiling,
+    /// A HELLO too short to state a version range.
+    MalformedHello,
+    /// Emit undecodable noise FIRST, then answer correctly. Ordinary UART
+    /// corruption must not permanently poison an open attempt.
+    GarbageThenValid,
+}
+
+struct ScriptedPeer {
+    device: PathBuf,
+    _thread: std::thread::JoinHandle<()>,
+}
+
+impl ScriptedPeer {
+    fn spawn(reply: Reply) -> Self {
+        let pair = nix::pty::openpty(None, None).expect("openpty");
+        // Raw mode on the pair, or the line discipline mangles the binary the
+        // same way it would on a real link.
+        {
+            use nix::sys::termios::{cfmakeraw, tcgetattr, tcsetattr, SetArg};
+            let mut attrs = tcgetattr(pair.slave.as_fd()).expect("tcgetattr");
+            cfmakeraw(&mut attrs);
+            tcsetattr(pair.slave.as_fd(), SetArg::TCSANOW, &attrs).expect("tcsetattr");
+        }
+        let device = nix::unistd::ttyname(pair.slave.as_fd()).expect("ttyname");
+        let slave = pair.slave;
+        let mut master = std::fs::File::from(pair.master);
+
+        let thread = std::thread::spawn(move || {
+            // Hold the slave open for the peer's lifetime so the master does
+            // not see EIO the moment the bridge closes.
+            let _slave = slave;
+            let mut reader = FrameReader::new();
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+            let mut chunk = [0u8; 512];
+            while std::time::Instant::now() < deadline {
+                let Ok(n) = master.read(&mut chunk) else {
+                    return;
+                };
+                if n == 0 {
+                    return;
+                }
+                for candidate in reader.push(&chunk[..n]) {
+                    let Ok(frame) = decode(&candidate) else {
+                        continue;
+                    };
+                    if frame.message_type != MessageType::Hello {
+                        continue;
+                    }
+                    let Ok(probe) = Hello::parse(&frame.payload) else {
+                        continue;
+                    };
+                    if master.write_all(&script(reply, probe)).is_err() {
+                        return;
+                    }
+                    let _ = master.flush();
+                    // Do NOT return here. Dropping `master` closes the pty
+                    // master, which hangs up the slave and can discard data
+                    // the bridge has not read yet — the reply would vanish
+                    // between the write and the read. A real MCU does not
+                    // disappear the instant it answers, so the peer stays
+                    // alive until the deadline.
+                    while std::time::Instant::now() < deadline {
+                        std::thread::sleep(std::time::Duration::from_millis(20));
+                    }
+                    return;
+                }
+            }
+        });
+
+        Self {
+            device,
+            _thread: thread,
+        }
+    }
+}
+
+/// Build the bytes this peer answers with.
+fn script(reply: Reply, probe: Hello) -> Vec<u8> {
+    let base = Hello {
+        nonce: probe.nonce,
+        implementation_id: SIM_IMPLEMENTATION_ID,
+        firmware_semver: 1,
+        minimum_major: 1,
+        maximum_major: 1,
+        maximum_frame: MAX_PAYLOAD as u16,
+    };
+    let mut out = Vec::new();
+    let hello = match reply {
+        Reply::WrongNonce => Hello {
+            nonce: [0xEE; 16],
+            ..base
+        },
+        Reply::NoVersionOverlap => Hello {
+            minimum_major: 2,
+            maximum_major: 3,
+            ..base
+        },
+        Reply::FrameBelowFloor => Hello {
+            maximum_frame: 16,
+            ..base
+        },
+        Reply::FrameAboveCeiling => Hello {
+            maximum_frame: 4096,
+            ..base
+        },
+        Reply::MalformedHello => {
+            // A HELLO frame whose payload is too short to carry a version
+            // range. Built by truncating, so the FRAME is well-formed and only
+            // the payload is wrong — the refusal must come from the handshake,
+            // not the decoder.
+            let mut frame = base.to_frame(1, 0, true);
+            frame.payload.truncate(20);
+            out.extend_from_slice(&encode(&frame).expect("encodes"));
+            return out;
+        }
+        Reply::GarbageThenValid => {
+            // Undecodable runs first — a burst of line noise — then the real
+            // answer. The bridge must still find it.
+            for i in 0..4u8 {
+                out.extend_from_slice(&[0x30 + i, 0x31, 0x32, 0x33, 0x00]);
+            }
+            base
+        }
+    };
+    out.extend_from_slice(&encode(&hello.to_frame(1, 0, true)).expect("encodes"));
+    out
+}
+
+fn open_link(device: &Path, timeout_ms: u16) -> (i32, *mut KirraR2cpLink) {
+    let c = CString::new(device.to_str().unwrap()).unwrap();
+    let mut handle: *mut KirraR2cpLink = std::ptr::null_mut();
+    let status = unsafe { kirra_r2cp_open(c.as_ptr(), timeout_ms, &mut handle) };
+    (status, handle)
+}
+
+#[test]
+fn every_bad_handshake_reply_refuses_through_the_real_open_call() {
+    for (reply, expected) in [
+        (Reply::WrongNonce, KIRRA_R2CP_BAD_HANDSHAKE_REPLY),
+        (Reply::NoVersionOverlap, KIRRA_R2CP_VERSION_MISMATCH),
+        (Reply::FrameBelowFloor, KIRRA_R2CP_FRAME_LIMIT),
+        (Reply::FrameAboveCeiling, KIRRA_R2CP_FRAME_LIMIT),
+        (Reply::MalformedHello, KIRRA_R2CP_BAD_HANDSHAKE_REPLY),
+    ] {
+        let peer = ScriptedPeer::spawn(reply);
+        let (status, handle) = open_link(&peer.device, 500);
+        assert_eq!(status, expected, "{reply:?} classified wrongly");
+        assert!(handle.is_null(), "{reply:?} produced a handle");
+        assert_eq!(
+            kirra_r2cp_status_class(status),
+            KIRRA_R2CP_CLASS_PROTOCOL,
+            "{reply:?} is a protocol disagreement, not config or availability"
+        );
+    }
+}
+
+#[test]
+fn a_valid_reply_after_line_noise_still_opens() {
+    // The non-vacuity case for the five refusals above, and the one that
+    // matters most operationally: ordinary UART corruption must not
+    // permanently poison an open attempt. If this failed, every refusal above
+    // could be passing because the scripted peer never works at all.
+    let peer = ScriptedPeer::spawn(Reply::GarbageThenValid);
+    let (status, handle) = open_link(&peer.device, 1000);
+    assert_eq!(
+        status, KIRRA_R2CP_OK,
+        "noise before a valid HELLO must not prevent identification"
+    );
+    assert!(!handle.is_null());
+
+    let mut info = KirraR2cpPeerInfo::default();
+    assert_eq!(
+        unsafe { kirra_r2cp_peer_info(handle, &mut info) },
+        KIRRA_R2CP_OK
+    );
+    assert_eq!(info.identified, 1);
+    assert_eq!(info.implementation_id, SIM_IMPLEMENTATION_ID);
+    unsafe { kirra_r2cp_close(handle) };
+}
+
+#[test]
+fn a_protocol_refusal_is_not_an_availability_refusal() {
+    // The three classes must stay distinguishable at the FFI boundary, since
+    // the consumer's exit code is derived from them: a peer that answered
+    // wrongly is not the same event as a peer that is not there.
+    let peer = ScriptedPeer::spawn(Reply::NoVersionOverlap);
+    let (protocol_status, handle) = open_link(&peer.device, 500);
+    assert!(handle.is_null());
+
+    // A silent device, for contrast.
+    let pair = nix::pty::openpty(None, None).expect("openpty");
+    let quiet_device = nix::unistd::ttyname(pair.slave.as_fd()).expect("ttyname");
+    let _keep = (pair.master, pair.slave);
+    let (availability_status, handle) = open_link(&quiet_device, 150);
+    assert!(handle.is_null());
+
+    assert_ne!(protocol_status, availability_status);
+    assert_ne!(
+        kirra_r2cp_status_class(protocol_status),
+        kirra_r2cp_status_class(availability_status),
+        "answered-wrongly and not-there must not collapse into one class"
+    );
+}

--- a/crates/kirra-r2cp/src/handshake.rs
+++ b/crates/kirra-r2cp/src/handshake.rs
@@ -1,0 +1,210 @@
+//! HELLO handshake — proving the thing on the other end of the cable is an
+//! R2CP peer *before* anything arms.
+//!
+//! ## Why this exists, concretely
+//!
+//! The bring-up robot's motor board today is a stock Yahboom/Rosmaster MCU
+//! running vendor firmware. It does not speak R2CP and never will. If the
+//! consumer's R2CP drive mode were a bare last-hop swap, pointing it at
+//! `/dev/myserial` would not merely produce no motion — it would write R2CP
+//! frames into a **vendor command parser**, where some byte sequence may well
+//! be a valid vendor opcode. "It just won't move" is the optimistic reading;
+//! the honest one is that the behaviour is undefined and the board is attached
+//! to motors.
+//!
+//! So the R2CP mode refuses to arm until a peer has ANSWERED. Silence, garbage,
+//! or an answer that does not match the probe are all refusals. This is the
+//! same fail-closed shape as the rest of the stack: the absence of evidence is
+//! never read as evidence of absence of a problem.
+//!
+//! ## Why HELLO and not CAPABILITIES
+//!
+//! `PROTOCOL.md` specifies HELLO's payload byte-for-byte. CAPABILITIES it
+//! describes only in prose ("fixed bitset plus board revision, MCU ID, IMU
+//! type, …") with no layout, so implementing it here would mean inventing a
+//! second, larger provisional wire format on top of the COMMAND_ACK result
+//! codes. One provisional area is a recorded obligation; two is a dialect.
+//!
+//! HELLO is sufficient for the job: it carries a nonce (so a reply can be tied
+//! to *this* probe rather than a stale or replayed one) and the peer's
+//! supported major-version range and maximum frame size — which is exactly the
+//! set of facts that decides whether it is safe to send this peer a command.
+//!
+//! ## What it does NOT establish
+//!
+//! Nothing about authorization. A successful handshake says "an R2CP peer is
+//! there and we agree on the wire format". It says nothing about whether the
+//! KIRRA checker authorized any motion — ADR-0033's token-verifying consumer
+//! remains that boundary — and nothing about the peer being genuine, since v1
+//! ships no link authentication (`FLAG_AUTH_TAG` is refused, not verified).
+
+use crate::{Frame, MessageType, MAX_PAYLOAD, PROTOCOL_MAJOR};
+
+/// HELLO's payload (`PROTOCOL.md` §HELLO): `nonce[16], implementation_id:u32,
+/// firmware_semver:u32, minimum_major:u8, maximum_major:u8, maximum_frame:u16`.
+pub const HELLO_PAYLOAD_LEN: usize = 28;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Hello {
+    pub nonce: [u8; 16],
+    pub implementation_id: u32,
+    pub firmware_semver: u32,
+    pub minimum_major: u8,
+    pub maximum_major: u8,
+    pub maximum_frame: u16,
+}
+
+impl Hello {
+    /// Parse a HELLO payload.
+    ///
+    /// # Errors
+    /// [`HandshakeError::MalformedHello`] if the payload is not exactly
+    /// [`HELLO_PAYLOAD_LEN`] bytes. A short payload is refused rather than
+    /// zero-filled: a peer that cannot state its version range has not
+    /// answered the question that was asked.
+    pub fn parse(payload: &[u8]) -> Result<Self, HandshakeError> {
+        if payload.len() != HELLO_PAYLOAD_LEN {
+            return Err(HandshakeError::MalformedHello);
+        }
+        let mut nonce = [0u8; 16];
+        nonce.copy_from_slice(&payload[0..16]);
+        Ok(Self {
+            nonce,
+            implementation_id: u32::from_le_bytes(payload[16..20].try_into().unwrap()),
+            firmware_semver: u32::from_le_bytes(payload[20..24].try_into().unwrap()),
+            minimum_major: payload[24],
+            maximum_major: payload[25],
+            maximum_frame: u16::from_le_bytes(payload[26..28].try_into().unwrap()),
+        })
+    }
+
+    #[must_use]
+    pub fn encode(&self) -> Vec<u8> {
+        let mut p = Vec::with_capacity(HELLO_PAYLOAD_LEN);
+        p.extend_from_slice(&self.nonce);
+        p.extend_from_slice(&self.implementation_id.to_le_bytes());
+        p.extend_from_slice(&self.firmware_semver.to_le_bytes());
+        p.push(self.minimum_major);
+        p.push(self.maximum_major);
+        p.extend_from_slice(&self.maximum_frame.to_le_bytes());
+        p
+    }
+
+    /// The host's probe. `nonce` must be unpredictable — it is what ties a
+    /// reply to this probe, so a caller passing a constant gets a handshake
+    /// that a recorded reply would satisfy.
+    #[must_use]
+    pub fn probe(nonce: [u8; 16]) -> Self {
+        Self {
+            nonce,
+            implementation_id: HOST_IMPLEMENTATION_ID,
+            firmware_semver: 0,
+            minimum_major: PROTOCOL_MAJOR,
+            maximum_major: PROTOCOL_MAJOR,
+            maximum_frame: MAX_PAYLOAD as u16,
+        }
+    }
+
+    #[must_use]
+    pub fn to_frame(self, sequence: u32, source_time_us: u64, response: bool) -> Frame {
+        let mut frame =
+            Frame::new(MessageType::Hello, sequence, source_time_us).with_payload(&self.encode());
+        if response {
+            frame.flags = crate::FLAG_RESPONSE;
+        }
+        frame
+    }
+}
+
+/// `kirra-r2cp`, the host bridge. Identifies the SPEAKER, not the peer.
+pub const HOST_IMPLEMENTATION_ID: u32 = 0x4B52_4231; // "KRB1"
+/// The simulated MCU. Deliberately distinct from any firmware id, so a log or
+/// a test can never mistake the simulator for a board.
+pub const SIM_IMPLEMENTATION_ID: u32 = 0x4B53_494D; // "KSIM"
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HandshakeError {
+    /// Nothing answered within the timeout. The overwhelmingly likely cause on
+    /// this robot is a peer that does not speak R2CP at all — a vendor board.
+    NoResponse,
+    /// Something answered, but not with a HELLO.
+    NotAHello,
+    /// A HELLO that was not marked as a response. A peer's own unsolicited
+    /// probe is not an answer to ours.
+    NotAResponse,
+    MalformedHello,
+    /// The nonce did not match the probe. Either a stale reply from a previous
+    /// session or a replayed recording — never accepted as this probe's answer.
+    NonceMismatch,
+    /// No overlap between our supported major range and the peer's.
+    VersionMismatch {
+        peer_min: u8,
+        peer_max: u8,
+    },
+    /// The peer cannot receive frames as large as we may send. Refused up
+    /// front rather than discovered when a long command is silently dropped.
+    FrameTooSmall {
+        peer_maximum: u16,
+        required: u16,
+    },
+}
+
+/// A peer that answered acceptably.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Peer {
+    pub implementation_id: u32,
+    pub firmware_semver: u32,
+    pub maximum_frame: u16,
+    /// The major version both ends agreed on.
+    pub agreed_major: u8,
+}
+
+/// Decide whether `response` is an acceptable answer to `probe`.
+///
+/// Pure, so every refusal below is testable without a link. `required_frame` is
+/// the largest payload this bridge intends to send.
+///
+/// # Errors
+/// See [`HandshakeError`]. Every arm is a refusal to arm.
+pub fn evaluate_hello_response(
+    probe: &Hello,
+    response: &Frame,
+    required_frame: u16,
+) -> Result<Peer, HandshakeError> {
+    if response.message_type != MessageType::Hello {
+        return Err(HandshakeError::NotAHello);
+    }
+    if response.flags & crate::FLAG_RESPONSE == 0 {
+        return Err(HandshakeError::NotAResponse);
+    }
+    let peer = Hello::parse(&response.payload)?;
+    // Checked BEFORE the version fields: an answer we cannot tie to this probe
+    // tells us nothing about the peer, so its claims are not evidence yet.
+    if peer.nonce != probe.nonce {
+        return Err(HandshakeError::NonceMismatch);
+    }
+    if peer.minimum_major > peer.maximum_major {
+        return Err(HandshakeError::MalformedHello);
+    }
+    // Range overlap, not equality: a peer supporting 1..2 can talk to a host
+    // supporting 1..1.
+    let agreed = probe.maximum_major.min(peer.maximum_major);
+    if agreed < probe.minimum_major.max(peer.minimum_major) {
+        return Err(HandshakeError::VersionMismatch {
+            peer_min: peer.minimum_major,
+            peer_max: peer.maximum_major,
+        });
+    }
+    if peer.maximum_frame < required_frame {
+        return Err(HandshakeError::FrameTooSmall {
+            peer_maximum: peer.maximum_frame,
+            required: required_frame,
+        });
+    }
+    Ok(Peer {
+        implementation_id: peer.implementation_id,
+        firmware_semver: peer.firmware_semver,
+        maximum_frame: peer.maximum_frame,
+        agreed_major: agreed,
+    })
+}

--- a/crates/kirra-r2cp/src/handshake.rs
+++ b/crates/kirra-r2cp/src/handshake.rs
@@ -147,7 +147,38 @@ pub enum HandshakeError {
         peer_maximum: u16,
         required: u16,
     },
+    /// The peer advertises a limit below the protocol's own floor — it could
+    /// not accept a fully-specified MOTION_COMMAND, so it cannot be a
+    /// conforming v1 peer whatever else it claims.
+    FrameBelowProtocolMinimum {
+        peer_maximum: u16,
+        minimum: u16,
+    },
+    /// The peer advertises a limit ABOVE what this major version permits.
+    /// Not harmless: within an agreed major the maximum is fixed, so a larger
+    /// claim means the two ends do not agree on the format they just agreed
+    /// on. Refused rather than clamped — a peer whose framing assumptions we
+    /// cannot pin down is not one to command motion on.
+    FrameAboveProtocolMaximum {
+        peer_maximum: u16,
+        maximum: u16,
+    },
 }
+
+/// The smallest maximum-frame a conforming v1 peer may advertise.
+///
+/// Derived, not chosen: `PROTOCOL.md` §MOTION_COMMAND is
+/// `command_id:u32, valid_for_us:u32, velocity_mps:f32, curvature_per_m:f32,
+/// acceleration_limit_mps2:f32, jerk_limit_mps3:f32, mode:u8, reserved[3],
+/// auth_tag[16]` — 44 bytes. A peer that cannot receive 44 cannot receive a
+/// fully-specified motion command.
+///
+/// This crate currently emits the 28-byte UNAUTHENTICATED form (the
+/// `auth_tag` path is a named phase gate, not implemented), so the floor is
+/// deliberately stricter than what we send today: a peer that cannot take an
+/// authenticated command should be rejected now rather than at the point
+/// authentication lands and motion silently stops.
+pub const MIN_ADVERTISED_FRAME: u16 = 44;
 
 /// A peer that answered acceptably.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -193,6 +224,24 @@ pub fn evaluate_hello_response(
         return Err(HandshakeError::VersionMismatch {
             peer_min: peer.minimum_major,
             peer_max: peer.maximum_major,
+        });
+    }
+    // Three separate frame checks, because they mean three different things
+    // and collapsing them would hide which one an operator has to fix.
+    //
+    //   below the protocol floor → the peer is not a conforming v1 peer
+    //   above the protocol ceiling → the peer disagrees about the format
+    //   below what WE need → the peer is conforming but we cannot use it here
+    if peer.maximum_frame < MIN_ADVERTISED_FRAME {
+        return Err(HandshakeError::FrameBelowProtocolMinimum {
+            peer_maximum: peer.maximum_frame,
+            minimum: MIN_ADVERTISED_FRAME,
+        });
+    }
+    if peer.maximum_frame > MAX_PAYLOAD as u16 {
+        return Err(HandshakeError::FrameAboveProtocolMaximum {
+            peer_maximum: peer.maximum_frame,
+            maximum: MAX_PAYLOAD as u16,
         });
     }
     if peer.maximum_frame < required_frame {

--- a/crates/kirra-r2cp/src/lib.rs
+++ b/crates/kirra-r2cp/src/lib.rs
@@ -50,10 +50,16 @@
 // opening the descriptor and the first handshake byte, and only this crate is
 // in that position.
 //
-// The single exception is marked `#[allow(unsafe_code)]` in `link.rs` and is
-// three lines wide. The codec (`lib.rs`, `sim.rs`, `handshake.rs`) contains no
-// unsafe at all, and a `--no-default-features` build — which drops `link.rs`
-// and `pty.rs` — has none anywhere.
+// The exceptions are THREE `#[allow(unsafe_code)]` functions in `link.rs`, one
+// per ioctl — claim (`TIOCEXCL`), read back (`TIOCGEXCL`) and release
+// (`TIOCNXCL`) — each a single call with a SAFETY comment. Nothing else in the
+// crate is exempt: the codec (`lib.rs`), the simulated MCU's rules (`sim.rs`),
+// the handshake evaluator (`handshake.rs`) and the PTY binding (`pty.rs`)
+// contain no `unsafe` at all, and a `--no-default-features` build — which drops
+// `link.rs` and `pty.rs` — has none anywhere.
+//
+// `ci/check_r2cp_unsafe.py` enforces that split, because "only in link.rs" is
+// the kind of boundary that erodes one convenient exception at a time.
 #![deny(unsafe_code)]
 
 pub const MAGIC: u16 = 0x3252;

--- a/crates/kirra-r2cp/src/lib.rs
+++ b/crates/kirra-r2cp/src/lib.rs
@@ -428,7 +428,11 @@ impl FrameReader {
     }
 }
 
+pub mod handshake;
 pub mod sim;
+
+#[cfg(feature = "pty")]
+pub mod link;
 
 #[cfg(feature = "pty")]
 pub mod pty;

--- a/crates/kirra-r2cp/src/lib.rs
+++ b/crates/kirra-r2cp/src/lib.rs
@@ -43,7 +43,18 @@
 //!   *refuses* a tagged frame with [`DecodeError::AuthRequired`], exactly as
 //!   `wire.cpp`'s `decode()` does — fail-closed, never a silent pass-through.
 
-#![forbid(unsafe_code)]
+// `deny`, not `forbid`, for exactly ONE reason: claiming TIOCEXCL on the serial
+// port is an ioctl, and there is no safe wrapper for it. `forbid` cannot be
+// overridden even locally, so it would push the claim out of this crate and
+// into the caller — which is worse, because the claim must happen between
+// opening the descriptor and the first handshake byte, and only this crate is
+// in that position.
+//
+// The single exception is marked `#[allow(unsafe_code)]` in `link.rs` and is
+// three lines wide. The codec (`lib.rs`, `sim.rs`, `handshake.rs`) contains no
+// unsafe at all, and a `--no-default-features` build — which drops `link.rs`
+// and `pty.rs` — has none anywhere.
+#![deny(unsafe_code)]
 
 pub const MAGIC: u16 = 0x3252;
 pub const PROTOCOL_MAJOR: u8 = 1;

--- a/crates/kirra-r2cp/src/link.rs
+++ b/crates/kirra-r2cp/src/link.rs
@@ -193,31 +193,40 @@ impl SerialLink {
         }
         tcsetattr(fd, SetArg::TCSANOW, &attrs).map_err(io::Error::from)?;
 
-        // Exclusivity is claimed HERE — after the descriptor exists and the
-        // line is configured, but BEFORE a single handshake byte goes out.
-        // The ordering is the point: a second writer that appears between the
-        // open and the claim would be invisible, and the whole reason this
-        // link exists is that exactly one process may reach the motors.
+        // Construct FIRST, then claim. This ordering is deliberate and is the
+        // difference between "nothing fallible happens to follow the claim
+        // today" and "a leaked claim is impossible".
         //
-        // On failure the `?` drops `port`, which closes the descriptor and
-        // releases any claim with it. There is no half-owned state to unwind.
-        claim_exclusive(&port)?;
-        // Confirmed, not assumed: a caller may only claim exclusivity in a log
-        // if the kernel says it holds. `TIOCGEXCL` predates nothing we support,
-        // but treat an error as "cannot confirm" rather than failing the open —
-        // the claim above already succeeded, and refusing to start because we
-        // could not re-read it would be stricter than the guarantee requires.
-        let exclusive = read_exclusive(&port).unwrap_or(false);
-
-        Ok(Self {
-            exclusive,
+        // Once `Self` exists, `Drop` covers it: any `?` below unwinds through
+        // `release_exclusive` and then closes the descriptor. Claiming before
+        // construction would mean that a fallible step added later — a second
+        // ioctl, a probe, a timeout — silently leaks exclusive mode on the
+        // error path, and on a tty another process is keeping alive that leak
+        // is permanent (see `release_exclusive`).
+        let mut link = Self {
             port,
             reader: FrameReader::new(),
             next_sequence: 1,
             peer: None,
             consecutive_undecodable: 0,
             fault: None,
-        })
+            exclusive: false,
+        };
+
+        // Exclusivity is claimed HERE — after the descriptor exists and the
+        // line is configured, but BEFORE a single handshake byte goes out.
+        // A second writer appearing between the open and the claim would be
+        // invisible, and the whole reason this link exists is that exactly one
+        // process may reach the motors.
+        claim_exclusive(&link.port)?;
+
+        // Confirmed, not assumed: a caller may only report exclusivity if the
+        // kernel says it holds. An error reading it back is "cannot confirm",
+        // not a failed open — the claim already succeeded, and refusing to
+        // start because the read-back was unavailable would be stricter than
+        // the guarantee requires.
+        link.exclusive = read_exclusive(&link.port).unwrap_or(false);
+        Ok(link)
     }
 
     /// The peer established by a successful [`Self::handshake`]. `None` until

--- a/crates/kirra-r2cp/src/link.rs
+++ b/crates/kirra-r2cp/src/link.rs
@@ -48,6 +48,30 @@ pub struct Received {
     pub undecodable: usize,
 }
 
+/// Consecutive undecodable runs that end the session's trust in its peer.
+///
+/// Not zero: a single corrupt frame is ordinary on a real UART (that is what
+/// the CRC is for) and re-handshaking on every one would make the link
+/// unusable. Not large either: sustained framing failure means the two ends
+/// have lost agreement about where frames begin, and everything decoded after
+/// that point is guesswork. The streak RESETS on any good frame, so this
+/// counts *sustained* failure rather than a total.
+pub const FRAMING_FAILURE_THRESHOLD: usize = 8;
+
+/// Why the link stopped trusting its peer. Kept so the caller can distinguish
+/// "never handshaken" from "was fine, then something broke" — the second is a
+/// hardware-availability event, the first is usually configuration.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LinkFault {
+    /// Sustained framing failure: the ends disagree about frame boundaries.
+    FramingLost { consecutive: usize },
+    /// The device went away — EOF or EIO on read. A cable pull, a USB
+    /// re-enumeration, an MCU reset.
+    Disconnected,
+    /// A caller explicitly reset the link (e.g. after a watchdog stop).
+    Reset,
+}
+
 #[derive(Debug)]
 pub struct SerialLink {
     port: File,
@@ -56,7 +80,13 @@ pub struct SerialLink {
     /// `sequence <= last_accepted`, so this must never repeat or go backwards
     /// within a session.
     next_sequence: u32,
+    /// The identified peer. Lives HERE, on the instance — not in a global and
+    /// not as a boolean the caller maintains. A new `SerialLink` (a reopen)
+    /// therefore starts unidentified by construction rather than by the
+    /// caller remembering to reset something.
     peer: Option<Peer>,
+    consecutive_undecodable: usize,
+    fault: Option<LinkFault>,
 }
 
 impl SerialLink {
@@ -81,14 +111,41 @@ impl SerialLink {
             reader: FrameReader::new(),
             next_sequence: 1,
             peer: None,
+            consecutive_undecodable: 0,
+            fault: None,
         })
     }
 
     /// The peer established by a successful [`Self::handshake`]. `None` until
-    /// then — and a caller must treat `None` as "do not send commands".
+    /// then, and `None` again after any [`LinkFault`] — a caller must treat
+    /// `None` as "do not send commands", which is enforced by
+    /// [`Self::arm_and_activate`] and [`Self::send_motion`] rather than left
+    /// to the caller's discipline.
     #[must_use]
     pub fn peer(&self) -> Option<Peer> {
         self.peer
+    }
+
+    /// Why the peer was dropped, if it was. `None` means either "still
+    /// identified" or "never was" — [`Self::peer`] distinguishes those.
+    #[must_use]
+    pub fn fault(&self) -> Option<LinkFault> {
+        self.fault
+    }
+
+    /// Drop the identified peer, requiring a fresh handshake before any
+    /// further command.
+    ///
+    /// Call this after a watchdog-triggered stop or any other event that makes
+    /// the peer's state uncertain. Re-identifying is cheap; commanding a peer
+    /// whose state we are guessing at is not.
+    pub fn reset(&mut self) {
+        self.invalidate(LinkFault::Reset);
+    }
+
+    fn invalidate(&mut self, fault: LinkFault) {
+        self.peer = None;
+        self.fault = Some(fault);
     }
 
     fn take_sequence(&mut self) -> u32 {
@@ -132,15 +189,39 @@ impl SerialLink {
             }
             let mut chunk = [0u8; 512];
             let n = match self.port.read(&mut chunk) {
-                Ok(0) => break,
+                // EOF and EIO both mean the device went away. On a real link
+                // that is a cable pull, a USB re-enumeration or an MCU reset —
+                // in every case the peer's state is now unknown, so the
+                // identification is dropped and a fresh handshake is required.
+                Ok(0) => {
+                    self.invalidate(LinkFault::Disconnected);
+                    break;
+                }
                 Ok(n) => n,
-                Err(e) if e.raw_os_error() == Some(nix::libc::EIO) => break,
+                Err(e) if e.raw_os_error() == Some(nix::libc::EIO) => {
+                    self.invalidate(LinkFault::Disconnected);
+                    break;
+                }
                 Err(e) => return Err(e),
             };
             for candidate in self.reader.push(&chunk[..n]) {
                 match decode(&candidate) {
-                    Ok(f) => out.frames.push(f),
-                    Err(_) => out.undecodable += 1,
+                    Ok(f) => {
+                        // A good frame proves the ends still agree on where
+                        // frames begin, so the streak is sustained failure,
+                        // not a lifetime total.
+                        self.consecutive_undecodable = 0;
+                        out.frames.push(f);
+                    }
+                    Err(_) => {
+                        out.undecodable += 1;
+                        self.consecutive_undecodable += 1;
+                        if self.consecutive_undecodable >= FRAMING_FAILURE_THRESHOLD {
+                            self.invalidate(LinkFault::FramingLost {
+                                consecutive: self.consecutive_undecodable,
+                            });
+                        }
+                    }
                 }
             }
             if !out.frames.is_empty() {
@@ -240,9 +321,26 @@ impl SerialLink {
     /// in Active where the next command can be honoured. DISARM is the
     /// heavier, one-way request.
     ///
+    /// 🔴 **BEST-EFFORT WHEN THE PEER IS UNIDENTIFIED, AND THE RETURN VALUE IS
+    /// NOT A STOP.** Unlike the others this does not require a handshake — a
+    /// shutdown path must not be blocked by the gate that protects startup —
+    /// but that means it may be writing to a device that is not an R2CP peer
+    /// at all. `Ok` here means *the bytes were written to the file
+    /// descriptor*. It is NOT evidence that:
+    ///
+    /// * a vendor board understood the frame (it did not — it does not speak
+    ///   R2CP, which is the entire reason [`Self::handshake`] exists);
+    /// * an R2CP peer received it (nothing is read back);
+    /// * the motors stopped.
+    ///
+    /// The thing that actually stops a governed robot is the peer's own
+    /// watchdog: commands cease, the command window lapses, the MCU enters
+    /// ControlledStop on its own. This call is an attempt to make that
+    /// immediate, not a substitute for it. A caller must not log it as
+    /// "stopped", only as "stop sent".
+    ///
     /// # Errors
-    /// Write failures. Unlike the others this does NOT require a handshake:
-    /// a stop must be attemptable on a link whose state is uncertain.
+    /// Write failures only.
     pub fn send_stop(&mut self, valid_for_us: u32, source_time_us: u64) -> io::Result<u32> {
         let cmd = MotionCommand {
             command_id: 0,

--- a/crates/kirra-r2cp/src/link.rs
+++ b/crates/kirra-r2cp/src/link.rs
@@ -48,6 +48,89 @@ pub struct Received {
     pub undecodable: usize,
 }
 
+/// Claim `TIOCEXCL` — kernel-enforced exclusive access for this descriptor's
+/// lifetime. While it is held, every further non-root `open(2)` of the port
+/// fails `EBUSY`.
+///
+/// This is ADR-0033's Tier-3 sole-writer guarantee for the R2CP path. The boot
+/// sentinel (owner, mode 0600, no other holder) proves nobody held the port
+/// *before* we started; this is what stops anyone taking it *after*.
+///
+/// The one `unsafe` in this crate. There is no safe wrapper for `TIOCEXCL` in
+/// `nix`, and the call is a plain `ioctl` with no arguments on a descriptor we
+/// own — the borrow of `port` is what keeps it valid across the call.
+#[allow(unsafe_code)]
+fn claim_exclusive(port: &File) -> io::Result<()> {
+    use std::os::fd::AsRawFd;
+    // SAFETY: `port` is an open descriptor owned by the caller and borrowed
+    // for the duration of this call; TIOCEXCL takes no argument and writes
+    // nothing back through the pointer-free varargs slot.
+    let rc = unsafe { nix::libc::ioctl(port.as_raw_fd(), nix::libc::TIOCEXCL) };
+    if rc == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+/// Read back whether the tty is in exclusive mode (`TIOCGEXCL`, Linux 3.8+).
+///
+/// The claim is only worth logging if it can be CONFIRMED, and `TIOCEXCL`
+/// returning 0 is not confirmation of much — so the startup path reports
+/// exclusivity from this, not from the fact that the claim call did not error.
+///
+/// It is also the only way to observe the claim from a privileged process:
+/// `tty_ioctl(4)` exempts `CAP_SYS_ADMIN` from the `EBUSY` that `TIOCEXCL`
+/// imposes on everyone else, so a root test can verify the STATE even though
+/// it cannot be blocked by it.
+#[allow(unsafe_code)]
+fn read_exclusive(port: &File) -> io::Result<bool> {
+    use std::os::fd::AsRawFd;
+    let mut set: i32 = 0;
+    // SAFETY: `port` is an open descriptor borrowed for this call, and
+    // TIOCGEXCL writes exactly one `int` through the pointer we supply.
+    let rc = unsafe {
+        nix::libc::ioctl(
+            port.as_raw_fd(),
+            nix::libc::TIOCGEXCL,
+            std::ptr::addr_of_mut!(set),
+        )
+    };
+    if rc == 0 {
+        Ok(set != 0)
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+/// Release exclusive mode (`TIOCNXCL`).
+///
+/// Closing the descriptor is NOT reliably enough. The kernel clears the tty's
+/// exclusive flag when the tty itself is released — which happens on the last
+/// close of a real UART, but NOT while any other descriptor keeps the tty
+/// alive. I confirmed that here: dropping the link's fd left the flag set
+/// because the simulator's pty master was still open.
+///
+/// On the robot the consumer is normally the sole opener, so the flag would
+/// usually clear anyway. "Usually" is the problem: if anything else is holding
+/// the tty when the consumer exits, the port stays exclusive, and the
+/// consumer's own unprivileged restart is then refused `EBUSY` — permanently,
+/// with no configuration wrong. Releasing explicitly costs one ioctl.
+#[allow(unsafe_code)]
+fn release_exclusive(port: &File) {
+    use std::os::fd::AsRawFd;
+    // SAFETY: `port` is an open descriptor borrowed for this call; TIOCNXCL
+    // takes no argument. The result is deliberately ignored — this runs in
+    // `Drop`, where there is nobody left to report to.
+    let _ = unsafe { nix::libc::ioctl(port.as_raw_fd(), nix::libc::TIOCNXCL) };
+}
+
+impl Drop for SerialLink {
+    fn drop(&mut self) {
+        release_exclusive(&self.port);
+    }
+}
+
 /// Consecutive undecodable runs that end the session's trust in its peer.
 ///
 /// Not zero: a single corrupt frame is ordinary on a real UART (that is what
@@ -87,6 +170,9 @@ pub struct SerialLink {
     peer: Option<Peer>,
     consecutive_undecodable: usize,
     fault: Option<LinkFault>,
+    /// Kernel-CONFIRMED exclusive mode, read back after the claim. A caller
+    /// may only tell an operator the port is exclusive when this is true.
+    exclusive: bool,
 }
 
 impl SerialLink {
@@ -106,7 +192,25 @@ impl SerialLink {
             cfsetspeed(&mut attrs, b).map_err(io::Error::from)?;
         }
         tcsetattr(fd, SetArg::TCSANOW, &attrs).map_err(io::Error::from)?;
+
+        // Exclusivity is claimed HERE — after the descriptor exists and the
+        // line is configured, but BEFORE a single handshake byte goes out.
+        // The ordering is the point: a second writer that appears between the
+        // open and the claim would be invisible, and the whole reason this
+        // link exists is that exactly one process may reach the motors.
+        //
+        // On failure the `?` drops `port`, which closes the descriptor and
+        // releases any claim with it. There is no half-owned state to unwind.
+        claim_exclusive(&port)?;
+        // Confirmed, not assumed: a caller may only claim exclusivity in a log
+        // if the kernel says it holds. `TIOCGEXCL` predates nothing we support,
+        // but treat an error as "cannot confirm" rather than failing the open —
+        // the claim above already succeeded, and refusing to start because we
+        // could not re-read it would be stricter than the guarantee requires.
+        let exclusive = read_exclusive(&port).unwrap_or(false);
+
         Ok(Self {
+            exclusive,
             port,
             reader: FrameReader::new(),
             next_sequence: 1,
@@ -124,6 +228,17 @@ impl SerialLink {
     #[must_use]
     pub fn peer(&self) -> Option<Peer> {
         self.peer
+    }
+
+    /// Whether the kernel CONFIRMS this descriptor holds the tty exclusively.
+    ///
+    /// Not "we called TIOCEXCL and it returned 0" — this is the state read
+    /// back with `TIOCGEXCL`. Report exclusivity to an operator only when it
+    /// is true; claiming it otherwise is exactly the kind of unearned
+    /// assurance ADR-0033 Tier-3 exists to remove.
+    #[must_use]
+    pub fn is_exclusive(&self) -> bool {
+        self.exclusive
     }
 
     /// Why the peer was dropped, if it was. `None` means either "still

--- a/crates/kirra-r2cp/src/link.rs
+++ b/crates/kirra-r2cp/src/link.rs
@@ -231,10 +231,31 @@ impl SerialLink {
         Ok(out)
     }
 
+    /// [`Self::handshake`] with a nonce drawn from the OS entropy pool.
+    ///
+    /// This is the entry point every non-test caller should use. Taking the
+    /// nonce as a parameter is right for tests, which need a known value, but
+    /// wrong as the only option: it pushes "must be unpredictable" out to every
+    /// caller, and a caller that gets it wrong produces a gate a recorded reply
+    /// can satisfy — with no visible symptom. One audited entropy source is the
+    /// safer default.
+    ///
+    /// # Errors
+    /// [`LinkError::Io`] if `/dev/urandom` cannot be read. FAIL-CLOSED on
+    /// purpose: there is no weaker fallback nonce, because a predictable one
+    /// silently converts the gate into theatre.
+    pub fn handshake_fresh(&mut self, timeout_ms: u16) -> Result<Peer, LinkError> {
+        let mut nonce = [0u8; 16];
+        let mut urandom = File::open("/dev/urandom")?;
+        urandom.read_exact(&mut nonce)?;
+        self.handshake(nonce, timeout_ms)
+    }
+
     /// Probe the peer and refuse unless it answers acceptably.
     ///
     /// `nonce` must be unpredictable — it is the only thing tying the reply to
     /// this probe, so a constant would let a recorded reply satisfy the gate.
+    /// Prefer [`Self::handshake_fresh`] outside tests.
     ///
     /// # Errors
     /// [`LinkError::Handshake`] for every refusal; see [`HandshakeError`]. The

--- a/crates/kirra-r2cp/src/link.rs
+++ b/crates/kirra-r2cp/src/link.rs
@@ -1,0 +1,331 @@
+//! `SerialLink` — the BRIDGE's side of the wire.
+//!
+//! [`crate::pty`] is the simulated MCU's end; this is the end the consumer
+//! holds. It opens a device path (a `/dev/pts/N` from the simulator, or a real
+//! `/dev/ttyTHS1`/`/dev/myserial`), puts it in raw mode, and speaks frames.
+//!
+//! It is deliberately the SAME code in both cases. A test that drives the
+//! simulator through a bespoke helper proves things about the helper; pointing
+//! the production link at the simulator is what makes the simulator a useful
+//! integration target.
+//!
+//! ## Raw mode is not optional here either
+//!
+//! Same reasoning as `pty.rs`: at tty defaults the line discipline rewrites
+//! binary (`ONLCR`/`ICRNL`, `IXON` flow control, `ISIG`), which for a frame
+//! format with uniformly distributed bytes is corruption on roughly every
+//! frame. On a real UART this also sets the baud rate; on a pty the kernel
+//! ignores speed, which is one of the several reasons a pty is not a link test.
+//!
+//! ## The handshake gate
+//!
+//! [`SerialLink::handshake`] must succeed before anything sends a command. See
+//! [`crate::handshake`] for why: on the bring-up robot the thing at the other
+//! end of `/dev/myserial` is a *vendor* MCU that does not speak R2CP, and
+//! writing R2CP frames into a vendor command parser is undefined behaviour on
+//! a board wired to motors.
+
+use std::fs::{File, OpenOptions};
+use std::io::{self, Read, Write};
+use std::os::fd::AsFd;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use nix::poll::{PollFd, PollFlags, PollTimeout};
+use nix::sys::termios::{cfmakeraw, cfsetspeed, tcgetattr, tcsetattr, BaudRate, SetArg};
+
+use crate::handshake::{evaluate_hello_response, HandshakeError, Hello, Peer};
+use crate::sim::{MotionCommand, MODE_STOP, MODE_TRACK};
+use crate::{decode, encode, Frame, FrameReader, MessageType, MAX_PAYLOAD};
+
+/// Frames read from the peer, and the runs the framer had to discard.
+#[derive(Debug, Default)]
+pub struct Received {
+    pub frames: Vec<Frame>,
+    /// Bytes that arrived but could not be decoded. Surfaced, not swallowed:
+    /// on a real link this is the signal that something is wrong with the
+    /// cable, the baud rate, or the peer.
+    pub undecodable: usize,
+}
+
+#[derive(Debug)]
+pub struct SerialLink {
+    port: File,
+    reader: FrameReader,
+    /// The bridge's own sequence space, strictly advancing. The peer refuses
+    /// `sequence <= last_accepted`, so this must never repeat or go backwards
+    /// within a session.
+    next_sequence: u32,
+    peer: Option<Peer>,
+}
+
+impl SerialLink {
+    /// Open `device` and put it in raw mode. `baud` is applied when `Some`;
+    /// a pty ignores it, a real UART does not.
+    ///
+    /// # Errors
+    /// If the device cannot be opened or raw mode cannot be set. Raw-mode
+    /// failure is fatal on purpose — a link that corrupts frames must not be
+    /// handed to a caller that is about to command motion on it.
+    pub fn open(device: &Path, baud: Option<BaudRate>) -> io::Result<Self> {
+        let port = OpenOptions::new().read(true).write(true).open(device)?;
+        let fd = port.as_fd();
+        let mut attrs = tcgetattr(fd).map_err(io::Error::from)?;
+        cfmakeraw(&mut attrs);
+        if let Some(b) = baud {
+            cfsetspeed(&mut attrs, b).map_err(io::Error::from)?;
+        }
+        tcsetattr(fd, SetArg::TCSANOW, &attrs).map_err(io::Error::from)?;
+        Ok(Self {
+            port,
+            reader: FrameReader::new(),
+            next_sequence: 1,
+            peer: None,
+        })
+    }
+
+    /// The peer established by a successful [`Self::handshake`]. `None` until
+    /// then — and a caller must treat `None` as "do not send commands".
+    #[must_use]
+    pub fn peer(&self) -> Option<Peer> {
+        self.peer
+    }
+
+    fn take_sequence(&mut self) -> u32 {
+        let s = self.next_sequence;
+        // Saturating, not wrapping: wrapping would hand the peer a sequence it
+        // has already accepted, which its replay rule correctly refuses — the
+        // link would go dead at 2^32 with no explanation. Saturating makes it
+        // stop advancing, which the peer also refuses, but the cause is then
+        // visible in this counter rather than hidden in a wrap.
+        self.next_sequence = self.next_sequence.saturating_add(1);
+        s
+    }
+
+    /// # Errors
+    /// Propagates write failures.
+    pub fn send(&mut self, mut frame: Frame) -> io::Result<u32> {
+        let seq = self.take_sequence();
+        frame.sequence = seq;
+        let bytes = encode(&frame)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, format!("{e:?}")))?;
+        self.port.write_all(&bytes)?;
+        self.port.flush()?;
+        Ok(seq)
+    }
+
+    /// Read for up to `timeout_ms`, returning whatever frames completed.
+    ///
+    /// # Errors
+    /// Propagates read failures.
+    pub fn receive(&mut self, timeout_ms: u16) -> io::Result<Received> {
+        let mut out = Received::default();
+        let deadline = Instant::now() + Duration::from_millis(u64::from(timeout_ms));
+        while Instant::now() < deadline {
+            let left = deadline
+                .saturating_duration_since(Instant::now())
+                .as_millis();
+            let mut fds = [PollFd::new(self.port.as_fd(), PollFlags::POLLIN)];
+            let ms = u16::try_from(left).unwrap_or(u16::MAX);
+            if nix::poll::poll(&mut fds, PollTimeout::from(ms)).map_err(io::Error::from)? == 0 {
+                break;
+            }
+            let mut chunk = [0u8; 512];
+            let n = match self.port.read(&mut chunk) {
+                Ok(0) => break,
+                Ok(n) => n,
+                Err(e) if e.raw_os_error() == Some(nix::libc::EIO) => break,
+                Err(e) => return Err(e),
+            };
+            for candidate in self.reader.push(&chunk[..n]) {
+                match decode(&candidate) {
+                    Ok(f) => out.frames.push(f),
+                    Err(_) => out.undecodable += 1,
+                }
+            }
+            if !out.frames.is_empty() {
+                break;
+            }
+        }
+        Ok(out)
+    }
+
+    /// Probe the peer and refuse unless it answers acceptably.
+    ///
+    /// `nonce` must be unpredictable — it is the only thing tying the reply to
+    /// this probe, so a constant would let a recorded reply satisfy the gate.
+    ///
+    /// # Errors
+    /// [`LinkError::Handshake`] for every refusal; see [`HandshakeError`]. The
+    /// case that matters most on the bring-up robot is `NoResponse`: a vendor
+    /// board is silent, and silence must never be read as agreement.
+    pub fn handshake(&mut self, nonce: [u8; 16], timeout_ms: u16) -> Result<Peer, LinkError> {
+        let probe = Hello::probe(nonce);
+        self.send(probe.to_frame(0, 0, false))?;
+
+        let deadline = Instant::now() + Duration::from_millis(u64::from(timeout_ms));
+        let mut last = HandshakeError::NoResponse;
+        while Instant::now() < deadline {
+            let left = deadline
+                .saturating_duration_since(Instant::now())
+                .as_millis();
+            let got = self.receive(u16::try_from(left).unwrap_or(u16::MAX))?;
+            for frame in &got.frames {
+                match evaluate_hello_response(&probe, frame, MAX_PAYLOAD as u16) {
+                    Ok(peer) => {
+                        self.peer = Some(peer);
+                        return Ok(peer);
+                    }
+                    // Keep looking within the window rather than failing on the
+                    // first non-answer: a peer may still be emitting telemetry
+                    // from before the probe, and that traffic is not a refusal.
+                    // The LAST refusal is reported, so the operator sees why
+                    // the frames that did arrive were not acceptable.
+                    Err(e) => last = e,
+                }
+            }
+        }
+        Err(LinkError::Handshake(last))
+    }
+
+    /// Send ARM then ACTIVATE, requiring each to be acknowledged.
+    ///
+    /// # Errors
+    /// [`LinkError::NotHandshaken`] if called before a successful handshake —
+    /// the ordering is enforced here rather than left to the caller, because
+    /// "arm a peer we have not identified" is exactly the mistake this whole
+    /// module exists to prevent.
+    pub fn arm_and_activate(&mut self, timeout_ms: u16) -> Result<(), LinkError> {
+        if self.peer.is_none() {
+            return Err(LinkError::NotHandshaken);
+        }
+        for ty in [MessageType::Arm, MessageType::Activate] {
+            let seq = self.send(Frame::new(ty, 0, 0))?;
+            let got = self.receive(timeout_ms)?;
+            if !got.frames.iter().any(|f| {
+                f.message_type == MessageType::CommandAcknowledgement
+                    && ack_received_sequence(f) == Some(seq)
+                    && ack_result(f) == Some(crate::sim::ack_result::ACCEPTED)
+            }) {
+                return Err(LinkError::NotAcknowledged(ty));
+            }
+        }
+        Ok(())
+    }
+
+    /// Send one MOTION_COMMAND. `velocity_mps`/`curvature_per_m` are the
+    /// values the governor already released — this transports them, it does
+    /// not decide them.
+    ///
+    /// # Errors
+    /// [`LinkError::NotHandshaken`] before a handshake; write failures.
+    pub fn send_motion(
+        &mut self,
+        cmd: &MotionCommand,
+        source_time_us: u64,
+    ) -> Result<u32, LinkError> {
+        if self.peer.is_none() {
+            return Err(LinkError::NotHandshaken);
+        }
+        let frame =
+            Frame::new(MessageType::MotionCommand, 0, source_time_us).with_payload(&cmd.encode());
+        Ok(self.send(frame)?)
+    }
+
+    /// The stop primitive: a MODE_STOP command, which the peer honours as zero
+    /// motion whatever the numeric fields say.
+    ///
+    /// Deliberately still a MOTION_COMMAND rather than a DISARM: it must be
+    /// safe to call repeatedly and from a shutdown path, and it keeps the peer
+    /// in Active where the next command can be honoured. DISARM is the
+    /// heavier, one-way request.
+    ///
+    /// # Errors
+    /// Write failures. Unlike the others this does NOT require a handshake:
+    /// a stop must be attemptable on a link whose state is uncertain.
+    pub fn send_stop(&mut self, valid_for_us: u32, source_time_us: u64) -> io::Result<u32> {
+        let cmd = MotionCommand {
+            command_id: 0,
+            valid_for_us,
+            velocity_mps: 0.0,
+            curvature_per_m: 0.0,
+            acceleration_limit_mps2: 0.0,
+            jerk_limit_mps3: 0.0,
+            mode: MODE_STOP,
+        };
+        let frame =
+            Frame::new(MessageType::MotionCommand, 0, source_time_us).with_payload(&cmd.encode());
+        self.send(frame)
+    }
+}
+
+/// `received_sequence` from a COMMAND_ACK payload, or `None` if the frame is
+/// not a well-formed ACK.
+#[must_use]
+pub fn ack_received_sequence(frame: &Frame) -> Option<u32> {
+    if frame.message_type != MessageType::CommandAcknowledgement || frame.payload.len() < 28 {
+        return None;
+    }
+    Some(u32::from_le_bytes(frame.payload[4..8].try_into().ok()?))
+}
+
+/// `result` from a COMMAND_ACK payload. See `sim::ack_result` — these values
+/// are PROVISIONAL until the firmware binds them.
+#[must_use]
+pub fn ack_result(frame: &Frame) -> Option<u16> {
+    if frame.message_type != MessageType::CommandAcknowledgement || frame.payload.len() < 28 {
+        return None;
+    }
+    Some(u16::from_le_bytes(frame.payload[16..18].try_into().ok()?))
+}
+
+/// `safety_state` from a COMMAND_ACK payload. Mirrors the firmware's
+/// `safety_manager.hpp` discriminants — NOT provisional.
+#[must_use]
+pub fn ack_safety_state(frame: &Frame) -> Option<u8> {
+    if frame.message_type != MessageType::CommandAcknowledgement || frame.payload.len() < 28 {
+        return None;
+    }
+    Some(frame.payload[18])
+}
+
+#[derive(Debug)]
+pub enum LinkError {
+    Io(io::Error),
+    Handshake(HandshakeError),
+    /// A command was attempted before the peer was identified.
+    NotHandshaken,
+    NotAcknowledged(MessageType),
+}
+
+impl From<io::Error> for LinkError {
+    fn from(e: io::Error) -> Self {
+        LinkError::Io(e)
+    }
+}
+
+impl std::fmt::Display for LinkError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LinkError::Io(e) => write!(f, "link I/O error: {e}"),
+            LinkError::Handshake(HandshakeError::NoResponse) => write!(
+                f,
+                "no R2CP peer answered. On this robot the most likely cause is that \
+                 the device is a VENDOR motor board, which does not speak R2CP — \
+                 refusing to send it frames"
+            ),
+            LinkError::Handshake(e) => write!(f, "R2CP handshake refused: {e:?}"),
+            LinkError::NotHandshaken => write!(
+                f,
+                "command attempted before a successful handshake (fail-closed)"
+            ),
+            LinkError::NotAcknowledged(ty) => write!(f, "{ty:?} was not acknowledged"),
+        }
+    }
+}
+
+impl std::error::Error for LinkError {}
+
+/// Re-exported so callers do not need `MODE_TRACK` from two places.
+pub use crate::sim::MODE_TRACK as MOTION_MODE_TRACK;
+const _: () = assert!(MODE_TRACK == MOTION_MODE_TRACK);

--- a/crates/kirra-r2cp/src/pty.rs
+++ b/crates/kirra-r2cp/src/pty.rs
@@ -143,21 +143,27 @@ impl SimulatedMcuPty {
             match decode(&candidate) {
                 Ok(frame) => {
                     let outcome = mcu.handle(&frame, now_us);
-                    let ack = mcu.ack_for(&frame, outcome, now_us);
-                    // encode() only fails on an over-long payload or an illegal
-                    // flag, neither of which ack_for can produce; an error here
-                    // would be a bug in this crate, not a link fault.
-                    let bytes = encode(&ack).map_err(|e| {
-                        io::Error::new(
-                            io::ErrorKind::InvalidData,
-                            format!("unencodable ACK: {e:?}"),
-                        )
-                    })?;
-                    self.master.write_all(&bytes)?;
-                    self.master.flush()?;
+                    let acknowledged = match mcu.reply_for(&frame, outcome, now_us) {
+                        Some(reply) => {
+                            // encode() only fails on an over-long payload or an
+                            // illegal flag, neither of which reply_for can
+                            // produce; an error here would be a bug in this
+                            // crate, not a link fault.
+                            let bytes = encode(&reply).map_err(|e| {
+                                io::Error::new(
+                                    io::ErrorKind::InvalidData,
+                                    format!("unencodable reply: {e:?}"),
+                                )
+                            })?;
+                            self.master.write_all(&bytes)?;
+                            self.master.flush()?;
+                            true
+                        }
+                        None => false,
+                    };
                     handled.push(Handled {
                         outcome: Ok(outcome),
-                        acknowledged: true,
+                        acknowledged,
                     });
                 }
                 Err(e) => handled.push(Handled {

--- a/crates/kirra-r2cp/src/pty.rs
+++ b/crates/kirra-r2cp/src/pty.rs
@@ -175,6 +175,22 @@ impl SimulatedMcuPty {
         Ok(handled)
     }
 
+    /// Emit arbitrary bytes toward the bridge.
+    ///
+    /// The mid-session fault-injection seam, and the counterpart to
+    /// [`crate::sim::inject`]: that one corrupts a frame before it is sent,
+    /// this one lets the simulator behave like a peer that has GONE WRONG —
+    /// a baud-rate mismatch, a desynchronised sender, a board emitting a
+    /// different protocol after a reset. A bridge must survive its peer
+    /// degrading, not only its peer being wrong from the first byte.
+    ///
+    /// # Errors
+    /// Propagates write failures on the PTY.
+    pub fn write_raw(&mut self, bytes: &[u8]) -> io::Result<()> {
+        self.master.write_all(bytes)?;
+        self.master.flush()
+    }
+
     /// Advance the MCU's clock, writing an unsolicited ACK if the watchdog
     /// fired. A controlled stop the host did not ask for is exactly the event a
     /// bridge must not learn about by inference.

--- a/crates/kirra-r2cp/src/sim.rs
+++ b/crates/kirra-r2cp/src/sim.rs
@@ -247,6 +247,42 @@ impl SimulatedMcu {
         }
     }
 
+    /// The frame to send back, if any.
+    ///
+    /// One dispatcher rather than an ACK-for-everything rule, because a HELLO
+    /// must be answered with a HELLO: a peer probing for "is anything there
+    /// that speaks R2CP" learns nothing from a COMMAND_ACK, and the whole point
+    /// of the probe is that a NON-peer cannot accidentally satisfy it.
+    ///
+    /// An undecodable frame never reaches here — the MCU cannot echo a
+    /// sequence it never read, so silence is the only honest answer.
+    pub fn reply_for(&mut self, to: &Frame, outcome: Outcome, now_us: u64) -> Option<Frame> {
+        if to.message_type == MessageType::Hello {
+            // A HELLO already marked as a response is someone else's answer,
+            // not a probe; replying would start a loop between two peers.
+            if to.flags & crate::FLAG_RESPONSE != 0 {
+                return None;
+            }
+            let probe = crate::handshake::Hello::parse(&to.payload).ok()?;
+            let seq = self.next_ack_sequence;
+            self.next_ack_sequence = self.next_ack_sequence.wrapping_add(1);
+            return Some(
+                crate::handshake::Hello {
+                    // The nonce is ECHOED, never regenerated: it is what ties
+                    // this answer to that probe.
+                    nonce: probe.nonce,
+                    implementation_id: crate::handshake::SIM_IMPLEMENTATION_ID,
+                    firmware_semver: 0,
+                    minimum_major: crate::PROTOCOL_MAJOR,
+                    maximum_major: crate::PROTOCOL_MAJOR,
+                    maximum_frame: crate::MAX_PAYLOAD as u16,
+                }
+                .to_frame(seq, now_us, true),
+            );
+        }
+        Some(self.ack_for(to, outcome, now_us))
+    }
+
     /// Build the COMMAND_ACK for `outcome`, in reply to `to`.
     ///
     /// "ACK proves protocol handling, not physical movement" (`PROTOCOL.md`
@@ -348,6 +384,8 @@ impl SimulatedMcu {
                     Outcome::Refused(Refusal::FaultLatched)
                 }
             }
+            // A HELLO is answered (see `reply_for`), not acted on: it changes
+            // no state, so it is `Ignored` by the state machine specifically.
             MessageType::Hello | MessageType::TimeSyncRequest => Outcome::Ignored,
             _ => {
                 self.refusals += 1;

--- a/crates/kirra-r2cp/tests/exclusivity.rs
+++ b/crates/kirra-r2cp/tests/exclusivity.rs
@@ -1,0 +1,268 @@
+//! ADR-0033 Tier-3 sole-writer, for the R2CP path.
+//!
+//! The boot sentinel proves nobody held the port *before* the consumer
+//! started. `TIOCEXCL` is what stops anyone taking it *after* — and on this
+//! path the descriptor lives inside `SerialLink`, so the claim has to happen
+//! there or not at all.
+//!
+//! Ordering is load-bearing: open, configure, CLAIM, then handshake. A second
+//! writer appearing between the open and the claim would be invisible, and the
+//! entire reason this link exists is that exactly one process may reach the
+//! motors.
+//!
+//! ## What these tests can and cannot observe
+//!
+//! `tty_ioctl(4)`: `TIOCEXCL` makes further `open(2)` calls fail `EBUSY`
+//! "except for a process with the `CAP_SYS_ADMIN` capability". CI runs as
+//! root, so a second open here SUCCEEDS even though the claim is held — I
+//! confirmed that empirically before writing these, rather than assuming the
+//! refusal.
+//!
+//! So the assertions split:
+//!
+//! * The claim's STATE is checked with `TIOCGEXCL`, which is readable at any
+//!   privilege and is what the link reports through `is_exclusive()`. This
+//!   runs everywhere and is the primary evidence.
+//! * The EBUSY REFUSAL is checked only when the suite runs unprivileged, and
+//!   says so loudly when it skips. On the robot the consumer runs as a
+//!   rendered non-root `User=`, which is where the refusal actually bites.
+//!
+//! A test that asserted the refusal unconditionally would have failed here and
+//! been "fixed" by deleting it. One that quietly skipped would have implied
+//! coverage it does not have.
+
+#![cfg(feature = "pty")]
+
+use std::os::fd::AsFd;
+use std::path::PathBuf;
+
+use kirra_r2cp::link::SerialLink;
+use kirra_r2cp::pty::SimulatedMcuPty;
+use kirra_r2cp::sim::SimulatedMcu;
+
+const NONCE: [u8; 16] = [0x11; 16];
+
+struct SimHandle {
+    device: PathBuf,
+    stop: std::sync::mpsc::Sender<()>,
+}
+
+fn spawn_sim() -> SimHandle {
+    let pty = SimulatedMcuPty::open().expect("pty");
+    let device = pty.device_path().to_path_buf();
+    let (stop_tx, stop_rx) = std::sync::mpsc::channel::<()>();
+    std::thread::spawn(move || {
+        let mut pty = pty;
+        let mut mcu = SimulatedMcu::new();
+        let started = std::time::Instant::now();
+        loop {
+            if stop_rx.try_recv().is_ok() {
+                return;
+            }
+            let now_us = u64::try_from(started.elapsed().as_micros()).unwrap_or(u64::MAX);
+            if pty.pump(&mut mcu, now_us, 20).is_err() {
+                return;
+            }
+        }
+    });
+    SimHandle {
+        device,
+        stop: stop_tx,
+    }
+}
+
+/// A plain second opener, exactly as another process would do it.
+fn second_open(device: &std::path::Path) -> std::io::Result<std::fs::File> {
+    std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(device)
+}
+
+/// Is this process exempt from the EBUSY that TIOCEXCL imposes?
+fn privileged() -> bool {
+    // `nix::unistd::geteuid` is behind the `user` feature this crate does not
+    // enable; libc is already in the dev graph via nix.
+    // SAFETY: geteuid() takes no arguments, cannot fail, and touches no memory.
+    (unsafe { nix::libc::geteuid() }) == 0
+}
+
+/// Assert a second opener is refused — or say clearly why it was not checked.
+fn assert_second_open_refused(device: &std::path::Path, context: &str) {
+    if privileged() {
+        eprintln!(
+            "SKIP [{context}]: running as root, which tty_ioctl(4) exempts from \
+             TIOCEXCL's EBUSY. The claim STATE is asserted instead; the refusal \
+             bites on the robot, where the consumer runs unprivileged."
+        );
+        return;
+    }
+    let err = second_open(device).expect_err("a second opener must be refused");
+    assert_eq!(
+        err.kind(),
+        std::io::ErrorKind::ResourceBusy,
+        "{context}: expected EBUSY, got {err:?}"
+    );
+}
+
+#[test]
+fn case_1_a_live_link_opens_and_holds_exclusivity() {
+    let sim = spawn_sim();
+    let mut link = SerialLink::open(&sim.device, None).expect("open");
+    link.handshake(NONCE, 1000).expect("handshake");
+    assert!(link.peer().is_some());
+
+    // The primary evidence, readable at any privilege.
+    assert!(
+        link.is_exclusive(),
+        "the kernel must confirm exclusive mode after a successful open"
+    );
+    assert_second_open_refused(&sim.device, "live link");
+    let _ = sim.stop.send(());
+}
+
+#[test]
+fn case_2_a_second_opener_is_refused_while_the_handle_exists() {
+    let sim = spawn_sim();
+    let link = SerialLink::open(&sim.device, None).expect("open");
+
+    // Repeatedly, not once: the claim is a property of the descriptor's
+    // lifetime, not a one-shot that a retry could slip past.
+    for attempt in 0..5 {
+        assert!(link.is_exclusive(), "attempt {attempt}: claim must persist");
+        assert_second_open_refused(&sim.device, &format!("attempt {attempt}"));
+    }
+    drop(link);
+    let _ = sim.stop.send(());
+}
+
+#[test]
+fn case_3_closing_the_handle_releases_the_port() {
+    // Non-vacuity for cases 1 and 2: if the port were unopenable for some
+    // other reason, those refusals would prove nothing.
+    let sim = spawn_sim();
+    let link = SerialLink::open(&sim.device, None).expect("open");
+    assert!(link.is_exclusive(), "held while the link lives");
+
+    drop(link);
+    // Exclusive mode is a property of the DESCRIPTOR, so closing it clears the
+    // tty's flag — observable at any privilege, and the reopen must also work.
+    let reopened = second_open(&sim.device).expect("closing the link releases the port");
+    assert!(
+        !crate_read_exclusive(&reopened),
+        "the tty must no longer be in exclusive mode once the link is dropped"
+    );
+    let _ = sim.stop.send(());
+}
+
+#[test]
+fn case_4_a_failed_handshake_leaves_no_lock_and_no_descriptor() {
+    // A silent device: the open and the claim both succeed, then the
+    // handshake refuses. The descriptor must not leak — otherwise a robot
+    // that failed to identify its MCU would hold the port against its own
+    // next restart, turning a transient fault into a permanent one.
+    let pair = nix::pty::openpty(None, None).expect("openpty");
+    let device = nix::unistd::ttyname(pair.slave.as_fd()).expect("ttyname");
+    let _keep_open = (pair.master, pair.slave);
+
+    {
+        let mut link = SerialLink::open(&device, None).expect("open");
+        assert!(
+            link.is_exclusive(),
+            "the claim should be held during the attempt"
+        );
+        link.handshake(NONCE, 150)
+            .expect_err("a silent device must not identify");
+        // `link` is dropped here.
+    }
+
+    let after = second_open(&device).expect("the port must be reopenable");
+    assert!(
+        !crate_read_exclusive(&after),
+        "a failed handshake must not leave the tty in exclusive mode"
+    );
+}
+
+#[test]
+fn case_5_a_reopen_claims_exclusivity_again() {
+    // Exclusivity is a property of the descriptor, so a fresh link must make
+    // a fresh claim — not inherit one, and not skip it because a previous
+    // link in this process already had it.
+    let sim = spawn_sim();
+
+    for round in 0..3 {
+        let mut link = SerialLink::open(&sim.device, None).expect("open");
+        link.handshake([round as u8; 16], 1000)
+            .unwrap_or_else(|e| panic!("round {round} handshake: {e}"));
+        assert!(
+            link.is_exclusive(),
+            "round {round}: the reopened link must hold the port"
+        );
+        assert_second_open_refused(&sim.device, &format!("round {round}"));
+        drop(link);
+        let free = second_open(&sim.device).expect("port free after drop");
+        assert!(
+            !crate_read_exclusive(&free),
+            "round {round}: the port must be free after the drop"
+        );
+    }
+    let _ = sim.stop.send(());
+}
+
+#[test]
+fn the_claim_happens_before_any_handshake_byte_goes_out() {
+    // The ordering requirement, made observable: a peer that never receives a
+    // probe cannot have been written to, and the port is already exclusive
+    // before `handshake` is even called.
+    let sim = spawn_sim();
+    let link = SerialLink::open(&sim.device, None).expect("open");
+    assert!(link.peer().is_none(), "no handshake has run yet");
+    assert!(
+        link.is_exclusive(),
+        "exclusivity must already be held before the first probe"
+    );
+    drop(link);
+    let _ = sim.stop.send(());
+}
+
+/// Read `TIOCGEXCL` on an arbitrary descriptor, so a test can check the tty's
+/// state through a handle the link does not own.
+fn crate_read_exclusive(f: &std::fs::File) -> bool {
+    use std::os::fd::AsRawFd;
+    let mut set: i32 = 0;
+    // SAFETY: `f` is an open descriptor borrowed for this call; TIOCGEXCL
+    // writes exactly one `int` through the supplied pointer.
+    let rc = unsafe {
+        nix::libc::ioctl(
+            f.as_raw_fd(),
+            nix::libc::TIOCGEXCL,
+            std::ptr::addr_of_mut!(set),
+        )
+    };
+    assert_eq!(
+        rc,
+        0,
+        "TIOCGEXCL failed: {:?}",
+        std::io::Error::last_os_error()
+    );
+    set != 0
+}
+
+#[test]
+fn the_exclusivity_probe_itself_is_not_vacuous() {
+    // If `crate_read_exclusive` always returned false, half the assertions
+    // above would pass for the wrong reason. A plain open is NOT exclusive; a
+    // link's open IS.
+    let sim = spawn_sim();
+    let plain = second_open(&sim.device).expect("plain open");
+    assert!(
+        !crate_read_exclusive(&plain),
+        "a plain open is not exclusive"
+    );
+    drop(plain);
+
+    let link = SerialLink::open(&sim.device, None).expect("open");
+    assert!(link.is_exclusive(), "the link's open IS exclusive");
+    drop(link);
+    let _ = sim.stop.send(());
+}

--- a/crates/kirra-r2cp/tests/exclusivity.rs
+++ b/crates/kirra-r2cp/tests/exclusivity.rs
@@ -266,3 +266,52 @@ fn the_exclusivity_probe_itself_is_not_vacuous() {
     drop(link);
     let _ = sim.stop.send(());
 }
+
+#[test]
+fn dropping_a_link_whose_peer_vanished_does_not_panic() {
+    // Review point: the release ioctl must not panic or block cleanup. Drop
+    // runs on paths where there is nobody left to report to, so it ignores the
+    // ioctl result — this proves it stays quiet when the far end is gone,
+    // which is the shape of a cable pull or an MCU reset during shutdown.
+    let sim = spawn_sim();
+    let mut link = SerialLink::open(&sim.device, None).expect("open");
+    link.handshake(NONCE, 1000).expect("handshake");
+
+    // The peer disappears, then we tear down.
+    let _ = sim.stop.send(());
+    std::thread::sleep(std::time::Duration::from_millis(80));
+    let _ = link.receive(50); // notice the disconnect
+    drop(link); // must not panic
+}
+
+#[test]
+fn drop_covers_the_link_from_the_moment_it_exists() {
+    // Review point: exclusivity must not leak on a partially-initialised open.
+    //
+    // `SerialLink::open` constructs Self BEFORE claiming, so every fallible
+    // step is inside Drop's coverage. This pins the ordering behaviourally:
+    // after a successful open the tty is exclusive, and after the drop it is
+    // not — with the tty kept alive throughout by a separate descriptor, which
+    // is precisely the case where relying on "last close" would fail.
+    let pair = nix::pty::openpty(None, None).expect("openpty");
+    let device = nix::unistd::ttyname(pair.slave.as_fd()).expect("ttyname");
+    let keepalive = second_open(&device).expect("hold the tty open independently");
+
+    {
+        let link = SerialLink::open(&device, None).expect("open");
+        assert!(link.is_exclusive());
+        assert!(
+            crate_read_exclusive(&keepalive),
+            "the flag is on the TTY, so an independent fd sees it too"
+        );
+    }
+
+    assert!(
+        !crate_read_exclusive(&keepalive),
+        "Drop must clear exclusive mode even though another descriptor is \
+         still holding the tty open — this is the case where waiting for the \
+         last close would leave the port permanently locked"
+    );
+    drop(keepalive);
+    drop(pair);
+}

--- a/crates/kirra-r2cp/tests/handshake_gate.rs
+++ b/crates/kirra-r2cp/tests/handshake_gate.rs
@@ -1,0 +1,348 @@
+//! The gate that decides whether it is safe to send this peer a command.
+//!
+//! The load-bearing case is the FIRST end-to-end test below: the bring-up
+//! robot's `/dev/myserial` is a stock vendor motor board that does not speak
+//! R2CP. Pointing the R2CP drive mode at it must refuse, not "produce no
+//! motion" — writing R2CP frames into a vendor command parser attached to
+//! motors is undefined behaviour, not a no-op.
+
+#![cfg(feature = "pty")]
+
+use std::io::Write;
+use std::os::fd::AsFd;
+use std::path::PathBuf;
+
+use kirra_r2cp::handshake::{
+    evaluate_hello_response, HandshakeError, Hello, HOST_IMPLEMENTATION_ID, SIM_IMPLEMENTATION_ID,
+};
+use kirra_r2cp::link::{LinkError, SerialLink};
+use kirra_r2cp::pty::SimulatedMcuPty;
+use kirra_r2cp::sim::{MotionCommand, Outcome, SimulatedMcu, MODE_TRACK};
+use kirra_r2cp::{encode, Frame, MessageType, MAX_PAYLOAD};
+
+const NONCE: [u8; 16] = [7u8; 16];
+
+fn peer_hello(nonce: [u8; 16]) -> Hello {
+    Hello {
+        nonce,
+        implementation_id: SIM_IMPLEMENTATION_ID,
+        firmware_semver: 1,
+        minimum_major: 1,
+        maximum_major: 1,
+        maximum_frame: MAX_PAYLOAD as u16,
+    }
+}
+
+// ------------------------------------------------------------ pure evaluator
+
+#[test]
+fn a_matching_response_is_accepted_and_names_the_peer() {
+    let probe = Hello::probe(NONCE);
+    let peer = evaluate_hello_response(
+        &probe,
+        &peer_hello(NONCE).to_frame(1, 0, true),
+        MAX_PAYLOAD as u16,
+    )
+    .expect("a well-formed matching response is accepted");
+    assert_eq!(peer.implementation_id, SIM_IMPLEMENTATION_ID);
+    assert_eq!(peer.agreed_major, 1);
+    assert_ne!(
+        peer.implementation_id, HOST_IMPLEMENTATION_ID,
+        "the peer must be distinguishable from ourselves in a log"
+    );
+}
+
+#[test]
+fn a_reply_carrying_someone_elses_nonce_is_refused() {
+    // This is the nonce doing its job: a recorded reply from an earlier session
+    // must not satisfy a fresh probe.
+    let probe = Hello::probe(NONCE);
+    let stale = peer_hello([9u8; 16]).to_frame(1, 0, true);
+    assert_eq!(
+        evaluate_hello_response(&probe, &stale, MAX_PAYLOAD as u16),
+        Err(HandshakeError::NonceMismatch)
+    );
+    // Positive control: identical in every other respect, with the right nonce.
+    assert!(evaluate_hello_response(
+        &probe,
+        &peer_hello(NONCE).to_frame(1, 0, true),
+        MAX_PAYLOAD as u16
+    )
+    .is_ok());
+}
+
+#[test]
+fn only_a_hello_marked_as_a_response_answers_a_probe() {
+    let probe = Hello::probe(NONCE);
+
+    // A COMMAND_ACK is not an answer to a HELLO.
+    let ack = Frame::new(MessageType::CommandAcknowledgement, 1, 0).with_payload(&[0u8; 28]);
+    assert_eq!(
+        evaluate_hello_response(&probe, &ack, MAX_PAYLOAD as u16),
+        Err(HandshakeError::NotAHello)
+    );
+
+    // A peer's own unsolicited HELLO is not an answer either.
+    let unsolicited = peer_hello(NONCE).to_frame(1, 0, false);
+    assert_eq!(
+        evaluate_hello_response(&probe, &unsolicited, MAX_PAYLOAD as u16),
+        Err(HandshakeError::NotAResponse)
+    );
+}
+
+#[test]
+fn version_ranges_must_overlap_and_overlap_is_enough() {
+    let probe = Hello::probe(NONCE); // host supports exactly major 1
+
+    for (min, max) in [(2u8, 3u8), (0, 0)] {
+        let mut h = peer_hello(NONCE);
+        h.minimum_major = min;
+        h.maximum_major = max;
+        assert_eq!(
+            evaluate_hello_response(&probe, &h.to_frame(1, 0, true), MAX_PAYLOAD as u16),
+            Err(HandshakeError::VersionMismatch {
+                peer_min: min,
+                peer_max: max
+            }),
+            "peer range {min}..{max} does not overlap the host's"
+        );
+    }
+
+    // Positive control: a peer supporting 1..2 CAN talk to a host on 1 — the
+    // check is overlap, not equality, or every firmware bump would break it.
+    let mut wide = peer_hello(NONCE);
+    wide.minimum_major = 1;
+    wide.maximum_major = 2;
+    let peer = evaluate_hello_response(&probe, &wide.to_frame(1, 0, true), MAX_PAYLOAD as u16)
+        .expect("overlapping ranges are acceptable");
+    assert_eq!(peer.agreed_major, 1, "agree on the highest common major");
+
+    // An inverted range is malformed, not merely non-overlapping.
+    let mut inverted = peer_hello(NONCE);
+    inverted.minimum_major = 3;
+    inverted.maximum_major = 1;
+    assert_eq!(
+        evaluate_hello_response(&probe, &inverted.to_frame(1, 0, true), MAX_PAYLOAD as u16),
+        Err(HandshakeError::MalformedHello)
+    );
+}
+
+#[test]
+fn a_peer_that_cannot_receive_our_largest_frame_is_refused_up_front() {
+    // Better than discovering it when a long command is silently dropped.
+    let probe = Hello::probe(NONCE);
+    let mut small = peer_hello(NONCE);
+    small.maximum_frame = 32;
+    assert_eq!(
+        evaluate_hello_response(&probe, &small.to_frame(1, 0, true), 64),
+        Err(HandshakeError::FrameTooSmall {
+            peer_maximum: 32,
+            required: 64
+        })
+    );
+    // Positive control: exactly enough is enough.
+    assert!(evaluate_hello_response(&probe, &small.to_frame(1, 0, true), 32).is_ok());
+}
+
+#[test]
+fn a_short_hello_payload_is_refused_not_zero_filled() {
+    let probe = Hello::probe(NONCE);
+    let mut truncated = peer_hello(NONCE).to_frame(1, 0, true);
+    truncated.payload.truncate(20);
+    assert_eq!(
+        evaluate_hello_response(&probe, &truncated, MAX_PAYLOAD as u16),
+        Err(HandshakeError::MalformedHello),
+        "a peer that cannot state its version range has not answered"
+    );
+}
+
+#[test]
+fn hello_round_trips_through_its_own_encoding() {
+    let h = peer_hello([0xABu8; 16]);
+    assert_eq!(Hello::parse(&h.encode()), Ok(h));
+}
+
+// ------------------------------------------------------------- over the wire
+
+/// A pty whose master nobody services — the shape of a device that is present
+/// and openable but is not an R2CP peer.
+struct SilentPeer {
+    _master: std::fs::File,
+    _slave: std::os::fd::OwnedFd,
+    device: PathBuf,
+}
+
+impl SilentPeer {
+    fn open() -> Self {
+        let pair = nix::pty::openpty(None, None).expect("openpty");
+        let device = nix::unistd::ttyname(pair.slave.as_fd()).expect("ttyname");
+        Self {
+            _master: std::fs::File::from(pair.master),
+            _slave: pair.slave,
+            device,
+        }
+    }
+}
+
+#[test]
+fn a_device_that_is_not_an_r2cp_peer_refuses_the_handshake() {
+    // 🔴 The case this whole module exists for. On the bring-up robot
+    // /dev/myserial is a stock vendor motor board: present, openable, and
+    // silent in R2CP terms. It must REFUSE, not fall through to sending
+    // frames into a vendor command parser attached to motors.
+    let quiet = SilentPeer::open();
+    let mut link = SerialLink::open(&quiet.device, None).expect("the device opens");
+
+    let err = link
+        .handshake(NONCE, 150)
+        .expect_err("a non-R2CP device must not satisfy the gate");
+    assert!(matches!(
+        err,
+        LinkError::Handshake(HandshakeError::NoResponse)
+    ));
+    assert!(link.peer().is_none());
+
+    // The operator-facing message must name the likely cause, because "no
+    // response" alone sends someone looking for a cable fault.
+    let msg = err.to_string();
+    assert!(
+        msg.contains("VENDOR"),
+        "the refusal should name the likely cause, got: {msg}"
+    );
+}
+
+#[test]
+fn a_device_that_chatters_a_foreign_protocol_still_refuses() {
+    // A vendor board is not necessarily silent — it may be emitting its own
+    // telemetry. Bytes arriving must not be mistaken for agreement.
+    let mut noisy = SilentPeer::open();
+    let mut link = SerialLink::open(&noisy.device, None).expect("the device opens");
+
+    // Yahboom-shaped framing: 0xFF 0xFE header, length, payload. Nothing here
+    // is valid R2CP, and none of it is an answer to our probe.
+    for _ in 0..8 {
+        noisy
+            ._master
+            .write_all(&[0xFF, 0xFE, 0x04, 0x01, 0x02, 0x03, 0x00])
+            .expect("write vendor chatter");
+    }
+    noisy._master.flush().expect("flush");
+
+    let err = link
+        .handshake(NONCE, 150)
+        .expect_err("foreign traffic is not a handshake");
+    assert!(matches!(err, LinkError::Handshake(_)));
+    assert!(link.peer().is_none());
+}
+
+/// Run the simulated MCU on a background thread so the link talks to a live
+/// peer, exactly as the consumer will.
+fn spawn_sim() -> (PathBuf, std::sync::mpsc::Sender<()>) {
+    let pty = SimulatedMcuPty::open().expect("allocate a pty");
+    let device = pty.device_path().to_path_buf();
+    let (stop_tx, stop_rx) = std::sync::mpsc::channel::<()>();
+    std::thread::spawn(move || {
+        let mut pty = pty;
+        let mut mcu = SimulatedMcu::new();
+        let started = std::time::Instant::now();
+        loop {
+            if stop_rx.try_recv().is_ok() {
+                return;
+            }
+            let now_us = u64::try_from(started.elapsed().as_micros()).unwrap_or(u64::MAX);
+            if pty.pump(&mut mcu, now_us, 20).is_err() {
+                return;
+            }
+        }
+    });
+    (device, stop_tx)
+}
+
+#[test]
+fn a_live_simulator_satisfies_the_gate_and_identifies_itself() {
+    // Positive control for the two refusals above: the identical code path,
+    // against a peer that does speak R2CP, succeeds.
+    let (device, stop) = spawn_sim();
+    let mut link = SerialLink::open(&device, None).expect("open");
+
+    let peer = link.handshake(NONCE, 1000).expect("the simulator answers");
+    assert_eq!(peer.implementation_id, SIM_IMPLEMENTATION_ID);
+    assert_eq!(peer.agreed_major, 1);
+    assert!(link.peer().is_some());
+    let _ = stop.send(());
+}
+
+#[test]
+fn commands_are_refused_before_the_handshake_and_accepted_after() {
+    let (device, stop) = spawn_sim();
+    let mut link = SerialLink::open(&device, None).expect("open");
+
+    let cmd = MotionCommand {
+        command_id: 1,
+        valid_for_us: 100_000,
+        velocity_mps: 0.3,
+        curvature_per_m: 0.0,
+        acceleration_limit_mps2: 1.0,
+        jerk_limit_mps3: 5.0,
+        mode: MODE_TRACK,
+    };
+
+    // Ordering is enforced by the link, not left to the caller.
+    assert!(matches!(
+        link.arm_and_activate(200),
+        Err(LinkError::NotHandshaken)
+    ));
+    assert!(matches!(
+        link.send_motion(&cmd, 0),
+        Err(LinkError::NotHandshaken)
+    ));
+
+    link.handshake(NONCE, 1000).expect("handshake");
+    link.arm_and_activate(1000).expect("arm and activate");
+    link.send_motion(&cmd, 0).expect("motion is sent");
+
+    let got = link.receive(1000).expect("receive");
+    let acked = got
+        .frames
+        .iter()
+        .find(|f| f.message_type == MessageType::CommandAcknowledgement)
+        .expect("the motion command is acknowledged");
+    assert_eq!(
+        kirra_r2cp::link::ack_result(acked),
+        Some(kirra_r2cp::sim::ack_result::ACCEPTED)
+    );
+    let _ = stop.send(());
+}
+
+#[test]
+fn a_stop_is_sendable_without_a_handshake() {
+    // Deliberate asymmetry: commanding motion requires an identified peer, but
+    // a stop must be attemptable on a link whose state is uncertain — a
+    // shutdown path must not be blocked by the gate that protects startup.
+    let quiet = SilentPeer::open();
+    let mut link = SerialLink::open(&quiet.device, None).expect("open");
+    assert!(link.peer().is_none());
+    link.send_stop(100_000, 0)
+        .expect("a stop is always sendable");
+}
+
+#[test]
+fn the_simulator_does_not_answer_its_own_kind_of_reply() {
+    // Two peers each answering the other's HELLO response would loop forever.
+    // A HELLO already flagged as a response gets no reply.
+    let mut mcu = SimulatedMcu::new();
+    let response = peer_hello(NONCE).to_frame(1, 0, true);
+    let outcome = mcu.handle(&response, 0);
+    assert_eq!(outcome, Outcome::Ignored);
+    assert!(mcu.reply_for(&response, outcome, 0).is_none());
+
+    // Positive control: a PROBE does get answered.
+    let probe = Hello::probe(NONCE).to_frame(2, 0, false);
+    let outcome = mcu.handle(&probe, 0);
+    let reply = mcu
+        .reply_for(&probe, outcome, 0)
+        .expect("a probe is answered");
+    assert_eq!(reply.message_type, MessageType::Hello);
+    assert_ne!(reply.flags & kirra_r2cp::FLAG_RESPONSE, 0);
+    assert!(encode(&reply).is_ok());
+}

--- a/crates/kirra-r2cp/tests/handshake_gate.rs
+++ b/crates/kirra-r2cp/tests/handshake_gate.rs
@@ -13,9 +13,10 @@ use std::os::fd::AsFd;
 use std::path::PathBuf;
 
 use kirra_r2cp::handshake::{
-    evaluate_hello_response, HandshakeError, Hello, HOST_IMPLEMENTATION_ID, SIM_IMPLEMENTATION_ID,
+    evaluate_hello_response, HandshakeError, Hello, HOST_IMPLEMENTATION_ID, MIN_ADVERTISED_FRAME,
+    SIM_IMPLEMENTATION_ID,
 };
-use kirra_r2cp::link::{LinkError, SerialLink};
+use kirra_r2cp::link::{LinkError, LinkFault, SerialLink, FRAMING_FAILURE_THRESHOLD};
 use kirra_r2cp::pty::SimulatedMcuPty;
 use kirra_r2cp::sim::{MotionCommand, Outcome, SimulatedMcu, MODE_TRACK};
 use kirra_r2cp::{encode, Frame, MessageType, MAX_PAYLOAD};
@@ -130,18 +131,73 @@ fn version_ranges_must_overlap_and_overlap_is_enough() {
 #[test]
 fn a_peer_that_cannot_receive_our_largest_frame_is_refused_up_front() {
     // Better than discovering it when a long command is silently dropped.
+    // 64 is a CONFORMING advertisement (above the protocol floor) that is
+    // still too small for a 128-byte requirement, which is what isolates this
+    // refusal from the two protocol-conformance ones below.
     let probe = Hello::probe(NONCE);
     let mut small = peer_hello(NONCE);
-    small.maximum_frame = 32;
+    small.maximum_frame = 64;
     assert_eq!(
-        evaluate_hello_response(&probe, &small.to_frame(1, 0, true), 64),
+        evaluate_hello_response(&probe, &small.to_frame(1, 0, true), 128),
         Err(HandshakeError::FrameTooSmall {
-            peer_maximum: 32,
-            required: 64
+            peer_maximum: 64,
+            required: 128
         })
     );
     // Positive control: exactly enough is enough.
-    assert!(evaluate_hello_response(&probe, &small.to_frame(1, 0, true), 32).is_ok());
+    assert!(evaluate_hello_response(&probe, &small.to_frame(1, 0, true), 64).is_ok());
+}
+
+#[test]
+fn a_peer_below_the_protocol_frame_floor_is_not_a_conforming_peer() {
+    // The floor is derived from PROTOCOL.md §MOTION_COMMAND (44 bytes with
+    // auth_tag), not chosen: a peer under it cannot receive a fully-specified
+    // motion command, whatever else it claims about itself.
+    let probe = Hello::probe(NONCE);
+    for advertised in [0u16, 1, MIN_ADVERTISED_FRAME - 1] {
+        let mut tiny = peer_hello(NONCE);
+        tiny.maximum_frame = advertised;
+        assert_eq!(
+            // required_frame is small here ON PURPOSE: the floor must fire on
+            // protocol conformance alone, not because we happen to want a big
+            // frame today.
+            evaluate_hello_response(&probe, &tiny.to_frame(1, 0, true), 8),
+            Err(HandshakeError::FrameBelowProtocolMinimum {
+                peer_maximum: advertised,
+                minimum: MIN_ADVERTISED_FRAME
+            }),
+            "advertised {advertised} is below the protocol floor"
+        );
+    }
+    // Positive control: the floor itself is acceptable.
+    let mut exact = peer_hello(NONCE);
+    exact.maximum_frame = MIN_ADVERTISED_FRAME;
+    assert!(evaluate_hello_response(&probe, &exact.to_frame(1, 0, true), 8).is_ok());
+}
+
+#[test]
+fn a_peer_claiming_more_than_the_major_version_permits_is_refused_not_clamped() {
+    // Within an agreed major the maximum is FIXED, so a larger claim means the
+    // two ends disagree about the format they just agreed on. Clamping would
+    // paper over that; a peer whose framing assumptions cannot be pinned down
+    // is not one to command motion on.
+    let probe = Hello::probe(NONCE);
+    for advertised in [(MAX_PAYLOAD as u16) + 1, 4096, u16::MAX] {
+        let mut huge = peer_hello(NONCE);
+        huge.maximum_frame = advertised;
+        assert_eq!(
+            evaluate_hello_response(&probe, &huge.to_frame(1, 0, true), 8),
+            Err(HandshakeError::FrameAboveProtocolMaximum {
+                peer_maximum: advertised,
+                maximum: MAX_PAYLOAD as u16
+            }),
+            "advertised {advertised} exceeds what major 1 permits"
+        );
+    }
+    // Positive control: the ceiling itself is acceptable.
+    let mut exact = peer_hello(NONCE);
+    exact.maximum_frame = MAX_PAYLOAD as u16;
+    assert!(evaluate_hello_response(&probe, &exact.to_frame(1, 0, true), 8).is_ok());
 }
 
 #[test]
@@ -235,12 +291,22 @@ fn a_device_that_chatters_a_foreign_protocol_still_refuses() {
     assert!(link.peer().is_none());
 }
 
+/// A live simulator on a background thread, plus a channel that makes it emit
+/// arbitrary bytes — so a test can degrade a peer that was previously fine,
+/// which is a different failure from a peer that was never right.
+struct SimHandle {
+    device: PathBuf,
+    inject: std::sync::mpsc::Sender<Vec<u8>>,
+    stop: std::sync::mpsc::Sender<()>,
+}
+
 /// Run the simulated MCU on a background thread so the link talks to a live
 /// peer, exactly as the consumer will.
-fn spawn_sim() -> (PathBuf, std::sync::mpsc::Sender<()>) {
+fn spawn_sim() -> SimHandle {
     let pty = SimulatedMcuPty::open().expect("allocate a pty");
     let device = pty.device_path().to_path_buf();
     let (stop_tx, stop_rx) = std::sync::mpsc::channel::<()>();
+    let (inject_tx, inject_rx) = std::sync::mpsc::channel::<Vec<u8>>();
     std::thread::spawn(move || {
         let mut pty = pty;
         let mut mcu = SimulatedMcu::new();
@@ -249,33 +315,42 @@ fn spawn_sim() -> (PathBuf, std::sync::mpsc::Sender<()>) {
             if stop_rx.try_recv().is_ok() {
                 return;
             }
+            while let Ok(bytes) = inject_rx.try_recv() {
+                if pty.write_raw(&bytes).is_err() {
+                    return;
+                }
+            }
             let now_us = u64::try_from(started.elapsed().as_micros()).unwrap_or(u64::MAX);
             if pty.pump(&mut mcu, now_us, 20).is_err() {
                 return;
             }
         }
     });
-    (device, stop_tx)
+    SimHandle {
+        device,
+        inject: inject_tx,
+        stop: stop_tx,
+    }
 }
 
 #[test]
 fn a_live_simulator_satisfies_the_gate_and_identifies_itself() {
     // Positive control for the two refusals above: the identical code path,
     // against a peer that does speak R2CP, succeeds.
-    let (device, stop) = spawn_sim();
-    let mut link = SerialLink::open(&device, None).expect("open");
+    let sim = spawn_sim();
+    let mut link = SerialLink::open(&sim.device, None).expect("open");
 
     let peer = link.handshake(NONCE, 1000).expect("the simulator answers");
     assert_eq!(peer.implementation_id, SIM_IMPLEMENTATION_ID);
     assert_eq!(peer.agreed_major, 1);
     assert!(link.peer().is_some());
-    let _ = stop.send(());
+    let _ = sim.stop.send(());
 }
 
 #[test]
 fn commands_are_refused_before_the_handshake_and_accepted_after() {
-    let (device, stop) = spawn_sim();
-    let mut link = SerialLink::open(&device, None).expect("open");
+    let sim = spawn_sim();
+    let mut link = SerialLink::open(&sim.device, None).expect("open");
 
     let cmd = MotionCommand {
         command_id: 1,
@@ -311,7 +386,7 @@ fn commands_are_refused_before_the_handshake_and_accepted_after() {
         kirra_r2cp::link::ack_result(acked),
         Some(kirra_r2cp::sim::ack_result::ACCEPTED)
     );
-    let _ = stop.send(());
+    let _ = sim.stop.send(());
 }
 
 #[test]
@@ -324,6 +399,119 @@ fn a_stop_is_sendable_without_a_handshake() {
     assert!(link.peer().is_none());
     link.send_stop(100_000, 0)
         .expect("a stop is always sendable");
+}
+
+#[test]
+fn sustained_framing_failure_drops_the_peer_and_forces_a_fresh_handshake() {
+    // The ends have lost agreement about where frames begin; everything
+    // decoded after that point is guesswork, so the identification cannot
+    // stand. A caller must re-handshake, not carry on.
+    let sim = spawn_sim();
+    let mut link = SerialLink::open(&sim.device, None).expect("open");
+    link.handshake(NONCE, 1000).expect("handshake");
+    assert!(link.peer().is_some());
+
+    // Garbage that frames (delimiters present) but never decodes, which is
+    // what a baud-rate mismatch or a desynchronised peer actually looks like —
+    // not an absence of bytes.
+    let mut noise = Vec::new();
+    for i in 0..(FRAMING_FAILURE_THRESHOLD + 4) {
+        noise.extend_from_slice(&[0x41 + (i as u8 % 16), 0x42, 0x43, 0x44, 0x00]);
+    }
+    sim.inject.send(noise).expect("inject");
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_millis(1500);
+    while link.peer().is_some() && std::time::Instant::now() < deadline {
+        let _ = link.receive(100).expect("receive");
+    }
+    assert!(
+        link.peer().is_none(),
+        "sustained undecodable traffic must drop the peer"
+    );
+    assert!(matches!(link.fault(), Some(LinkFault::FramingLost { .. })));
+    // And the gate is now closed again: commands refuse until re-identified.
+    assert!(matches!(
+        link.arm_and_activate(100),
+        Err(LinkError::NotHandshaken)
+    ));
+    let _ = sim.stop.send(());
+}
+
+#[test]
+fn one_corrupt_frame_does_not_drop_the_peer() {
+    // Non-vacuity for the threshold: a single corrupt frame is ORDINARY on a
+    // real UART — that is what the CRC is for — and re-handshaking on every
+    // one would make the link unusable. The streak must count sustained
+    // failure, not a lifetime total.
+    let sim = spawn_sim();
+    let mut link = SerialLink::open(&sim.device, None).expect("open");
+    link.handshake(NONCE, 1000).expect("handshake");
+
+    sim.inject
+        .send(vec![0x41, 0x42, 0x43, 0x00])
+        .expect("inject");
+    let _ = link.receive(150).expect("receive");
+    assert!(
+        link.peer().is_some(),
+        "a single corrupt frame must not drop the peer"
+    );
+    assert!(link.fault().is_none());
+    let _ = sim.stop.send(());
+}
+
+#[test]
+fn an_explicit_reset_forces_a_fresh_handshake() {
+    // The hook for a watchdog-triggered stop: after it, the peer's state is
+    // uncertain, and re-identifying is cheaper than guessing.
+    let sim = spawn_sim();
+    let mut link = SerialLink::open(&sim.device, None).expect("open");
+    link.handshake(NONCE, 1000).expect("handshake");
+    link.arm_and_activate(1000).expect("arm");
+
+    link.reset();
+    assert!(link.peer().is_none());
+    assert_eq!(link.fault(), Some(LinkFault::Reset));
+    assert!(matches!(
+        link.arm_and_activate(100),
+        Err(LinkError::NotHandshaken)
+    ));
+
+    // Positive control: re-handshaking restores the link rather than
+    // permanently poisoning it.
+    link.handshake([3u8; 16], 1000).expect("re-handshake");
+    assert!(link.peer().is_some());
+    let _ = sim.stop.send(());
+}
+
+#[test]
+fn a_reopened_link_starts_unidentified_by_construction() {
+    // The peer state lives on the instance, so a reopen cannot inherit a
+    // stale identification — there is no global or caller-held flag to forget
+    // to clear.
+    let sim = spawn_sim();
+    let mut first = SerialLink::open(&sim.device, None).expect("open");
+    first.handshake(NONCE, 1000).expect("handshake");
+    assert!(first.peer().is_some());
+    drop(first);
+
+    let mut second = SerialLink::open(&sim.device, None).expect("reopen");
+    assert!(second.peer().is_none(), "a reopen is not identified");
+    assert!(matches!(
+        second.send_motion(
+            &MotionCommand {
+                command_id: 1,
+                valid_for_us: 100_000,
+                velocity_mps: 0.3,
+                curvature_per_m: 0.0,
+                acceleration_limit_mps2: 1.0,
+                jerk_limit_mps3: 5.0,
+                mode: MODE_TRACK,
+            },
+            0
+        ),
+        Err(LinkError::NotHandshaken)
+    ));
+    let _ = sim.stop.send(());
 }
 
 #[test]

--- a/robot/consumer_config_contract.py
+++ b/robot/consumer_config_contract.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 MODE_R2 = "r2_ackermann"
 MODE_X3 = "x3"
+MODE_R2CP = "r2cp"
 
 # Required in EVERY mode — the governed-consumer safety envelope.
 ALWAYS_REQUIRED = (
@@ -57,6 +58,23 @@ R2_REQUIRED = (
     "KIRRA_R2_STEER_SIGN",
     "KIRRA_R2_CENTER_TRIM",
 )
+
+# R2CP: the host speaks GOVERNED PHYSICAL UNITS to an MCU that owns its own
+# calibration, so none of the R2 Ackermann measurements above apply here. PWM
+# scaling, steering geometry, drive limits and watchdog policy belong in the
+# MCU's manifest/firmware, not duplicated on the Jetson — duplicating them is
+# how the two ends drift, and the MCU is the one attached to the motors.
+#
+# What the host genuinely needs is the link itself.
+R2CP_REQUIRED = (
+    "KIRRA_MOTOR_PORT",  # also in ALWAYS_REQUIRED; named here for the reader
+    "KIRRA_R2CP_HANDSHAKE_TIMEOUT_MS",
+    "KIRRA_R2CP_COMMAND_TIMEOUT_MS",
+)
+
+# Deliberately NOT required yet: an expected MCU identity. The protocol does
+# not define stable identity semantics, and inventing one here would create a
+# host-only convention the firmware never agreed to. Revisit when it does.
 
 # Only when the corresponding feature is switched on.
 ODOM_REQUIRED = ("KIRRA_R2_M_PER_TICK",)
@@ -89,7 +107,12 @@ def required_keys(env) -> list[str]:
     """Every key this env's MODE actually needs, in report order."""
     mode = drive_mode(env)
     keys = list(ALWAYS_REQUIRED) + [FFI_KEY]
-    if mode == MODE_R2:
+    if mode == MODE_R2CP:
+        # Only the link settings on top of the always-required envelope. No
+        # vendor car-type handshake and no measured calibration: the MCU holds
+        # its own.
+        keys += [k for k in R2CP_REQUIRED if k not in ALWAYS_REQUIRED]
+    elif mode == MODE_R2:
         keys += list(R2_REQUIRED)
         if odom_enabled(env):
             keys += list(ODOM_REQUIRED)
@@ -104,6 +127,15 @@ def inapplicable_keys(env) -> list[str]:
     """Keys that belong to a DIFFERENT mode than the configured one. Reported
     as a warning, never a failure — a leftover value is untidy, not unsafe."""
     mode = drive_mode(env)
+    if mode == MODE_R2CP:
+        # Everything physical belongs to the MCU in this mode.
+        return (
+            list(X3_ONLY)
+            + list(R2_REQUIRED)
+            + list(ODOM_REQUIRED)
+            + list(CLOSED_LOOP_REQUIRED)
+            + ["KIRRA_R2_DRIVE_DEADBAND_PWM"]
+        )
     if mode == MODE_R2:
         out = list(X3_ONLY)
         if not odom_enabled(env):

--- a/robot/kirra_ffi.py
+++ b/robot/kirra_ffi.py
@@ -474,6 +474,12 @@ class BoundKirraConsumer:
                 "stop_decel_mps2 (finite > 0), and vx_max/vz_max (finite > 0)."
             )
 
+    @property
+    def lib(self) -> ctypes.CDLL:
+        """The loaded library, so sibling bindings (e.g. the R2CP link) reuse
+        this handle instead of dlopening a second copy of the same .so."""
+        return self._lib
+
     def _handle(self):
         if not getattr(self, "_h", None):
             # A use-after-free would pass a dangling pointer to Rust. Refuse.

--- a/robot/kirra_motor_consumer.py
+++ b/robot/kirra_motor_consumer.py
@@ -514,6 +514,16 @@ def main() -> int:
             return 2 if e.is_config else 1
         info = r2cp_link.peer_info()
         print(f"R2CP peer identified: {info.describe()}", file=sys.stderr)
+        # Only claimed when the KERNEL confirms it (TIOCGEXCL read back in
+        # Rust). Saying "exclusivity claimed" because a call returned 0 is the
+        # kind of unearned assurance ADR-0033 Tier-3 exists to remove.
+        if info.exclusive:
+            print(f"serial exclusivity: TIOCEXCL confirmed on {motor_port} "
+                  "(further non-root opens refused by the kernel)", file=sys.stderr)
+        else:
+            print(f"WARNING: kernel exclusivity NOT confirmed on {motor_port} — "
+                  "the boot sentinel and udev mode still apply, but this session "
+                  "is not kernel-locked", file=sys.stderr)
         try:
             r2cp_link.activate(r2cp_command_timeout_ms)
         except r2cp_mod.R2cpError as e:

--- a/robot/kirra_motor_consumer.py
+++ b/robot/kirra_motor_consumer.py
@@ -117,6 +117,38 @@ from r2_drive import (  # noqa: E402
 # docs/hardware/R2_PATH_B_ACKERMANN_DRIVE.md §6. Off by default.
 DRIVE_MODE_X3 = "x3_set_car_motion"
 DRIVE_MODE_R2 = "r2_ackermann"
+# 🔴 R2CP: the last hop is the Kirra MCU protocol, NOT the vendor board.
+# In this mode the vendor library is never imported, never constructed, and
+# never called — see the r2cp branch in main(). There is deliberately NO
+# fallback to r2_ackermann or x3: if the R2CP peer cannot be identified,
+# motion stays unavailable. A fallback would silently return actuation to the
+# unverified vendor path precisely when the verified one failed.
+DRIVE_MODE_R2CP = "r2cp"
+
+
+def _now_us() -> int:
+    """Monotonic microseconds for the R2CP source-time field.
+
+    Monotonic, never wall clock: a clock step backwards would make fresh
+    commands look stale and stale ones fresh, which is AOU-TIMESYNC-001 and
+    exactly the property the peer's freshness rule depends on.
+    """
+    return time.monotonic_ns() // 1000
+
+
+_COMMAND_ID = 0
+
+
+def _next_command_id() -> int:
+    """A strictly advancing correlation id for the ACK to echo.
+
+    Not a security property — the peer's replay watermark is on the frame
+    SEQUENCE, which the Rust link owns. This is only so a log can pair a
+    command with its acknowledgement.
+    """
+    global _COMMAND_ID
+    _COMMAND_ID = (_COMMAND_ID + 1) & 0xFFFF_FFFF
+    return _COMMAND_ID
 R2_CAR_TYPE = 5  # Ackermann drive model; RAM-volatile, re-asserted every start.
 
 
@@ -300,7 +332,18 @@ def main() -> int:
     import rclpy
     from rclpy.node import Node
     from std_msgs.msg import UInt8MultiArray
-    from Rosmaster_Lib import Rosmaster
+
+    # The mode is resolved BEFORE the vendor import so an r2cp deployment does
+    # not need Rosmaster_Lib installed at all. "No vendor library" is then a
+    # property of the image, not a promise about which code path runs.
+    drive_mode = (os.environ.get("KIRRA_DRIVE_MODE") or DRIVE_MODE_X3).strip() or DRIVE_MODE_X3
+    if drive_mode not in (DRIVE_MODE_X3, DRIVE_MODE_R2, DRIVE_MODE_R2CP):
+        print(f"FATAL: KIRRA_DRIVE_MODE must be {DRIVE_MODE_X3!r}, "
+              f"{DRIVE_MODE_R2!r} or {DRIVE_MODE_R2CP!r}, got {drive_mode!r}",
+              file=sys.stderr)
+        return 2
+    if drive_mode != DRIVE_MODE_R2CP:
+        from Rosmaster_Lib import Rosmaster
 
     vk_hex = _req("KIRRA_GOVERNOR_VK_HEX").strip()
     try:
@@ -335,15 +378,19 @@ def main() -> int:
     vx_max = _req_float("KIRRA_DEMO_VX_MAX")
     vz_max = _req_float("KIRRA_DEMO_VZ_MAX")
     motor_port = _req("KIRRA_MOTOR_PORT")
-    drive_mode = (os.environ.get("KIRRA_DRIVE_MODE") or DRIVE_MODE_X3).strip() or DRIVE_MODE_X3
-    if drive_mode not in (DRIVE_MODE_X3, DRIVE_MODE_R2):
-        print(f"FATAL: KIRRA_DRIVE_MODE must be {DRIVE_MODE_X3!r} or "
-              f"{DRIVE_MODE_R2!r}, got {drive_mode!r}", file=sys.stderr)
-        return 2
     # x3 mode asserts the board's car-type register against the platform
     # mapping; r2 mode SETS car-type 5 (below) and loads the measured
     # calibration instead — fail-closed if any measured value is missing.
     expected_car_type = _req_int("KIRRA_EXPECTED_CAR_TYPE") if drive_mode == DRIVE_MODE_X3 else None
+    # r2cp link settings. Required in that mode only; the MCU owns everything
+    # physical (PWM scaling, steering geometry, limits, watchdog policy), so
+    # none of the R2 measured calibration is read here.
+    r2cp_handshake_timeout_ms = (
+        _req_int("KIRRA_R2CP_HANDSHAKE_TIMEOUT_MS") if drive_mode == DRIVE_MODE_R2CP else 0
+    )
+    r2cp_command_timeout_ms = (
+        _req_int("KIRRA_R2CP_COMMAND_TIMEOUT_MS") if drive_mode == DRIVE_MODE_R2CP else 0
+    )
     r2_cal = None
     r2_matcher = None  # closed-loop speed matcher (r2 mode + KIRRA_R2_CLOSED_LOOP)
     if drive_mode == DRIVE_MODE_R2:
@@ -436,20 +483,65 @@ def main() -> int:
     print(("WARNING: " if verdict == "acknowledged" else "") + sentinel_msg,
           file=sys.stderr)
 
-    bot = Rosmaster(com=motor_port)
+    r2cp_link = None
+    if drive_mode == DRIVE_MODE_R2CP:
+        # 🔴 No Rosmaster construction, no car-type read or write, no
+        # set_motor, no set_car_motion. The vendor library was not even
+        # imported. `bot` stays None and every use of it below is behind a
+        # mode branch.
+        #
+        # ⚠ TIOCEXCL is NOT claimed on this path: the file descriptor lives
+        # inside the Rust link, and reaching into it from Python would defeat
+        # the point of the opaque handle. The boot sentinel above (owner,
+        # 0600, no other holder) and the udev rule still hold, so the port is
+        # still not shareable — but kernel-enforced session exclusivity is a
+        # recorded gap for the r2cp path, not something this claims to have.
+        bot = None
+        import kirra_r2cp as r2cp_mod
+
+        # Same .so the verify core already loaded — one dlopen, one library.
+        r2cp_lib = r2cp_mod.bind(consumer.lib)
+        try:
+            r2cp_link = r2cp_mod.open(r2cp_lib, motor_port, r2cp_handshake_timeout_ms)
+        except r2cp_mod.R2cpError as e:
+            # Exit CLASS matters: kirra-consumer.service carries
+            # RestartPreventExitStatus=2, so returning 2 here for a peer that
+            # is merely absent would leave the unit permanently dead after
+            # someone reconnects the MCU. Only deterministic configuration
+            # earns 2.
+            print(f"FATAL: R2CP peer unavailable: {e}", file=sys.stderr)
+            print("motion output remains unavailable", file=sys.stderr)
+            return 2 if e.is_config else 1
+        info = r2cp_link.peer_info()
+        print(f"R2CP peer identified: {info.describe()}", file=sys.stderr)
+        try:
+            r2cp_link.activate(r2cp_command_timeout_ms)
+        except r2cp_mod.R2cpError as e:
+            print(f"FATAL: R2CP peer would not arm: {e}", file=sys.stderr)
+            print("motion output remains unavailable", file=sys.stderr)
+            r2cp_link.send_stop(1_000_000, 0)
+            r2cp_link.close()
+            return 2 if e.is_config else 1
+        print("R2CP drive mode armed", file=sys.stderr)
+    else:
+        bot = Rosmaster(com=motor_port)
     # Layer 2 — kernel-enforced exclusivity for the session: TIOCEXCL makes
     # every further non-root open of the port fail EBUSY while we hold it.
     # Best-effort by design: a vendor-lib layout change (fd not found) or a
     # non-tty degrades to a WARN — the boot sentinel + udev rule still hold.
-    _ser_fd = serial_exclusivity.serial_fd_of(bot)
+    #
+    # Skipped in r2cp mode: the descriptor lives inside the Rust link and there
+    # is no vendor object to reach into. See the note in that branch.
+    _ser_fd = None if bot is None else serial_exclusivity.serial_fd_of(bot)
     if _ser_fd is not None and serial_exclusivity.claim_exclusive(_ser_fd):
         print(f"serial exclusivity: TIOCEXCL claimed on {motor_port} "
               "(further opens refused by the kernel)", file=sys.stderr)
-    else:
+    elif bot is not None:
         print("WARNING: could not set TIOCEXCL on the motor port (vendor lib "
               "layout changed?) — boot sentinel + udev mode still enforce "
               "exclusivity", file=sys.stderr)
-    bot.create_receive_threading()
+    if bot is not None:
+        bot.create_receive_threading()
 
     # Closed-loop speed matching AND wheel-odometry read the encoders
     # (get_motor_encoder), which ONLY update from the MCU's auto-report frames.
@@ -457,7 +549,7 @@ def main() -> int:
     # a stale 0, so the matcher would trip a stall→MRC fault (or never converge)
     # and odom would never advance. Open-loop-without-odom paths never read
     # encoders, so this is scoped to those consumers only (byte-identical otherwise).
-    if r2_matcher is not None or odom_enabled:
+    if bot is not None and (r2_matcher is not None or odom_enabled):
         try:
             bot.set_auto_report_state(True)
         except Exception as e:  # noqa: BLE001 — no encoder feed → refuse to start
@@ -485,7 +577,11 @@ def main() -> int:
                 return t
         return None
 
-    if drive_mode == DRIVE_MODE_R2:
+    if drive_mode == DRIVE_MODE_R2CP:
+        # No car-type register exists on this path: the peer is a Kirra MCU
+        # reached over R2CP, already identified and armed above.
+        pass
+    elif drive_mode == DRIVE_MODE_R2:
         # 🔴 R2 Path-B init: enable the AKM steering servo by setting car-type 5
         # (§2a — RAM-volatile, re-asserted every start). set_motor drive is
         # car-type independent; set_car_motion is NEVER called in this mode
@@ -527,7 +623,16 @@ def main() -> int:
     def safe_stop() -> None:
         # SS-002 shutdown guarantee: command zero, best-effort, idempotent.
         try:
-            if drive_mode == DRIVE_MODE_R2:
+            if drive_mode == DRIVE_MODE_R2CP:
+                # Best-effort: True means the bytes were written, NOT that
+                # anything stopped. The peer's own watchdog is what actually
+                # halts a governed robot when commands cease.
+                sent = r2cp_link is not None and r2cp_link.send_stop(
+                    max(r2cp_command_timeout_ms, 1) * 1000, _now_us()
+                )
+                print(f"safe_stop: R2CP stop {'sent' if sent else 'NOT sent'}",
+                      file=sys.stderr)
+            elif drive_mode == DRIVE_MODE_R2:
                 r2_safe_stop(bot)  # set_motor(0,0,0,0) + centre steering
             else:
                 bot.set_car_motion(0.0, 0.0, 0.0)
@@ -556,6 +661,34 @@ def main() -> int:
 
     def actuate(linear: float, angular: float) -> None:
         nonlocal cl_debug_ctr, last_delta_rad
+        if drive_mode == DRIVE_MODE_R2CP:
+            # 🔴 TRANSPORT ONLY. `linear`/`angular` are what the verify core
+            # already released; nothing here decides, clamps or authorizes.
+            # Exactly one MOTION_COMMAND per call — the release boundary is
+            # upstream, and a refused release never reaches this function.
+            #
+            # Curvature from angular/linear: at a standstill there is no
+            # kinematic curvature to express, so a stop carries zero rather
+            # than an infinity the peer would refuse as non-finite.
+            curvature = (angular / linear) if abs(linear) > 1e-6 else 0.0
+            ack = r2cp_link.command(
+                velocity_mps=linear,
+                curvature_per_m=curvature,
+                acceleration_limit_mps2=stop_decel_mps2,
+                jerk_limit_mps3=0.0,
+                valid_for_us=max(control_period_ms * missed_periods, 20) * 1000,
+                command_id=_next_command_id(),
+                source_time_us=_now_us(),
+                timeout_ms=r2cp_command_timeout_ms,
+            )
+            if not ack.accepted:
+                # A refusal is an expected operating condition (disarmed,
+                # stale, replayed), not a link fault — surfaced, never
+                # retried, and never worked around.
+                print(f"R2CP command refused: result={ack.result} "
+                      f"safety_state={ack.safety_state} "
+                      f"timed_out={ack.timed_out}", file=sys.stderr)
+            return
         if drive_mode == DRIVE_MODE_R2:
             # Path B: the Ackermann last-hop runs AFTER verify (the same place
             # the x3 firmware mixing runs after verify). translate() is

--- a/robot/kirra_r2cp.py
+++ b/robot/kirra_r2cp.py
@@ -92,6 +92,7 @@ class PeerInfo:
     maximum_frame: int
     agreed_major: int
     identified: bool
+    exclusive: bool
 
     def describe(self) -> str:
         # Rendered as ASCII when the id is four printable bytes (the
@@ -126,6 +127,7 @@ class _PeerInfoStruct(ctypes.Structure):
         ("maximum_frame", ctypes.c_uint16),
         ("agreed_major", ctypes.c_uint8),
         ("identified", ctypes.c_uint8),
+        ("exclusive", ctypes.c_uint8),
     ]
 
 
@@ -221,6 +223,7 @@ class R2cpLink:
             maximum_frame=int(out.maximum_frame),
             agreed_major=int(out.agreed_major),
             identified=bool(out.identified),
+            exclusive=bool(out.exclusive),
         )
 
     def activate(self, timeout_ms: int) -> None:

--- a/robot/kirra_r2cp.py
+++ b/robot/kirra_r2cp.py
@@ -1,0 +1,324 @@
+"""Thin ctypes binding over the Rust R2CP link (`libkirra_consumer_ffi.so`).
+
+🔴 THIS FILE MUST NOT LEARN THE PROTOCOL.
+
+Same rule that keeps `kirra_ffi.py` free of keys, signatures and watermarks.
+There is exactly ONE R2CP implementation on the host — `crates/kirra-r2cp`,
+differentially tested against the firmware's normative `wire.cpp` — and a
+second one here would be a third dialect that nothing tests against either of
+the others. So this module contains no:
+
+    message IDs · frame sizes · ACK numeric codes · COBS · CRC
+    HELLO fields · nonce generation · version comparison · sequence numbers
+
+It contains a handle, four verbs, and typed errors. `robot/r2cp_purity_test.py`
+asserts that mechanically, because a convention nobody checks is a convention
+that erodes.
+
+## The handle only exists for an identified peer
+
+`open()` performs the HELLO handshake inside Rust and either returns a live
+link or raises. There is no object representing "a device we have not
+identified", so commanding one is not a mistake this API can express.
+
+That matters concretely on the bring-up robot: `/dev/myserial` is a stock
+vendor motor board that does not speak R2CP, and writing R2CP frames into a
+vendor command parser attached to motors is undefined behaviour.
+
+## Failure CLASSES, not just failures
+
+`R2cpError.is_config` / `.is_availability` / `.is_protocol` exist because the
+consumer's exit code depends on the difference and `kirra-consumer.service`
+carries `RestartPreventExitStatus=2`. A missing device is deterministic
+configuration and should stop the unit; an MCU that was merely unplugged at
+boot must NOT, or reconnecting it would leave the unit dead until someone runs
+`systemctl reset-failed`.
+"""
+
+from __future__ import annotations
+
+import ctypes
+from dataclasses import dataclass
+
+# Status classes, mirrored from the Rust side. These are CLASSES, not protocol
+# values — they say what KIND of failure occurred so systemd can behave
+# correctly, and carry no wire meaning.
+CLASS_OK = 0
+CLASS_CONFIG = 1
+CLASS_AVAILABILITY = 2
+CLASS_PROTOCOL = 3
+CLASS_RUNTIME = 4
+
+
+class R2cpError(RuntimeError):
+    """A link failure, carrying the Rust side's status and its class.
+
+    The message is the Rust side's operator-facing sentence — not composed
+    here, so there is one wording per failure across every caller.
+    """
+
+    def __init__(self, status: int, klass: int, message: str, device: str) -> None:
+        super().__init__(f"{message} (device={device})")
+        self.status = status
+        self.klass = klass
+        self.device = device
+
+    @property
+    def is_config(self) -> bool:
+        """Deterministic configuration: restarting will only repeat it."""
+        return self.klass == CLASS_CONFIG
+
+    @property
+    def is_availability(self) -> bool:
+        """Hardware availability: may resolve without a configuration change.
+
+        A bounded restart is the right response. Mapping this to the
+        consumer's config exit would make a reconnected MCU unrecoverable.
+        """
+        return self.klass == CLASS_AVAILABILITY
+
+    @property
+    def is_protocol(self) -> bool:
+        """The peer answered and we cannot work with it."""
+        return self.klass == CLASS_PROTOCOL
+
+
+@dataclass(frozen=True)
+class PeerInfo:
+    """What the peer said about itself. For the log, not for decisions."""
+
+    implementation_id: int
+    firmware_semver: int
+    maximum_frame: int
+    agreed_major: int
+    identified: bool
+
+    def describe(self) -> str:
+        # Rendered as ASCII when the id is four printable bytes (the
+        # convention the Rust side uses: "KSIM"), else hex. Presentation only.
+        raw = self.implementation_id.to_bytes(4, "big")
+        name = raw.decode("ascii") if all(0x20 <= b < 0x7F for b in raw) else raw.hex()
+        return (
+            f"mcu_id={name} version={self.agreed_major} "
+            f"max_frame={self.maximum_frame} semver={self.firmware_semver}"
+        )
+
+
+@dataclass(frozen=True)
+class Ack:
+    """One command's outcome.
+
+    `accepted` is the field to branch on. `result` and `safety_state` are
+    DIAGNOSTICS: the numeric ACK result codes are provisional until the
+    firmware binds them, so no control flow here may depend on their values.
+    """
+
+    accepted: bool
+    safety_state: int
+    result: int
+    timed_out: bool
+
+
+class _PeerInfoStruct(ctypes.Structure):
+    _fields_ = [
+        ("implementation_id", ctypes.c_uint32),
+        ("firmware_semver", ctypes.c_uint32),
+        ("maximum_frame", ctypes.c_uint16),
+        ("agreed_major", ctypes.c_uint8),
+        ("identified", ctypes.c_uint8),
+    ]
+
+
+class _AckStruct(ctypes.Structure):
+    _fields_ = [
+        ("accepted", ctypes.c_uint8),
+        ("safety_state", ctypes.c_uint8),
+        ("result", ctypes.c_uint16),
+        ("timed_out", ctypes.c_uint8),
+    ]
+
+
+def bind(lib: ctypes.CDLL) -> ctypes.CDLL:
+    """Resolve the R2CP entry points on an already-loaded library.
+
+    Separate from `kirra_ffi._load` so a deployment whose `.so` predates R2CP
+    keeps working: the symbols resolve when a link is actually opened, and a
+    missing one becomes a clear error there rather than breaking every
+    existing caller at import.
+    """
+    lib.kirra_r2cp_open.restype = ctypes.c_int32
+    lib.kirra_r2cp_open.argtypes = [
+        ctypes.c_char_p,  # device path
+        ctypes.c_uint16,  # handshake timeout ms
+        ctypes.POINTER(ctypes.c_void_p),
+    ]
+    lib.kirra_r2cp_activate.restype = ctypes.c_int32
+    lib.kirra_r2cp_activate.argtypes = [ctypes.c_void_p, ctypes.c_uint16]
+
+    lib.kirra_r2cp_peer_info.restype = ctypes.c_int32
+    lib.kirra_r2cp_peer_info.argtypes = [
+        ctypes.c_void_p,
+        ctypes.POINTER(_PeerInfoStruct),
+    ]
+    lib.kirra_r2cp_command.restype = ctypes.c_int32
+    lib.kirra_r2cp_command.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_float,  # velocity_mps
+        ctypes.c_float,  # curvature_per_m
+        ctypes.c_float,  # acceleration_limit_mps2
+        ctypes.c_float,  # jerk_limit_mps3
+        ctypes.c_uint32,  # valid_for_us
+        ctypes.c_uint32,  # command_id
+        ctypes.c_uint64,  # source_time_us
+        ctypes.c_uint16,  # timeout_ms
+        ctypes.POINTER(_AckStruct),
+    ]
+    lib.kirra_r2cp_stop.restype = ctypes.c_int32
+    lib.kirra_r2cp_stop.argtypes = [ctypes.c_void_p, ctypes.c_uint32, ctypes.c_uint64]
+
+    lib.kirra_r2cp_reset.restype = ctypes.c_int32
+    lib.kirra_r2cp_reset.argtypes = [ctypes.c_void_p]
+
+    lib.kirra_r2cp_close.restype = None
+    lib.kirra_r2cp_close.argtypes = [ctypes.c_void_p]
+
+    lib.kirra_r2cp_status_class.restype = ctypes.c_int32
+    lib.kirra_r2cp_status_class.argtypes = [ctypes.c_int32]
+
+    lib.kirra_r2cp_status_message.restype = ctypes.c_char_p
+    lib.kirra_r2cp_status_message.argtypes = [ctypes.c_int32]
+    return lib
+
+
+def _raise(lib: ctypes.CDLL, status: int, device: str) -> None:
+    raise R2cpError(
+        status,
+        int(lib.kirra_r2cp_status_class(status)),
+        (lib.kirra_r2cp_status_message(status) or b"").decode("utf-8", "replace"),
+        device,
+    )
+
+
+class R2cpLink:
+    """A link to an IDENTIFIED R2CP peer.
+
+    Constructed only by `open()`, which raises rather than returning an
+    unidentified link — so holding one of these is itself the evidence that a
+    peer answered.
+    """
+
+    def __init__(self, lib: ctypes.CDLL, handle: ctypes.c_void_p, device: str) -> None:
+        self._lib = lib
+        self._handle = handle
+        self.device = device
+
+    def peer_info(self) -> PeerInfo:
+        out = _PeerInfoStruct()
+        self._lib.kirra_r2cp_peer_info(self._handle, ctypes.byref(out))
+        return PeerInfo(
+            implementation_id=int(out.implementation_id),
+            firmware_semver=int(out.firmware_semver),
+            maximum_frame=int(out.maximum_frame),
+            agreed_major=int(out.agreed_major),
+            identified=bool(out.identified),
+        )
+
+    def activate(self, timeout_ms: int) -> None:
+        """ARM then ACTIVATE. Raises on refusal — never a silent no-op."""
+        status = self._lib.kirra_r2cp_activate(self._handle, ctypes.c_uint16(timeout_ms))
+        if status != 0:
+            _raise(self._lib, status, self.device)
+
+    def command(
+        self,
+        velocity_mps: float,
+        curvature_per_m: float,
+        acceleration_limit_mps2: float,
+        jerk_limit_mps3: float,
+        valid_for_us: int,
+        command_id: int,
+        source_time_us: int,
+        timeout_ms: int,
+    ) -> Ack:
+        """Transport one already-authorized motion command.
+
+        Nothing here decides, clamps or authorizes: the governor released
+        these values upstream and this is the wire. A refusal comes back as an
+        `Ack` with `accepted=False` rather than an exception, because a peer
+        refusing a command is an expected operating condition (disarmed,
+        stale, replayed) and not a link failure.
+        """
+        out = _AckStruct()
+        self._lib.kirra_r2cp_command(
+            self._handle,
+            ctypes.c_float(velocity_mps),
+            ctypes.c_float(curvature_per_m),
+            ctypes.c_float(acceleration_limit_mps2),
+            ctypes.c_float(jerk_limit_mps3),
+            ctypes.c_uint32(valid_for_us),
+            ctypes.c_uint32(command_id),
+            ctypes.c_uint64(source_time_us),
+            ctypes.c_uint16(timeout_ms),
+            ctypes.byref(out),
+        )
+        return Ack(
+            accepted=bool(out.accepted),
+            safety_state=int(out.safety_state),
+            result=int(out.result),
+            timed_out=bool(out.timed_out),
+        )
+
+    def send_stop(self, valid_for_us: int, source_time_us: int) -> bool:
+        """Attempt a stop. Returns whether the BYTES WERE WRITTEN.
+
+        🔴 True is not proof that anything stopped. Nothing is read back, and
+        if the peer has been de-identified this may be writing to a device
+        that is not an R2CP peer at all. What actually stops a governed robot
+        is the peer's own watchdog: commands cease, the command window lapses,
+        the MCU enters a controlled stop by itself. This makes that immediate
+        when the peer is real.
+
+        Log it as "stop sent", never as "stopped".
+        """
+        return self._lib.kirra_r2cp_stop(
+            self._handle, ctypes.c_uint32(valid_for_us), ctypes.c_uint64(source_time_us)
+        ) == 0
+
+    def reset(self) -> None:
+        """Drop the identified peer; a fresh `open()` is then required."""
+        self._lib.kirra_r2cp_reset(self._handle)
+
+    def close(self) -> None:
+        if self._handle:
+            self._lib.kirra_r2cp_close(self._handle)
+            self._handle = None
+
+    def __enter__(self) -> R2cpLink:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.close()
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except Exception:  # noqa: BLE001 — never raise from a finalizer
+            pass
+
+
+def open(lib: ctypes.CDLL, device: str, handshake_timeout_ms: int) -> R2cpLink:  # noqa: A001
+    """Open `device` and identify the peer, or raise `R2cpError`.
+
+    The HELLO handshake — including the nonce, which is drawn from the OS
+    entropy pool inside Rust — happens here. On failure there is no handle and
+    no link object: an unidentified device is not representable.
+    """
+    handle = ctypes.c_void_p()
+    status = lib.kirra_r2cp_open(
+        device.encode("utf-8"),
+        ctypes.c_uint16(handshake_timeout_ms),
+        ctypes.byref(handle),
+    )
+    if status != 0 or not handle:
+        _raise(lib, status, device)
+    return R2cpLink(lib, handle, device)

--- a/robot/r2cp_purity_test.py
+++ b/robot/r2cp_purity_test.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Guard: the Python side must not learn R2CP.
+
+There is exactly ONE R2CP implementation on the host — `crates/kirra-r2cp`,
+differentially tested against the firmware's normative `wire.cpp`. A second one
+in Python would be a third dialect that nothing tests against either of the
+others, and the way that happens is never a decision: it is someone adding
+"just a constant" to avoid an FFI round-trip.
+
+So this checks mechanically. It walks the AST rather than grepping, because
+every file under test DOCUMENTS what it must not contain — a grep for "COBS"
+would fire on the docstring explaining why there is no COBS here.
+
+Run: python3 robot/r2cp_purity_test.py
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+
+# The Python files allowed to mention R2CP at all. Anything else importing the
+# link module is fine; these are the ones whose CONTENTS are constrained.
+GUARDED = ("kirra_r2cp.py", "kirra_motor_consumer.py")
+
+# Protocol facts that must live only in Rust. Matched against identifier names
+# and string literals in EXECUTABLE positions — never docstrings or comments.
+FORBIDDEN_NAMES = {
+    "cobs", "cobs_encode", "cobs_decode",
+    "crc32c", "crc32", "crc",
+    "magic", "protocol_major", "protocol_minor",
+    "header_size", "max_payload", "max_frame_size", "max_encoded_frame",
+    "flag_auth_tag", "flag_response", "flag_ack_required", "known_flag_mask",
+    "nonce", "make_nonce", "gen_nonce",
+    "hello", "hello_payload_len",
+    "ack_accepted", "ack_stale", "ack_replay", "ack_disarmed", "ack_faulted",
+    "message_type", "motion_command", "command_ack",
+    "min_advertised_frame", "agreed_major_of",
+}
+
+# Numeric literals that would betray a re-implementation. Deliberately small:
+# a list of every protocol number would itself be a duplication of the
+# protocol. These are the load-bearing ones.
+FORBIDDEN_NUMBERS = {
+    0x3252,      # R2CP magic
+    0x82F63B78,  # CRC32C polynomial
+}
+
+
+class Visitor(ast.NodeVisitor):
+    """Collect violations from executable positions only."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.violations: list[str] = []
+        self._docstrings: set[int] = set()
+
+    def _note_docstring(self, node: ast.AST) -> None:
+        body = getattr(node, "body", None)
+        if (
+            body
+            and isinstance(body[0], ast.Expr)
+            and isinstance(body[0].value, ast.Constant)
+            and isinstance(body[0].value.value, str)
+        ):
+            self._docstrings.add(id(body[0].value))
+
+    def visit_Module(self, node: ast.Module) -> None:
+        self._note_docstring(node)
+        self.generic_visit(node)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._note_docstring(node)
+        self._check_name(node.name, node.lineno, "function")
+        self.generic_visit(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._note_docstring(node)
+        self._check_name(node.name, node.lineno, "function")
+        self.generic_visit(node)
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self._note_docstring(node)
+        self._check_name(node.name, node.lineno, "class")
+        self.generic_visit(node)
+
+    def visit_Name(self, node: ast.Name) -> None:
+        # Only BINDINGS, not reads: reading an attribute called `nonce` from
+        # somewhere else is not a re-implementation, defining one is.
+        if isinstance(node.ctx, (ast.Store, ast.Del)):
+            self._check_name(node.id, node.lineno, "variable")
+        self.generic_visit(node)
+
+    def visit_Constant(self, node: ast.Constant) -> None:
+        if id(node) in self._docstrings:
+            return
+        if isinstance(node.value, int) and not isinstance(node.value, bool):
+            if node.value in FORBIDDEN_NUMBERS:
+                self.violations.append(
+                    f"{self.path.name}:{node.lineno}: protocol constant "
+                    f"{node.value:#x} — this number belongs in kirra-r2cp"
+                )
+        self.generic_visit(node)
+
+    def _check_name(self, name: str, lineno: int, kind: str) -> None:
+        if name.lower().lstrip("_") in FORBIDDEN_NAMES:
+            self.violations.append(
+                f"{self.path.name}:{lineno}: {kind} named {name!r} — R2CP "
+                "protocol detail must stay in kirra-r2cp, reached over the FFI"
+            )
+
+
+def check(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    v = Visitor(path)
+    v.visit(tree)
+    return v.violations
+
+
+def main() -> int:
+    failures: list[str] = []
+    checked = 0
+    for name in GUARDED:
+        path = HERE / name
+        if not path.is_file():
+            # kirra_motor_consumer.py always exists; kirra_r2cp.py must too
+            # once the mode lands. A missing guarded file is a failure, not a
+            # skip — otherwise a rename silently disables the guard.
+            failures.append(f"{name}: guarded file is missing")
+            continue
+        checked += 1
+        failures.extend(check(path))
+
+    # Non-vacuity: the guard must actually be capable of failing. If the
+    # detector cannot flag a deliberately dirty sample, a clean run proves
+    # nothing about the real files.
+    dirty = ast.parse("magic = 0x3252\ndef cobs_encode(x):\n    return x\n")
+    probe = Visitor(Path("synthetic"))
+    probe.visit(dirty)
+    if len(probe.violations) < 2:
+        failures.append(
+            "SELF-TEST: the purity detector failed to flag a deliberately "
+            "dirty sample — a clean result would be meaningless"
+        )
+
+    for f in failures:
+        print(f"  FAIL {f}")
+    if failures:
+        print(f"\n{len(failures)} violation(s)")
+        return 1
+    print(f"  ok   {checked} guarded file(s) contain no R2CP protocol detail")
+    print("  ok   the detector flags a dirty sample (non-vacuous)")
+    print("\nall checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Stage 4 of `firmware/rosmaster-r2/docs/ROADMAP.md` §Deployment reality: `KIRRA_DRIVE_MODE=r2cp`. **No floor motion is part of this PR.**

## The authorization boundary

> **Rejected, expired, tampered, and replayed releases produce zero additional MOTION_COMMAND frames on the wire.**

R2CP transports authorized motion. It does not become a second intent or authorization path. Proven by fusing both FFI surfaces in the consumer's own order — verify, then actuate only on a release — against a simulator that **counts the MOTION_COMMAND frames it receives, refused ones included**. "No motion happened" and "no frame left the host" are different claims, and only the second rules out a bypass.

| release | verify core | MOTION_COMMAND frames | COMMAND_ACK |
|---|---|---|---|
| valid | releases | **exactly 1** | exactly 1 |
| tampered proposal digest | refuses | **0** | — |
| expired | refuses | **0** | — |
| tampered signature | refuses | **0** | — |
| replayed | refuses | **0 additional** | — |

Each zero is followed by a good release on the **same link and same simulator**, asserted to reach 1 — a zero would otherwise be exactly what a dead wire looks like.

Writing these caught a real defect: renaming the cases to an enum silently broke a `name == "expired release"` comparison, so the expired case ran with an in-window clock and *released*. The selector now matches on the enum, with a comment saying why.

## The handshake gate

On the bring-up robot `/dev/myserial` is a stock vendor motor board that does not speak R2CP. A bare last-hop swap would write R2CP frames into a **vendor command parser attached to motors** — undefined behaviour, not a no-op. So the mode cannot arm until a peer has answered.

`kirra_r2cp_open` performs the HELLO handshake and returns a handle **only** on success. There is no object representing an unidentified device, so commanding one is unrepresentable rather than discouraged; a test asserts `out` stays NULL across every failure mode, with a live-peer positive control.

Built on HELLO, not CAPABILITIES: `PROTOCOL.md` specifies HELLO byte-for-byte and describes CAPABILITIES only in prose with no layout. One provisional wire area is a recorded obligation; two is a dialect.

## ⚠ Provisional COMMAND_ACK result codes

> COMMAND_ACK numeric result codes are provisional because `PROTOCOL.md` currently defines names but not wire values. Firmware must adopt these assignments or update the protocol, simulator, and bridge together before HIL.

`SafetyState` values are **not** provisional — they mirror the `safety_manager.hpp` discriminants.

## Kernel exclusivity — and what "exclusive" does not mean

Ordering: open → configure line → **claim TIOCEXCL** → **verify TIOCGEXCL** → handshake → return.

> 🔴 **`TIOCEXCL` does not restrain root.** `tty_ioctl(4)` exempts `CAP_SYS_ADMIN` from the `EBUSY` it imposes on everyone else. This is a strong operational boundary against ordinary processes — the vendor `/cmd_vel` driver, a stray bring-up script, a second consumer — and **not** protection against a privileged administrator. Same distinction as serial authority generally.

Two things I got wrong first and fixed by measuring:

1. **The refusal is unobservable as root.** All six tests failed on first run asserting an `EBUSY` that cannot happen in CI. The product code was right; the test's model was not. The claim's *state* is now read back with `TIOCGEXCL` (privilege-independent) as the primary evidence asserted everywhere; the `EBUSY` refusal is asserted only unprivileged and **skips loudly** otherwise. On the robot the consumer runs as a rendered non-root `User=`, where it bites.

2. **Closing the descriptor does not reliably clear exclusive mode.** The kernel clears it when the *tty* is released — the last close of a real UART, but not while anything else keeps the tty alive. That is a live hazard: if anything holds the tty when the consumer exits, the port stays exclusive and the consumer's own unprivileged restart is refused `EBUSY` forever, with no configuration wrong. `SerialLink` releases explicitly on `Drop`, and a test proves it clears the flag *while a separate descriptor still holds the tty open*.

**Drop coverage is structural.** `open` constructs `Self` **before** claiming, so every fallible step unwinds through `release_exclusive`. Claiming first would have been safe only because nothing fallible happens to follow it today — a property of the current code, not an invariant.

The startup log claims exclusivity **only** when the kernel confirms it, and warns plainly when it cannot.

## The unsafe boundary

`kirra-r2cp` moves from `forbid(unsafe_code)` to `deny` with **three** narrow `#[allow]`s in `link.rs`, one per ioctl — `claim_exclusive` (TIOCEXCL), `read_exclusive` (TIOCGEXCL), `release_exclusive` (TIOCNXCL) — each a single call with a SAFETY comment. `forbid` cannot be overridden even locally, which would have pushed the claim to a caller that cannot make it between the open and the first handshake byte, reopening the race.

*(An earlier revision of this description said "two" — corrected in `080cc273`, along with the same error in the crate-level comment. The count is exactly what an audit of this boundary checks against.)*

`ci/check_r2cp_unsafe.py` enforces the split rather than trusting it: `lib.rs`, `sim.rs`, `handshake.rs` and `pty.rs` must contain no `unsafe` block; `link.rs` may only inside the three named wrappers. It also fails if the wrappers go **missing**, so deleting exclusivity outright cannot make every other check pass trivially. Verified non-vacuous by injecting `unsafe {}` into `sim.rs` and watching it red.

## Consumer mode

`KIRRA_DRIVE_MODE=r2cp`: no `Rosmaster_Lib` import (the mode resolves *before* it, so "no vendor library" is a property of the image), no board object, no car-type read/write, no `set_motor`/`set_car_motion`, **no fallback** to `r2_ackermann` or `x3`. A fallback would return actuation to the unverified vendor path at exactly the moment the verified one failed.

```
R2CP peer identified: mcu_id=KSIM version=1 max_frame=192 semver=0
serial exclusivity: TIOCEXCL confirmed on /dev/myserial
R2CP drive mode armed
```
```
FATAL: R2CP peer unavailable: no R2CP peer answered … VENDOR motor board …
motion output remains unavailable
```

**Exit code follows the failure class.** Only deterministic configuration returns 2, because the unit carries `RestartPreventExitStatus=2` and an MCU merely unplugged at boot must stay restartable — otherwise reconnecting it leaves the unit dead until someone runs `systemctl reset-failed`. A silent peer and a busy port are both **availability**.

## Python stays thin

`robot/kirra_r2cp.py` is a handle, four verbs and typed errors. No message IDs, frame sizes, ACK codes, COBS, CRC, HELLO fields, nonce logic or version comparison — `handshake_fresh` draws the nonce from `/dev/urandom` inside Rust and fails closed, so Python cannot weaken the gate. `robot/r2cp_purity_test.py` enforces it by AST walk (a grep would fire on the docstrings explaining why there is no COBS) and self-tests that the detector flags a dirty sample.

## Config contract

`r2cp` requires the governed envelope plus `KIRRA_R2CP_HANDSHAKE_TIMEOUT_MS` / `KIRRA_R2CP_COMMAND_TIMEOUT_MS`. These nine are reported **not applicable** — PWM scaling, steering geometry, limits and watchdog policy belong in the MCU manifest, and duplicating them on the Jetson is how the ends drift:

`KIRRA_EXPECTED_CAR_TYPE` · `KIRRA_R2_WHEELBASE_M` · `KIRRA_R2_V_PER_PWM` · `KIRRA_R2_PWM_MAX` · `KIRRA_R2_STEER_UNITS_PER_RAD` · `KIRRA_R2_DELTA_MAX_RAD` · `KIRRA_R2_STEER_SIGN` · `KIRRA_R2_CENTER_TRIM` · `KIRRA_R2_DRIVE_DEADBAND_PWM`

An expected MCU identity is deliberately **not** invented: the protocol defines no stable identity semantics, and a host-only convention the firmware never agreed to is worse than none.

## Commits

| commit | scope |
|---|---|
| `f96005f5` | HELLO handshake gate + `SerialLink` |
| `a3fb38e2` | opaque FFI handle, status classes, link invalidation |
| `277f5bcc` | scripted-peer failures, nonce into Rust, Python binding + purity guard |
| `b54b33fd` | consumer mode, config contract, release-boundary proof, CI lane |
| `78f01466` | TIOCEXCL claim + confirmation |
| `080cc273` | structural Drop coverage, unsafe-boundary guard, count correction |

## Tests — 102 Rust + Python and CI guards

Handshake/link 19 · exclusivity 9 · FFI-vs-simulator 8 · scripted peer 3 · release boundary 3 · simulator 21 · differential vs `wire.cpp` 9 · framer 6 · PTY loop 9 · FFI lib 15.

`r2cp-bridge` CI lane: PTY + framer + exclusivity, the dependency-free-core guard (`cargo tree -e normal` must be exactly one line — the default tree is five), FFI boundary and release-boundary tests, clippy at `-D warnings` in both feature configs, the unsafe-boundary guard, and the Python purity + contract guards.

## Environment incident — not a test failure

Mid-session the sandbox's 252 GB writable allowance filled. `kirra-collector` (unrelated to this branch, no dependency on `kirra-r2cp`) failed with `collect2: fatal error: ld terminated with signal 7` and `No space left on device`. **This was disk exhaustion, not a code defect.** I removed 9.1 GB of `target/debug/incremental` and re-ran; after cleanup:

- `cargo test -p kirra-r2cp -p kirra-consumer-ffi` → 102 passed, 0 failed
- `cargo clippy -p kirra-r2cp -p kirra-consumer-ffi --all-targets -- -D warnings` → clean
- `cargo build -p kirra-r2cp --no-default-features` → clean
- `cargo fmt --all` → clean
- `python3 ci/check_r2cp_unsafe.py` → clean, and verified to red on an injected violation
- `python3 robot/r2cp_purity_test.py`, `consumer_config_contract_test.py`, `preflight_consumer_env_test.py` → all pass
- `python3 -m compileall robot/*.py` → clean

`cargo-deny` is not installed in this environment; the supply-chain lane is the first real check on the `nix` dependency (MIT, crates.io, MSRV 1.69).

## Scope

Passing here is evidence about the **host**. A PTY never drops a byte and never delays one — it cannot model baud rate, framing errors, line noise, cable pull, brown-out or on-target timing. HIL is what tests the link and the firmware.

R2CP's `AUTH_TAG` authenticates the *link*; it says nothing about whether the checker authorized the motion. ADR-0033's token-verifying consumer remains the authorization boundary, and this crate's `AUTH_TAG` path fails closed rather than downgrading.

## Recorded remainders

- COMMAND_ACK result codes are provisional (above).
- The `EBUSY` refusal is unproven in CI (root); the claim state is proven, and exclusivity does not restrain root by design.
- Odometry and closed-loop wheel matching remain deliberately disabled.
- `KIRRA_GOVERNOR_VK_HEX` on the live robot is a bench/dev key.

Next is HIL — where the failures should be real UART, electrical, watchdog and motor-driver behaviour, not host protocol bugs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjDFKPcBVHURDZpXsvnYhC)_