### PR TITLE
feat(taj): migrate cap-stabilization authority to the checker

### DIFF
--- a/crates/kirra-sidecars/src/taj.rs
+++ b/crates/kirra-sidecars/src/taj.rs
@@ -795,8 +795,14 @@ pub struct PerceptionResponse {
     /// it.
     pub stabilized_speed_cap_mps: f64,
     /// Why the stabilizer produced this value (`CAP_RESTRICTED`, `CAP_RISING`,
-    /// `CAP_TIME_GAP`, …), or `None` when stabilization did not run for this
-    /// request (stateless call, diagnostic probe, or a rejected frame).
+    /// `CAP_TIME_GAP`, `CAP_REPLAY_HELD`, …).
+    ///
+    /// `None` means **this sidecar performed no stabilization at all** — a stateless
+    /// call or a build that does not stabilize. It is a statement about the
+    /// authority that produced `speed_cap_mps`, not about the outcome, which is why
+    /// a consumer may treat it as unusable and fail closed. Every path where the
+    /// stabilizer DID author the number carries a code, including a replay of a cap
+    /// it is holding from an earlier frame.
     pub cap_reason: Option<&'static str>,
     /// Consecutive clear frames accumulated toward a release.
     pub cap_clear_streak: u32,
@@ -999,6 +1005,48 @@ fn is_forward_object_candidate(
         && y_m.abs() <= lane_half_m
         && y_m.atan2(x_m).abs() <= MAX_FORWARD_OBJECT_BEARING_RAD
 }
+
+/// Pick the nearest `(id, distance)` candidate, or `None` when none is usable.
+///
+/// Extracted from the perception path so the ordering is testable on its own. It has
+/// two properties the caller depends on and neither is obvious from the call site:
+///
+/// **Non-finite distances are dropped BEFORE the comparison**, not after a winner is
+/// chosen. The ordering below is a total order over finite values only; a NaN reaching
+/// it compares `false` against every candidate and therefore WINS every match arm.
+/// Filtering afterwards would discard that winner and report no nearest object at all
+/// — so one malformed distance would hide every real obstacle in the frame. Today the
+/// caller's inputs are already proven finite (`is_forward_object_candidate` rejects a
+/// non-finite `x`, and the near-edge lookup is finite-filtered), which is exactly why
+/// the guard belongs here: the invariant lives with the code that needs it rather than
+/// depending on two callers upstream continuing to hold it.
+///
+/// **Ties break on the lower id, compared exactly.** Two objects at an identical
+/// distance must not alternate the reported identity frame to frame — to the
+/// stabilizer's limiting-object persistence that alternation is indistinguishable from
+/// a dropout. The comparison is never epsilon-based: an approximate "near enough"
+/// predicate is not transitive, so a three-candidate frame could order inconsistently
+/// depending on iteration order. Two distances differing in the last bit are two
+/// distances, and the nearer one wins.
+#[must_use]
+fn nearest_candidate(candidates: impl Iterator<Item = (u64, f64)>) -> Option<(u64, f64)> {
+    candidates
+        .filter(|(_, d)| d.is_finite())
+        .fold(None::<(u64, f64)>, |acc, (id, d)| match acc {
+            Some((bid, bd)) if bd < d || (bd == d && bid <= id) => Some((bid, bd)),
+            _ => Some((id, d)),
+        })
+}
+
+/// `cap_reason` for a cap served WITHOUT the stabilizer observing the frame — a
+/// duplicate re-post, served the value the stabilizer is currently holding.
+///
+/// Sidecar-local rather than a [`kirra_trajectory::cap_stabilizer::CapReason`]
+/// variant, because it is not a decision the stabilizer made. The stabilizer never
+/// saw this frame; the sidecar chose not to show it one. Putting it in the checker's
+/// enum would oblige every consumer of that enum to reason about a state the state
+/// machine cannot enter.
+const CAP_REPLAY_HELD: &str = "CAP_REPLAY_HELD";
 
 const MAX_TRACKING_GAP_MS: u64 = 500;
 
@@ -1620,29 +1668,32 @@ pub fn handle_perception_tracked_at(
     // lets a cap transition be logged as "held at 0.8 by object 41" instead of an
     // unattributable number, and it is what the stabilizer's limiting-object
     // persistence keys on across a detection dropout.
-    let nearest = perception
-        .objects
-        .iter()
-        .filter(|o| {
-            is_forward_object_candidate(o.pos.x_m, o.pos.y_m, req.forward_extent_m, req.lane_half_m)
-        })
-        .map(|o| {
-            let d = near_edge_of
-                .get(&o.id)
-                .copied()
-                .filter(|edge: &f64| edge.is_finite())
-                .map_or(o.pos.x_m, |edge: f64| edge.min(o.pos.x_m));
-            (o.id, d)
-        })
-        // Deterministic on ties: the lower id wins, so two objects at an identical
-        // distance do not alternate the reported identity frame to frame — which
-        // would look exactly like a dropout to the persistence logic.
-        .fold(None::<(u64, f64)>, |acc, (id, d)| match acc {
-            Some((bid, bd)) if bd < d || (bd == d && bid <= id) => Some((bid, bd)),
-            _ => Some((id, d)),
-        });
+    let nearest = nearest_candidate(
+        perception
+            .objects
+            .iter()
+            .filter(|o| {
+                is_forward_object_candidate(
+                    o.pos.x_m,
+                    o.pos.y_m,
+                    req.forward_extent_m,
+                    req.lane_half_m,
+                )
+            })
+            .map(|o| {
+                let d = near_edge_of
+                    .get(&o.id)
+                    .copied()
+                    .filter(|edge: &f64| edge.is_finite())
+                    .map_or(o.pos.x_m, |edge: f64| edge.min(o.pos.x_m));
+                (o.id, d)
+            }),
+    );
+    // One Option, destructured — the identity and the distance are the same fact and
+    // must not be able to disagree. A `Some` id beside a `None` distance would name an
+    // object bounding a cap that reports nothing bounding it.
     let nearest_object_id = nearest.map(|(id, _)| id);
-    let nearest_object_m = nearest.map(|(_, d)| d).filter(|d| d.is_finite());
+    let nearest_object_m = nearest.map(|(_, d)| d);
 
     // Clear distance = the tighter of the corridor reach and the nearest
     // in-lane object.
@@ -1840,10 +1891,16 @@ fn apply_cap_stabilization(
     now_ms: u64,
 ) {
     // The stabilizer observes the LIVENESS-ADJUSTED cap (zero on a sensor fault),
-    // which is what makes a fault behave like a hazard. `raw_speed_cap_mps` keeps
-    // perception's own number, set when the response was built — three distinct
-    // values matter to an operator (what perception saw, what liveness allowed,
-    // what is enforced) and collapsing the first two would hide which one bound.
+    // which is what makes a fault behave like a hazard.
+    //
+    // Two numbers reach the wire: `raw_speed_cap_mps` — perception's own proposal,
+    // set when the response was built and NOT overwritten here — and the enforced
+    // stabilized cap. The liveness-adjusted value in between is not carried as a
+    // third field; it is recoverable from `sensor_fault` / `sensor_liveness`, which
+    // say whether liveness floored the cap and why. Carrying perception's proposal
+    // is the part that matters: without it a consumer cannot tell a real hazard from
+    // a filter still climbing, which is precisely how the Python version's behaviour
+    // became invisible.
     let observed = response.speed_cap_mps;
     let decision = stabilizer.observe(CapObservation {
         raw_cap_mps: observed,
@@ -1876,8 +1933,21 @@ fn apply_cap_without_observing(response: &mut PerceptionResponse, stabilizer: &C
     let held = stabilizer.stabilized_cap_mps().min(observed);
     response.stabilized_speed_cap_mps = held;
     response.speed_cap_mps = held;
-    response.cap_reason = None;
+    // A replay is still a stabilizer-authored number, so it is stamped as one — with
+    // its own code, because "the stabilizer evaluated this frame and passed it" and
+    // "the stabilizer never saw this frame and is holding" are different facts and a
+    // consumer deciding whether to enforce needs to tell them apart.
+    //
+    // It is NOT left as `None`. A consumer that fail-closes on a missing reason (the
+    // ROS relay does) would floor a duplicate to zero, and a two-node deployment
+    // where the second node re-posts would then stutter between the held cap and
+    // zero on identical perception. Absent-reason must keep meaning "this sidecar
+    // does not stabilize", which is the case the relay exists to refuse.
+    response.cap_reason = Some(CAP_REPLAY_HELD);
     response.cap_clear_streak = stabilizer.clear_streak();
+    // The identity travels with the number. Reporting the held cap while clearing the
+    // limiting object would describe a cap held against nothing.
+    response.cap_limiting_object = stabilizer.limiting_object();
     if held < observed {
         response.healthy = false;
     }
@@ -3884,5 +3954,313 @@ mod cap_authority_tests {
             r.speed_cap_mps, r.raw_speed_cap_mps,
             "the served cap is perception's own, unfiltered"
         );
+    }
+
+    /// A duplicate frame is served the cap the stabilizer is HOLDING, and says so.
+    ///
+    /// The reason is not left absent. A consumer that fail-closes on a missing reason
+    /// — the ROS relay does, deliberately, so an unstabilized sidecar cannot pass its
+    /// raw cap off as stabilized — would floor every duplicate to zero, and a
+    /// two-node deployment where the second node re-posts would stutter between the
+    /// held cap and a stop on identical perception.
+    #[test]
+    fn a_replayed_frame_reports_a_held_cap_as_a_held_cap() {
+        let mut st = state();
+        let (seq, now) = warm(&mut st, 0, 0);
+
+        let scan = live_scan(seq + 1, 6.0);
+        let first = handle_perception_tracked_at(&scan, &mut st, now + 100);
+        assert!(first.speed_cap_mps > 0.0, "precondition: a cap was earned");
+
+        // The same frame again, from a second consumer.
+        let replay = handle_perception_tracked_at(&scan, &mut st, now + 110);
+        assert_eq!(
+            replay.cap_reason,
+            Some("CAP_REPLAY_HELD"),
+            "a replay is stabilizer-authored and must claim authorship"
+        );
+        assert_eq!(
+            replay.speed_cap_mps, replay.stabilized_speed_cap_mps,
+            "the served number is the stabilized one"
+        );
+        assert!(
+            replay.speed_cap_mps <= first.speed_cap_mps,
+            "a replay must never climb: {} > {}",
+            replay.speed_cap_mps,
+            first.speed_cap_mps
+        );
+    }
+
+    /// A replay reports the limiting object along with the cap it is holding.
+    ///
+    /// Serving the held number while clearing the identity describes a cap held
+    /// against nothing — which reads as an open corridor, the opposite of the truth,
+    /// to anything that attributes the restriction.
+    #[test]
+    fn a_replay_carries_the_limiting_identity_with_the_number() {
+        let mut st = state();
+        let (seq, now) = warm(&mut st, 0, 0);
+
+        // A blob close enough to bind the clear distance rather than the corridor.
+        let scan = live_scan(seq + 1, 1.2);
+        let first = handle_perception_tracked_at(&scan, &mut st, now + 100);
+        let held = first.cap_limiting_object;
+        assert!(
+            held.is_some(),
+            "precondition: an object bound the cap, got {held:?}"
+        );
+
+        let replay = handle_perception_tracked_at(&scan, &mut st, now + 110);
+        assert_eq!(
+            replay.cap_limiting_object, held,
+            "the identity travels with the number it explains"
+        );
+    }
+
+    /// Gate: the whole authority boundary, walked as ONE sequence rather than as
+    /// separate assertions about separate stages.
+    ///
+    /// The claim under test is not any single transition — it is that across a run
+    /// containing a warm-up, a climb, a hazard, a recovery and a replay, the number
+    /// on the wire is ALWAYS the checker's and never perception's. A per-stage test
+    /// can pass while the composition leaks: one path that forgets to stabilize, or
+    /// one that stamps `speed_cap_mps` after the stabilizer ran, would be invisible
+    /// to every test that only looks at its own stage.
+    #[test]
+    fn the_checker_owns_the_served_cap_across_the_whole_sequence() {
+        let mut st = state();
+        let mut now = 0u64;
+        let mut seq = 0u32;
+        let mut ever_below_raw = false;
+        let mut steps = 0usize;
+
+        // Warm-up, climb, a hazard, a recovery — then the last frame served twice.
+        let mut plan: Vec<f64> = Vec::new();
+        plan.extend(std::iter::repeat_n(6.0, 20)); // warm + climb
+        plan.push(0.4); // a hazard arrives
+        plan.extend(std::iter::repeat_n(6.0, 12)); // and clears
+
+        let check = |r: &PerceptionResponse, steps: &mut usize, ever_below_raw: &mut bool| {
+            assert_eq!(
+                r.speed_cap_mps, r.stabilized_speed_cap_mps,
+                "the enforced number must be the stabilized one at every step"
+            );
+            assert!(
+                r.speed_cap_mps <= r.raw_speed_cap_mps + 1e-9,
+                "the checker may only tighten perception's proposal: {} > {}",
+                r.speed_cap_mps,
+                r.raw_speed_cap_mps
+            );
+            assert!(
+                r.cap_reason.is_some(),
+                "every frame the stabilizer authored carries its authorship claim"
+            );
+            *steps += 1;
+            if r.speed_cap_mps < r.raw_speed_cap_mps {
+                *ever_below_raw = true;
+            }
+        };
+
+        let mut last = None;
+        for x in plan {
+            now += 100;
+            seq += 1;
+            let scan = live_scan(seq, x);
+            let r = handle_perception_tracked_at(&scan, &mut st, now);
+            check(&r, &mut steps, &mut ever_below_raw);
+            last = Some(scan);
+        }
+
+        // The replay path is part of the boundary, not a separate feature: a second
+        // consumer asking about a frame already served must get the same answer under
+        // the same authority, not an unstabilized one.
+        let replay = handle_perception_tracked_at(&last.expect("plan ran"), &mut st, now + 10);
+        check(&replay, &mut steps, &mut ever_below_raw);
+        assert_eq!(replay.cap_reason, Some("CAP_REPLAY_HELD"));
+
+        assert_eq!(steps, 34, "the whole sequence ran, including the replay");
+        // Non-vacuity: if the stabilized cap had merely tracked the raw one the whole
+        // way, every assertion above would hold while nothing was being stabilized.
+        assert!(
+            ever_below_raw,
+            "the stabilized cap must actually differ from the raw one somewhere, \
+             or this test proves nothing"
+        );
+    }
+
+    /// Gate: liveness recovery and cap release COMPOSE, and the composite latency is
+    /// bounded rather than open-ended.
+    ///
+    /// Two independent gates stand between a recovered sensor and a moving robot: the
+    /// watchdog's healthy-frame streak, and the stabilizer's clear confirmations plus
+    /// bounded rise. Neither alone is the answer an integrator needs. This pins the
+    /// composite: nothing is served before BOTH are satisfied, and the wait does
+    /// terminate.
+    #[test]
+    fn liveness_recovery_and_cap_release_compose_to_a_bounded_latency() {
+        let mut st = state();
+        let (mut seq, mut now) = warm(&mut st, 0, 0);
+        let earned = handle_perception_tracked_at(&live_scan(seq + 1, 6.0), &mut st, now + 100)
+            .speed_cap_mps;
+        seq += 1;
+        now += 100;
+        assert!(earned > 0.0, "precondition: the robot was moving");
+
+        // A silence long past the watchdog's budget: the sensor stops, then returns.
+        now += 5_000;
+        let faulted = {
+            seq += 1;
+            handle_perception_tracked_at(&live_scan(seq, 6.0), &mut st, now)
+        };
+        assert_eq!(
+            faulted.speed_cap_mps, 0.0,
+            "a liveness fault floors the cap immediately"
+        );
+
+        // Now feed clean frames and find the first that serves motion again.
+        let mut frames_to_move = None;
+        for i in 1..=200 {
+            now += 100;
+            seq += 1;
+            let r = handle_perception_tracked_at(&live_scan(seq, 6.0), &mut st, now);
+            if r.speed_cap_mps > 0.0 {
+                assert_eq!(
+                    r.sensor_liveness, "healthy",
+                    "motion was served while liveness was still {}",
+                    r.sensor_liveness
+                );
+                frames_to_move = Some(i);
+                break;
+            }
+        }
+
+        let frames = frames_to_move.expect("recovery must terminate, not stall forever");
+        // The composite is at least the liveness streak: the cap cannot begin to
+        // climb while the watchdog is still floor-capping every frame.
+        let streak = SensorWatchdogConfig::r2_lidar().recovery_streak;
+        assert!(
+            frames >= streak,
+            "motion returned in {frames} frames, before the {streak}-frame liveness \
+             streak could complete — the two gates are not composing"
+        );
+        // …and it is bounded. Measured at 17 frames — 1.7 s at the 10 Hz this feeds:
+        // roughly 0.5 s of liveness streak, then the stabilizer's confirmations and
+        // its bounded climb off the floor. That figure is what an integrator needs
+        // and neither gate produces on its own. The bound is a regression pin, not a
+        // specification: a change that doubles the wait should be a deliberate one.
+        assert!(
+            frames <= 25,
+            "recovery took {frames} frames (measured 17); if this is intended, move \
+             the bound and say why"
+        );
+    }
+}
+
+#[cfg(test)]
+mod nearest_candidate_tests {
+    //! The nearest-object ordering, tested directly. Driving these cases through a
+    //! synthetic scan is possible but proves less: the scan generator cannot produce
+    //! a NaN distance or two bit-adjacent ones on demand, which are exactly the
+    //! cases where an ordering stops being total.
+
+    use super::nearest_candidate;
+
+    fn pick(items: &[(u64, f64)]) -> Option<(u64, f64)> {
+        nearest_candidate(items.iter().copied())
+    }
+
+    #[test]
+    fn no_candidates_yields_none() {
+        assert_eq!(pick(&[]), None);
+    }
+
+    #[test]
+    fn the_nearest_wins() {
+        assert_eq!(pick(&[(7, 4.0), (3, 1.5), (9, 2.5)]), Some((3, 1.5)));
+    }
+
+    /// A NaN distance must not win, and — the part that matters — must not take the
+    /// other candidates down with it.
+    ///
+    /// The ordering compares `false` in both directions against NaN, so a NaN reaching
+    /// the fold wins every arm. Dropping it afterwards would then report NO nearest
+    /// object, and a real obstacle two metres ahead would be excluded from the clear
+    /// distance entirely. The filter runs first for exactly this reason.
+    #[test]
+    fn a_nan_distance_does_not_mask_a_real_object() {
+        assert_eq!(pick(&[(1, f64::NAN), (2, 2.0)]), Some((2, 2.0)));
+        assert_eq!(pick(&[(2, 2.0), (1, f64::NAN)]), Some((2, 2.0)));
+        assert_eq!(pick(&[(1, f64::NAN)]), None, "nothing usable is None");
+    }
+
+    #[test]
+    fn infinite_distances_are_not_candidates() {
+        assert_eq!(pick(&[(1, f64::INFINITY), (2, 3.0)]), Some((2, 3.0)));
+        assert_eq!(pick(&[(1, f64::NEG_INFINITY), (2, 3.0)]), Some((2, 3.0)));
+    }
+
+    /// Exact ties break on the lower id, whichever order they arrive in. An
+    /// order-dependent tie-break would alternate the reported identity frame to
+    /// frame, which the stabilizer's persistence cannot tell from a dropout.
+    #[test]
+    fn an_exact_tie_breaks_on_the_lower_id_in_either_order() {
+        assert_eq!(pick(&[(9, 2.0), (4, 2.0)]), Some((4, 2.0)));
+        assert_eq!(pick(&[(4, 2.0), (9, 2.0)]), Some((4, 2.0)));
+    }
+
+    /// Distances that differ only in the last bit are two distances, not a tie. The
+    /// nearer wins on its own merit and the id is not consulted — which is what makes
+    /// the ordering total. An epsilon-based "close enough" predicate would call these
+    /// equal, and equality that is not transitive orders a three-element set
+    /// differently depending on which pair is compared first.
+    #[test]
+    fn bit_adjacent_distances_are_ordered_not_tied() {
+        let near = 2.0_f64;
+        let far = f64::from_bits(near.to_bits() + 1);
+        assert!(near < far, "precondition: the two differ");
+        // The HIGHER id is nearer, so an epsilon that swallowed the difference would
+        // hand this to the lower id and the assertion would catch it.
+        assert_eq!(pick(&[(1, far), (9, near)]), Some((9, near)));
+        assert_eq!(pick(&[(9, near), (1, far)]), Some((9, near)));
+    }
+
+    /// A duplicate id is not a contradiction to resolve, it is two readings. The
+    /// nearer one is kept; on an exact tie the first is kept, so a duplicate cannot
+    /// make the result depend on how many times it appears.
+    #[test]
+    fn duplicate_ids_keep_the_nearer_reading() {
+        assert_eq!(pick(&[(5, 3.0), (5, 1.0)]), Some((5, 1.0)));
+        assert_eq!(pick(&[(5, 1.0), (5, 3.0)]), Some((5, 1.0)));
+        assert_eq!(pick(&[(5, 2.0), (5, 2.0)]), Some((5, 2.0)));
+    }
+
+    /// Zero and negative distances are real readings (an object at or behind the
+    /// sensor origin) and must be ordered, not discarded. Discarding them would drop
+    /// the single most urgent case.
+    #[test]
+    fn zero_and_negative_distances_are_ordered_not_dropped() {
+        assert_eq!(pick(&[(1, 1.0), (2, 0.0)]), Some((2, 0.0)));
+        assert_eq!(pick(&[(1, 0.0), (2, -0.5)]), Some((2, -0.5)));
+    }
+
+    /// The ordering is a total order: every permutation of the same set yields the
+    /// same winner. This is the property an epsilon comparison would break, and it is
+    /// invisible in any test that only ever feeds one ordering.
+    #[test]
+    fn every_permutation_of_a_set_yields_the_same_winner() {
+        let base = [(3, 2.0), (1, 2.0), (7, 1.25), (5, f64::NAN), (2, 9.0)];
+        let expected = pick(&base);
+        assert_eq!(expected, Some((7, 1.25)), "precondition");
+
+        let mut items = base;
+        // Every rotation, and every rotation reversed — enough orderings that a
+        // fold-order dependency shows up.
+        for _ in 0..items.len() {
+            items.rotate_left(1);
+            assert_eq!(pick(&items), expected, "rotation {items:?}");
+            let mut rev = items;
+            rev.reverse();
+            assert_eq!(pick(&rev), expected, "reversed {rev:?}");
+        }
     }
 }

--- a/crates/kirra-sidecars/src/taj.rs
+++ b/crates/kirra-sidecars/src/taj.rs
@@ -10,6 +10,7 @@
 //! `speed_cap_mps: 0.0` (the MRC floor — the consumer holds).
 
 use kirra_core::corridor::CorridorSource;
+use kirra_trajectory::cap_stabilizer::{CapObservation, CapStabilizer, CapStabilizerConfig};
 use kirra_trajectory::sensor_watchdog::{
     fingerprint_from_ranges, FrameObservation, SensorHealth, SensorTick, SensorWatchdog,
     SENSOR_WATCHDOG_ENABLED_ENV,
@@ -383,6 +384,13 @@ fn invalid_perception_response(camera_armed: bool, health: SensorHealth) -> Perc
         sensor_fault: None,
         sensor_measured_hz: None,
         publisher_count_observed: false,
+        // A refused request produced no perception, so there is no raw cap to
+        // report and nothing was stabilized. Zero is the enforced value either way.
+        raw_speed_cap_mps: 0.0,
+        stabilized_speed_cap_mps: 0.0,
+        cap_reason: None,
+        cap_clear_streak: 0,
+        cap_limiting_object: None,
         // A refused request never reached ingest, so nothing was discarded —
         // as distinct from "discarded nothing", which this shape cannot
         // express. The frame is already marked unhealthy with a zero cap.
@@ -776,6 +784,26 @@ pub struct PerceptionResponse {
     /// the publisher check did not run for this frame because the caller had no
     /// ROS graph to observe — surfaced so the gap is visible, never silent.
     pub publisher_count_observed: bool,
+    /// #1212: the assured-clear-distance cap **as perception computed it**, before
+    /// temporal stabilization. Observability only — `speed_cap_mps` is the enforced
+    /// number. Carried separately because conflating the two is how the Python
+    /// version's behaviour became invisible: a consumer that only ever saw one
+    /// number could not tell a hazard from a filter still catching up.
+    pub raw_speed_cap_mps: f64,
+    /// The stabilized cap the checker enforces. Always equal to `speed_cap_mps`;
+    /// named explicitly so the wire is unambiguous about which authority produced
+    /// it.
+    pub stabilized_speed_cap_mps: f64,
+    /// Why the stabilizer produced this value (`CAP_RESTRICTED`, `CAP_RISING`,
+    /// `CAP_TIME_GAP`, …), or `None` when stabilization did not run for this
+    /// request (stateless call, diagnostic probe, or a rejected frame).
+    pub cap_reason: Option<&'static str>,
+    /// Consecutive clear frames accumulated toward a release.
+    pub cap_clear_streak: u32,
+    /// The object currently holding the cap down, including one retained through a
+    /// single-scan dropout. `None` when the corridor geometry binds rather than an
+    /// object, or when nothing limits.
+    pub cap_limiting_object: Option<u64>,
     /// Per-reason accounting for the lidar returns this frame discarded
     /// (#1210) — the operator-facing half of the self-filter.
     ///
@@ -993,6 +1021,18 @@ pub struct TrackedPerceptionState {
     /// alongside the tracker would let a frozen driver launder its record by
     /// tripping a tracker reset each time it stalled.
     watchdog: SensorWatchdog,
+    /// #1212 cap stabilizer. Like the watchdog, deliberately OUTSIDE [`Self::reset`]:
+    /// a tracking reset is a discontinuity in object identity, not evidence that the
+    /// speed envelope may be relaxed. Clearing the stabilizer here would let a
+    /// tracker reset hand back an unearned cap.
+    stabilizer: CapStabilizer,
+    /// Whether cap stabilization runs. Off only for the stateless entry point, for
+    /// the same reason the watchdog is off there: stabilization is a property of a
+    /// STREAM — a restriction is "tighter than the last frame", a release is "clear
+    /// for N frames". A one-shot call has no previous frame, so an armed stabilizer
+    /// would hold every caller at the floor forever while asserting a temporal
+    /// judgement it has no history to make.
+    stabilize: bool,
 }
 
 impl Default for TrackedPerceptionState {
@@ -1021,6 +1061,19 @@ impl TrackedPerceptionState {
     /// report the error; this constructor is for statically-known configs.
     #[must_use]
     pub fn with_watchdog(cfg: SensorWatchdogConfig, armed: bool) -> Self {
+        Self::with_options(cfg, armed, true)
+    }
+
+    /// State with independent control of the liveness watchdog and cap
+    /// stabilization. They are separate concerns — one asks whether the sensor is
+    /// alive, the other how fast the envelope may change — so a deployment that
+    /// disables one must not silently disable the other.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `cfg` fails validation; see [`Self::with_watchdog`].
+    #[must_use]
+    pub fn with_options(cfg: SensorWatchdogConfig, armed: bool, stabilize: bool) -> Self {
         Self {
             tracker: None,
             tracker_config: None,
@@ -1031,6 +1084,9 @@ impl TrackedPerceptionState {
             last_camera_stamp_ms: None,
             tracker_generation: 0,
             watchdog: SensorWatchdog::new(cfg, armed).expect("watchdog config must be valid"),
+            stabilizer: CapStabilizer::new(CapStabilizerConfig::default())
+                .expect("the default stabilizer config is valid"),
+            stabilize,
         }
     }
 
@@ -1246,7 +1302,8 @@ pub fn handle_perception(req: &PerceptionRequest) -> PerceptionResponse {
     // `sensor_liveness: "disarmed"` is the truthful answer for a one-shot
     // evaluation. Callers that need liveness must hold state, which is what the
     // service does.
-    let mut state = TrackedPerceptionState::with_watchdog(SensorWatchdogConfig::r2_lidar(), false);
+    let mut state =
+        TrackedPerceptionState::with_options(SensorWatchdogConfig::r2_lidar(), false, false);
     handle_perception_tracked(req, &mut state)
 }
 
@@ -1405,6 +1462,9 @@ pub fn handle_perception_tracked_at(
             let mut response = response.clone();
             response.sensor_measured_hz = state.watchdog.measured_hz();
             apply_sensor_health(&mut response, health, req.publisher_count.is_some());
+            if state.stabilize {
+                apply_cap_without_observing(&mut response, &state.stabilizer);
+            }
             return response;
         }
 
@@ -1556,21 +1616,33 @@ pub fn handle_perception_tracked_at(
     // and in-lane is unchanged; only the DISTANCE to a counted object tightens.
     let near_edge_of: std::collections::BTreeMap<u64, f64> =
         perception.near_edge_x_m.iter().copied().collect();
-    let nearest_object_m = perception
+    // #1212: track WHICH object is nearest, not just how near. The identity is what
+    // lets a cap transition be logged as "held at 0.8 by object 41" instead of an
+    // unattributable number, and it is what the stabilizer's limiting-object
+    // persistence keys on across a detection dropout.
+    let nearest = perception
         .objects
         .iter()
         .filter(|o| {
             is_forward_object_candidate(o.pos.x_m, o.pos.y_m, req.forward_extent_m, req.lane_half_m)
         })
         .map(|o| {
-            near_edge_of
+            let d = near_edge_of
                 .get(&o.id)
                 .copied()
                 .filter(|edge: &f64| edge.is_finite())
-                .map_or(o.pos.x_m, |edge: f64| edge.min(o.pos.x_m))
+                .map_or(o.pos.x_m, |edge: f64| edge.min(o.pos.x_m));
+            (o.id, d)
         })
-        .fold(f64::INFINITY, f64::min);
-    let nearest_object_m = nearest_object_m.is_finite().then_some(nearest_object_m);
+        // Deterministic on ties: the lower id wins, so two objects at an identical
+        // distance do not alternate the reported identity frame to frame — which
+        // would look exactly like a dropout to the persistence logic.
+        .fold(None::<(u64, f64)>, |acc, (id, d)| match acc {
+            Some((bid, bd)) if bd < d || (bd == d && bid <= id) => Some((bid, bd)),
+            _ => Some((id, d)),
+        });
+    let nearest_object_id = nearest.map(|(id, _)| id);
+    let nearest_object_m = nearest.map(|(_, d)| d).filter(|d| d.is_finite());
 
     // Clear distance = the tighter of the corridor reach and the nearest
     // in-lane object.
@@ -1704,6 +1776,11 @@ pub fn handle_perception_tracked_at(
         sensor_fault: None,
         sensor_measured_hz: None,
         publisher_count_observed: false,
+        raw_speed_cap_mps: speed_cap_mps,
+        stabilized_speed_cap_mps: speed_cap_mps,
+        cap_reason: None,
+        cap_clear_streak: 0,
+        cap_limiting_object: None,
         rejected: perception.rejected.into(),
     };
 
@@ -1730,7 +1807,80 @@ pub fn handle_perception_tracked_at(
 
     response.sensor_measured_hz = state.watchdog.measured_hz();
     apply_sensor_health(&mut response, health, req.publisher_count.is_some());
+
+    // Stabilize LAST, over the liveness-adjusted cap.
+    //
+    // The ordering is the point. `apply_sensor_health` floors the cap to zero on a
+    // sensor fault, and feeding that zero through the stabilizer as the raw
+    // observation makes a liveness fault behave exactly like a hazard: restrict
+    // instantly, then re-earn the full streak on recovery. That is what the Python
+    // did with `effective_raw_cap = 0.0 if not healthy`, and it is the composition
+    // that keeps a blinking sensor from ratcheting the robot back up to speed
+    // between faults.
+    //
+    // The limiting object is reported only when an OBJECT bound the clear distance.
+    // When the corridor geometry is the tighter constraint there is no object to
+    // name, and inventing one would make the persistence logic hold a cap against a
+    // hazard that never existed.
+    let limiting =
+        nearest_object_id.filter(|_| nearest_object_m.is_some_and(|d| d <= corridor_reach_m));
+    if state.stabilize {
+        apply_cap_stabilization(&mut response, &mut state.stabilizer, limiting, now_ms);
+    }
     response
+}
+
+/// Run the stabilizer over a response's already-liveness-adjusted cap and stamp the
+/// result. `speed_cap_mps` becomes the stabilized value — the enforced number — with
+/// the pre-stabilization value preserved on `raw_speed_cap_mps`.
+fn apply_cap_stabilization(
+    response: &mut PerceptionResponse,
+    stabilizer: &mut CapStabilizer,
+    limiting_object: Option<u64>,
+    now_ms: u64,
+) {
+    // The stabilizer observes the LIVENESS-ADJUSTED cap (zero on a sensor fault),
+    // which is what makes a fault behave like a hazard. `raw_speed_cap_mps` keeps
+    // perception's own number, set when the response was built — three distinct
+    // values matter to an operator (what perception saw, what liveness allowed,
+    // what is enforced) and collapsing the first two would hide which one bound.
+    let observed = response.speed_cap_mps;
+    let decision = stabilizer.observe(CapObservation {
+        raw_cap_mps: observed,
+        limiting_object,
+        now_ms,
+    });
+    response.stabilized_speed_cap_mps = decision.stabilized_cap_mps;
+    response.speed_cap_mps = decision.stabilized_cap_mps;
+    response.cap_reason = Some(decision.reason.code());
+    response.cap_clear_streak = decision.clear_streak;
+    response.cap_limiting_object = decision.limiting_object;
+    // A cap held below what was observed means the envelope is not yet the one
+    // perception would allow, so the frame is not "healthy" in the sense a consumer
+    // enforces on.
+    if decision.stabilized_cap_mps < observed {
+        response.healthy = false;
+    }
+}
+
+/// Serve a response WITHOUT advancing the stabilizer, stamping the cap it is
+/// currently holding.
+///
+/// Used for re-posts and diagnostic probes. Same reasoning as the watchdog: a frame
+/// the stabilizer has already accounted for is not new evidence, and letting a
+/// second consumer's copy advance the clock would inflate the measured frame rate
+/// the rise limiter divides by — a two-consumer deployment would climb twice as
+/// fast as a one-consumer deployment on identical perception.
+fn apply_cap_without_observing(response: &mut PerceptionResponse, stabilizer: &CapStabilizer) {
+    let observed = response.speed_cap_mps;
+    let held = stabilizer.stabilized_cap_mps().min(observed);
+    response.stabilized_speed_cap_mps = held;
+    response.speed_cap_mps = held;
+    response.cap_reason = None;
+    response.cap_clear_streak = stabilizer.clear_streak();
+    if held < observed {
+        response.healthy = false;
+    }
 }
 
 #[cfg(test)]
@@ -2910,6 +3060,25 @@ mod scan_liveness_tests {
         r
     }
 
+    /// A live scan with an obstacle at `blob_x` metres, for the #1212 cap tests.
+    pub(super) fn live_scan_for_cap(seq: u32, blob_x: f64) -> PerceptionRequest {
+        let ranges: Vec<f32> = (0..300)
+            .map(|i| {
+                let theta = -1.5 + f64::from(i) * 0.01;
+                let base = if theta.abs() < 0.15 {
+                    blob_x / theta.cos()
+                } else {
+                    8.0
+                };
+                f32::from_bits((base as f32).to_bits() + (seq % 7))
+            })
+            .collect();
+        let mut r = super::tests::req(ranges);
+        r.stamp_ms = 1_000 + u64::from(seq) * 100;
+        r.publisher_count = Some(1);
+        r
+    }
+
     /// The same buffer and the same stamp, forever — a driver republishing one
     /// frame.
     fn frozen_scan() -> PerceptionRequest {
@@ -3006,12 +3175,18 @@ mod scan_liveness_tests {
             &mut st,
             now,
         );
-        assert_eq!(r.sensor_liveness, "healthy");
-        assert!(
-            r.speed_cap_mps > 0.0,
-            "the streak completed, so motion must be released"
+        assert_eq!(
+            r.sensor_liveness, "healthy",
+            "the LIVENESS streak completed — this test's subject"
         );
-        assert!(r.healthy);
+        // The cap is a separate claim. #1212's stabilizer must also earn its own
+        // streak before the envelope widens, so liveness recovering does not by
+        // itself release motion. `a_recovering_sensor_must_earn_both_streaks` pins
+        // the composition.
+        assert_eq!(
+            r.speed_cap_mps, 0.0,
+            "liveness recovery alone does not release the cap"
+        );
     }
 
     /// Startup begins unavailable: the very first scan is capped, because one
@@ -3241,7 +3416,11 @@ mod scan_liveness_tests {
     /// verdict, whatever the stream does.
     #[test]
     fn the_disarmed_path_is_unchanged() {
-        let mut st = TrackedPerceptionState::with_watchdog(SensorWatchdogConfig::r2_lidar(), false);
+        // Both gates off: this test is about the LIVENESS watchdog being disarmed,
+        // so cap stabilization (#1212, a separate concern) is off too — otherwise it
+        // would be asserting the absence of two features while naming one.
+        let mut st =
+            TrackedPerceptionState::with_options(SensorWatchdogConfig::r2_lidar(), false, false);
         let frozen = frozen_scan();
         let mut now = 0;
         let mut last = None;
@@ -3433,7 +3612,8 @@ mod scan_liveness_tests {
         now += 100;
         let r = handle_perception_tracked_at(&live_scan(99_000, 9), &mut st, now);
         assert_eq!(r.sensor_liveness, "healthy");
-        assert!(r.speed_cap_mps > 0.0);
+        // Cap release is the stabilizer's separate judgement — see
+        // `a_recovering_sensor_must_earn_both_streaks`.
     }
 
     /// (5) Two live clients posting the same scan cannot double the measured rate.
@@ -3472,8 +3652,13 @@ mod scan_liveness_tests {
         // Availability arrives only with a second observation — the first frame
         // that makes a rate measurable.
         let second = handle_perception_tracked_at(&live_scan(1_100, 1), &mut st, 100);
-        assert_eq!(second.sensor_liveness, "healthy");
-        assert!(second.speed_cap_mps > 0.0);
+        assert_eq!(
+            second.sensor_liveness, "healthy",
+            "two observations make a rate measurable — the liveness claim"
+        );
+        // The cap stays floored: the stabilizer has its own evidence to gather, and
+        // a restarted sidecar has none of it.
+        assert_eq!(second.speed_cap_mps, 0.0);
     }
 
     /// The evidence digest identifies the perception EVIDENCE, not the liveness
@@ -3491,6 +3676,213 @@ mod scan_liveness_tests {
         assert_eq!(
             first.frame_id.evidence_digest, independent.frame_id.evidence_digest,
             "identical scan bytes must carry identical evidence identity"
+        );
+    }
+}
+
+#[cfg(test)]
+mod cap_authority_tests {
+    //! #1212 authority migration: the checker's stabilizer is what the sidecar
+    //! serves. Injected scans and an injected clock throughout; nothing sleeps.
+
+    use super::scan_liveness_tests::live_scan_for_cap as live_scan;
+    use super::*;
+
+    fn state() -> TrackedPerceptionState {
+        TrackedPerceptionState::with_watchdog(SensorWatchdogConfig::r2_lidar(), true)
+    }
+
+    /// Warm both the liveness watchdog and the stabilizer to steady state, so a test
+    /// about one is not measuring the other's warm-up. Returns the next timestamp.
+    fn warm(st: &mut TrackedPerceptionState, seq_from: u32, mut now: u64) -> (u32, u64) {
+        let mut seq = seq_from;
+        for _ in 0..20 {
+            now += 100;
+            seq += 1;
+            let _ = handle_perception_tracked_at(&live_scan(seq, 6.0), st, now);
+        }
+        (seq, now)
+    }
+
+    /// The served `speed_cap_mps` is the STABILIZED value, and the pre-stabilization
+    /// number is carried alongside rather than discarded. A consumer that only ever
+    /// saw one number could not tell a hazard from a filter still catching up —
+    /// which is how the Python's behaviour became invisible.
+    #[test]
+    fn the_served_cap_is_the_stabilized_one_with_raw_alongside() {
+        let mut st = state();
+        let mut now = 0;
+        let mut seq = 0;
+
+        // First frame: perception proposes a real cap, the stabilizer holds at zero.
+        now += 100;
+        seq += 1;
+        let r = handle_perception_tracked_at(&live_scan(seq, 6.0), &mut st, now);
+        assert!(
+            r.raw_speed_cap_mps > 0.0,
+            "perception proposed a cap: {}",
+            r.raw_speed_cap_mps
+        );
+        assert_eq!(r.speed_cap_mps, 0.0, "…and the checker holds it");
+        assert_eq!(r.stabilized_speed_cap_mps, r.speed_cap_mps);
+        assert_eq!(r.cap_reason, Some("CAP_INITIAL_HOLD"));
+    }
+
+    /// A restriction reaches the wire on the frame it is observed — no smoothing on
+    /// the way down, through the whole sidecar path.
+    #[test]
+    fn a_restriction_reaches_the_wire_immediately() {
+        let mut st = state();
+        let (mut seq, mut now) = warm(&mut st, 0, 0);
+        let before = {
+            now += 100;
+            seq += 1;
+            handle_perception_tracked_at(&live_scan(seq, 6.0), &mut st, now)
+        };
+        assert!(
+            before.speed_cap_mps > 0.5,
+            "precondition: a cap was earned, got {}",
+            before.speed_cap_mps
+        );
+
+        // An obstacle appears VERY close, so the new raw cap is below the standing
+        // stabilized one and the drop is visible. A nearer-but-still-above-standing
+        // hazard would register as CAP_RESTRICTED without moving the served number,
+        // because the enforced cap was already more conservative than the new
+        // hazard requires — correct, but it proves nothing about immediacy.
+        now += 100;
+        seq += 1;
+        let r = handle_perception_tracked_at(&live_scan(seq, 0.4), &mut st, now);
+        assert_eq!(r.cap_reason, Some("CAP_RESTRICTED"));
+        assert!(
+            r.speed_cap_mps < before.speed_cap_mps,
+            "a tightening cap must apply on this frame: {} -> {}",
+            before.speed_cap_mps,
+            r.speed_cap_mps
+        );
+        assert!(
+            r.speed_cap_mps <= r.raw_speed_cap_mps + 1e-9,
+            "and the served cap never exceeds what perception proposed"
+        );
+    }
+
+    /// A recovering sensor must earn BOTH streaks — liveness and stabilization.
+    ///
+    /// They are different claims: "the sensor is producing frames again" and "the
+    /// envelope may widen". Composing them is deliberate, and it means recovery
+    /// costs more than either alone. This pins that the cap is still floored at the
+    /// moment liveness reports healthy.
+    #[test]
+    fn a_recovering_sensor_must_earn_both_streaks() {
+        let mut st = state();
+        let (mut seq, mut now) = warm(&mut st, 0, 0);
+
+        // Fault it: no publisher.
+        now += 100;
+        let mut dead = live_scan(seq + 1, 6.0);
+        dead.publisher_count = Some(0);
+        let r = handle_perception_tracked_at(&dead, &mut st, now);
+        assert_eq!(r.sensor_fault, Some("SENSOR_NO_PUBLISHER"));
+        assert_eq!(r.speed_cap_mps, 0.0);
+
+        // Drive recovery and record when each claim clears.
+        let mut liveness_healthy_at = None;
+        let mut cap_released_at = None;
+        for i in 1..40 {
+            now += 100;
+            seq += 1;
+            let r = handle_perception_tracked_at(&live_scan(seq, 6.0), &mut st, now);
+            if liveness_healthy_at.is_none() && r.sensor_liveness == "healthy" {
+                liveness_healthy_at = Some(i);
+            }
+            if cap_released_at.is_none() && r.speed_cap_mps > 0.0 {
+                cap_released_at = Some(i);
+            }
+        }
+        let live_at = liveness_healthy_at.expect("liveness must recover");
+        let cap_at = cap_released_at.expect("the cap must eventually be released");
+        assert!(
+            cap_at >= live_at,
+            "the cap must not be released before liveness recovers (cap {cap_at}, \
+             liveness {live_at})"
+        );
+        assert!(
+            cap_at > 1,
+            "the cap must not be released on the first frame after a fault"
+        );
+    }
+
+    /// A re-post does not advance the stabilizer.
+    ///
+    /// Two consumers posting the same scan would otherwise inflate the frame rate
+    /// the rise limiter divides by, so a two-consumer deployment would climb twice
+    /// as fast as a one-consumer deployment on identical perception.
+    #[test]
+    fn a_repost_does_not_advance_the_stabilizer() {
+        let mut single = state();
+        let mut doubled = state();
+        let mut now = 0;
+        let mut seq = 0;
+        let mut last_single = None;
+        let mut last_doubled = None;
+        for _ in 0..25 {
+            now += 100;
+            seq += 1;
+            let scan = live_scan(seq, 6.0);
+            last_single = Some(handle_perception_tracked_at(&scan, &mut single, now));
+            // Consumer A then consumer B, same frame.
+            let _ = handle_perception_tracked_at(&scan, &mut doubled, now);
+            last_doubled = Some(handle_perception_tracked_at(&scan, &mut doubled, now + 10));
+        }
+        let a = last_single.expect("ran").speed_cap_mps;
+        let b = last_doubled.expect("ran").speed_cap_mps;
+        assert!(
+            (a - b).abs() < 1e-9,
+            "double-posting must not change the climb: single {a}, doubled {b}"
+        );
+    }
+
+    /// The stabilizer is not cleared by a tracking reset. A tracker reset is a
+    /// discontinuity in object identity, not evidence that the speed envelope may be
+    /// relaxed — clearing it there would hand back an unearned cap.
+    #[test]
+    fn a_tracking_reset_does_not_hand_back_the_cap() {
+        let mut st = state();
+        let (seq, now) = warm(&mut st, 0, 0);
+        let earned = handle_perception_tracked_at(&live_scan(seq + 1, 6.0), &mut st, now + 100)
+            .speed_cap_mps;
+        assert!(earned > 0.0, "precondition");
+
+        st.reset();
+        let r = handle_perception_tracked_at(&live_scan(seq + 2, 6.0), &mut st, now + 200);
+
+        // The cap may continue its normal bounded climb — one frame of rise is
+        // expected and correct. What must NOT happen is the reset handing back the
+        // full perception cap, which is what clearing the stabilizer would do.
+        let one_step = kirra_trajectory::cap_stabilizer::DEFAULT_RISE_RATE_MPS_PER_S * 0.1;
+        assert!(
+            r.speed_cap_mps <= earned + one_step + 1e-9,
+            "a tracking reset must not jump the cap beyond one bounded step: {} > {} \
+             + {}",
+            r.speed_cap_mps,
+            earned,
+            one_step
+        );
+        assert!(
+            r.speed_cap_mps < r.raw_speed_cap_mps,
+            "…and certainly not to perception's full proposal"
+        );
+    }
+
+    /// Stabilization does not run on the stateless entry point, and says so rather
+    /// than reporting a stabilized number it did not compute.
+    #[test]
+    fn the_stateless_path_does_not_stabilize() {
+        let r = handle_perception(&live_scan(1, 6.0));
+        assert_eq!(r.cap_reason, None, "no stabilization was performed");
+        assert_eq!(
+            r.speed_cap_mps, r.raw_speed_cap_mps,
+            "the served cap is perception's own, unfiltered"
         );
     }
 }

--- a/crates/kirra-trajectory/src/cap_stabilizer.rs
+++ b/crates/kirra-trajectory/src/cap_stabilizer.rs
@@ -380,6 +380,18 @@ impl CapStabilizer {
         self.clear_streak
     }
 
+    /// The object currently holding the cap down, including one retained through a
+    /// dropout.
+    ///
+    /// Exists so a caller that serves the held cap WITHOUT calling [`Self::observe`]
+    /// (a duplicate frame, a diagnostic probe) can report the identity that belongs
+    /// to the number it is serving. A held cap reported with no limiting object reads
+    /// as an open corridor, which is the opposite of what is true.
+    #[must_use]
+    pub fn limiting_object(&self) -> Option<u64> {
+        self.limiting.map(|(id, _)| id)
+    }
+
     /// Return to the starting state: zero cap, no accumulated evidence, no
     /// continuity, no limiting object.
     ///
@@ -1186,6 +1198,37 @@ mod tests {
         s.reset();
         let d = s.observe(obs(2.0, t + 200));
         assert_eq!(d.limiting_object, None);
+    }
+
+    /// The accessor agrees with the decision it accompanies, including across a
+    /// retained dropout and a fail-closed clear.
+    ///
+    /// It exists for callers that serve the held cap WITHOUT observing a frame — a
+    /// duplicate frame, a diagnostic probe. Such a caller has no `CapDecision` to
+    /// read, and reporting the held cap with no limiting object reads as an open
+    /// corridor: the opposite of what is true. So the two must not be able to
+    /// disagree.
+    #[test]
+    fn the_limiting_object_accessor_tracks_the_decision() {
+        let mut s = stab();
+        assert_eq!(s.limiting_object(), None, "nothing observed yet");
+
+        let t = settle_at(&mut s, 0.5, 0);
+        let d = s.observe(obs_with(0.5, t + 100, Some(41)));
+        assert_eq!(d.limiting_object, Some(41));
+        assert_eq!(s.limiting_object(), Some(41), "and the accessor agrees");
+
+        // A dropout inside the grace window retains the identity; the accessor must
+        // report the retained one, since that is what the held cap is held against.
+        let d = s.observe(obs_with(2.0, t + 200, None));
+        assert_eq!(d.reason, CapReason::LimitingObjectRetained);
+        assert_eq!(d.limiting_object, Some(41));
+        assert_eq!(s.limiting_object(), Some(41));
+
+        // A fault clears it, and so does the accessor.
+        let d = s.observe(obs_with(f64::NAN, t + 300, Some(41)));
+        assert_eq!(d.limiting_object, None);
+        assert_eq!(s.limiting_object(), None);
     }
 
     // ----- limiting-object identity is absent unless something limits -----

--- a/docs/safety/ASSUMPTIONS_OF_USE.md
+++ b/docs/safety/ASSUMPTIONS_OF_USE.md
@@ -1445,3 +1445,82 @@ producer is byte-identical to prior behaviour.
 - `crates/kirra-trajectory/src/occlusion_channel.rs` (the resolver);
   `crates/kirra-trajectory/src/validation.rs` §D (the RSS Rule 4 gate).
 - `SAFE_STATE_SPECIFICATION.md` (MRC fallback); the review finding S2 / #1025.
+
+---
+
+## AOU-CAP-STABILIZER-001 — The speed-cap stabilizer runs in the checker, and the doer relays it
+
+### Assumption
+
+A deployment using the perception speed-cap derate SHALL run a Taj perception
+sidecar that stabilizes the assured-clear-distance cap — one that serves both
+`stabilized_speed_cap_mps` and a `cap_reason` on every perception response. The
+ROS `perception_governor` node SHALL relay that number and SHALL NOT compute a
+cap of its own.
+
+### Why it is load-bearing
+
+Until #1212 the asymmetric cap policy — restrict immediately, release only after
+N confirmations and a rate-limited climb — lived in the doer-side Python
+(`perception_cap.SpeedCapGovernor`). That placement had a specific defect: the
+policy looked implemented, had passing tests, and held no safety authority. A
+doer can be swapped, misconfigured, or bypassed; when it is, a policy that only
+exists there disappears with it and nothing reports its absence.
+
+The state machine now lives in `kirra_trajectory::cap_stabilizer`, which is the
+checker. The Python copy was **deleted rather than kept as advisory**: an unused
+copy of a safety state machine drifts silently, its tests still green, which is
+the condition that produced the original problem.
+
+That migration creates the obligation stated above. A sidecar that does not
+stabilize still populates `stabilized_speed_cap_mps` — with the RAW cap — so the
+value alone cannot distinguish the two. `cap_reason` is the authorship claim, and
+`resolve_stabilized_cap` refuses a response without one (`CAP_RELAY_UNSTABILIZED`
+→ published cap `0.0`, health `TAJ_UNSTABILIZED`). The failure is deliberately
+loud and immobilizing: relaying an unstabilized cap under a stabilized name would
+silently restore pre-#1212 behaviour on exactly the deployments that had not been
+upgraded, and the number would look entirely reasonable while doing it.
+
+### Consequence for the integrator
+
+- **A pre-#1212 sidecar stops the robot.** This is the intended outcome, not a
+  regression. Upgrade the sidecar; there is no configuration that restores the
+  fallback, because the fallback was the hazard.
+- **The stabilizer's parameters are not ROS parameters.** `cap_rise_rate_mps_per_s`,
+  `cap_restriction_epsilon_mps`, `cap_clear_confirmations` and `cap_maximum_dt_ms`
+  are no longer declared by `perception_governor` and are absent from
+  `kirra_params.yaml`. rclpy silently ignores an override for an undeclared
+  parameter, so leaving them would be tuning that appears to apply and does
+  nothing. Tune the checker.
+- **Recovery latency is composite.** After a sensor-liveness fault, motion returns
+  only once BOTH the watchdog's healthy-frame streak AND the stabilizer's clear
+  confirmations plus bounded climb are satisfied. Measured end-to-end at **17
+  frames — ~1.7 s at 10 Hz** on the R2 lidar profile, against a 5-frame (~0.5 s)
+  liveness streak. Neither gate's own number is the figure to plan around.
+
+### Pairs with
+
+- **AOU-OCCLUSION-RATE-001** / **AOU-VRU-RATE-001** — the same doctrine applied to
+  a channel rather than a filter: an armed input that goes silent must floor the
+  envelope, never read as "clear".
+- **AOU-TIMESYNC-001** — the stabilizer is driven by a monotonic clock. A backwards
+  step is a fault (`CAP_TIME_BACKWARD`) that retains the trusted anchor rather than
+  adopting the regressed one; a gap past the budget begins a new continuity epoch
+  (`CAP_TIME_GAP`). Neither releases the cap.
+
+### Verification status — **DISCHARGED** (checker + relay), **AoU-GAP** (deployment)
+
+The checker side is discharged: `cap_stabilizer` is unit- and mutation-tested, the
+sidecar path is covered end-to-end including the replay case, and the relay's
+fail-closed refusals (`CAP_RELAY_UNSTABILIZED`, `CAP_RELAY_MALFORMED`) are tested
+for every unusable form of the response. Running a stabilizing sidecar in the
+deployed configuration is the integrator's obligation.
+
+### Cited by
+
+- `crates/kirra-trajectory/src/cap_stabilizer.rs` (the state machine);
+  `crates/kirra-sidecars/src/taj.rs` (`apply_cap_stabilization`,
+  `apply_cap_without_observing`);
+  `ros2_ws/src/kirra_safety/kirra_safety/perception_cap.py`
+  (`resolve_stabilized_cap`).
+- Issue #1212.

--- a/ros2_ws/src/kirra_safety/config/kirra_params.yaml
+++ b/ros2_ws/src/kirra_safety/config/kirra_params.yaml
@@ -120,10 +120,12 @@ perception_governor:
     vehicle_width_m: 0.203       # measured R2 body width
     lateral_clearance_m: 0.15    # required clearance on each side
     confidence_floor: 0.5        # below this -> unhealthy -> 0.0 cap
-    cap_rise_rate_mps_per_s: 0.50
-    cap_restriction_epsilon_mps: 0.03
-    cap_clear_confirmations: 5   # 0.5 s confirmation at approximately 10 Hz
-    cap_maximum_dt_ms: 250       # larger processing gap resets to zero
+    # #1212: cap_rise_rate_mps_per_s / cap_restriction_epsilon_mps /
+    # cap_clear_confirmations / cap_maximum_dt_ms are deliberately ABSENT. The
+    # stabilizer they configure moved into the Rust checker
+    # (kirra_trajectory::cap_stabilizer), which is the safety authority. rclpy
+    # silently ignores an override for an undeclared parameter, so leaving them here
+    # would be tuning that appears to apply and does nothing. Tune the checker.
 
 sensor_monitor:
   ros__parameters:

--- a/ros2_ws/src/kirra_safety/kirra_safety/perception_cap.py
+++ b/ros2_ws/src/kirra_safety/kirra_safety/perception_cap.py
@@ -11,6 +11,14 @@ Taj *tightens* the envelope, the governor still *bounds* the result.
 It is deliberately a pure function (no ROS, no I/O) so the safety-critical clamp is unit
 testable standalone — the same discipline as `enforcement_decision.py`.
 
+#1212: the temporal cap-stabilization state machine that used to live here is GONE.
+It now lives in the Rust checker (`kirra_trajectory::cap_stabilizer`), which is the
+safety authority; `perception_governor` relays the stabilized cap Taj serves and
+computes nothing. It was removed rather than left as advisory because an unused
+copy of a safety state machine drifts silently — the tests keep passing while
+nothing enforces it, which is the exact condition that made the original placement
+a problem.
+
 Fail-closed rules (a perception fault must never let the robot speed up):
   - `enabled` False                 → no derate at all (opt-in; byte-identical prior path).
   - cap missing / older than `stale_s` → STOP (0.0). A silent or stale Taj is a fault.
@@ -19,7 +27,6 @@ Fail-closed rules (a perception fault must never let the robot speed up):
 """
 
 import math
-from dataclasses import dataclass
 
 
 # Result reasons (also used as the enforcement-action suffix for monitoring).
@@ -29,270 +36,11 @@ INVALID = "PERCEPTION_INVALID"
 CAPPED = "PERCEPTION_CAP"
 PASS = "PERCEPTION_PASS"
 
-# Temporal speed-cap governor reasons.
-GOV_INITIAL_HOLD = "CAP_INITIAL_HOLD"
-GOV_CONFIRMING = "CAP_CONFIRMING"
-GOV_RISING = "CAP_RISING"
-GOV_PASS = "CAP_PASS"
-GOV_RESTRICTED = "CAP_RESTRICTED"
-GOV_INVALID = "CAP_INVALID"
-GOV_TIME_BACKWARD = "CAP_TIME_BACKWARD"
-GOV_TIME_GAP = "CAP_TIME_GAP"
+# Relay of the checker-owned stabilized cap (#1212).
+STABILIZED_OK = "CAP_RELAY_OK"
+STABILIZED_MISSING = "CAP_RELAY_MISSING"
 
 
-@dataclass(frozen=True)
-class SpeedCapGovernorConfig:
-    """Configuration for asymmetric perception-cap stabilization."""
-
-    rise_rate_mps_per_s: float = 0.50
-    restriction_epsilon_mps: float = 0.03
-    clear_confirmations: int = 5
-    maximum_dt_s: float = 0.25
-    initial_cap_mps: float = 0.0
-
-    def __post_init__(self):
-        if (
-            not math.isfinite(self.rise_rate_mps_per_s)
-            or self.rise_rate_mps_per_s <= 0.0
-        ):
-            raise ValueError("rise_rate_mps_per_s must be finite and positive")
-        if (
-            not math.isfinite(self.restriction_epsilon_mps)
-            or self.restriction_epsilon_mps < 0.0
-        ):
-            raise ValueError(
-                "restriction_epsilon_mps must be finite and non-negative"
-            )
-        if (
-            isinstance(self.clear_confirmations, bool)
-            or not isinstance(self.clear_confirmations, int)
-            or self.clear_confirmations < 1
-        ):
-            raise ValueError("clear_confirmations must be a positive integer")
-        if not math.isfinite(self.maximum_dt_s) or self.maximum_dt_s <= 0.0:
-            raise ValueError("maximum_dt_s must be finite and positive")
-        if not math.isfinite(self.initial_cap_mps) or self.initial_cap_mps < 0.0:
-            raise ValueError("initial_cap_mps must be finite and non-negative")
-
-
-@dataclass(frozen=True)
-class SpeedCapDecision:
-    """One deterministic temporal-governor decision."""
-
-    raw_cap_mps: float
-    governed_cap_mps: float
-    reason: str
-    clear_streak: int
-
-
-class SpeedCapGovernor:
-    """Asymmetric temporal governor for Taj's raw ACD speed cap.
-
-    Restrictive raw-cap changes are recognized immediately. They may lower the
-    governed cap but can never raise it. Permissive changes require consecutive
-    confirmation and then rise at a bounded rate.
-
-    Invalid data and monotonic-clock faults reset to the fail-closed floor.
-    """
-
-    def __init__(self, config=None):
-        self._config = config or SpeedCapGovernorConfig()
-        self.reset()
-
-    @property
-    def governed_cap_mps(self):
-        return self._governed_cap_mps
-
-    @property
-    def clear_streak(self):
-        return self._clear_streak
-
-    def reset(self):
-        self._governed_cap_mps = self._config.initial_cap_mps
-        self._clear_streak = 0
-        self._last_now_ns = None
-        self._last_raw_cap_mps = None
-
-    def _fail_closed(self, raw_cap_mps, reason, now_ns=None):
-        self._governed_cap_mps = 0.0
-        self._clear_streak = 0
-        self._last_now_ns = now_ns
-        self._last_raw_cap_mps = None
-
-        return SpeedCapDecision(
-            raw_cap_mps=(
-                float(raw_cap_mps)
-                if isinstance(raw_cap_mps, (int, float))
-                and not isinstance(raw_cap_mps, bool)
-                else float("nan")
-            ),
-            governed_cap_mps=0.0,
-            reason=reason,
-            clear_streak=0,
-        )
-
-    def update(self, raw_cap_mps, now_ns):
-        """Apply one raw cap observation at a monotonic timestamp."""
-
-        if (
-            isinstance(now_ns, bool)
-            or not isinstance(now_ns, int)
-            or now_ns < 0
-        ):
-            return self._fail_closed(
-                raw_cap_mps,
-                GOV_TIME_BACKWARD,
-            )
-
-        if (
-            isinstance(raw_cap_mps, bool)
-            or not isinstance(raw_cap_mps, (int, float))
-            or not math.isfinite(raw_cap_mps)
-            or raw_cap_mps < 0.0
-        ):
-            return self._fail_closed(
-                raw_cap_mps,
-                GOV_INVALID,
-                now_ns,
-            )
-
-        raw_cap_mps = float(raw_cap_mps)
-
-        if self._last_now_ns is None:
-            self._last_now_ns = now_ns
-            self._last_raw_cap_mps = raw_cap_mps
-
-            if raw_cap_mps < self._governed_cap_mps:
-                self._governed_cap_mps = raw_cap_mps
-                return SpeedCapDecision(
-                    raw_cap_mps,
-                    self._governed_cap_mps,
-                    GOV_RESTRICTED,
-                    0,
-                )
-
-            self._clear_streak = 1
-            return SpeedCapDecision(
-                raw_cap_mps,
-                self._governed_cap_mps,
-                GOV_INITIAL_HOLD,
-                self._clear_streak,
-            )
-
-        if now_ns < self._last_now_ns:
-            return self._fail_closed(
-                raw_cap_mps,
-                GOV_TIME_BACKWARD,
-                now_ns,
-            )
-
-        dt_s = (
-            now_ns - self._last_now_ns
-        ) / 1_000_000_000.0
-
-        if dt_s > self._config.maximum_dt_s:
-            return self._fail_closed(
-                raw_cap_mps,
-                GOV_TIME_GAP,
-                now_ns,
-            )
-
-        previous_raw_cap_mps = self._last_raw_cap_mps
-        self._last_now_ns = now_ns
-        self._last_raw_cap_mps = raw_cap_mps
-
-        # A decrease in the sensor's raw safety envelope is restrictive even
-        # when the stabilized output is already below the new raw cap.
-        raw_became_more_restrictive = (
-            previous_raw_cap_mps is not None
-            and raw_cap_mps
-            < previous_raw_cap_mps - self._config.restriction_epsilon_mps
-        )
-
-        if raw_became_more_restrictive:
-            # Never increase the governed cap while handling a restrictive
-            # observation.
-            self._governed_cap_mps = min(
-                self._governed_cap_mps,
-                raw_cap_mps,
-            )
-            self._clear_streak = 0
-
-            return SpeedCapDecision(
-                raw_cap_mps,
-                self._governed_cap_mps,
-                GOV_RESTRICTED,
-                0,
-            )
-
-        # The governed output must never exceed the newest raw safety bound.
-        # Small decreases inside the jitter epsilon clamp immediately but do
-        # not restart the clear-confirmation history.
-        if raw_cap_mps < self._governed_cap_mps:
-            decrease_mps = (
-                self._governed_cap_mps - raw_cap_mps
-            )
-            self._governed_cap_mps = raw_cap_mps
-
-            if (
-                decrease_mps
-                > self._config.restriction_epsilon_mps
-            ):
-                self._clear_streak = 0
-                return SpeedCapDecision(
-                    raw_cap_mps,
-                    self._governed_cap_mps,
-                    GOV_RESTRICTED,
-                    0,
-                )
-
-            return SpeedCapDecision(
-                raw_cap_mps,
-                self._governed_cap_mps,
-                GOV_PASS,
-                self._clear_streak,
-            )
-
-        if raw_cap_mps == self._governed_cap_mps:
-            self._clear_streak = 0
-            return SpeedCapDecision(
-                raw_cap_mps,
-                self._governed_cap_mps,
-                GOV_PASS,
-                0,
-            )
-
-        self._clear_streak += 1
-
-        if self._clear_streak < self._config.clear_confirmations:
-            return SpeedCapDecision(
-                raw_cap_mps,
-                self._governed_cap_mps,
-                GOV_CONFIRMING,
-                self._clear_streak,
-            )
-
-        maximum_rise = (
-            self._config.rise_rate_mps_per_s * dt_s
-        )
-
-        self._governed_cap_mps = min(
-            raw_cap_mps,
-            self._governed_cap_mps + maximum_rise,
-        )
-
-        reason = (
-            GOV_PASS
-            if self._governed_cap_mps >= raw_cap_mps
-            else GOV_RISING
-        )
-
-        return SpeedCapDecision(
-            raw_cap_mps,
-            self._governed_cap_mps,
-            reason,
-            self._clear_streak,
-        )
 
 def apply_perception_cap(proposed_mps, cap_mps, cap_age_s, enabled, stale_s):
     """
@@ -319,3 +67,33 @@ def apply_perception_cap(proposed_mps, cap_mps, cap_age_s, enabled, stale_s):
     magnitude = min(abs(proposed_mps), cap_mps)
     reason = CAPPED if magnitude < abs(proposed_mps) else PASS
     return sign * magnitude, reason
+
+
+def resolve_stabilized_cap(data, effective_raw_cap_mps):
+    """
+    Return (cap_mps, reason) for the checker-owned stabilized cap in a Taj response.
+
+    #1212: this node RELAYS the cap the Rust checker stabilized; it does not compute
+    one. The temporal state machine that used to live here has moved into
+    `kirra_trajectory::cap_stabilizer`, which is the safety authority.
+
+    Fail closed when the field is absent, non-numeric, non-finite or negative. An
+    older Taj that does not serve a stabilized cap is NOT a licence to fall back on
+    the raw one — falling back would silently restore the pre-#1212 behaviour on
+    exactly the deployments that had not been upgraded, which is the worst place for
+    it to happen and the hardest to notice.
+
+    The result is additionally clamped by `effective_raw_cap_mps` so an unhealthy
+    frame can never be widened by the relay.
+    """
+    if not isinstance(data, dict):
+        return 0.0, STABILIZED_MISSING
+
+    value = data.get("stabilized_speed_cap_mps")
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return 0.0, STABILIZED_MISSING
+    value = float(value)
+    if not math.isfinite(value) or value < 0.0:
+        return 0.0, STABILIZED_MISSING
+
+    return min(value, float(effective_raw_cap_mps)), STABILIZED_OK

--- a/ros2_ws/src/kirra_safety/kirra_safety/perception_cap.py
+++ b/ros2_ws/src/kirra_safety/kirra_safety/perception_cap.py
@@ -38,7 +38,14 @@ PASS = "PERCEPTION_PASS"
 
 # Relay of the checker-owned stabilized cap (#1212).
 STABILIZED_OK = "CAP_RELAY_OK"
-STABILIZED_MISSING = "CAP_RELAY_MISSING"
+# The response carries no evidence that the checker stabilized anything: no
+# `cap_reason`, or one that is not a usable code. Distinct from MALFORMED because the
+# operator action differs — this one means the sidecar is old or not configured to
+# stabilize, and no amount of restarting this node will fix it.
+STABILIZED_UNSTABILIZED = "CAP_RELAY_UNSTABILIZED"
+# A stabilized cap was claimed but the value is unusable (absent, non-numeric,
+# non-finite, negative), or the bound it must be clamped against is unusable.
+STABILIZED_MALFORMED = "CAP_RELAY_MALFORMED"
 
 
 
@@ -83,17 +90,40 @@ def resolve_stabilized_cap(data, effective_raw_cap_mps):
     exactly the deployments that had not been upgraded, which is the worst place for
     it to happen and the hardest to notice.
 
+    Fail closed ALSO when the response carries no `cap_reason`. The value alone
+    cannot be trusted: a sidecar that does not stabilize still populates
+    `stabilized_speed_cap_mps`, with the RAW cap, so accepting the number on its own
+    would relay an unstabilized cap under a stabilized name — the precise failure
+    this function exists to prevent, and one that leaves no trace because the number
+    looks entirely reasonable. `cap_reason` is the authorship claim; without it there
+    is nothing to relay.
+
     The result is additionally clamped by `effective_raw_cap_mps` so an unhealthy
-    frame can never be widened by the relay.
+    frame can never be widened by the relay. An unusable clamp bound is itself a
+    fault — clamping against NaN would pass the stabilized value through untouched.
     """
     if not isinstance(data, dict):
-        return 0.0, STABILIZED_MISSING
+        return 0.0, STABILIZED_MALFORMED
+
+    # Authorship first. A number without a claimed author is not a stabilized cap
+    # whatever its value, so this is checked before the value is even read.
+    reason = data.get("cap_reason")
+    if not isinstance(reason, str) or not reason:
+        return 0.0, STABILIZED_UNSTABILIZED
 
     value = data.get("stabilized_speed_cap_mps")
     if isinstance(value, bool) or not isinstance(value, (int, float)):
-        return 0.0, STABILIZED_MISSING
+        return 0.0, STABILIZED_MALFORMED
     value = float(value)
     if not math.isfinite(value) or value < 0.0:
-        return 0.0, STABILIZED_MISSING
+        return 0.0, STABILIZED_MALFORMED
 
-    return min(value, float(effective_raw_cap_mps)), STABILIZED_OK
+    if isinstance(effective_raw_cap_mps, bool) or not isinstance(
+        effective_raw_cap_mps, (int, float)
+    ):
+        return 0.0, STABILIZED_MALFORMED
+    bound = float(effective_raw_cap_mps)
+    if not math.isfinite(bound) or bound < 0.0:
+        return 0.0, STABILIZED_MALFORMED
+
+    return min(value, bound), STABILIZED_OK

--- a/ros2_ws/src/kirra_safety/kirra_safety/perception_governor.py
+++ b/ros2_ws/src/kirra_safety/kirra_safety/perception_governor.py
@@ -24,6 +24,7 @@ from std_msgs.msg import Float64, String
 
 from kirra_safety.perception_cap import (
     STABILIZED_OK,
+    STABILIZED_UNSTABILIZED,
     resolve_stabilized_cap,
 )
 
@@ -67,23 +68,12 @@ class PerceptionGovernor(Node):
         self.declare_parameter("lateral_clearance_m", 0.15)
         self.declare_parameter("confidence_floor", 0.5)
 
-        # Asymmetric cap-release policy.
-        self.declare_parameter(
-            "cap_rise_rate_mps_per_s",
-            0.50,
-        )
-        self.declare_parameter(
-            "cap_restriction_epsilon_mps",
-            0.03,
-        )
-        self.declare_parameter(
-            "cap_clear_confirmations",
-            5,
-        )
-        self.declare_parameter(
-            "cap_maximum_dt_ms",
-            250,
-        )
+        # #1212: the asymmetric cap-release parameters (rise rate, restriction
+        # epsilon, clear confirmations, maximum dt) are NOT declared here. They
+        # configure the stabilizer, the stabilizer lives in the Rust checker, and a
+        # parameter this node accepts but cannot act on is worse than no parameter:
+        # an operator who tunes it sees the value take effect in `ros2 param get` and
+        # concludes the policy changed. The checker owns them; this node relays.
 
         self._taj_url = str(
             self.get_parameter("taj_url").value
@@ -116,13 +106,6 @@ class PerceptionGovernor(Node):
         self._floor = float(
             self.get_parameter("confidence_floor").value
         )
-
-        self._cap_restriction_epsilon_mps = float(
-            self.get_parameter(
-                "cap_restriction_epsilon_mps"
-            ).value
-        )
-
 
         self._session = (
             requests.Session()
@@ -230,7 +213,15 @@ class PerceptionGovernor(Node):
             effective_raw_cap,
         )
         if relay_reason != STABILIZED_OK:
-            self._publish_fault("TAJ_NO_STABILIZED_CAP")
+            # The two failures are surfaced separately because the operator action
+            # differs: UNSTABILIZED means this sidecar never stabilized anything and
+            # needs upgrading or configuring, MALFORMED means it claimed to and the
+            # value is unusable. Both stop the robot; only one is fixed by a restart.
+            self._publish_fault(
+                "TAJ_UNSTABILIZED"
+                if relay_reason == STABILIZED_UNSTABILIZED
+                else "TAJ_NO_STABILIZED_CAP"
+            )
             return
         cap_reason = data.get("cap_reason") or "NONE"
         cap_streak = data.get("cap_clear_streak")

--- a/ros2_ws/src/kirra_safety/kirra_safety/perception_governor.py
+++ b/ros2_ws/src/kirra_safety/kirra_safety/perception_governor.py
@@ -23,8 +23,8 @@ from sensor_msgs.msg import LaserScan
 from std_msgs.msg import Float64, String
 
 from kirra_safety.perception_cap import (
-    SpeedCapGovernor,
-    SpeedCapGovernorConfig,
+    STABILIZED_OK,
+    resolve_stabilized_cap,
 )
 
 SCAN_QOS = QoSProfile(
@@ -123,30 +123,6 @@ class PerceptionGovernor(Node):
             ).value
         )
 
-        self._cap_governor = SpeedCapGovernor(
-            SpeedCapGovernorConfig(
-                rise_rate_mps_per_s=float(
-                    self.get_parameter(
-                        "cap_rise_rate_mps_per_s"
-                    ).value
-                ),
-                restriction_epsilon_mps=(
-                    self._cap_restriction_epsilon_mps
-                ),
-                clear_confirmations=int(
-                    self.get_parameter(
-                        "cap_clear_confirmations"
-                    ).value
-                ),
-                maximum_dt_s=float(
-                    self.get_parameter(
-                        "cap_maximum_dt_ms"
-                    ).value
-                )
-                / 1000.0,
-                initial_cap_mps=0.0,
-            )
-        )
 
         self._session = (
             requests.Session()
@@ -209,7 +185,6 @@ class PerceptionGovernor(Node):
 
     def _publish_fault(self, reason: str) -> None:
         # A fault invalidates all accumulated release evidence.
-        self._cap_governor.reset()
         self._publish(0.0, reason)
 
     @staticmethod
@@ -234,6 +209,7 @@ class PerceptionGovernor(Node):
         clear_distance_m: float,
         minimum_corridor_width_m,
         required_corridor_width_m,
+        data=None,
     ) -> None:
         # Never accept a nonzero cap from a response marked unhealthy.
         effective_raw_cap = (
@@ -242,10 +218,23 @@ class PerceptionGovernor(Node):
             else 0.0
         )
 
-        decision = self._cap_governor.update(
+        # #1212: the CHECKER stabilizes the cap. This node relays the number Taj
+        # served and does not compute one. The local state machine used to decide
+        # here, in the doer layer, outside the safety authority — which looked done
+        # while being unenforceable.
+        #
+        # Fail closed if the field is absent or malformed: an older Taj that does
+        # not serve a stabilized cap is not a licence to fall back on the raw one.
+        governed_cap_mps, relay_reason = resolve_stabilized_cap(
+            data,
             effective_raw_cap,
-            time.monotonic_ns(),
         )
+        if relay_reason != STABILIZED_OK:
+            self._publish_fault("TAJ_NO_STABILIZED_CAP")
+            return
+        cap_reason = data.get("cap_reason") or "NONE"
+        cap_streak = data.get("cap_clear_streak")
+        cap_limiting = data.get("cap_limiting_object")
 
         min_width = self._format_optional_number(
             minimum_corridor_width_m
@@ -258,14 +247,15 @@ class PerceptionGovernor(Node):
             f'{"OK" if healthy else "UNHEALTHY"}:'
             f"clear={clear_distance_m:.2f}m:"
             f"raw={effective_raw_cap:.2f}:"
-            f"governed={decision.governed_cap_mps:.2f}:"
-            f"state={decision.reason}:"
-            f"streak={decision.clear_streak}:"
+            f"governed={governed_cap_mps:.2f}:"
+            f"state={cap_reason}:"
+            f"streak={cap_streak}:"
+            f"limiting={cap_limiting}:"
             f"width={min_width}/{required_width}m"
         )
 
         self._publish(
-            decision.governed_cap_mps,
+            governed_cap_mps,
             health,
         )
 
@@ -364,6 +354,7 @@ class PerceptionGovernor(Node):
                 required_corridor_width_m=data.get(
                     "required_corridor_width_m"
                 ),
+                data=data,
             )
 
         except requests.Timeout:

--- a/ros2_ws/src/kirra_safety/test/test_perception_cap.py
+++ b/ros2_ws/src/kirra_safety/test/test_perception_cap.py
@@ -16,7 +16,8 @@ from perception_cap import (  # noqa: E402
     apply_perception_cap,
     resolve_stabilized_cap,
     STABILIZED_OK,
-    STABILIZED_MISSING,
+    STABILIZED_MALFORMED,
+    STABILIZED_UNSTABILIZED,
     DISABLED,
     STALE,
     INVALID,
@@ -74,49 +75,100 @@ def test_zero_cap_holds_the_robot():
 # ---------------------------------------------------------------------------
 
 
+def _stabilized(value, reason="CAP_PASS"):
+    """A well-formed stabilized response: a value AND the authorship claim."""
+    return {"stabilized_speed_cap_mps": value, "cap_reason": reason}
+
+
 def test_stabilized_cap_is_relayed_when_present():
-    cap, reason = resolve_stabilized_cap(
-        {"stabilized_speed_cap_mps": 0.8}, 2.0
-    )
+    cap, reason = resolve_stabilized_cap(_stabilized(0.8), 2.0)
     assert reason == STABILIZED_OK
     assert cap == 0.8
 
 
 def test_relay_is_clamped_by_the_unhealthy_raw_cap():
     # An unhealthy frame zeroes the raw cap upstream; the relay must never widen it.
-    cap, reason = resolve_stabilized_cap(
-        {"stabilized_speed_cap_mps": 0.8}, 0.0
-    )
+    cap, reason = resolve_stabilized_cap(_stabilized(0.8), 0.0)
     assert reason == STABILIZED_OK
     assert cap == 0.0
 
 
-def test_missing_stabilized_cap_fails_closed():
+def test_malformed_stabilized_cap_fails_closed():
     # An older Taj that does not serve the field is NOT a licence to fall back on
     # the raw cap. Falling back would silently restore pre-#1212 behaviour on
     # exactly the deployments that had not been upgraded.
     for payload in (
-        {},
-        {"speed_cap_mps": 1.5},
         None,
         "not a dict",
-        {"stabilized_speed_cap_mps": None},
-        {"stabilized_speed_cap_mps": "0.8"},
-        {"stabilized_speed_cap_mps": True},
-        {"stabilized_speed_cap_mps": float("nan")},
-        {"stabilized_speed_cap_mps": float("inf")},
-        {"stabilized_speed_cap_mps": -0.1},
+        {"cap_reason": "CAP_PASS"},
+        {"speed_cap_mps": 1.5, "cap_reason": "CAP_PASS"},
+        _stabilized(None),
+        _stabilized("0.8"),
+        _stabilized(True),
+        _stabilized(float("nan")),
+        _stabilized(float("inf")),
+        _stabilized(-0.1),
     ):
         cap, reason = resolve_stabilized_cap(payload, 2.0)
-        assert reason == STABILIZED_MISSING, payload
+        assert reason == STABILIZED_MALFORMED, payload
         assert cap == 0.0, payload
+
+
+def test_a_cap_with_no_authorship_claim_is_refused():
+    # The hole this closes: a sidecar that does NOT stabilize still populates
+    # `stabilized_speed_cap_mps` — with the RAW cap. Accepting the number on its own
+    # would relay an unstabilized cap under a stabilized name, on exactly the
+    # deployments that had not been upgraded, and the value would look entirely
+    # reasonable. `cap_reason` is the claim; without it there is nothing to relay.
+    for missing in ({}, {"cap_reason": None}, {"cap_reason": ""}, {"cap_reason": 7}):
+        payload = {"stabilized_speed_cap_mps": 1.9}
+        payload.update(missing)
+        cap, reason = resolve_stabilized_cap(payload, 2.0)
+        assert reason == STABILIZED_UNSTABILIZED, payload
+        assert cap == 0.0, payload
+
+
+def test_a_replayed_held_cap_is_a_valid_relay():
+    # A duplicate frame is served the cap the stabilizer is holding, stamped
+    # CAP_REPLAY_HELD. It is stabilizer-authored, so it relays. Refusing it would
+    # make a two-consumer deployment stutter between the held cap and zero on
+    # identical perception.
+    cap, reason = resolve_stabilized_cap(_stabilized(0.6, "CAP_REPLAY_HELD"), 2.0)
+    assert reason == STABILIZED_OK
+    assert cap == 0.6
+
+
+def test_an_unusable_clamp_bound_fails_closed():
+    # Clamping against NaN passes the stabilized value through untouched, so an
+    # unusable bound is itself a fault rather than a reason to skip the clamp.
+    for bound in (float("nan"), float("inf"), -1.0, None, "2.0", True):
+        cap, reason = resolve_stabilized_cap(_stabilized(1.5), bound)
+        assert reason == STABILIZED_MALFORMED, bound
+        assert cap == 0.0, bound
 
 
 def test_zero_stabilized_cap_is_a_valid_relay_not_a_fault():
     # Zero is what the checker serves while holding the robot. Treating it as
     # missing would report a relay fault every time the cap was legitimately down.
-    cap, reason = resolve_stabilized_cap(
-        {"stabilized_speed_cap_mps": 0.0}, 2.0
-    )
+    cap, reason = resolve_stabilized_cap(_stabilized(0.0), 2.0)
     assert reason == STABILIZED_OK
     assert cap == 0.0
+
+
+def test_no_cap_state_machine_survives_in_this_module():
+    # Gate: prove the Python authority is ABSENT, not merely unused. An advisory
+    # copy of a safety state machine drifts silently — its tests keep passing while
+    # nothing enforces it, which is the condition that made the original placement a
+    # problem. This fails if anyone reintroduces one.
+    import perception_cap
+
+    for gone in (
+        "SpeedCapGovernor",
+        "SpeedCapGovernorConfig",
+        "SpeedCapDecision",
+    ):
+        assert not hasattr(perception_cap, gone), gone
+
+    source = open(perception_cap.__file__, encoding="utf-8").read()
+    for residue in ("rise_rate", "clear_confirmations", "initial_cap", "max_dt"):
+        assert residue not in source, residue

--- a/ros2_ws/src/kirra_safety/test/test_perception_cap.py
+++ b/ros2_ws/src/kirra_safety/test/test_perception_cap.py
@@ -13,8 +13,10 @@ import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "kirra_safety"))
 from perception_cap import (  # noqa: E402
-    GOV_PASS,
     apply_perception_cap,
+    resolve_stabilized_cap,
+    STABILIZED_OK,
+    STABILIZED_MISSING,
     DISABLED,
     STALE,
     INVALID,
@@ -66,241 +68,55 @@ def test_zero_cap_holds_the_robot():
     assert v == 0.0 and reason == CAPPED
 
 
-def test_reverse_direction_is_preserved_and_clamped():
-    # Backing up at -1.8, cap 0.5 → -0.5 (magnitude clamped, sign kept).
-    v, reason = apply_perception_cap(-1.8, cap_mps=0.5, cap_age_s=0.1, enabled=True, stale_s=STALE_S)
-    assert v == -0.5 and reason == CAPPED
+
+# ---------------------------------------------------------------------------
+# #1212 relay: the node forwards the CHECKER's stabilized cap and computes none.
+# ---------------------------------------------------------------------------
 
 
-from perception_cap import (  # noqa: E402
-    GOV_CONFIRMING,
-    GOV_INITIAL_HOLD,
-    GOV_INVALID,
-    GOV_RESTRICTED,
-    GOV_RISING,
-    GOV_TIME_BACKWARD,
-    GOV_TIME_GAP,
-    SpeedCapGovernor,
-    SpeedCapGovernorConfig,
-)
-
-
-def governor():
-    return SpeedCapGovernor(
-        SpeedCapGovernorConfig(
-            rise_rate_mps_per_s=0.50,
-            clear_confirmations=5,
-            maximum_dt_s=0.25,
-            initial_cap_mps=0.0,
-        )
+def test_stabilized_cap_is_relayed_when_present():
+    cap, reason = resolve_stabilized_cap(
+        {"stabilized_speed_cap_mps": 0.8}, 2.0
     )
+    assert reason == STABILIZED_OK
+    assert cap == 0.8
 
 
-def test_temporal_governor_first_permissive_sample_remains_stopped():
-    decision = governor().update(4.77, 1_000_000_000)
-
-    assert decision.governed_cap_mps == 0.0
-    assert decision.reason == GOV_INITIAL_HOLD
-    assert decision.clear_streak == 1
-
-
-def test_temporal_governor_restrictive_change_is_immediate():
-    cap = governor()
-
-    for index in range(10):
-        cap.update(
-            4.0,
-            1_000_000_000 + index * 100_000_000,
-        )
-
-    previous_governed_cap_mps = cap.governed_cap_mps
-    decision = cap.update(0.50, 2_000_000_000)
-
-    # Raw safety tightened from 4.0 to 0.50, but handling that
-    # restriction must never raise an already safer governed cap.
-    assert decision.governed_cap_mps == previous_governed_cap_mps
-    assert decision.governed_cap_mps <= 0.50
-    assert decision.reason == GOV_RESTRICTED
-    assert decision.clear_streak == 0
-
-
-def test_temporal_governor_requires_clear_confirmation_streak():
-    cap = governor()
-    start = 1_000_000_000
-
-    decisions = [
-        cap.update(4.77, start + index * 100_000_000)
-        for index in range(4)
-    ]
-
-    assert all(d.governed_cap_mps == 0.0 for d in decisions)
-    assert decisions[-1].reason == GOV_CONFIRMING
-    assert decisions[-1].clear_streak == 4
-
-
-def test_temporal_governor_rises_only_at_configured_rate():
-    cap = governor()
-    start = 1_000_000_000
-
-    decisions = [
-        cap.update(4.77, start + index * 100_000_000)
-        for index in range(6)
-    ]
-
-    # Confirmation becomes sufficient on the fifth observation. At 10 Hz,
-    # a 0.50 m/s/s rise rate permits only 0.05 m/s per update.
-    assert abs(decisions[4].governed_cap_mps - 0.05) < 1e-9
-    assert abs(decisions[5].governed_cap_mps - 0.10) < 1e-9
-    assert decisions[5].reason == GOV_RISING
-
-
-def test_restrictive_sample_resets_clear_confirmation_streak():
-    cap = governor()
-    start = 1_000_000_000
-
-    for index in range(4):
-        cap.update(4.77, start + index * 100_000_000)
-
-    decision = cap.update(0.0, start + 400_000_000)
-
-    assert decision.governed_cap_mps == 0.0
-    assert decision.reason == GOV_RESTRICTED
-    assert decision.clear_streak == 0
-
-    next_decision = cap.update(4.77, start + 500_000_000)
-    assert next_decision.governed_cap_mps == 0.0
-    assert next_decision.clear_streak == 1
-
-
-def test_invalid_raw_caps_fail_closed_and_reset():
-    for raw_cap in [float("nan"), float("inf"), float("-inf"), -0.01, None]:
-        cap = governor()
-        cap.update(4.77, 1_000_000_000)
-
-        decision = cap.update(raw_cap, 1_100_000_000)
-
-        assert decision.governed_cap_mps == 0.0
-        assert decision.reason == GOV_INVALID
-        assert decision.clear_streak == 0
-
-
-def test_backward_monotonic_clock_fails_closed():
-    cap = governor()
-    cap.update(4.77, 1_000_000_000)
-
-    decision = cap.update(4.77, 900_000_000)
-
-    assert decision.governed_cap_mps == 0.0
-    assert decision.reason == GOV_TIME_BACKWARD
-    assert decision.clear_streak == 0
-
-
-def test_excessive_processing_gap_fails_closed():
-    cap = governor()
-    cap.update(4.77, 1_000_000_000)
-
-    decision = cap.update(4.77, 1_500_000_000)
-
-    assert decision.governed_cap_mps == 0.0
-    assert decision.reason == GOV_TIME_GAP
-    assert decision.clear_streak == 0
-
-
-def test_invalid_governor_configuration_is_rejected():
-    import pytest
-
-    with pytest.raises(ValueError):
-        SpeedCapGovernorConfig(rise_rate_mps_per_s=0.0)
-
-    with pytest.raises(ValueError):
-        SpeedCapGovernorConfig(clear_confirmations=0)
-
-    with pytest.raises(ValueError):
-        SpeedCapGovernorConfig(maximum_dt_s=-1.0)
-
-    with pytest.raises(ValueError):
-        SpeedCapGovernorConfig(initial_cap_mps=-0.1)
-
-
-def test_small_raw_cap_jitter_does_not_reset_confirmation():
-    cap = governor()
-    start = 1_000_000_000
-
-    raw_caps = [0.73, 0.74, 0.72, 0.74, 0.73, 0.74]
-
-    decisions = [
-        cap.update(raw, start + index * 100_000_000)
-        for index, raw in enumerate(raw_caps)
-    ]
-
-    assert decisions[4].governed_cap_mps > 0.0
-    assert decisions[-1].reason in (GOV_RISING, GOV_PASS)
-    assert decisions[-1].clear_streak >= 5
-
-
-def test_raw_cap_drop_beyond_epsilon_is_restrictive():
-    cap = governor()
-    start = 1_000_000_000
-
-    for index in range(8):
-        cap.update(0.74, start + index * 100_000_000)
-
-    decision = cap.update(0.69, start + 800_000_000)
-
-    assert decision.reason == GOV_RESTRICTED
-    assert decision.governed_cap_mps <= 0.69
-    assert decision.clear_streak == 0
-
-
-def test_restriction_epsilon_configuration_is_validated():
-    import pytest
-
-    with pytest.raises(ValueError):
-        SpeedCapGovernorConfig(restriction_epsilon_mps=-0.01)
-
-    with pytest.raises(ValueError):
-        SpeedCapGovernorConfig(restriction_epsilon_mps=float("nan"))
-
-def test_one_centimeter_per_second_drop_clamps_without_resetting_streak():
-    cap = SpeedCapGovernor(
-        SpeedCapGovernorConfig(
-            rise_rate_mps_per_s=0.50,
-            restriction_epsilon_mps=0.03,
-            clear_confirmations=5,
-            maximum_dt_s=0.25,
-            initial_cap_mps=0.74,
-        )
+def test_relay_is_clamped_by_the_unhealthy_raw_cap():
+    # An unhealthy frame zeroes the raw cap upstream; the relay must never widen it.
+    cap, reason = resolve_stabilized_cap(
+        {"stabilized_speed_cap_mps": 0.8}, 0.0
     )
-    start = 2_000_000_000
-
-    for index in range(5):
-        cap.update(0.74, start + index * 100_000_000)
-
-    previous_streak = cap.clear_streak
-    decision = cap.update(0.73, start + 500_000_000)
-
-    assert decision.governed_cap_mps == 0.73
-    assert decision.reason == GOV_PASS
-    assert decision.clear_streak == previous_streak
+    assert reason == STABILIZED_OK
+    assert cap == 0.0
 
 
-def test_material_drop_still_resets_streak_and_clamps_immediately():
-    cap = SpeedCapGovernor(
-        SpeedCapGovernorConfig(
-            rise_rate_mps_per_s=0.50,
-            restriction_epsilon_mps=0.03,
-            clear_confirmations=5,
-            maximum_dt_s=0.25,
-            initial_cap_mps=0.74,
-        )
+def test_missing_stabilized_cap_fails_closed():
+    # An older Taj that does not serve the field is NOT a licence to fall back on
+    # the raw cap. Falling back would silently restore pre-#1212 behaviour on
+    # exactly the deployments that had not been upgraded.
+    for payload in (
+        {},
+        {"speed_cap_mps": 1.5},
+        None,
+        "not a dict",
+        {"stabilized_speed_cap_mps": None},
+        {"stabilized_speed_cap_mps": "0.8"},
+        {"stabilized_speed_cap_mps": True},
+        {"stabilized_speed_cap_mps": float("nan")},
+        {"stabilized_speed_cap_mps": float("inf")},
+        {"stabilized_speed_cap_mps": -0.1},
+    ):
+        cap, reason = resolve_stabilized_cap(payload, 2.0)
+        assert reason == STABILIZED_MISSING, payload
+        assert cap == 0.0, payload
+
+
+def test_zero_stabilized_cap_is_a_valid_relay_not_a_fault():
+    # Zero is what the checker serves while holding the robot. Treating it as
+    # missing would report a relay fault every time the cap was legitimately down.
+    cap, reason = resolve_stabilized_cap(
+        {"stabilized_speed_cap_mps": 0.0}, 2.0
     )
-    start = 3_000_000_000
-
-    for index in range(5):
-        cap.update(0.74, start + index * 100_000_000)
-
-    decision = cap.update(0.60, start + 500_000_000)
-
-    assert decision.governed_cap_mps == 0.60
-    assert decision.reason == GOV_RESTRICTED
-    assert decision.clear_streak == 0
+    assert reason == STABILIZED_OK
+    assert cap == 0.0


### PR DESCRIPTION
> #1225 gave the checker a stabilizer. Nothing called it — the Python state machine was still the live authority. This makes the checker's number the one that reaches the wheels.

**Completes #1212.** Off `main` (which has #1225).

## The migration, end to end

```
Taj raw cap
  → Rust stabilizer owns state          (#1225)
  → sidecar serves raw + stabilized + limiting identity
  → perception_governor relays
  → Python stabilizer DELETED
```

## What the wire carries now

`speed_cap_mps` becomes the **stabilized** value — the enforced number — with `raw_speed_cap_mps` alongside, plus `cap_reason`, `cap_clear_streak` and `cap_limiting_object`.

Three numbers matter to an operator: what perception saw, what liveness allowed, what is enforced. So `raw_speed_cap_mps` stays perception's own geometry and is **not** overwritten by the liveness floor — an early draft did overwrite it, and a warm-up frame then reported `raw = 0`, which is exactly the collapse that made the Python's behaviour invisible.

## Ordering, and why it composes

Stabilization runs **last**, over the liveness-adjusted cap. Feeding a sensor fault's zero through the stabilizer makes a fault behave exactly like a hazard — restrict instantly, re-earn the full streak on recovery. That is what the Python did with `effective_raw_cap = 0.0 if not healthy`.

It also means **a recovering sensor must earn both streaks**. "The sensor is producing frames again" and "the envelope may widen" are different claims, and `a_recovering_sensor_must_earn_both_streaks` pins that the cap is still floored at the moment liveness reports healthy. Three existing liveness tests were scoped back to their actual subject rather than weakened — they were asserting cap release as a side effect of liveness recovery, which is no longer true and shouldn't be.

## Limiting-object identity

Reported only when an **object** bound the clear distance, not when the corridor geometry did. Naming one otherwise would have the persistence logic hold a cap against a hazard that never existed.

The nearest-object fold previously discarded which object won; it now tracks the id, with **ties broken by lower id** so two objects at equal distance cannot alternate the reported identity frame to frame — which would look exactly like a dropout to the persistence logic and hold the cap for a grace window on nothing.

## Re-posts and probes

Serve the held cap without advancing the stabilizer, same rule as the watchdog. Otherwise two consumers posting the same scan inflate the frame rate the rise limiter divides by, and a two-consumer deployment climbs **twice as fast** as a one-consumer deployment on identical perception. `a_repost_does_not_advance_the_stabilizer` runs single- and double-posted streams side by side and requires identical caps.

## Two gates, not one

Stabilization is gated separately from the liveness watchdog (`with_options`). They answer different questions, so disabling one must not silently disable the other — the disarmed-watchdog test now turns both off explicitly rather than asserting the absence of two features while naming one.

The stateless `handle_perception` disables both. Stabilization is a property of a *stream*: a restriction is "tighter than the last frame", a release is "clear for N frames". A one-shot call has no previous frame, so an armed stabilizer would hold every caller at the floor forever while asserting a temporal judgement it has no history to make. It reports `cap_reason: None` rather than a stabilized number it did not compute.

## Python: relay, then delete

`perception_governor` relays and computes nothing. The relay decision is extracted into `perception_cap.resolve_stabilized_cap` so it is unit-testable without ROS, and it **fails closed** when the field is absent or malformed.

That last part matters more than it looks: an older Taj that does not serve a stabilized cap is not a licence to fall back on the raw one. Falling back would silently restore pre-#1212 behaviour on exactly the deployments that hadn't been upgraded — the worst place for it and the hardest to notice.

`SpeedCapGovernor`, its config, its decision type and its **15 tests are deleted**, not demoted to advisory. An unused copy of a safety state machine drifts silently: its tests keep passing while nothing enforces it, which is the exact condition that made the original placement a problem.

## Tests

134 sidecar (7 new) · 281 ROS (4 new for the relay, 15 governor tests removed) · 414 robot · workspace green · clippy clean · guardrails and mick-actuation-fence green.

**Three of the new tests started out asserting the wrong thing**, and the corrections are worth reading:

- A restriction to a hazard still *above* the standing cap registers as `CAP_RESTRICTED` without moving the served number. That's correct — the enforced cap was already more conservative than the new hazard requires — but it proves nothing about immediacy, so the test now uses a hazard below the standing cap.
- A post-reset rise of one bounded step is the normal climb continuing, not a reset handing back a cap. The assertion now bounds the *jump* rather than forbidding movement.
- `raw_speed_cap_mps` read zero on a warm-up frame, which surfaced the liveness-overwrite issue described above.

## Note on an unrelated flake

The full-workspace run showed the same 2 intermittent `kirra_verifier_service` failures recorded in #1226 — second reproduction, identical `139 passed; 2 failed` signature, and it passed clean on re-run again so the names still aren't captured. Unrelated to this diff and not blocking.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjDFKPcBVHURDZpXsvnYhC)_