### PR TITLE
ci(console): skip Vercel builds when console/ did not change

### DIFF
--- a/console/vercel-ignore-build.sh
+++ b/console/vercel-ignore-build.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+#
+# Vercel "Ignored Build Step" for the Kirra console.
+#
+#   EXIT 0  =>  SKIP the build.
+#   EXIT 1  =>  RUN the build.
+#
+# That is Vercel's convention, and it reads backwards from every other exit
+# code in this repository. Inverting it does not fail loudly — it either never
+# deploys the console again, or never saves a single build. If you change this
+# script, re-read those two lines first.
+#
+# ---------------------------------------------------------------------------
+# Why this exists
+#
+# This repository is overwhelmingly Rust. A typical pull request touches
+# crates/ and nothing else, yet every push rebuilds the Next.js console —
+# once per connected Vercel project. That is how the account reached its
+# build-rate limit while the changes under review contained no console code
+# at all.
+#
+# Vercel builds this project from the console/ Root Directory, so console/ is
+# the complete set of inputs. If nothing under it changed, the previous
+# deployment is already an accurate preview of the console at this commit and
+# rebuilding produces a byte-identical result at the cost of a build slot.
+#
+# ---------------------------------------------------------------------------
+# The fail-safe direction is BUILD, not SKIP
+#
+# Every uncertain case below exits 1. The two errors are not symmetric:
+#
+#   * Building unnecessarily costs a build slot. Visible, cheap, self-correcting.
+#   * Skipping a build that should have run leaves the previous deployment in
+#     place while the preview URL still resolves. A reviewer opens it, sees a
+#     page that looks current, and reviews code that was never deployed. The
+#     failure is silent and it looks like success.
+#
+# So this script only ever skips when it can positively demonstrate that
+# nothing under console/ changed. "I could not tell" means build.
+# ---------------------------------------------------------------------------
+
+set -u
+
+log() { echo "[vercel-ignore] $*"; }
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [ -z "$repo_root" ]; then
+    log "not a git checkout — cannot prove nothing changed, so building"
+    exit 1
+fi
+
+# Vercel clones shallowly. Without a parent commit there is no diff to take.
+if ! git -C "$repo_root" rev-parse --verify --quiet 'HEAD^' >/dev/null 2>&1; then
+    log "no parent commit in this checkout (shallow clone or root commit) — building"
+    exit 1
+fi
+
+# Resolved from the repo root rather than the current directory, so the answer
+# does not depend on which directory Vercel happens to invoke this from.
+if git -C "$repo_root" diff --quiet 'HEAD^' 'HEAD' -- console; then
+    log "no changes under console/ between HEAD^ and HEAD — skipping build"
+    exit 0
+fi
+
+log "console/ changed between HEAD^ and HEAD — building"
+exit 1
+
+# ---------------------------------------------------------------------------
+# A note on the obvious objection
+#
+# This compares HEAD against its parent, not against the base branch. On a
+# branch whose first commit changed console/ and whose later commits did not,
+# the later pushes skip — and that is correct rather than a gap. Vercel built
+# the earlier commit, and since console/ has not changed since, that existing
+# deployment IS the current console for this branch. The preview URL stays
+# accurate.
+#
+# The one case it does not cover: if that earlier build failed or was itself
+# skipped, later pushes will keep skipping until something under console/
+# changes again. Re-run the deployment from the Vercel dashboard if you land
+# there. Widening this to diff against the base branch would fix it, but the
+# base ref is not reliably available to an ignore step, and guessing it wrong
+# fails in the silent direction this script is written to avoid.
+# ---------------------------------------------------------------------------

--- a/console/vercel.json
+++ b/console/vercel.json
@@ -1,0 +1,3 @@
+{
+  "ignoreCommand": "bash ./vercel-ignore-build.sh"
+}


### PR DESCRIPTION
> The three watchdog PRs contained no console code and still triggered seven console builds each. That is how the account hit its build-rate limit and started reporting failures on diffs Vercel never looked at.

Two files, no application code. Independent of #1221 / #1222 / #1223.

## What it does

Adds a Vercel **Ignored Build Step**: if nothing under `console/` changed between `HEAD^` and `HEAD`, skip the build.

Vercel builds this project from the `console/` Root Directory, so `console/` is the complete set of build inputs — verified, there are no `../` references and no workspace linkage into the Rust tree. When nothing under it changed, the existing deployment already *is* an accurate preview of the console at this commit; rebuilding produces the same output and spends a build slot to do it.

## Two things worth reading closely

**The exit-code convention is inverted.** `0` skips, `1` builds. That is Vercel's, not mine, and it reads backwards from every other exit code in the repo. Getting it wrong fails silently in *both* directions — invert it and you either never deploy the console again, or never save a single build. The script says exactly that in its first six lines, before anything else.

**Uncertainty always builds.** The two errors are not symmetric:

- An unnecessary build costs a slot. Visible, cheap, self-correcting.
- A skipped build that should have run leaves the previous deployment in place *while the preview URL still resolves*. A reviewer opens it, sees a page that looks current, and reviews code that was never deployed. Silent, and it looks like success.

So the script skips only when it can positively demonstrate `console/` is unchanged. A non-git checkout, a missing parent commit, or a shallow clone all build. "I could not tell" means build.

## Verified against the real repository

Not reasoned about — run.

| Case | Exit | Result |
|---|---|---|
| Commit touching `console/` | 1 | BUILD |
| Rust-only commit | 0 | SKIP |
| Invoked from repo root instead of `console/` | 0 | SKIP (same answer — cwd-independent) |
| Shallow clone, no reachable parent | 1 | BUILD (fail-safe) |
| Script missing entirely | 127 | BUILD (fail-safe) |

The shallow-clone case is not hypothetical: this container's clone is shallow, which is also what Vercel does, and the guard caught it. The positive case had to be built synthetically because no console-touching commit has its parent available locally.

## The obvious objection, and why it holds

This compares against `HEAD^`, not the base branch. On a branch whose first commit changed `console/` and whose later commits did not, the later pushes skip — and that is correct, not a gap: Vercel built the earlier commit, `console/` has not changed since, so that deployment *is* the current console for the branch and the preview URL stays accurate.

The one case it does not cover is an earlier build that failed or was itself skipped; later pushes then keep skipping until `console/` changes again. Re-run from the dashboard if you land there. Diffing against the base branch would close it, but the base ref is not reliably available to an ignore step and guessing it wrong fails in the silent direction this script exists to avoid.

## What this does not fix

The duplicate projects. **Seven** Vercel projects are connected to this repo, all with the same `console/` root:

`kirra-runtime-sdk` · `-1vdc` · `-f35q` · `-og6p` · `-hdy4` · `-tgo8` · `-5lt3`

That is dashboard-side state this repository cannot reach, and no repo-side config can single one out — all seven read the same `vercel.json`. Consolidating to one is still worth doing; check which project owns the production domain first, since the suffixed names are Vercel's collision-avoidance naming and the survivor may not be the unsuffixed one. This change cuts the per-push cost for all seven in the meantime.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjDFKPcBVHURDZpXsvnYhC)_