### PR TITLE
feat(taj): wire R2 scan liveness into perception cap

### DIFF
--- a/crates/kirra-sidecars/src/bin/taj_service.rs
+++ b/crates/kirra-sidecars/src/bin/taj_service.rs
@@ -16,7 +16,22 @@ use std::net::{TcpListener, TcpStream};
 use kirra_sidecars::capabilities::Capabilities;
 use kirra_sidecars::http::{read_request, respond, respond_error};
 use kirra_sidecars::net::{allow_nonlocal_from_env, enforce_bind_policy};
-use kirra_sidecars::taj::{handle_perception_tracked, PerceptionRequest, TrackedPerceptionState};
+use kirra_sidecars::taj::{
+    handle_perception_tracked_at, watchdog_armed_from_env, PerceptionRequest, SensorWatchdogConfig,
+    TrackedPerceptionState,
+};
+
+/// Wall clock in ms, for the watchdog's ARRIVAL observation.
+///
+/// Read here in the binary rather than inside the perception core so the core
+/// stays a pure function of its inputs and every test can inject a clock instead
+/// of sleeping.
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
 
 fn serve(mut stream: TcpStream, perception_state: &mut TrackedPerceptionState) {
     let req = match read_request(&mut stream) {
@@ -44,8 +59,12 @@ fn serve(mut stream: TcpStream, perception_state: &mut TrackedPerceptionState) {
             Ok(p) => respond(
                 &mut stream,
                 "200 OK",
-                &serde_json::to_string(&handle_perception_tracked(&p, perception_state))
-                    .unwrap_or_else(|_| "{}".into()),
+                &serde_json::to_string(&handle_perception_tracked_at(
+                    &p,
+                    perception_state,
+                    now_ms(),
+                ))
+                .unwrap_or_else(|_| "{}".into()),
             ),
             Err(e) => respond(
                 &mut stream,
@@ -74,7 +93,21 @@ fn main() {
     println!("Taj perception service on http://{addr}  (POST /perception, GET /health)");
     // Single-threaded service: one deterministic tracker state persists
     // across consecutive POST /perception requests.
-    let mut perception_state = TrackedPerceptionState::new();
+    let armed = watchdog_armed_from_env();
+    if armed {
+        eprintln!(
+            "taj_service: scan-liveness watchdog ARMED (#1211) — a frozen, starved \
+             or blinded /scan floors the speed cap. Set \
+             KIRRA_SENSOR_WATCHDOG_ENABLED=0 to opt out."
+        );
+    } else {
+        eprintln!(
+            "taj_service: scan-liveness watchdog DISARMED — a frozen /scan will \
+             NOT be detected. This is the pre-#1211 behaviour."
+        );
+    }
+    let mut perception_state =
+        TrackedPerceptionState::with_watchdog(SensorWatchdogConfig::r2_lidar(), armed);
 
     for stream in listener.incoming() {
         match stream {

--- a/crates/kirra-sidecars/src/bin/taj_service.rs
+++ b/crates/kirra-sidecars/src/bin/taj_service.rs
@@ -45,12 +45,23 @@ fn serve(mut stream: TcpStream, perception_state: &mut TrackedPerceptionState) {
         // healthy during R2 bring-up.
         ("GET", "/health") => {
             let caps = Capabilities::taj();
+            // #1211: report whether scan-liveness checking is ARMED, and whether it
+            // has latched terminal. A safety check that is switched off must not be
+            // indistinguishable from one that is on and passing — the same reason
+            // this endpoint already reports `contract` instead of a bare "ok".
             respond(
                 &mut stream,
                 "200 OK",
                 &format!(
-                    "{{\"status\":\"ok\",\"service\":\"taj\",\"contract\":{}}}",
-                    caps.contract
+                    "{{\"status\":\"ok\",\"service\":\"taj\",\"contract\":{},\
+                     \"scan_liveness_watchdog\":\"{}\",\"scan_liveness_terminal\":{}}}",
+                    caps.contract,
+                    if perception_state.sensor_watchdog_armed() {
+                        "armed"
+                    } else {
+                        "disarmed"
+                    },
+                    perception_state.sensor_watchdog_terminal(),
                 ),
             )
         }

--- a/crates/kirra-sidecars/src/taj.rs
+++ b/crates/kirra-sidecars/src/taj.rs
@@ -1006,6 +1006,18 @@ impl TrackedPerceptionState {
     pub fn sensor_watchdog_terminal(&self) -> bool {
         self.watchdog.is_terminal()
     }
+
+    /// Whether scan-liveness checking is ARMED on this service.
+    ///
+    /// Surfaced on `GET /health` so a disarmed deployment is legible to a
+    /// diagnostic rather than only to whoever read the startup log. A safety check
+    /// that is off must never be indistinguishable from one that is on and
+    /// passing — that is the same failure the `/health` endpoint's own contract
+    /// field exists to prevent.
+    #[must_use]
+    pub fn sensor_watchdog_armed(&self) -> bool {
+        self.watchdog.is_armed()
+    }
 }
 
 /// Whether the scan-liveness watchdog is armed, from
@@ -2750,6 +2762,9 @@ mod scan_liveness_tests {
 
     use super::*;
 
+    /// The configured recovery streak, for readability in the tests below.
+    const SENSOR_RECOVERY_STREAK_LOCAL: u32 = 5;
+
     /// A live-stream scan: an obstacle straight ahead, with per-frame variation
     /// in the low bits so consecutive frames are NOT bit-identical. Real sensor
     /// noise looks like this, and it is what the freeze check keys on.
@@ -3120,6 +3135,223 @@ mod scan_liveness_tests {
             "disarmed must not floor the cap — that is the pre-#1211 behaviour \
              this gate exists to change only when armed"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Pre-merge review focus (#1223). Each names the property it pins.
+    // -----------------------------------------------------------------------
+
+    /// (1) A diagnostic probe cannot advance the recovery streak.
+    ///
+    /// `diagnostic_probe` must be observationally INERT: it may neither create
+    /// liveness state nor clear it. A probe that could pay down a recovery streak
+    /// would let a diagnostic tool restore motion the sensor had not earned.
+    #[test]
+    fn a_probe_cannot_advance_the_recovery_streak() {
+        let mut st = state();
+        let mut now = 0;
+        // Fault the stream.
+        for _ in 0..10 {
+            let _ = handle_perception_tracked_at(&frozen_scan(), &mut st, now);
+            now += 100;
+        }
+
+        // A live frame starts the streak at 1.
+        now += 100;
+        let r = handle_perception_tracked_at(&live_scan(50_000, 1), &mut st, now);
+        assert_eq!(
+            r.sensor_liveness, "recovering",
+            "precondition: the stream is recovering"
+        );
+
+        // Probes in between must not pay it down.
+        let mut probe = live_scan(51_000, 2);
+        probe.diagnostic_probe = true;
+        for _ in 0..10 {
+            now += 10;
+            let _ = handle_perception_tracked_at(&probe, &mut st, now);
+        }
+
+        now += 100;
+        let r = handle_perception_tracked_at(&live_scan(50_100, 2), &mut st, now);
+        assert_eq!(
+            r.sensor_liveness, "recovering",
+            "10 probes must not have completed a 5-frame streak"
+        );
+        assert_eq!(r.speed_cap_mps, 0.0);
+    }
+
+    /// (2) Duplicate re-posts cannot advance the recovery streak.
+    ///
+    /// The subtle one. A re-post is not silence — the budget has not expired — so
+    /// it reaches the watchdog as a clean tick. If a clean tick advanced the
+    /// streak, a frozen driver's own repetitions would earn its recovery: the
+    /// stream would "recover" from a freeze on the strength of the very
+    /// repetitions that constitute the freeze.
+    #[test]
+    fn duplicate_reposts_cannot_advance_the_recovery_streak() {
+        let mut st = state();
+        let mut now = 0;
+        for _ in 0..10 {
+            let _ = handle_perception_tracked_at(&frozen_scan(), &mut st, now);
+            now += 100;
+        }
+
+        // One real frame — streak 1.
+        now += 100;
+        let fresh = live_scan(60_000, 1);
+        let r = handle_perception_tracked_at(&fresh, &mut st, now);
+        assert_eq!(r.sensor_liveness, "recovering");
+
+        // Re-post that SAME frame repeatedly, inside the silence budget.
+        for _ in 0..10 {
+            now += 10;
+            let r = handle_perception_tracked_at(&fresh, &mut st, now);
+            assert_eq!(
+                r.sensor_liveness, "recovering",
+                "a re-post must never complete the streak"
+            );
+            assert_eq!(r.speed_cap_mps, 0.0);
+        }
+
+        // The streak is still owed: four more REAL frames are required.
+        for i in 2..SENSOR_RECOVERY_STREAK_LOCAL {
+            now += 100;
+            let r = handle_perception_tracked_at(
+                &live_scan(60_000 + u64::from(i) * 100, i),
+                &mut st,
+                now,
+            );
+            assert_eq!(
+                r.sensor_liveness, "recovering",
+                "frame {i} still recovering"
+            );
+        }
+        now += 100;
+        let r = handle_perception_tracked_at(&live_scan(70_000, 9), &mut st, now);
+        assert_eq!(r.sensor_liveness, "healthy");
+    }
+
+    /// (3) Continuous duplicate re-posts eventually fault as no-new-messages.
+    #[test]
+    fn continuous_reposts_fault_as_no_new_messages() {
+        let mut st = state();
+        let mut now = 0;
+        for seq in 0..8 {
+            let _ = handle_perception_tracked_at(
+                &live_scan(1_000 + u64::from(seq) * 100, seq),
+                &mut st,
+                now,
+            );
+            now += 100;
+        }
+        let seeded = live_scan(80_000, 1);
+        assert_eq!(
+            handle_perception_tracked_at(&seeded, &mut st, now).sensor_liveness,
+            "healthy"
+        );
+
+        // Nothing but re-posts from here.
+        let mut last = None;
+        for _ in 0..10 {
+            now += 100;
+            last = Some(handle_perception_tracked_at(&seeded, &mut st, now));
+        }
+        let last = last.expect("ran");
+        assert_eq!(last.sensor_fault, Some("SENSOR_NO_MESSAGES"));
+        assert_eq!(last.speed_cap_mps, 0.0);
+    }
+
+    /// (4) A real new frame after duplicates resumes from the correct state —
+    /// recovering with the streak the stream actually earned, not healthy and not
+    /// reset to zero.
+    #[test]
+    fn a_real_frame_after_duplicates_resumes_correctly() {
+        let mut st = state();
+        let mut now = 0;
+        for seq in 0..8 {
+            let _ = handle_perception_tracked_at(
+                &live_scan(1_000 + u64::from(seq) * 100, seq),
+                &mut st,
+                now,
+            );
+            now += 100;
+        }
+
+        // Freeze into a fault via re-posts.
+        let stuck = live_scan(90_000, 1);
+        for _ in 0..10 {
+            now += 100;
+            let _ = handle_perception_tracked_at(&stuck, &mut st, now);
+        }
+        assert_eq!(
+            handle_perception_tracked_at(&stuck, &mut st, now).sensor_fault,
+            Some("SENSOR_NO_MESSAGES")
+        );
+
+        // A genuinely new frame resumes recovery from 1 — not healthy (the streak
+        // is owed) and not stuck faulted (the sensor is producing again).
+        now += 100;
+        let r = handle_perception_tracked_at(&live_scan(95_000, 2), &mut st, now);
+        assert_eq!(
+            r.sensor_liveness, "recovering",
+            "a new frame after a freeze resumes recovery"
+        );
+        assert_eq!(r.speed_cap_mps, 0.0);
+
+        // …and the streak completes normally from there.
+        for i in 2..SENSOR_RECOVERY_STREAK_LOCAL {
+            now += 100;
+            let _ = handle_perception_tracked_at(
+                &live_scan(95_000 + u64::from(i) * 100, i),
+                &mut st,
+                now,
+            );
+        }
+        now += 100;
+        let r = handle_perception_tracked_at(&live_scan(99_000, 9), &mut st, now);
+        assert_eq!(r.sensor_liveness, "healthy");
+        assert!(r.speed_cap_mps > 0.0);
+    }
+
+    /// (5) Two live clients posting the same scan cannot double the measured rate.
+    ///
+    /// If re-posts recorded arrivals, a 10 Hz sensor read by two consumers would
+    /// measure 20 Hz — which would mask a sensor that had genuinely halved its
+    /// rate to 10 Hz while two clients kept it looking nominal.
+    #[test]
+    fn two_clients_cannot_double_the_measured_rate() {
+        let mut st = state();
+        let mut now = 0;
+        let mut last = None;
+        for seq in 0..12 {
+            let scan = live_scan(1_000 + u64::from(seq) * 100, seq);
+            let _ = handle_perception_tracked_at(&scan, &mut st, now);
+            last = Some(handle_perception_tracked_at(&scan, &mut st, now + 10));
+            now += 100;
+        }
+        let hz = last.expect("ran").sensor_measured_hz.expect("measurable");
+        assert!(
+            (hz - 10.0).abs() < 0.5,
+            "double-posted 10 Hz must measure ~10 Hz, got {hz}"
+        );
+    }
+
+    /// (7) A restarted sidecar begins unavailable and stays there until the
+    /// required healthy evidence has arrived — fresh state is the restart.
+    #[test]
+    fn a_restarted_sidecar_begins_unavailable() {
+        let mut st = state();
+        let first = handle_perception_tracked_at(&live_scan(1_000, 0), &mut st, 0);
+        assert_eq!(first.sensor_liveness, "warming_up");
+        assert_eq!(first.speed_cap_mps, 0.0);
+        assert!(!first.healthy);
+
+        // Availability arrives only with a second observation — the first frame
+        // that makes a rate measurable.
+        let second = handle_perception_tracked_at(&live_scan(1_100, 1), &mut st, 100);
+        assert_eq!(second.sensor_liveness, "healthy");
+        assert!(second.speed_cap_mps > 0.0);
     }
 
     /// The evidence digest identifies the perception EVIDENCE, not the liveness

--- a/crates/kirra-sidecars/src/taj.rs
+++ b/crates/kirra-sidecars/src/taj.rs
@@ -10,12 +10,19 @@
 //! `speed_cap_mps: 0.0` (the MRC floor — the consumer holds).
 
 use kirra_core::corridor::CorridorSource;
+use kirra_trajectory::sensor_watchdog::{
+    fingerprint_from_ranges, FrameObservation, SensorHealth, SensorTick, SensorWatchdog,
+    SENSOR_WATCHDOG_ENABLED_ENV,
+};
+// Re-exported so the service binary configures the watchdog through this module
+// rather than depending on kirra-trajectory directly.
 use kirra_taj::{
     clip_corridor_to_hazards, hazard_clip_x, CameraVruFusionConfig, CameraVruObservation,
     LaserScan, PredictedVruMotion, SemanticClass, SemanticDetection, TajConfig, TajTracker,
     VruClassifierConfig, VruIntentClass, VruIntentReason, VruMotionModel,
     VruMotionPredictionConfig, VruPredictionFallbackReason,
 };
+pub use kirra_trajectory::sensor_watchdog::SensorWatchdogConfig;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
@@ -148,6 +155,35 @@ pub struct PerceptionRequest {
     /// Freshness budget for `camera_stamp_ms` against `stamp_ms`.
     #[serde(default = "default_camera_age")]
     pub camera_max_age_ms: u64,
+    /// Publishers currently advertising the scan topic, as observed by the ROS
+    /// subscriber that produced this request (#1211).
+    ///
+    /// This value can only be obtained by inspecting the ROS graph, which this
+    /// HTTP service cannot do — so it is carried as DATA from the layer that can.
+    /// `None` means "not observed", not "zero": a non-ROS caller (a test harness,
+    /// `inspect_corridor.py`) has no graph to look at, and faulting it for a fact
+    /// it cannot know would make the publisher check fire on the wrong condition.
+    /// The response reports which case applied via
+    /// [`PerceptionResponse::publisher_count_observed`], so an omission is visible
+    /// rather than silent.
+    #[serde(default)]
+    pub publisher_count: Option<usize>,
+    /// This request is a DIAGNOSTIC PROBE, not a frame from the live scan stream
+    /// (`kirra_doctor`'s profile-digest probe, `verify_deployment`). Excluded from
+    /// liveness accounting.
+    ///
+    /// Necessary because those tools POST a canned scan — identical bytes, a fixed
+    /// `stamp_ms` — on every run. To the watchdog that is indistinguishable from a
+    /// driver republishing one buffer forever, so an unflagged probe run would trip
+    /// `SENSOR_FROZEN_FRAME` and hold the real robot in recovery afterwards. A
+    /// diagnostic must not be able to cause the fault it is diagnosing.
+    ///
+    /// This never RELAXES a bound: a probe is not observed, so it can neither set
+    /// nor clear a fault, and any standing verdict from the live stream is
+    /// untouched. The probe's own response reports `sensor_liveness: "disarmed"`,
+    /// because liveness genuinely was not assessed for it.
+    #[serde(default)]
+    pub diagnostic_probe: bool,
 }
 fn default_camera_age() -> u64 {
     DEFAULT_CAMERA_MAX_AGE_MS
@@ -323,8 +359,8 @@ fn validate_perception_request(req: &PerceptionRequest) -> Result<(), Perception
 /// Empty geometry prevents downstream consumers from accidentally planning
 /// against partially processed evidence, while `healthy=false` and
 /// `speed_cap_mps=0.0` enforce stop-and-hold behavior.
-fn invalid_perception_response(camera_armed: bool) -> PerceptionResponse {
-    PerceptionResponse {
+fn invalid_perception_response(camera_armed: bool, health: SensorHealth) -> PerceptionResponse {
+    let mut response = PerceptionResponse {
         frame_id: PerceptionFrameId::invalid(),
         healthy: false,
         confidence: 0.0,
@@ -343,7 +379,15 @@ fn invalid_perception_response(camera_armed: bool) -> PerceptionResponse {
         predicted_vrus: Vec::new(),
         camera_healthy: !camera_armed,
         camera_clip_x_m: None,
-    }
+        sensor_liveness: "disarmed",
+        sensor_fault: None,
+        sensor_measured_hz: None,
+        publisher_count_observed: false,
+    };
+    // The response is already at the MRC floor, so the liveness verdict cannot
+    // lower it further — it is stamped so the REASON travels with the refusal.
+    apply_sensor_health(&mut response, health, false);
+    response
 }
 
 #[derive(Clone, Serialize)]
@@ -713,6 +757,21 @@ pub struct PerceptionResponse {
     /// detection bound it. `None` = no camera hazard bound the corridor. The
     /// clip can only SHORTEN the drivable space.
     pub camera_clip_x_m: Option<f64>,
+    /// #1211 sensor-liveness verdict for this scan: `disarmed` | `healthy` |
+    /// `warming_up` | `recovering` | `faulted`.
+    pub sensor_liveness: &'static str,
+    /// The distinct fault code when the watchdog faulted (`SENSOR_FROZEN_FRAME`,
+    /// `SENSOR_RATE_BELOW_FLOOR`, …), else `None`. Never collapsed into a single
+    /// "sensor bad" — the whole point of #1211's reason codes.
+    pub sensor_fault: Option<&'static str>,
+    /// Measured publish rate over the watchdog's arrival window, when enough
+    /// frames have been seen to compute one. A NUMBER, so an operator can see how
+    /// starved the sensor is rather than only that it tripped a threshold.
+    pub sensor_measured_hz: Option<f64>,
+    /// Whether the request carried a ROS-observed publisher count. `false` means
+    /// the publisher check did not run for this frame because the caller had no
+    /// ROS graph to observe — surfaced so the gap is visible, never silent.
+    pub publisher_count_observed: bool,
 }
 
 /// The corridor's straight-ahead reach: the smaller of the two boundary
@@ -877,6 +936,12 @@ pub struct TrackedPerceptionState {
     last_camera_stamp_ms: Option<u64>,
     /// Advances whenever temporal tracking state is invalidated.
     tracker_generation: u64,
+    /// #1211 sensor-liveness watchdog. Deliberately OUTSIDE [`Self::reset`]: the
+    /// tracker resets on a timestamp regression or an oversized gap, and those are
+    /// exactly the events the watchdog exists to remember. Clearing its history
+    /// alongside the tracker would let a frozen driver launder its record by
+    /// tripping a tracker reset each time it stalled.
+    watchdog: SensorWatchdog,
 }
 
 impl Default for TrackedPerceptionState {
@@ -886,8 +951,25 @@ impl Default for TrackedPerceptionState {
 }
 
 impl TrackedPerceptionState {
+    /// State with the watchdog ARMED on the R2 LiDAR defaults — the deployment
+    /// posture, since #1211's whole subject is that a frozen scan currently drives
+    /// the robot. `KIRRA_SENSOR_WATCHDOG_ENABLED=0` is the opt-out; see
+    /// [`watchdog_armed_from_env`].
     #[must_use]
     pub fn new() -> Self {
+        Self::with_watchdog(SensorWatchdogConfig::r2_lidar(), true)
+    }
+
+    /// State with an explicitly configured watchdog. Tests use this to inject
+    /// thresholds and to run the disarmed path.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `cfg` fails [`SensorWatchdogConfig::validate`]. Callers holding a
+    /// config from configuration input should validate it themselves first and
+    /// report the error; this constructor is for statically-known configs.
+    #[must_use]
+    pub fn with_watchdog(cfg: SensorWatchdogConfig, armed: bool) -> Self {
         Self {
             tracker: None,
             tracker_config: None,
@@ -897,9 +979,11 @@ impl TrackedPerceptionState {
             camera_sequence: 0,
             last_camera_stamp_ms: None,
             tracker_generation: 0,
+            watchdog: SensorWatchdog::new(cfg, armed).expect("watchdog config must be valid"),
         }
     }
 
+    /// Reset TRACKING state. The watchdog is untouched — see the field comment.
     pub fn reset(&mut self) {
         self.tracker = None;
         self.tracker_config = None;
@@ -908,6 +992,179 @@ impl TrackedPerceptionState {
         self.last_camera_stamp_ms = None;
         self.tracker_generation = self.tracker_generation.saturating_add(1);
     }
+
+    /// Operator reset of the watchdog's terminal latch (the counterpart to its
+    /// sticky restart exhaustion). Separate from [`Self::reset`] precisely because
+    /// clearing a terminal sensor fault is a human decision, not a side effect of
+    /// a tracking discontinuity.
+    pub fn reset_sensor_watchdog(&mut self) {
+        self.watchdog.reset();
+    }
+
+    /// The watchdog's current terminal state, for operator surfaces.
+    #[must_use]
+    pub fn sensor_watchdog_terminal(&self) -> bool {
+        self.watchdog.is_terminal()
+    }
+}
+
+/// Whether the scan-liveness watchdog is armed, from
+/// `KIRRA_SENSOR_WATCHDOG_ENABLED`.
+///
+/// **Default ARMED**, inverting the pure module's default-off. The inversion is
+/// deliberate and belongs here: `kirra_trajectory::sensor_watchdog` defaults off
+/// because it is a library with unknown consumers, while this sidecar IS the R2
+/// deployment, and #1211 exists because a frozen LiDAR currently drives that
+/// robot. Shipping the wiring disarmed would leave the failure exactly where the
+/// issue found it.
+///
+/// `0` / `false` / `no` (case-insensitive) opts out — the immediate mitigation if
+/// bring-up shows false trips before the thresholds are characterised on hardware.
+#[must_use]
+pub fn watchdog_armed_from_env() -> bool {
+    std::env::var(SENSOR_WATCHDOG_ENABLED_ENV)
+        .map(|v| {
+            let t = v.trim();
+            !(t == "0" || t.eq_ignore_ascii_case("false") || t.eq_ignore_ascii_case("no"))
+        })
+        .unwrap_or(true)
+}
+
+/// Whether a rejected request was rejected because of the SENSOR or because of
+/// the CALLER's configuration.
+///
+/// The split matters because the two have different owners and different fixes. A
+/// sensor fault must reach the watchdog (it resets the recovery streak, and it is
+/// what an operator needs to see); a caller's bad `margin_m` must not, or a
+/// misconfigured client could pin a perfectly healthy LiDAR in recovery forever.
+fn is_scan_fault(err: PerceptionRequestError) -> bool {
+    match err {
+        // The scan itself, or the geometry describing it.
+        PerceptionRequestError::EmptyScan
+        | PerceptionRequestError::ScanTooLarge
+        | PerceptionRequestError::NanRangeSample
+        | PerceptionRequestError::InvalidRangeBounds
+        | PerceptionRequestError::InvalidAngleMinimum
+        | PerceptionRequestError::InvalidAngleIncrement => true,
+        // Everything else describes how the CALLER wants the scan interpreted.
+        PerceptionRequestError::InvalidForwardExtent
+        | PerceptionRequestError::ForwardExtentTooLarge
+        | PerceptionRequestError::InvalidDeceleration
+        | PerceptionRequestError::InvalidMargin
+        | PerceptionRequestError::InvalidLaneHalfWidth
+        | PerceptionRequestError::InvalidVehicleWidth
+        | PerceptionRequestError::InvalidLateralClearance
+        | PerceptionRequestError::LaneNarrowerThanRequiredCorridor
+        | PerceptionRequestError::InvalidConfidenceFloor => false,
+    }
+}
+
+/// Count returns that are finite AND inside the sensor's own declared range
+/// bounds.
+///
+/// The ROS convention is that a no-return reads `+inf`, so an infinite value is
+/// not a broken ray — it is "nothing out there". It is still not *evidence of
+/// clear space* the way a real measurement is, which is why it does not count
+/// toward the valid ratio: a scan of nothing but no-returns is a scan that saw
+/// nothing, and `SENSOR_LOW_VALID_RAY_RATIO` is the correct verdict on it.
+fn count_valid_rays(req: &PerceptionRequest) -> u32 {
+    req.ranges
+        .iter()
+        .filter(|r| r.is_finite() && **r >= req.range_min_m as f32 && **r <= req.range_max_m as f32)
+        .count()
+        .min(u32::MAX as usize) as u32
+}
+
+/// Build the frame observation and tick the watchdog.
+///
+/// The fingerprint comes from `kirra_trajectory::sensor_watchdog` rather than
+/// being computed here. That is not merely code reuse: the freeze check's entire
+/// discrimination between a frozen buffer and a static scene rests on hashing raw
+/// IEEE bits, and a second implementation in this file would be free to quantise
+/// and silently destroy it.
+fn observe_scan(
+    state: &mut TrackedPerceptionState,
+    req: &PerceptionRequest,
+    now_ms: u64,
+) -> SensorHealth {
+    let frame = FrameObservation {
+        header_stamp_ms: req.stamp_ms,
+        fingerprint: fingerprint_from_ranges(&req.ranges),
+        valid_rays: count_valid_rays(req),
+        total_rays: req.ranges.len().min(u32::MAX as usize) as u32,
+    };
+    state.watchdog.observe(SensorTick {
+        now_ms,
+        // An unobserved publisher count is passed as 1 — "not zero" — so the
+        // publisher check is inert rather than firing on a fact the caller could
+        // not know. `publisher_count_observed` on the response records which
+        // happened, so this is visible rather than an invisible default.
+        publisher_count: req.publisher_count.unwrap_or(1),
+        frame: Some(frame),
+    })
+}
+
+/// Tick the watchdog for a scan that failed validation.
+///
+/// The frame is reported as it actually is — zero valid rays for an empty or
+/// all-NaN scan — so a malformed scan lands on the same `SENSOR_LOW_VALID_RAY_RATIO`
+/// code a blinded one does, rather than inventing a parallel vocabulary for the
+/// same physical condition.
+fn observe_scan_fault(
+    state: &mut TrackedPerceptionState,
+    req: &PerceptionRequest,
+    now_ms: u64,
+) -> SensorHealth {
+    let total_rays = req.ranges.len().min(u32::MAX as usize) as u32;
+    let frame = FrameObservation {
+        header_stamp_ms: req.stamp_ms,
+        fingerprint: fingerprint_from_ranges(&req.ranges),
+        // Range bounds may themselves be the invalid thing, so no ray can be
+        // certified valid against them.
+        valid_rays: 0,
+        total_rays,
+    };
+    state.watchdog.observe(SensorTick {
+        now_ms,
+        publisher_count: req.publisher_count.unwrap_or(1),
+        frame: Some(frame),
+    })
+}
+
+/// The wire name for a liveness verdict.
+fn sensor_liveness_name(health: SensorHealth) -> &'static str {
+    match health {
+        SensorHealth::Disarmed => "disarmed",
+        SensorHealth::Healthy => "healthy",
+        SensorHealth::WarmingUp { .. } => "warming_up",
+        SensorHealth::Recovering { .. } => "recovering",
+        SensorHealth::Faulted(_) => "faulted",
+    }
+}
+
+/// Compose the liveness verdict into a response.
+///
+/// The cap is composed with `min`, never assignment, so a watchdog fault cannot be
+/// overwritten by a healthier channel — and equally, a healthy watchdog cannot
+/// raise a cap that Taj's own corridor arithmetic, the camera channel, or the
+/// confidence floor already lowered. Whichever bound is tighter wins, which is the
+/// same composition rule every sibling perception channel uses.
+fn apply_sensor_health(
+    response: &mut PerceptionResponse,
+    health: SensorHealth,
+    publisher_count_observed: bool,
+) {
+    response.sensor_liveness = sensor_liveness_name(health);
+    response.sensor_fault = health.fault().map(|f| f.code());
+    response.publisher_count_observed = publisher_count_observed;
+
+    if let Some(cap) = health.perception_cap() {
+        response.speed_cap_mps = response.speed_cap_mps.min(cap);
+        // A sensor that is not demonstrably live makes the whole perception
+        // result unhealthy, not merely slow. A consumer watching `healthy` must
+        // not read "the corridor is fine" off evidence the watchdog just refused.
+        response.healthy = false;
+    }
 }
 
 /// Stateless compatibility entry point.
@@ -915,7 +1172,18 @@ impl TrackedPerceptionState {
 /// Production callers should use [`handle_perception_tracked`] with persistent
 /// state so object IDs and velocity estimates survive across scan frames.
 pub fn handle_perception(req: &PerceptionRequest) -> PerceptionResponse {
-    let mut state = TrackedPerceptionState::new();
+    // The watchdog is DISARMED on this path, and that is a correctness choice
+    // rather than a compatibility concession. Liveness is a property of a STREAM:
+    // frozen stamps, repeated buffers and measured rate all mean "compared to the
+    // frames before this one". A stateless call has no frames before this one, so
+    // an armed watchdog here would report `WarmingUp` on every single call and cap
+    // every caller forever — asserting a liveness verdict from one sample with no
+    // continuity to derive it from.
+    //
+    // `sensor_liveness: "disarmed"` is the truthful answer for a one-shot
+    // evaluation. Callers that need liveness must hold state, which is what the
+    // service does.
+    let mut state = TrackedPerceptionState::with_watchdog(SensorWatchdogConfig::r2_lidar(), false);
     handle_perception_tracked(req, &mut state)
 }
 
@@ -987,23 +1255,94 @@ fn predicted_vru_to_wire(prediction: &PredictedVruMotion) -> PredictedVruMotionO
 /// Tracking state is reset on malformed input, timestamp regression, excessive
 /// inter-frame gaps, or a material tracker-configuration change. Every reset
 /// returns to conservative first-sighting behavior with zero estimated velocity.
+///
+/// Reads the wall clock for the watchdog's arrival observation. Prefer
+/// [`handle_perception_tracked_at`], which takes the clock as a parameter — the
+/// service binary uses it, and every test does.
 pub fn handle_perception_tracked(
     req: &PerceptionRequest,
     state: &mut TrackedPerceptionState,
 ) -> PerceptionResponse {
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+    handle_perception_tracked_at(req, state, now_ms)
+}
+
+/// [`handle_perception_tracked`] with the arrival clock supplied by the caller.
+///
+/// `now_ms` is the time this scan was OBSERVED, not the stamp the sensor wrote.
+/// Keeping them separate is the point: a frozen driver's stamp stops advancing
+/// while arrivals keep coming, and a watchdog reading liveness off the sensor's
+/// own stamp would freeze with it.
+pub fn handle_perception_tracked_at(
+    req: &PerceptionRequest,
+    state: &mut TrackedPerceptionState,
+    now_ms: u64,
+) -> PerceptionResponse {
     // Priority 0: validate every request-level assumption before cloning the
     // scan, constructing Taj, or performing floating-point safety arithmetic.
-    if validate_perception_request(req).is_err() {
+    if let Err(err) = validate_perception_request(req) {
         state.reset();
-        return invalid_perception_response(req.camera_armed);
+        // A rejected request still tells the watchdog something — but only when
+        // the SENSOR is what was wrong. An empty scan, a NaN ray or impossible
+        // range bounds are sensor faults and must land on the #1211 reason codes
+        // (and must reset any recovery streak). A bad `margin_m` or
+        // `confidence_floor` is the CALLER's configuration error: faulting the
+        // sensor for it would blame the wrong component and, worse, would let a
+        // misconfigured client hold a healthy sensor in recovery indefinitely.
+        let health = if is_scan_fault(err) && !req.diagnostic_probe {
+            observe_scan_fault(state, req, now_ms)
+        } else {
+            SensorHealth::Disarmed
+        };
+        return invalid_perception_response(req.camera_armed, health);
     }
+
+    // Observe BEFORE the duplicate short-circuit below — a driver republishing one
+    // frame forever produces exactly the duplicate-stamp case, so a tick placed
+    // after the short-circuit would never see the freeze it exists to catch.
+    //
+    // But a repeated stamp is NOT automatically a frozen sensor here. This service
+    // has several legitimate consumers (`perception_governor` and `occy_doer` both
+    // post the same live scan; that is why the short-circuit below exists at all),
+    // so the same frame arriving twice usually means two nodes asked about it.
+    // Counting the second copy as a fresh observation would let a perfectly healthy
+    // two-consumer deployment trip the frozen-stamp check and ground the robot.
+    //
+    // So a re-post is observed as an ARRIVAL THAT CARRIES NO NEW FRAME. A frozen
+    // driver still fails closed, because it produces no NEW frames either: the
+    // watchdog's silence budget expires and the fault surfaces as
+    // `SENSOR_NO_MESSAGES` — "nothing new arrived", which is exactly the truth
+    // about a driver replaying one buffer. Detection is preserved; the false
+    // positive is not.
+    let is_repost = state.last_stamp_ms == Some(req.stamp_ms);
+    let health = if req.diagnostic_probe {
+        SensorHealth::Disarmed
+    } else if is_repost {
+        state.watchdog.observe(SensorTick {
+            now_ms,
+            publisher_count: req.publisher_count.unwrap_or(1),
+            frame: None,
+        })
+    } else {
+        observe_scan(state, req, now_ms)
+    };
 
     // Multiple consumers may submit the exact same LaserScan. Replaying a
     // duplicate must not advance tracking, increment frames_seen, or overwrite
     // velocity with a zero-dt estimate.
     if state.last_stamp_ms == Some(req.stamp_ms) {
         if let Some(response) = state.last_response.as_ref() {
-            return response.clone();
+            // Serve the cached perception, but re-apply THIS tick's liveness
+            // verdict: the cached response was computed when the sensor may still
+            // have looked healthy, and a stale cap is exactly what a frozen driver
+            // would be served otherwise.
+            let mut response = response.clone();
+            response.sensor_measured_hz = state.watchdog.measured_hz();
+            apply_sensor_health(&mut response, health, req.publisher_count.is_some());
+            return response;
         }
 
         // Defensive fallback: duplicate metadata without a cached response is
@@ -1298,13 +1637,35 @@ pub fn handle_perception_tracked(
         predicted_vrus,
         camera_healthy,
         camera_clip_x_m,
+        sensor_liveness: "disarmed",
+        sensor_fault: None,
+        sensor_measured_hz: None,
+        publisher_count_observed: false,
     };
 
     response.frame_id.profile_digest = compute_perception_profile_digest(req);
+    // The evidence digest is computed BEFORE the liveness verdict is stamped, and
+    // the cached response is stored before it too. Both are deliberate.
+    //
+    // The digest identifies the perception EVIDENCE — what the sensor showed and
+    // what Taj made of it. Liveness is a verdict about whether that evidence is
+    // CURRENT, which is orthogonal: the same scan bytes produce the same evidence
+    // whether they arrived first or third in a frozen run. Folding it in would make
+    // the digest of a scan depend on the history of unrelated scans, and would
+    // change the identity of a frame that a downstream consumer binds commands to.
+    // This is the same line #1210 drew for the rejection tally.
+    //
+    // Caching pre-verdict matters for the duplicate path: a stale `Some(0.0)` baked
+    // into the cache would compose with `min` forever, so a transient fault would
+    // outlive itself. The cache holds the perception result; the verdict is applied
+    // fresh on every serve, including every replay.
     response.frame_id.evidence_digest = compute_perception_evidence_digest(&response);
 
     state.last_stamp_ms = Some(req.stamp_ms);
     state.last_response = Some(response.clone());
+
+    response.sensor_measured_hz = state.watchdog.measured_hz();
+    apply_sensor_health(&mut response, health, req.publisher_count.is_some());
     response
 }
 
@@ -1314,7 +1675,7 @@ mod tests {
 
     /// A request over `ranges`, with the camera channel DISARMED by default —
     /// so every pre-existing assertion still describes the lidar-only path.
-    fn req(ranges: Vec<f32>) -> PerceptionRequest {
+    pub(super) fn req(ranges: Vec<f32>) -> PerceptionRequest {
         PerceptionRequest {
             angle_min_rad: -1.5,
             angle_increment_rad: 0.01,
@@ -1334,6 +1695,8 @@ mod tests {
             camera_observations: Vec::new(),
             camera_stamp_ms: None,
             camera_max_age_ms: DEFAULT_CAMERA_MAX_AGE_MS,
+            publisher_count: None,
+            diagnostic_probe: false,
         }
     }
 
@@ -1403,7 +1766,7 @@ mod tests {
         // evidence, so two frames identical but for what was actually seen must
         // not share an evidence identity. If the marker were presentation-only
         // this assertion fails and the audit trail is forgeable by omission.
-        let mut response = invalid_perception_response(false);
+        let mut response = invalid_perception_response(false, SensorHealth::Disarmed);
         response.objects = vec![ObjOut {
             id: 7,
             x: 4.0,
@@ -1627,7 +1990,7 @@ mod tests {
 
     #[test]
     fn invalid_perception_response_has_no_vru_predictions() {
-        let response = invalid_perception_response(true);
+        let response = invalid_perception_response(true, SensorHealth::Disarmed);
 
         assert!(response.predicted_vrus.is_empty());
         assert!(!response.healthy);
@@ -2234,6 +2597,8 @@ mod tracked_perception_tests {
             camera_armed: false,
             camera_stamp_ms: None,
             camera_max_age_ms: DEFAULT_CAMERA_MAX_AGE_MS,
+            publisher_count: None,
+            diagnostic_probe: false,
             detections: Vec::new(),
             camera_observations: Vec::new(),
         }
@@ -2345,6 +2710,8 @@ mod duplicate_frame_tracking_tests {
             camera_armed: false,
             camera_stamp_ms: None,
             camera_max_age_ms: DEFAULT_CAMERA_MAX_AGE_MS,
+            publisher_count: None,
+            diagnostic_probe: false,
             detections: Vec::new(),
             camera_observations: Vec::new(),
         }
@@ -2370,6 +2737,406 @@ mod duplicate_frame_tracking_tests {
             moved.objects[0].vx > 0.5 && moved.objects[0].vx < 1.5,
             "expected roughly 1 m/s after one real 100 ms interval, got {}",
             moved.objects[0].vx,
+        );
+    }
+}
+
+#[cfg(test)]
+mod scan_liveness_tests {
+    //! #1211 end-to-end: a frozen `/scan` reaching the served speed cap.
+    //!
+    //! Every test injects scans and a clock. Nothing sleeps — wall-clock waits
+    //! would make a timing gate's own tests the flakiest thing in CI.
+
+    use super::*;
+
+    /// A live-stream scan: an obstacle straight ahead, with per-frame variation
+    /// in the low bits so consecutive frames are NOT bit-identical. Real sensor
+    /// noise looks like this, and it is what the freeze check keys on.
+    fn live_scan(stamp_ms: u64, seq: u32) -> PerceptionRequest {
+        let ranges: Vec<f32> = (0..300)
+            .map(|i| {
+                let theta = -1.5 + f64::from(i) * 0.01;
+                let base = if theta.abs() < 0.15 {
+                    6.0 / theta.cos()
+                } else {
+                    8.0
+                };
+                // One ulp of jitter, varying per frame — the low-bit noise a real
+                // lidar produces even when nothing in the world moved.
+                f32::from_bits((base as f32).to_bits() + (seq % 7))
+            })
+            .collect();
+        let mut r = super::tests::req(ranges);
+        r.stamp_ms = stamp_ms;
+        r.publisher_count = Some(1);
+        r
+    }
+
+    /// The same buffer and the same stamp, forever — a driver republishing one
+    /// frame.
+    fn frozen_scan() -> PerceptionRequest {
+        live_scan(1_000, 0)
+    }
+
+    fn state() -> TrackedPerceptionState {
+        TrackedPerceptionState::with_watchdog(SensorWatchdogConfig::r2_lidar(), true)
+    }
+
+    /// THE issue: repeated identical `/scan` messages eventually floor the served
+    /// cap. Before this wiring the same sequence produced a healthy corridor and a
+    /// non-zero cap indefinitely.
+    #[test]
+    fn repeated_identical_scans_eventually_floor_the_served_cap() {
+        let mut st = state();
+        let frozen = frozen_scan();
+
+        // Warm-up already holds the cap, so step past it on live frames first and
+        // confirm the service is genuinely serving motion before the freeze.
+        let mut now = 0;
+        for seq in 0..6 {
+            let _ = handle_perception_tracked_at(
+                &live_scan(1_000 + u64::from(seq) * 100, seq),
+                &mut st,
+                now,
+            );
+            now += 100;
+        }
+        let healthy = handle_perception_tracked_at(&live_scan(1_600, 99), &mut st, now);
+        assert_eq!(healthy.sensor_liveness, "healthy");
+        assert!(
+            healthy.speed_cap_mps > 0.0,
+            "precondition: a live stream must serve a moving cap, else the \
+             assertion below proves nothing"
+        );
+
+        // Now the driver freezes: same bytes, same stamp, still arriving at the
+        // same 10 Hz. Run past the 500 ms silence budget.
+        let mut last = healthy;
+        for _ in 0..8 {
+            now += 100;
+            last = handle_perception_tracked_at(&frozen, &mut st, now);
+        }
+
+        assert_eq!(last.sensor_liveness, "faulted");
+        assert_eq!(last.speed_cap_mps, 0.0, "a frozen scan must floor the cap");
+        assert!(!last.healthy);
+        // A driver replaying one buffer produces no NEW frames, so the liveness
+        // failure surfaces as "nothing new arrived" rather than as a frozen-stamp
+        // count. See the dedupe rationale in `handle_perception_tracked_at`: the
+        // frozen-stamp counter cannot be used at this call site without falsely
+        // faulting a healthy two-consumer deployment.
+        assert_eq!(last.sensor_fault, Some("SENSOR_NO_MESSAGES"));
+    }
+
+    /// Recovery takes the EXACT streak — not one frame, not an approximation.
+    #[test]
+    fn health_returns_only_after_the_exact_recovery_streak() {
+        let mut st = state();
+        let mut now = 0;
+
+        // Fault it: a frozen stream, run past the silence budget.
+        for _ in 0..10 {
+            let _ = handle_perception_tracked_at(&frozen_scan(), &mut st, now);
+            now += 100;
+        }
+        assert_eq!(
+            handle_perception_tracked_at(&frozen_scan(), &mut st, now).sensor_liveness,
+            "faulted"
+        );
+
+        // Valid, CHANGING frames at an acceptable rate. The cap must stay floored
+        // for exactly `recovery_streak - 1` of them.
+        let streak = SensorWatchdogConfig::r2_lidar().recovery_streak;
+        for i in 1..streak {
+            now += 100;
+            let r = handle_perception_tracked_at(
+                &live_scan(5_000 + u64::from(i) * 100, i),
+                &mut st,
+                now,
+            );
+            assert_eq!(
+                r.sensor_liveness, "recovering",
+                "frame {i} of {streak} must still be recovering"
+            );
+            assert_eq!(r.speed_cap_mps, 0.0, "frame {i} must stay floored");
+            assert!(!r.healthy);
+        }
+
+        now += 100;
+        let r = handle_perception_tracked_at(
+            &live_scan(5_000 + u64::from(streak) * 100, streak),
+            &mut st,
+            now,
+        );
+        assert_eq!(r.sensor_liveness, "healthy");
+        assert!(
+            r.speed_cap_mps > 0.0,
+            "the streak completed, so motion must be released"
+        );
+        assert!(r.healthy);
+    }
+
+    /// Startup begins unavailable: the very first scan is capped, because one
+    /// observation is not evidence of a rate.
+    #[test]
+    fn startup_begins_unavailable() {
+        let mut st = state();
+        let first = handle_perception_tracked_at(&live_scan(1_000, 0), &mut st, 0);
+        assert_eq!(first.sensor_liveness, "warming_up");
+        assert_eq!(first.speed_cap_mps, 0.0);
+        assert!(!first.healthy);
+    }
+
+    /// A watchdog fault cannot be overwritten by a healthy camera channel. The
+    /// cap composes with `min`, so the tighter bound always wins regardless of
+    /// which channel produced it.
+    #[test]
+    fn a_healthy_camera_cannot_lift_a_watchdog_fault() {
+        let mut st = state();
+        let mut now = 0;
+        for _ in 0..10 {
+            let _ = handle_perception_tracked_at(&frozen_scan(), &mut st, now);
+            now += 100;
+        }
+
+        // Same frozen scan, but with the camera channel armed and fresh — the
+        // healthiest possible companion channel.
+        let mut req = frozen_scan();
+        req.camera_armed = true;
+        req.camera_stamp_ms = Some(req.stamp_ms);
+        let r = handle_perception_tracked_at(&req, &mut st, now + 100);
+
+        assert!(
+            r.camera_healthy,
+            "precondition: the camera channel is healthy"
+        );
+        assert_eq!(r.sensor_liveness, "faulted");
+        assert_eq!(
+            r.speed_cap_mps, 0.0,
+            "a healthy camera must not lift the scan-liveness floor"
+        );
+    }
+
+    /// The duplicate-stamp short-circuit serves a CACHED perception result. That
+    /// path must still carry this tick's liveness verdict — otherwise a frozen
+    /// driver is served the healthy cap computed before it froze, which is
+    /// precisely the bug.
+    #[test]
+    fn the_cached_duplicate_response_still_carries_the_verdict() {
+        let mut st = state();
+        let mut now = 0;
+        for seq in 0..6 {
+            let _ = handle_perception_tracked_at(
+                &live_scan(1_000 + u64::from(seq) * 100, seq),
+                &mut st,
+                now,
+            );
+            now += 100;
+        }
+        // Establish a cached healthy response at this stamp.
+        let seeded = handle_perception_tracked_at(&live_scan(9_000, 1), &mut st, now);
+        assert_eq!(seeded.sensor_liveness, "healthy");
+        assert!(seeded.speed_cap_mps > 0.0);
+
+        // Replay the SAME stamp until the freeze trips. Every reply is served from
+        // cache, so if the verdict were not re-applied these would stay healthy.
+        let replay = live_scan(9_000, 1);
+        let mut last = seeded;
+        for _ in 0..8 {
+            now += 100;
+            last = handle_perception_tracked_at(&replay, &mut st, now);
+        }
+        assert_eq!(last.sensor_liveness, "faulted");
+        assert_eq!(last.speed_cap_mps, 0.0);
+    }
+
+    /// Two legitimate consumers posting the SAME live scan must not read as a
+    /// frozen sensor.
+    ///
+    /// `perception_governor` and `occy_doer` both subscribe to `/scan` and both POST
+    /// what they receive, so every frame reaches this service twice. Counting the
+    /// second copy as a fresh observation would trip the frozen-stamp check on a
+    /// perfectly healthy robot — the false positive that would have grounded the R2
+    /// the first time this shipped.
+    #[test]
+    fn two_consumers_posting_the_same_scan_are_not_a_frozen_sensor() {
+        let mut st = state();
+        let mut now = 0;
+        let mut last = None;
+        for seq in 0..12 {
+            let scan = live_scan(1_000 + u64::from(seq) * 100, seq);
+            // Consumer A, then consumer B, on the identical frame.
+            let _ = handle_perception_tracked_at(&scan, &mut st, now);
+            last = Some(handle_perception_tracked_at(&scan, &mut st, now + 10));
+            now += 100;
+        }
+        let last = last.expect("ran");
+        assert_eq!(
+            last.sensor_liveness, "healthy",
+            "a double-posted healthy stream must stay healthy"
+        );
+        assert_eq!(last.sensor_fault, None);
+        assert!(last.speed_cap_mps > 0.0);
+    }
+
+    /// A diagnostic probe is excluded from liveness accounting, so running the
+    /// doctor repeatedly cannot manufacture the freeze it is looking for.
+    #[test]
+    fn a_diagnostic_probe_cannot_trip_the_freeze_it_diagnoses() {
+        let mut st = state();
+        let mut now = 0;
+        for seq in 0..6 {
+            let _ = handle_perception_tracked_at(
+                &live_scan(1_000 + u64::from(seq) * 100, seq),
+                &mut st,
+                now,
+            );
+            now += 100;
+        }
+
+        // Ten identical probes, INTERLEAVED with the live stream — which is how a
+        // doctor run actually happens: the lidar keeps publishing while the tool
+        // pokes the service. (Ten probes with no live frames between them would be
+        // a genuine one-second scan outage, and the watchdog is right to fault
+        // that; excluding probes from liveness must not extend to masking silence.)
+        let mut probe = frozen_scan();
+        probe.diagnostic_probe = true;
+        for seq in 10..20 {
+            let r = handle_perception_tracked_at(&probe, &mut st, now);
+            assert_eq!(r.sensor_liveness, "disarmed", "a probe is not assessed");
+            now += 100;
+            let _ = handle_perception_tracked_at(
+                &live_scan(2_000 + u64::from(seq) * 100, seq),
+                &mut st,
+                now,
+            );
+        }
+
+        // The live stream is untouched: still healthy, no recovery streak owed.
+        now += 100;
+        let live = handle_perception_tracked_at(&live_scan(20_000, 3), &mut st, now);
+        assert_eq!(
+            live.sensor_liveness, "healthy",
+            "probes must not have left the live stream in recovery"
+        );
+        assert!(live.speed_cap_mps > 0.0);
+    }
+
+    /// A malformed scan lands on the already-defined reason code rather than a
+    /// parallel vocabulary for the same physical condition.
+    #[test]
+    fn an_all_invalid_scan_reports_the_ray_ratio_code() {
+        let mut st = state();
+        let mut bad = live_scan(1_000, 0);
+        bad.ranges = vec![f32::NAN; 300];
+        let r = handle_perception_tracked_at(&bad, &mut st, 0);
+        assert_eq!(r.sensor_fault, Some("SENSOR_LOW_VALID_RAY_RATIO"));
+        assert_eq!(r.speed_cap_mps, 0.0);
+        assert!(!r.healthy);
+    }
+
+    /// A CALLER's configuration error is not a sensor fault. Blaming the sensor
+    /// would both misdirect the operator and let a misconfigured client hold a
+    /// healthy lidar in recovery indefinitely.
+    #[test]
+    fn a_caller_config_error_is_not_charged_to_the_sensor() {
+        let mut st = state();
+        let mut now = 0;
+        for seq in 0..6 {
+            let _ = handle_perception_tracked_at(
+                &live_scan(1_000 + u64::from(seq) * 100, seq),
+                &mut st,
+                now,
+            );
+            now += 100;
+        }
+        assert_eq!(
+            handle_perception_tracked_at(&live_scan(2_000, 9), &mut st, now).sensor_liveness,
+            "healthy"
+        );
+
+        // A bad margin — nothing to do with the lidar.
+        now += 100;
+        let mut bad = live_scan(2_100, 10);
+        bad.margin_m = -1.0;
+        let r = handle_perception_tracked_at(&bad, &mut st, now);
+        assert_eq!(r.speed_cap_mps, 0.0, "the request is still refused");
+        assert_eq!(r.sensor_fault, None, "…but not blamed on the sensor");
+
+        // …and the sensor is still healthy on the next good frame, with no
+        // recovery streak owed.
+        now += 100;
+        let r = handle_perception_tracked_at(&live_scan(2_200, 11), &mut st, now);
+        assert_eq!(r.sensor_liveness, "healthy");
+        assert!(r.speed_cap_mps > 0.0);
+    }
+
+    /// An unobserved publisher count is reported as unobserved rather than
+    /// silently treated as zero publishers.
+    #[test]
+    fn an_unobserved_publisher_count_is_visible_not_assumed() {
+        let mut st = state();
+        let mut req = live_scan(1_000, 0);
+        req.publisher_count = None;
+        let r = handle_perception_tracked_at(&req, &mut st, 0);
+        assert!(!r.publisher_count_observed);
+        assert_eq!(r.sensor_fault, None, "absence is not a NoPublisher fault");
+
+        let mut req = live_scan(1_100, 1);
+        req.publisher_count = Some(1);
+        let r = handle_perception_tracked_at(&req, &mut st, 100);
+        assert!(r.publisher_count_observed);
+    }
+
+    /// Zero publishers, observed at the ROS layer, is its own fault code.
+    #[test]
+    fn zero_observed_publishers_faults_distinctly() {
+        let mut st = state();
+        let mut req = live_scan(1_000, 0);
+        req.publisher_count = Some(0);
+        let r = handle_perception_tracked_at(&req, &mut st, 0);
+        assert_eq!(r.sensor_fault, Some("SENSOR_NO_PUBLISHER"));
+        assert_eq!(r.speed_cap_mps, 0.0);
+    }
+
+    /// The disarmed path is byte-identical to pre-#1211 behaviour: no cap, no
+    /// verdict, whatever the stream does.
+    #[test]
+    fn the_disarmed_path_is_unchanged() {
+        let mut st = TrackedPerceptionState::with_watchdog(SensorWatchdogConfig::r2_lidar(), false);
+        let frozen = frozen_scan();
+        let mut now = 0;
+        let mut last = None;
+        for _ in 0..10 {
+            last = Some(handle_perception_tracked_at(&frozen, &mut st, now));
+            now += 100;
+        }
+        let last = last.expect("ran");
+        assert_eq!(last.sensor_liveness, "disarmed");
+        assert_eq!(last.sensor_fault, None);
+        assert!(
+            last.speed_cap_mps > 0.0,
+            "disarmed must not floor the cap — that is the pre-#1211 behaviour \
+             this gate exists to change only when armed"
+        );
+    }
+
+    /// The evidence digest identifies the perception EVIDENCE, not the liveness
+    /// verdict about it: the same scan bytes digest identically whether they
+    /// arrived first or third in a frozen run.
+    #[test]
+    fn the_liveness_verdict_stays_out_of_the_evidence_digest() {
+        let mut st = state();
+        let frozen = frozen_scan();
+        let first = handle_perception_tracked_at(&frozen, &mut st, 0);
+
+        let mut fresh = state();
+        let independent = handle_perception_tracked_at(&frozen, &mut fresh, 0);
+
+        assert_eq!(
+            first.frame_id.evidence_digest, independent.frame_id.evidence_digest,
+            "identical scan bytes must carry identical evidence identity"
         );
     }
 }

--- a/crates/kirra-trajectory/src/sensor_watchdog.rs
+++ b/crates/kirra-trajectory/src/sensor_watchdog.rs
@@ -71,13 +71,16 @@
 //! [`LowValidRayRatio`] would refuse it regardless. Stopping is right in both
 //! readings of that frame.
 //!
-//! ## Disarmed by default
+//! ## Arming
 //!
-//! Like every sibling channel, the watchdog ships disarmed
-//! ([`SENSOR_WATCHDOG_ENABLED_ENV`]) and is byte-identical to prior behaviour when
-//! off. Arming it on a fleet whose LiDAR rate has never been characterised would
-//! ground robots on a threshold nobody measured; the rate floor in particular is a
-//! per-platform number.
+//! This module defaults DISARMED, like every sibling channel: it is a library with
+//! unknown consumers, and arming it on a fleet whose LiDAR rate has never been
+//! characterised would ground robots on a threshold nobody measured.
+//!
+//! The R2 deployment inverts that default at the integration layer — the Taj
+//! sidecar arms the watchdog unless `KIRRA_SENSOR_WATCHDOG_ENABLED=0`, because that
+//! sidecar IS the robot #1211 was filed about. The inversion belongs there, where
+//! the platform is known, not here. See `kirra_sidecars::taj::watchdog_armed_from_env`.
 
 use std::collections::VecDeque;
 
@@ -323,9 +326,13 @@ pub enum SensorHealth {
     /// streak. Motion stays refused — this is the state that stops a flapping
     /// sensor from being trusted the instant it blinks back.
     Recovering { healthy_streak: u32, required: u32 },
-    /// Not yet enough frames to measure a rate. Other checks still apply; the rate
-    /// check alone is suspended. Not a fault — a starting sensor is not a broken one,
-    /// and genuine silence during warm-up is caught by [`SensorFault::NoMessages`].
+    /// Not yet enough frames to measure a rate. Not a *fault* — a starting sensor
+    /// is not a broken one, and the distinction is worth reporting — but it **caps
+    /// like one**: a sensor that has produced one frame has not yet evidenced that
+    /// it produces a second, and "publishes at all" is not "publishes at rate".
+    ///
+    /// Startup therefore begins unavailable and earns availability, which is the
+    /// same direction as every other decision here.
     WarmingUp { frames: usize },
 }
 
@@ -334,14 +341,21 @@ impl SensorHealth {
     /// [`crate::perception_redundancy::more_restrictive_cap`] into the same Track-C
     /// derate the sibling channels use.
     ///
-    /// `Some(0.0)` — the MRC floor — for both [`Faulted`](Self::Faulted) and
-    /// [`Recovering`](Self::Recovering). Recovering caps deliberately: releasing
-    /// motion on the first healthy frame is what the streak exists to prevent.
+    /// `Some(0.0)` — the MRC floor — for everything except [`Disarmed`] and
+    /// [`Healthy`]. [`Recovering`] caps because releasing motion on the first
+    /// healthy frame is what the streak exists to prevent; [`WarmingUp`] caps
+    /// because a sensor that has not yet been observed at rate has not yet
+    /// evidenced that it runs at rate.
+    ///
+    /// [`Disarmed`]: Self::Disarmed
+    /// [`Healthy`]: Self::Healthy
+    /// [`Recovering`]: Self::Recovering
+    /// [`WarmingUp`]: Self::WarmingUp
     #[must_use]
     pub fn perception_cap(&self) -> Option<f64> {
         match self {
-            Self::Faulted(_) | Self::Recovering { .. } => Some(0.0),
-            Self::Disarmed | Self::Healthy | Self::WarmingUp { .. } => None,
+            Self::Faulted(_) | Self::Recovering { .. } | Self::WarmingUp { .. } => Some(0.0),
+            Self::Disarmed | Self::Healthy => None,
         }
     }
 
@@ -463,6 +477,21 @@ impl SensorWatchdog {
                 self.was_faulted = true;
                 self.healthy_streak = 0;
                 self.streak_started_ms = None;
+                // A break in the stream invalidates the arrival window that was
+                // measuring it. Without this, the gap created BY the fault stays in
+                // the window and keeps the measured rate under the floor long after
+                // the sensor recovered — so recovery would take "until the outage
+                // ages out of the window" rather than the configured streak, and
+                // the sensor would be punished twice for one fault.
+                //
+                // `RateBelowFloor` is the exception: that fault IS the window's own
+                // verdict, and erasing the evidence for it would make a genuinely
+                // starved sensor oscillate between reporting the rate fault and
+                // reporting nothing measurable. It stays fail-closed either way,
+                // but the operator deserves the stable, accurate code.
+                if !matches!(fault, SensorFault::RateBelowFloor { .. }) {
+                    self.arrivals.clear();
+                }
                 SensorHealth::Faulted(fault)
             }
             None => self.advance_recovery(tick.now_ms),
@@ -1050,13 +1079,24 @@ mod tests {
         }
     }
 
-    /// Warm-up suspends only the rate check, and does not cap. A starting sensor is
-    /// not a broken one; genuine silence during warm-up is caught as NoMessages.
+    /// Startup begins UNAVAILABLE and earns availability. Warm-up is reported
+    /// distinctly from a fault — a starting sensor is not a broken one — but it caps
+    /// exactly like one, because a sensor observed once has not evidenced that it
+    /// publishes at rate, and "publishes at all" is not "publishes at rate".
     #[test]
-    fn warm_up_does_not_cap() {
+    fn warm_up_caps_so_startup_begins_unavailable() {
         let mut w = armed();
         let h = w.observe(tick(0, Some(good_frame(0))));
         assert_eq!(h, SensorHealth::WarmingUp { frames: 1 });
+        assert_eq!(
+            h.perception_cap(),
+            Some(0.0),
+            "a single observation must not release motion"
+        );
+        // The second frame establishes a measurable rate, and only then is the
+        // sensor available.
+        let h = w.observe(tick(100, Some(good_frame(1))));
+        assert_eq!(h, SensorHealth::Healthy);
         assert_eq!(h.perception_cap(), None);
     }
 
@@ -1208,6 +1248,69 @@ mod tests {
         );
         // …and nothing else faulted, so the restart is attributable to the window.
         assert!(h.fault().is_none());
+    }
+
+    /// A break in the stream clears the arrival window, so recovery takes the
+    /// configured streak rather than "until the outage ages out of the window".
+    /// Without this the gap created BY the fault keeps the measured rate under the
+    /// floor and the sensor is punished twice for one fault.
+    #[test]
+    fn a_stream_break_clears_the_rate_window_so_recovery_is_the_streak() {
+        let mut w = armed();
+        // Healthy at 10 Hz.
+        run_healthy(&mut w, 0, 0, 6);
+        // A one-second outage.
+        let h = w.observe(tick(1_500, None));
+        assert!(matches!(
+            h,
+            SensorHealth::Faulted(SensorFault::NoMessages { .. })
+        ));
+
+        // Frames resume at 10 Hz. If the window still held the pre-outage arrivals,
+        // the measured rate across the gap would be ~1 Hz and this would fault.
+        for i in 1..SENSOR_RECOVERY_STREAK as u64 {
+            let h = w.observe(tick(1_500 + i * 100, Some(good_frame(10 + i))));
+            assert_eq!(
+                h,
+                SensorHealth::Recovering {
+                    healthy_streak: i as u32,
+                    required: SENSOR_RECOVERY_STREAK
+                },
+                "recovery must progress on the streak, not stall on a stale window"
+            );
+        }
+        let h = w.observe(tick(
+            1_500 + SENSOR_RECOVERY_STREAK as u64 * 100,
+            Some(good_frame(99)),
+        ));
+        assert_eq!(h, SensorHealth::Healthy);
+    }
+
+    /// …but a RATE fault keeps its window: that fault IS the window's verdict, and
+    /// erasing its evidence would make a genuinely starved sensor oscillate between
+    /// reporting the rate fault and reporting nothing measurable.
+    #[test]
+    fn a_rate_fault_keeps_its_own_evidence() {
+        let mut w = armed();
+        // 2 Hz — under the 5 Hz floor.
+        let mut last = SensorHealth::Disarmed;
+        for i in 0..5 {
+            last = w.observe(tick(i * 500, Some(good_frame(i))));
+        }
+        assert!(matches!(
+            last,
+            SensorHealth::Faulted(SensorFault::RateBelowFloor { .. })
+        ));
+        // Still starved on the next frame, and still REPORTED as starved rather
+        // than degrading to an unmeasurable warm-up.
+        let next = w.observe(tick(3_000, Some(good_frame(9))));
+        assert!(
+            matches!(
+                next,
+                SensorHealth::Faulted(SensorFault::RateBelowFloor { .. })
+            ),
+            "got {next:?}"
+        );
     }
 
     // ----- bounded restart -----

--- a/crates/kirra-trajectory/src/sensor_watchdog.rs
+++ b/crates/kirra-trajectory/src/sensor_watchdog.rs
@@ -472,6 +472,11 @@ impl SensorWatchdog {
             });
         }
 
+        // Whether this tick carried a NEW frame. Only a new frame is evidence of
+        // liveness, so only a new frame may advance the recovery streak — see
+        // `advance_recovery`.
+        let had_frame = tick.frame.is_some();
+
         match self.check(tick) {
             Some(fault) => {
                 self.was_faulted = true;
@@ -494,7 +499,7 @@ impl SensorWatchdog {
                 }
                 SensorHealth::Faulted(fault)
             }
-            None => self.advance_recovery(tick.now_ms),
+            None => self.advance_recovery(tick.now_ms, had_frame),
         }
     }
 
@@ -646,16 +651,33 @@ impl SensorWatchdog {
 
     /// A clean tick. Report warm-up, hold the cap through the recovery streak, or
     /// clear to healthy.
-    fn advance_recovery(&mut self, now_ms: u64) -> SensorHealth {
+    ///
+    /// `had_frame` is whether this tick carried a NEW frame, and it gates the
+    /// streak. A tick that arrived without one — a second consumer re-posting a
+    /// frame already observed, an idle poll between frames — is not silence (the
+    /// budget has not expired) but it is not evidence of liveness either. Letting
+    /// it advance the streak would mean a frozen driver's own re-posts earned its
+    /// recovery: the stream would "recover" from a freeze on the strength of the
+    /// very repetitions that constitute the freeze.
+    fn advance_recovery(&mut self, now_ms: u64, had_frame: bool) -> SensorHealth {
         if !self.was_faulted {
             // Never faulted — nothing to recover from. Warm-up is reported so the
-            // caller can see the rate check is not yet live, but it does not cap.
+            // caller can see the rate check is not yet live.
             if self.arrivals.len() < 2 {
                 return SensorHealth::WarmingUp {
                     frames: self.arrivals.len(),
                 };
             }
             return SensorHealth::Healthy;
+        }
+
+        if !had_frame {
+            // Recovering, but no new evidence this tick — hold the streak exactly
+            // where it is. The cap stays floored either way.
+            return SensorHealth::Recovering {
+                healthy_streak: self.healthy_streak,
+                required: self.cfg.recovery_streak,
+            };
         }
 
         // The streak is time-bounded as well as counted. A count alone is satisfied
@@ -715,6 +737,14 @@ impl SensorWatchdog {
     #[must_use]
     pub fn is_terminal(&self) -> bool {
         self.terminal
+    }
+
+    /// Whether this watchdog is armed. Exposed so an integration layer can report
+    /// a disarmed safety check on its diagnostic surfaces instead of leaving it
+    /// indistinguishable from an armed one that is passing.
+    #[must_use]
+    pub fn is_armed(&self) -> bool {
+        self.armed
     }
 
     /// Operator reset — clears the terminal latch and all history. The deliberate

--- a/crates/kirra-trajectory/src/sensor_watchdog.rs
+++ b/crates/kirra-trajectory/src/sensor_watchdog.rs
@@ -1559,6 +1559,32 @@ mod tests {
         assert!(w.is_terminal(), "the third attempt exhausts the budget");
     }
 
+    /// The arm-state accessor must report the truth, because a diagnostic surface
+    /// consumes it: the Taj sidecar puts it on `GET /health` so a DISARMED
+    /// watchdog is visible rather than indistinguishable from an armed one that is
+    /// passing. An accessor stuck at `true` would have a switched-off safety check
+    /// reporting itself as on — the exact confusion it was added to prevent.
+    #[test]
+    fn the_arm_state_accessor_reports_the_truth() {
+        let cfg = SensorWatchdogConfig::r2_lidar();
+        assert!(
+            SensorWatchdog::new(cfg, true).expect("valid").is_armed(),
+            "an armed watchdog must report armed"
+        );
+        assert!(
+            !SensorWatchdog::new(cfg, false).expect("valid").is_armed(),
+            "a disarmed watchdog must report disarmed — never claim a check is \
+             running when it is not"
+        );
+        // …and it survives an operator reset, which rebuilds the state.
+        let mut w = SensorWatchdog::new(cfg, false).expect("valid");
+        w.reset();
+        assert!(
+            !w.is_armed(),
+            "reset must not silently arm a disarmed watchdog"
+        );
+    }
+
     /// Every config error renders a distinct, non-empty operator message naming
     /// the offending value. A refusal whose reason does not reach the operator is
     /// a silent refusal.

--- a/robot/doctor/modules/profile_digest.py
+++ b/robot/doctor/modules/profile_digest.py
@@ -126,6 +126,12 @@ def build_probe(geometry, forward_extent_m, camera_armed, camera_max_age_ms):
         "stamp_ms": 0,
         "forward_extent_m": forward_extent_m,
         "camera_armed": camera_armed,
+        # #1211: this probe POSTs identical bytes at a fixed stamp on every run,
+        # which is exactly what a frozen lidar driver looks like. Flag it so the
+        # scan-liveness watchdog does not observe it — a diagnostic must not be
+        # able to cause the fault it is diagnosing, nor leave the live stream
+        # owing a recovery streak afterwards.
+        "diagnostic_probe": True,
     })
     if camera_armed:
         probe["camera_max_age_ms"] = camera_max_age_ms

--- a/robot/inspect_corridor.py
+++ b/robot/inspect_corridor.py
@@ -111,6 +111,12 @@ def main():
             "range_min_m": float(scan.range_min),
             "range_max_m": float(scan.range_max),
             "ranges": ranges, "stamp_ms": 0, "forward_extent_m": FORWARD_EXTENT_M,
+            # #1211: a one-shot "what do you see" query with a fixed
+            # stamp_ms. It shares taj_service state with the live scan
+            # stream, so without this flag repeated queries would look
+            # like a frozen driver and leave the real robot owing a
+            # recovery streak.
+            "diagnostic_probe": True,
         }).json()
     except Exception as e:
         node.destroy_node(); rclpy.shutdown()

--- a/robot/rabbit_ask.py
+++ b/robot/rabbit_ask.py
@@ -211,6 +211,12 @@ def gather_perception():
             "range_min_m": float(scan.range_min),
             "range_max_m": float(scan.range_max),
             "ranges": ranges, "stamp_ms": 0, "forward_extent_m": 8.0,
+            # #1211: a one-shot "what do you see" query with a fixed
+            # stamp_ms. It shares taj_service state with the live scan
+            # stream, so without this flag repeated queries would look
+            # like a frozen driver and leave the real robot owing a
+            # recovery streak.
+            "diagnostic_probe": True,
         }).json()
         objs = taj.get("objects", [])
         left, right = taj.get("left", []), taj.get("right", [])

--- a/ros2_ws/src/kirra_safety/kirra_safety/perception_governor.py
+++ b/ros2_ws/src/kirra_safety/kirra_safety/perception_governor.py
@@ -297,7 +297,29 @@ class PerceptionGovernor(Node):
                 self._lateral_clearance
             ),
             "confidence_floor": self._floor,
+            # #1211 scan liveness. Publisher count can ONLY be obtained by
+            # inspecting the ROS graph, which the Taj sidecar (plain HTTP) cannot
+            # do — so this node, which holds the subscription, observes it and
+            # carries it as data. Taj reports `publisher_count_observed` so an
+            # omission is visible rather than silently read as zero.
+            "publisher_count": self._scan_publisher_count(),
         }
+
+    def _scan_publisher_count(self):
+        """Publishers currently advertising the scan topic, or None.
+
+        Zero publishers is a real, distinct fault (the driver died or never
+        started) and must reach Taj as 0. None means this rclpy build could not
+        tell us — reported as unobserved so the check is skipped rather than
+        firing on an unknown.
+        """
+        subscription = self._scan_subscription
+        if subscription is None:
+            return None
+        try:
+            return int(subscription.get_publisher_count())
+        except (AttributeError, TypeError, ValueError):
+            return None
 
     def _on_scan(self, msg: LaserScan) -> None:
         if self._session is None:


### PR DESCRIPTION
> #1222 proved the watchdog logic; nothing called it. A frozen LiDAR still drove the robot. This connects it.

**Stacked on #1222** — based on `claude/r2-sensor-watchdogs-1211`, so the diff here is the wiring commit alone. Merge #1222 first; this retargets to `main` automatically. Independent of #1221.

## The path

```
raw /scan observation
        ↓
liveness watchdog tick
        ↓
sensor-health reason / cap
        ↓
existing Taj perception result
        ↓
perception_cap composition (min — tighter always wins)
```

**Publisher count is observed where it can be.** The ROS subscriber holds the graph handle, so `perception_governor` reads `get_publisher_count()` and carries it as data. The HTTP sidecar cannot inspect a ROS graph and does not pretend to — no graph inspection was pushed into the Rust state machine. An absent count is reported as `publisher_count_observed: false` rather than read as zero, so the check is skipped on a fact the caller could not know instead of firing on one. Timestamp, fingerprint, valid-ray ratio and rate stay in the pure watchdog.

**Fingerprinting is imported, never reimplemented.** The freeze check's entire discrimination between a frozen buffer and a static scene rests on hashing raw IEEE bits; a second implementation in the sidecar would be free to quantise and silently destroy it.

## Ordering that carries weight

The tick runs **before** the duplicate-stamp short-circuit. A driver replaying one buffer produces exactly the duplicate case, so a tick placed after it would never see the freeze it exists to catch. The cached response served on that path gets this tick's verdict re-applied — otherwise a frozen driver is handed the healthy cap computed before it froze, which is the bug.

## Three problems that only appeared against the real system

These are the parts worth reviewing closely. None were visible from the pure module.

**1. Two consumers post the same scan.** `perception_governor` and `occy_doer` both subscribe to `/scan` and both POST what they receive, so every frame reaches this service twice — which is why the duplicate short-circuit already existed. Counting the second copy as a fresh observation trips the frozen-stamp check on a perfectly healthy robot. **This would have grounded the R2.**

A re-post is now observed as *an arrival carrying no new frame*. A frozen driver still fails closed, because it also produces no new frames: the silence budget expires and it surfaces as `SENSOR_NO_MESSAGES` — "nothing new arrived", which is precisely true of a driver replaying one buffer. Detection preserved, false positive removed. The trade is that `SENSOR_FROZEN_TIMESTAMP` is no longer reachable *from this call site*; the condition is still caught, under a different and equally accurate code.

**2. Diagnostics caused the fault they diagnosed.** `kirra_doctor`'s profile-digest probe, `inspect_corridor` and `rabbit_ask` all POST canned scans with a fixed `stamp_ms` on every run, and share service state with the live stream. Unflagged, running the doctor would trip `SENSOR_FROZEN_FRAME` and leave the real robot owing a recovery streak afterwards. They now set `diagnostic_probe`, which excludes them from liveness accounting.

The flag can only *decline to observe* — it never sets or clears a fault, and never relaxes a bound. It also does not mask silence: ten probes with no live frames between them is a genuine one-second outage and still faults.

**3. A fault left its own outage in the rate window.** The gap created *by* a fault kept the measured rate under the floor long after the sensor recovered, so recovery took "until the outage ages out of the window" rather than the configured streak — the sensor punished twice for one fault. A stream break now clears the window. A rate fault **keeps** its window, because that fault *is* the window's verdict and erasing the evidence would make a genuinely starved sensor oscillate between reporting the rate fault and reporting nothing measurable.

## Two deliberate scope choices

**Startup begins unavailable.** `WarmingUp` now caps (it did not in #1222). A sensor observed once has not evidenced that it publishes at a rate, and "publishes at all" is not "publishes at rate".

**The stateless `handle_perception` keeps the watchdog disarmed.** This is correctness, not a compatibility concession: liveness is a property of a *stream* — frozen stamps, repeated buffers and measured rate all mean "compared to the frames before this one". A one-shot call has no frames before it, so an armed watchdog there would assert a verdict from one sample with no continuity to derive it from, and would cap every caller forever. `sensor_liveness: "disarmed"` is the truthful answer for a single-shot evaluation.

## Digest and cache ordering

The evidence digest is computed **before** the verdict is stamped, and the cache stores the pre-verdict response.

The digest identifies the perception *evidence* — what the sensor showed and what Taj made of it. Liveness is a verdict about whether that evidence is *current*, which is orthogonal: the same scan bytes produce the same evidence whether they arrived first or third in a frozen run. Folding it in would make a frame's identity depend on the history of unrelated frames, changing what a downstream consumer binds commands to. Same line #1210 drew for the rejection tally. `kirra_doctor` reads `profile_digest` (request-derived), unaffected either way.

Caching pre-verdict matters for the duplicate path: a stale `Some(0.0)` baked into the cache would compose with `min` forever, so a transient fault would outlive itself.

## Armed by default here

Unlike the library default. `kirra_trajectory::sensor_watchdog` defaults off because it is a library with unknown consumers; this sidecar **is** the R2 deployment #1211 was filed about, and shipping the wiring disarmed would leave the failure exactly where the issue found it. The service logs which posture it started in.

`KIRRA_SENSOR_WATCHDOG_ENABLED=0` is the opt-out and the immediate mitigation if bring-up shows false trips before thresholds are characterised on hardware.

## Tests

13 end-to-end, all with injected scans and an injected clock — **no sleeps**, since wall-clock waits would make a timing gate's own tests the flakiest thing in CI. `handle_perception_tracked_at` takes the clock; the binary reads it.

Frozen stream floors the cap (with a precondition assertion that the stream was serving motion first, so the test cannot pass vacuously) · recovery takes the exact streak, floored for every frame before it · a healthy camera cannot lift the floor · the cached duplicate carries the verdict · two consumers stay healthy · probes cannot trip the freeze but cannot mask silence either · malformed scans land on the existing reason codes · a caller's bad `margin_m` is not charged to the sensor · disarmed is unchanged · the verdict stays out of the evidence digest.

One test caught a real distinction while being written: ten probes with no live frames between them *is* a one-second outage, and the watchdog was right to fault it. The test was wrong, not the code.

`cargo test --workspace` green · 292 ROS package tests · 414 robot tests · clippy clean on both changed crates (the one `kirra-sidecars` warning is pre-existing in `capabilities.rs`) · quality-guardrails, safety-constants, re-export-shim and mick-actuation-fence ratchets green.

## After this, #1211 can close

Remaining work is tracked separately, as agreed:

- udev / device identity binding
- camera watchdog parity
- hardware threshold tuning (the 5 Hz / 0.15 defaults are deliberately loose placeholders)
- the #1210 self-filter mount measurement and mask capture

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjDFKPcBVHURDZpXsvnYhC)_