### PR TITLE
feat(perception): make the scan callback non-blocking and identity-checked

### DIFF
--- a/ros2_ws/src/kirra_safety/config/kirra_params.yaml
+++ b/ros2_ws/src/kirra_safety/config/kirra_params.yaml
@@ -112,7 +112,14 @@ perception_governor:
     scan_topic: "/scan"
     cap_topic: "/kirra/perception_speed_cap"
     health_topic: "/kirra/perception_health"
-    timeout_ms: 40
+    timeout_ms: 40               # PER-SOCKET-OPERATION budget; see deadline_ms
+    # #1218 non-blocking cycle. deadline_ms is NOT a second timeout: `requests`
+    # times out per socket operation, so a sidecar dribbling bytes never trips
+    # timeout_ms. This is the wall-clock budget the NODE enforces, after which
+    # the cap is floored regardless of what the transport is doing.
+    publish_period_ms: 100       # how often the cap is (re)decided and published
+    deadline_ms: 250             # in-flight budget before the cap is floored
+    scan_stale_ms: 500           # max age of the SCAN behind a published cap
     forward_extent_m: 8.0        # Taj geometric horizon (m)
     decel_mps2: 1.5              # assumed comfortable brake for the ACD cap
     margin_m: 0.4                # standoff distance (matches the checker's lateral margin)

--- a/ros2_ws/src/kirra_safety/kirra_safety/async_perception.py
+++ b/ros2_ws/src/kirra_safety/kirra_safety/async_perception.py
@@ -49,10 +49,28 @@ counters, no slot state beyond its own deposit. Every publish decision is made
 by the executor thread calling into this module. These functions are pure, so
 they hold no lock and can never be the thing that stalls a callback.
 
-The timer is not an implementation detail that could be dropped by having the
-worker publish directly. It is what makes the DEADLINE enforceable: a worker
-blocked on a socket cannot notice that it is late, so something else has to be
-running in order to floor the cap on time. See `deadline_breached`.
+THE TIMER IS AN INDEPENDENT LIVENESS AUTHORITY, NOT A POLLING LOOP
+------------------------------------------------------------------
+Read this before moving deadline handling anywhere else.
+
+The worker CANNOT be trusted to report that it missed its deadline, because the
+failure mode is precisely that it may never regain execution. Self-reported
+lateness is only available from a thread that is still running, which excludes
+every case the deadline exists for.
+
+So the timer is not an implementation detail that could be dropped by having the
+worker publish on completion. It is the one component that can, without
+depending on transport progress at all:
+
+  - age the last result out of usefulness,
+  - floor the cap when the deadline passes,
+  - report displacement and blockage,
+  - and surface that process-level recovery is needed.
+
+A refactor that moves deadline handling into the worker — "simpler, it already
+knows when it started" — silently removes every one of those, and does so in a
+way that passes every test written against a sidecar that eventually answers.
+The failure only appears against one that never does. See `deadline_breached`.
 
 WHY A DEADLINE IS NOT A SOCKET TIMEOUT
 --------------------------------------

--- a/ros2_ws/src/kirra_safety/kirra_safety/async_perception.py
+++ b/ros2_ws/src/kirra_safety/kirra_safety/async_perception.py
@@ -74,6 +74,30 @@ cannot presently justify a non-zero speed cap, so it publishes zero. They are
 kept as distinct reasons because the operator response differs, not because the
 verdict does.
 
+WHAT THIS DOES NOT FIX — a claim boundary worth stating
+-------------------------------------------------------
+This makes the ROS EXECUTOR recoverable. It does not make a blocked socket
+recoverable. Those are different claims and conflating them would be the most
+consequential misreading of this module.
+
+If a worker never returns — a socket that neither completes nor times out — the
+one-in-flight bound means no replacement is ever started, and the newest scan
+sits in the slot unprocessed for as long as that lasts. The cap stays floored,
+so the outcome is SAFE; but the node does not recover on its own, and
+availability is lost indefinitely.
+
+That bound is not a defect to remove. It is what stops a sick sidecar exhausting
+threads, and abandoning a worker whose socket may still be live would trade a
+bounded availability loss for an unbounded resource one.
+
+Recovery therefore belongs to the RUNTIME, not to this module, and the options
+are process-level rather than thread-level: supervision that restarts the node,
+a sidecar circuit-breaker and restart, a replaceable worker PROCESS rather than
+a thread, or transport cancellation where the transport supports it. None is
+implemented here. Pinned by
+`test_a_wedged_worker_blocks_every_later_scan_which_is_an_availability_limit`,
+so a future change that does add recovery has to come here and say so.
+
 TRANSPORT IS TRANSITIONAL
 ------------------------
 JSON over HTTP is not the intended long-term carrier for a per-scan safety

--- a/ros2_ws/src/kirra_safety/kirra_safety/async_perception.py
+++ b/ros2_ws/src/kirra_safety/kirra_safety/async_perception.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""
+Pure decision logic for the perception governor's non-blocking scan cycle.
+
+No ROS / rclpy, no `requests`, no clock reads, no globals, no environment. Every
+function takes explicit values and returns a decision, so the whole issue /
+resolve state machine is unit-testable without a ROS graph or a sidecar.
+
+Sibling of `async_plan`, which does the same job for the doer's plan cycle. The
+vocabulary is deliberately shared where the meaning is shared, and deliberately
+different where it is not — see SCAN-DRIVEN, NOT TIMER-DRIVEN below.
+
+WHY THIS EXISTS
+---------------
+`perception_governor._on_scan` used to POST to Taj and block on the reply INSIDE
+the scan subscription callback. Under rclpy's single-threaded executor that
+couples sensor ingest to a network round trip: while the callback waits, no
+other callback on the node runs, and inbound scans queue behind it. A slow or
+wedged sidecar therefore backs up the very ingest it is supposed to be judging.
+
+Worse, nothing established that a reply belonged to the scan currently in hand.
+A reply for scan N applied to scan N+3 is perception evidence attributed to the
+wrong instant — and the #1214 evidence-binding work cannot help, because that
+mismatch happens BEFORE the frame identity is stamped onto anything.
+
+SCAN-DRIVEN, NOT TIMER-DRIVEN
+-----------------------------
+`async_plan`'s doer runs on a timer and asks "may I start a job this tick?".
+Perception is driven by scan ARRIVAL, which is not under the node's control, so
+the shape differs in one important way: a scan that arrives while a job is in
+flight must go somewhere.
+
+It goes into a LATEST-FRAME SLOT of exactly one entry. A newer scan OVERWRITES
+an older un-started one rather than queueing behind it, so the backlog is
+bounded by construction rather than by a queue length nobody tuned. Overwriting
+is correct for perception in a way it would not be for commands: the newest scan
+is strictly better evidence than the one it replaces, and the older scan's only
+remaining value would be to make the robot act on a staler view of the world.
+
+Overwrites are COUNTED. Bounded-by-construction is a design property; how often
+it actually engages is an operational fact, and a governor silently dropping
+every second scan should be visible to whoever is wondering why the cap is low.
+
+THREAD DISCIPLINE THIS MODULE ASSUMES
+-------------------------------------
+The worker computes; the PUBLISH TIMER publishes. A worker deposits an immutable
+`PerceptionResult` into a slot and touches nothing else — no publisher, no
+counters, no slot state beyond its own deposit. Every publish decision is made
+by the executor thread calling into this module. These functions are pure, so
+they hold no lock and can never be the thing that stalls a callback.
+
+The timer is not an implementation detail that could be dropped by having the
+worker publish directly. It is what makes the DEADLINE enforceable: a worker
+blocked on a socket cannot notice that it is late, so something else has to be
+running in order to floor the cap on time. See `deadline_breached`.
+
+WHY A DEADLINE IS NOT A SOCKET TIMEOUT
+--------------------------------------
+`requests`' timeout is per socket operation, not wall-clock. A server that
+dribbles bytes holds a worker open indefinitely without ever tripping it — the
+same hazard `async_plan.job_overdue_s` exists for. Here it is not merely an
+observability problem: perception drives a SPEED CAP, so a sidecar that stops
+answering must floor that cap on a schedule the node controls, not whenever the
+transport eventually gives up.
+
+So the deadline is judged against the node's own monotonic clock, independently
+of whether the HTTP call has returned, and a breach publishes the MRC floor.
+
+EVERY NON-USE OUTCOME FLOORS THE CAP
+------------------------------------
+There is exactly one publishable outcome, `USE`. Absent, superseded, stale,
+faulted and deadline-breached all mean the same thing to the wheels: the node
+cannot presently justify a non-zero speed cap, so it publishes zero. They are
+kept as distinct reasons because the operator response differs, not because the
+verdict does.
+
+TRANSPORT IS TRANSITIONAL
+------------------------
+JSON over HTTP is not the intended long-term carrier for a per-scan safety
+signal, and nothing here should be read as endorsing it. This work makes the
+CURRENT transport non-blocking and identity-checked; it does not make it the
+right transport.
+
+The migration target is a typed carrier — ROS 2 messages, or iceoryx2 shared
+memory (`tools/iceoryx2-spike/`, #270/#339) — where a reply cannot be
+mis-attributed because there is no request/response pairing to get wrong, and
+where serialization is not on the path at all.
+
+Two things here survive that migration and two do not. The DECISIONS survive:
+one in flight, newest-scan-wins, publish-at-most-once, deadline-floors-the-cap
+are properties of the cycle, not of HTTP. The request/response sequence pairing
+and the JSON body do not — they exist because this transport cannot express
+identity itself.
+"""
+
+from collections import namedtuple
+
+# --- issue decision --------------------------------------------------------
+ISSUE = "ISSUE"                    # start a request for the pending scan
+IN_FLIGHT = "IN_FLIGHT"            # a request is already running — never start a second
+NO_PENDING = "NO_PENDING"          # the slot is empty; nothing to ask about
+
+# --- result resolution -----------------------------------------------------
+USE = "USE"                # publish the cap this result carries
+ABSENT = "ABSENT"          # no result yet (first cycles, or request still running)
+SUPERSEDED = "SUPERSEDED"  # the result describes a scan we have already published or moved past
+STALE = "STALE"            # the scan behind it aged out of the budget
+FAULT = "FAULT"            # the request failed, or the response was unusable
+
+#: Outcomes that publish the MRC floor. Every resolution except `USE`, listed
+#: explicitly rather than derived as "not USE" so that adding a state forces a
+#: deliberate decision about which side of the line it falls on.
+FLOOR_STATES = frozenset({ABSENT, SUPERSEDED, STALE, FAULT})
+
+#: One completed request. Immutable, and built ONLY from values the worker
+#: copied out of the HTTP response — never a live ROS message.
+PerceptionResult = namedtuple("PerceptionResult", [
+    "request_sequence",   # node-local id of the scan this request was issued for
+    "scan_received_s",    # monotonic receipt time of that scan
+    "response",           # the Taj response dict, or None on fault
+    "fault",              # None, or a short stable reason tag
+])
+
+#: The immutable snapshot a worker is handed. Plain Python values only: the scan
+#: callback copies everything it needs out of the ROS message first, so the
+#: worker can never read a message the executor thread is mutating.
+PerceptionRequest = namedtuple("PerceptionRequest", [
+    "request_sequence",
+    "scan_received_s",
+    "taj_url",
+    "timeout_s",
+    "body",               # fully-built Taj request body
+])
+
+Resolution = namedtuple("Resolution", ["state", "reason"])
+
+_ABSENT = Resolution(ABSENT, "no completed request yet")
+
+
+class LatestFrameSlot:
+    """A one-entry slot holding the newest scan not yet handed to a worker.
+
+    Bounded by construction: `offer` replaces whatever is there. The count of
+    replacements is the observable an operator needs — see the module docstring.
+
+    Not thread-safe by itself. The caller holds it under the same lock it uses
+    for the in-flight flag, because "is a job running" and "what would it run
+    on" have to be read together or the answer is a race.
+    """
+
+    def __init__(self):
+        self._pending = None
+        self._overwrites = 0
+
+    @property
+    def overwrites(self) -> int:
+        """How many un-started scans have been displaced by a newer one."""
+        return self._overwrites
+
+    @property
+    def has_pending(self) -> bool:
+        return self._pending is not None
+
+    def offer(self, request) -> bool:
+        """Place `request` in the slot. Returns True if it displaced another.
+
+        The displaced scan is NOT counted as a fault. Displacement is the
+        intended behaviour under load — the newer scan is better evidence — and
+        counting it as an error would make normal operation at a high scan rate
+        look like a malfunction.
+        """
+        displaced = self._pending is not None
+        if displaced:
+            self._overwrites += 1
+        self._pending = request
+        return displaced
+
+    def take(self):
+        """Remove and return the pending request, or None."""
+        pending, self._pending = self._pending, None
+        return pending
+
+
+def decide_issue(request_in_flight: bool, has_pending: bool) -> str:
+    """May a request be started right now?
+
+    `IN_FLIGHT` is the bound on concurrency: exactly one request may run, so a
+    slow sidecar cannot cause unbounded thread creation however fast scans
+    arrive. Requests cannot be cancelled, so the only way to avoid a pile-up is
+    not to start one.
+    """
+    if request_in_flight:
+        return IN_FLIGHT
+    if not has_pending:
+        return NO_PENDING
+    return ISSUE
+
+
+def resolve_result(
+    result,
+    newest_request_sequence: int,
+    last_published_sequence: int,
+    now_s: float,
+    scan_stale_s: float,
+) -> Resolution:
+    """May this cycle publish the cap `result` carries?
+
+    Order is deliberate. Absence and faults are decided before identity, because
+    a failed request carries no evidence to compare. Identity is decided before
+    staleness, because a result about the wrong scan tells us nothing regardless
+    of its age.
+
+    Staleness is measured on the SCAN the result describes, not on when the
+    request completed: the safety question is "how old is the perception behind
+    this cap", and `scan_stale_s` is the operator-set answer to exactly that.
+    """
+    if result is None:
+        return _ABSENT
+
+    if result.fault:
+        return Resolution(FAULT, result.fault)
+
+    sequence = result.request_sequence
+
+    # Published at most once, and never backwards. A result for a scan already
+    # acted on is refused rather than republished — otherwise a wedged sidecar's
+    # last good answer would be re-served forever and a frozen world would look
+    # like a clear one.
+    if sequence <= last_published_sequence:
+        return Resolution(
+            SUPERSEDED,
+            "scan {} already published (watermark {})".format(
+                sequence, last_published_sequence
+            ),
+        )
+
+    # A result claiming a scan the node has never issued means the worker and the
+    # node disagree about identity — refuse rather than guess which is right.
+    if sequence > newest_request_sequence:
+        return Resolution(
+            SUPERSEDED,
+            "scan {} ahead of newest issued {}".format(
+                sequence, newest_request_sequence
+            ),
+        )
+
+    age_s = now_s - result.scan_received_s
+    if age_s > scan_stale_s:
+        return Resolution(
+            STALE,
+            "scan {:.3f}s old (budget {:.3f}s)".format(age_s, scan_stale_s),
+        )
+
+    return Resolution(USE, "")
+
+
+def deadline_breached(in_flight_since_s, now_s: float, deadline_s: float) -> bool:
+    """Has the outstanding request passed the node's own deadline?
+
+    Judged on the node's monotonic clock, deliberately independent of whether
+    the HTTP call has returned. `requests`' timeout is per socket operation, so
+    a server dribbling bytes never trips it; perception drives a speed cap, so
+    the cap has to be floored on a schedule the node controls rather than
+    whenever the transport eventually gives up.
+
+    `in_flight_since_s` is None when no request is running. A non-positive or
+    non-finite deadline disables the check rather than converting an operator's
+    configuration mistake into a permanent floor.
+    """
+    if in_flight_since_s is None:
+        return False
+    if not (deadline_s > 0.0) or deadline_s != deadline_s or deadline_s == float("inf"):
+        return False
+    return (now_s - in_flight_since_s) > deadline_s

--- a/ros2_ws/src/kirra_safety/kirra_safety/perception_governor.py
+++ b/ros2_ws/src/kirra_safety/kirra_safety/perception_governor.py
@@ -5,6 +5,13 @@ Kirra Perception Governor.
 Receives the latest lidar scan, requests a fused safety envelope from Taj, and
 publishes an asymmetrically stabilized speed cap.
 
+#1218: the scan callback is NON-BLOCKING. It stamps and copies the scan into a
+one-entry latest-frame slot and returns; a single bounded worker performs the
+HTTP round trip; a publish timer decides what reaches the wire. The callback no
+longer waits on a socket, so a slow sidecar cannot back up sensor ingest, and a
+reply can no longer be attributed to a scan other than the one it was issued
+for. Decisions live in `async_perception`; this module is the shell.
+
 Safety behavior:
 - Restrictive cap changes apply immediately.
 - Permissive changes require consecutive confirmation and rate-limited release.
@@ -14,6 +21,7 @@ Safety behavior:
 """
 
 import math
+import threading
 import time
 
 import rclpy
@@ -22,6 +30,18 @@ from rclpy.qos import HistoryPolicy, QoSProfile, ReliabilityPolicy
 from sensor_msgs.msg import LaserScan
 from std_msgs.msg import Float64, String
 
+from kirra_safety.async_perception import (
+    ISSUE,
+    LatestFrameSlot,
+    PerceptionRequest,
+    PerceptionResult,
+    STALE,
+    SUPERSEDED,
+    USE,
+    deadline_breached,
+    decide_issue,
+    resolve_result,
+)
 from kirra_safety.perception_cap import (
     STABILIZED_OK,
     STABILIZED_UNSTABILIZED,
@@ -107,6 +127,34 @@ class PerceptionGovernor(Node):
             self.get_parameter("confidence_floor").value
         )
 
+        # #1218 non-blocking cycle. The publish period is what bounds how long a
+        # wedged sidecar can leave a stale cap on the wire, and the deadline is
+        # what floors it — deliberately separate from `timeout_ms`, which is a
+        # PER-SOCKET-OPERATION budget and cannot bound wall-clock latency.
+        self.declare_parameter("publish_period_ms", 100)
+        self.declare_parameter("deadline_ms", 250)
+        self.declare_parameter("scan_stale_ms", 500)
+        publish_period_s = (
+            float(self.get_parameter("publish_period_ms").value) / 1000.0
+        )
+        self._deadline_s = float(self.get_parameter("deadline_ms").value) / 1000.0
+        self._scan_stale_s = (
+            float(self.get_parameter("scan_stale_ms").value) / 1000.0
+        )
+
+        # One lock over everything the worker and the executor thread both
+        # touch. The in-flight flag and the slot MUST be read together — "is a
+        # job running" and "what would it run on" is one question, and splitting
+        # it is a race that starts two workers.
+        self._lock = threading.Lock()
+        self._slot = LatestFrameSlot()
+        self._request_sequence = 0
+        self._last_published_sequence = 0
+        self._in_flight_since_s = None
+        self._result = None
+        self._discarded_replies = 0
+        self._deadline_breaches = 0
+
         self._session = (
             requests.Session()
             if REQUESTS_AVAILABLE
@@ -139,6 +187,12 @@ class PerceptionGovernor(Node):
             self._on_scan,
             SCAN_QOS,
         )
+        # The only publisher. Runs whether or not scans are arriving, which is
+        # the point: a sidecar that stops answering, or a lidar that stops
+        # producing, must still floor the cap on a schedule this node controls.
+        self._publish_timer = self.create_timer(
+            publish_period_s, self._on_publish_timer
+        )
 
         if not REQUESTS_AVAILABLE:
             self.get_logger().error(
@@ -166,9 +220,24 @@ class PerceptionGovernor(Node):
             String(data=health)
         )
 
+    def _counters(self) -> str:
+        """#1218 counters, appended to every health message.
+
+        On the health topic rather than a new one: an operator diagnosing "why
+        is the cap zero" is already reading this string, and a counter they have
+        to go and find separately is a counter they will not find. Read without
+        the lock — these are diagnostic totals, and a torn read costs nothing
+        that matters.
+        """
+        return (
+            f"discarded={self._discarded_replies}:"
+            f"deadline={self._deadline_breaches}:"
+            f"overwritten={self._slot.overwrites}"
+        )
+
     def _publish_fault(self, reason: str) -> None:
         # A fault invalidates all accumulated release evidence.
-        self._publish(0.0, reason)
+        self._publish(0.0, f"{reason}:{self._counters()}")
 
     @staticmethod
     def _finite_number(value) -> bool:
@@ -242,7 +311,8 @@ class PerceptionGovernor(Node):
             f"state={cap_reason}:"
             f"streak={cap_streak}:"
             f"limiting={cap_limiting}:"
-            f"width={min_width}/{required_width}m"
+            f"width={min_width}/{required_width}m:"
+            f"{self._counters()}"
         )
 
         self._publish(
@@ -302,63 +372,176 @@ class PerceptionGovernor(Node):
         except (AttributeError, TypeError, ValueError):
             return None
 
+    # ------------------------------------------------------------------
+    # #1218 non-blocking scan cycle.
+    #
+    # The callback COPIES and RETURNS; a worker does the network; a timer
+    # publishes. Nothing here waits on a socket, so a slow or wedged sidecar can
+    # no longer back up the sensor ingest it is being asked to judge.
+    #
+    # The decisions live in `async_perception` so they are testable without a
+    # ROS graph. This node is the shell: it owns the lock, the thread and the
+    # publishers, and asks that module what to do.
+    # ------------------------------------------------------------------
+
     def _on_scan(self, msg: LaserScan) -> None:
+        """Stamp, copy, offer, return. No network, no publishing, no blocking.
+
+        Publishing from here is deliberately avoided even for the
+        NO_REQUESTS_LIB case: the timer already floors the cap when nothing
+        resolves, so a second publisher on the scan callback would only add a
+        path that could disagree with it.
+        """
+        received_s = time.monotonic()
+        # Built BEFORE the lock. It reads the live ROS message — which the
+        # worker must never touch, hence copying here — but that copy is pure
+        # computation over a few hundred floats and holding the lock across it
+        # would stall the worker's deposit for no reason.
+        body = self._request_body(msg)
+        with self._lock:
+            self._request_sequence += 1
+            self._slot.offer(
+                PerceptionRequest(
+                    request_sequence=self._request_sequence,
+                    scan_received_s=received_s,
+                    taj_url=self._taj_url,
+                    timeout_s=self._timeout_s,
+                    body=body,
+                )
+            )
+        self._maybe_issue()
+
+    def _maybe_issue(self) -> None:
+        """Start a worker if one may run. Returns immediately either way."""
         if self._session is None:
-            self._publish_fault("NO_REQUESTS_LIB")
             return
+        with self._lock:
+            if decide_issue(self._in_flight_since_s is not None,
+                            self._slot.has_pending) != ISSUE:
+                return
+            pending = self._slot.take()
+            self._in_flight_since_s = time.monotonic()
+
+        worker = threading.Thread(
+            target=self._run_request, args=(pending,), daemon=True
+        )
+        worker.start()
+
+    def _run_request(self, pending) -> None:
+        """Worker body. Computes; deposits; touches nothing else.
+
+        Every exit path deposits a result, including the failures. A worker that
+        returned without depositing would leave the node unable to distinguish
+        "still working" from "died", and the deadline would be the only thing
+        that ever cleared it.
+        """
+        outcome = self._fetch(pending)
+        with self._lock:
+            self._result = outcome
+            self._in_flight_since_s = None
+        # A scan may have arrived while this ran; start its request now rather
+        # than waiting for the next one.
+        self._maybe_issue()
+
+    def _fetch(self, pending) -> PerceptionResult:
+        def faulted(reason):
+            return PerceptionResult(
+                request_sequence=pending.request_sequence,
+                scan_received_s=pending.scan_received_s,
+                response=None,
+                fault=reason,
+            )
 
         try:
             response = self._session.post(
-                f"{self._taj_url}/perception",
-                json=self._request_body(msg),
-                timeout=self._timeout_s,
+                f"{pending.taj_url}/perception",
+                json=pending.body,
+                timeout=pending.timeout_s,
             )
-
             if response.status_code != 200:
-                self._publish_fault(
-                    f"TAJ_HTTP_{response.status_code}"
-                )
-                return
+                return faulted(f"TAJ_HTTP_{response.status_code}")
 
             data = response.json()
-
             cap = data.get("speed_cap_mps")
             clear = data.get("clear_distance_m")
             healthy_value = data.get("healthy")
-
             if (
                 not self._finite_number(cap)
                 or float(cap) < 0.0
                 or not self._finite_number(clear)
                 or not isinstance(healthy_value, bool)
             ):
-                self._publish_fault("TAJ_MALFORMED")
-                return
+                return faulted("TAJ_MALFORMED")
 
-            self._publish_stabilized(
-                raw_cap_mps=float(cap),
-                healthy=healthy_value,
-                clear_distance_m=float(clear),
-                minimum_corridor_width_m=data.get(
-                    "minimum_corridor_width_m"
-                ),
-                required_corridor_width_m=data.get(
-                    "required_corridor_width_m"
-                ),
-                data=data,
+            return PerceptionResult(
+                request_sequence=pending.request_sequence,
+                scan_received_s=pending.scan_received_s,
+                response=data,
+                fault=None,
             )
-
         except requests.Timeout:
-            self._publish_fault("TAJ_TIMEOUT")
+            return faulted("TAJ_TIMEOUT")
         except requests.ConnectionError:
-            self._publish_fault("TAJ_UNREACHABLE")
+            return faulted("TAJ_UNREACHABLE")
         except (ValueError, TypeError):
-            self._publish_fault("TAJ_MALFORMED")
+            return faulted("TAJ_MALFORMED")
         except Exception as error:  # noqa: BLE001
-            self.get_logger().error(
-                f"perception governor error: {error}"
-            )
-            self._publish_fault("TAJ_ERROR")
+            self.get_logger().error(f"perception governor error: {error}")
+            return faulted("TAJ_ERROR")
+
+    def _on_publish_timer(self) -> None:
+        """The only publisher. Decides once per period and always publishes.
+
+        Always, not only on success: a cap that stops being republished is a cap
+        a consumer will age out on its own staleness rule, which is fail-closed
+        but silent. Publishing the floor with a named reason says WHY the robot
+        is holding.
+        """
+        now_s = time.monotonic()
+
+        # Decide under the lock; publish outside it. Holding a lock across a ROS
+        # publish would couple the worker's deposit to publisher latency, which
+        # is exactly the kind of coupling this issue exists to remove.
+        accepted = None
+        fault = None
+        with self._lock:
+            if self._session is None:
+                fault = "NO_REQUESTS_LIB"
+            elif deadline_breached(self._in_flight_since_s, now_s, self._deadline_s):
+                self._deadline_breaches += 1
+                # The request is left running — it cannot be cancelled, and the
+                # one-in-flight bound is what keeps a sick sidecar from spawning
+                # threads. It will deposit late and be refused as superseded.
+                fault = "TAJ_DEADLINE"
+            else:
+                verdict = resolve_result(
+                    self._result,
+                    newest_request_sequence=self._request_sequence,
+                    last_published_sequence=self._last_published_sequence,
+                    now_s=now_s,
+                    scan_stale_s=self._scan_stale_s,
+                )
+                if verdict.state == USE:
+                    accepted = self._result
+                    self._last_published_sequence = accepted.request_sequence
+                else:
+                    if verdict.state in (SUPERSEDED, STALE):
+                        self._discarded_replies += 1
+                    fault = f"TAJ_{verdict.state}"
+
+        if accepted is None:
+            self._publish_fault(fault)
+            return
+
+        data = accepted.response
+        self._publish_stabilized(
+            raw_cap_mps=float(data.get("speed_cap_mps")),
+            healthy=data.get("healthy"),
+            clear_distance_m=float(data.get("clear_distance_m")),
+            minimum_corridor_width_m=data.get("minimum_corridor_width_m"),
+            required_corridor_width_m=data.get("required_corridor_width_m"),
+            data=data,
+        )
 
     def destroy_node(self):
         if self._session is not None:

--- a/ros2_ws/src/kirra_safety/test/test_async_perception.py
+++ b/ros2_ws/src/kirra_safety/test/test_async_perception.py
@@ -350,3 +350,65 @@ def test_the_guard_would_notice_a_blocking_call():
         "the detector found nothing blocking in the worker, so finding nothing "
         "in the callback proves nothing"
     )
+
+
+# ---------------------------------------------------------------------------
+# Deadline and freshness are INDEPENDENT axes.
+#
+# They answer different questions:
+#
+#   deadline   — did the sidecar respond within the permitted service interval?
+#   freshness  — is the underlying scan still recent enough to use NOW?
+#
+# Conflating them is the "simplification" a future reader is most likely to
+# attempt: treating any post-deadline reply as invalid, or treating transport
+# completion as evidence of freshness. Both are wrong, and the matrix below is
+# what makes that concrete rather than a comment.
+# ---------------------------------------------------------------------------
+
+
+def _resolve_at(now_s, scan_received_s=100.0):
+    return resolve_result(
+        result(sequence=5, scan_received_s=scan_received_s),
+        newest_request_sequence=5,
+        last_published_sequence=4,
+        now_s=now_s,
+        scan_stale_s=STALE_S,
+    )
+
+
+def test_matrix_reply_before_deadline_with_a_fresh_scan_is_used():
+    assert _resolve_at(100.25).state == USE
+    assert deadline_breached(100.0, 100.25, 0.5) is False
+
+
+def test_matrix_reply_after_deadline_with_a_fresh_scan_is_still_used():
+    # The case that must NOT be simplified away. The deadline already did its
+    # job — the cap was floored while the node waited. Once real, current
+    # evidence arrives, refusing it would mean one slow round trip permanently
+    # discarded a usable scan.
+    assert deadline_breached(100.0, 100.25, 0.0625) is True, "deadline passed"
+    assert _resolve_at(100.25).state == USE, "…but the scan is still fresh"
+
+
+def test_matrix_reply_before_deadline_with_an_already_stale_scan_is_refused():
+    # The converse: fast transport is not evidence of fresh perception. A reply
+    # that arrives promptly about a scan submitted long ago is still stale.
+    assert deadline_breached(100.0, 100.0625, 0.5) is False, "inside the deadline"
+    assert _resolve_at(100.0625, scan_received_s=99.0).state == STALE
+
+
+def test_matrix_reply_after_both_deadline_and_freshness_is_refused():
+    assert deadline_breached(100.0, 101.0, 0.0625) is True
+    assert _resolve_at(101.0).state == STALE
+
+
+def test_freshness_is_judged_at_publish_time_not_at_reply_time():
+    # The same result becomes unusable as it ages in the slot, with no new
+    # information arriving. That is the property that stops a wedged sidecar's
+    # last good answer being served indefinitely.
+    held = result(sequence=5, scan_received_s=100.0)
+    fresh = resolve_result(held, 5, 4, 100.25, STALE_S)
+    later = resolve_result(held, 5, 4, 101.0, STALE_S)
+    assert fresh.state == USE
+    assert later.state == STALE, "the identical result must age out where it sits"

--- a/ros2_ws/src/kirra_safety/test/test_async_perception.py
+++ b/ros2_ws/src/kirra_safety/test/test_async_perception.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+"""
+Tests for the perception governor's non-blocking scan cycle (#1218).
+
+Pure — no ROS, no sidecar, no clock. Every value is injected, so the states that
+matter (a reply for a superseded scan, a sidecar that stops answering) are
+exercised directly rather than provoked.
+
+Run:  pytest ros2_ws/src/kirra_safety/test/test_async_perception.py
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "kirra_safety"))
+from async_perception import (  # noqa: E402
+    ABSENT,
+    FAULT,
+    FLOOR_STATES,
+    IN_FLIGHT,
+    ISSUE,
+    LatestFrameSlot,
+    NO_PENDING,
+    PerceptionRequest,
+    PerceptionResult,
+    STALE,
+    SUPERSEDED,
+    USE,
+    deadline_breached,
+    decide_issue,
+    resolve_result,
+)
+
+STALE_S = 0.5
+
+
+def result(sequence=5, scan_received_s=100.0, response=None, fault=None):
+    return PerceptionResult(
+        request_sequence=sequence,
+        scan_received_s=scan_received_s,
+        response=response if response is not None else {"speed_cap_mps": 1.0},
+        fault=fault,
+    )
+
+
+def request(sequence=5):
+    return PerceptionRequest(
+        request_sequence=sequence,
+        scan_received_s=100.0,
+        taj_url="http://localhost:8101",
+        timeout_s=0.04,
+        body={},
+    )
+
+
+# ---------------------------------------------------------------------------
+# decide_issue — the concurrency bound
+# ---------------------------------------------------------------------------
+
+
+def test_a_pending_scan_with_nothing_in_flight_is_issued():
+    assert decide_issue(request_in_flight=False, has_pending=True) == ISSUE
+
+
+def test_only_one_request_may_be_in_flight():
+    # The bound on thread creation. Requests cannot be cancelled, so the only
+    # way to avoid a pile-up against a slow sidecar is not to start one.
+    assert decide_issue(request_in_flight=True, has_pending=True) == IN_FLIGHT
+
+
+def test_in_flight_wins_over_pending():
+    # Both true is the interesting case: scans are arriving AND a request is
+    # running. It must not start a second.
+    assert decide_issue(request_in_flight=True, has_pending=True) == IN_FLIGHT
+
+
+def test_nothing_pending_is_not_an_issue():
+    assert decide_issue(request_in_flight=False, has_pending=False) == NO_PENDING
+
+
+# ---------------------------------------------------------------------------
+# LatestFrameSlot — bounded by construction, and visibly so
+# ---------------------------------------------------------------------------
+
+
+def test_the_slot_holds_the_newest_scan_and_discards_the_older():
+    slot = LatestFrameSlot()
+    assert not slot.has_pending
+
+    assert slot.offer(request(1)) is False
+    assert slot.has_pending
+    assert slot.offer(request(2)) is True, "the second offer displaced the first"
+
+    taken = slot.take()
+    assert taken.request_sequence == 2, "the NEWER scan survives, not the older"
+    assert not slot.has_pending
+    assert slot.take() is None
+
+
+def test_overwrites_are_counted():
+    # Bounded-by-construction is a design property; how often it engages is an
+    # operational fact. A governor silently dropping every second scan should be
+    # visible to whoever is wondering why the cap is low.
+    slot = LatestFrameSlot()
+    assert slot.overwrites == 0
+
+    slot.offer(request(1))
+    assert slot.overwrites == 0, "the first offer displaces nothing"
+
+    for _ in range(4):
+        slot.offer(request(9))
+    assert slot.overwrites == 4
+
+
+def test_taking_and_re_offering_does_not_count_an_overwrite():
+    # The steady state under load: take, run, a new scan arrives. That is not a
+    # displacement, and counting it as one would make normal operation at a high
+    # scan rate look like a malfunction.
+    slot = LatestFrameSlot()
+    for sequence in range(1, 20):
+        slot.offer(request(sequence))
+        slot.take()
+    assert slot.overwrites == 0
+
+
+# ---------------------------------------------------------------------------
+# resolve_result — one publishable outcome, everything else floors
+# ---------------------------------------------------------------------------
+
+
+def test_a_fresh_result_for_the_newest_scan_is_used():
+    verdict = resolve_result(
+        result(sequence=5, scan_received_s=100.0),
+        newest_request_sequence=5,
+        last_published_sequence=4,
+        now_s=100.1,
+        scan_stale_s=STALE_S,
+    )
+    assert verdict.state == USE
+
+
+def test_no_result_yet_is_absent_not_a_fault():
+    # The first cycles, and every cycle while a request is running. Reporting
+    # this as a fault would make a healthy startup look broken.
+    verdict = resolve_result(None, 5, 0, 100.0, STALE_S)
+    assert verdict.state == ABSENT
+
+
+def test_a_faulted_request_is_reported_as_its_own_fault():
+    verdict = resolve_result(
+        result(fault="TAJ_TIMEOUT"), 5, 4, 100.1, STALE_S
+    )
+    assert verdict.state == FAULT
+    assert verdict.reason == "TAJ_TIMEOUT"
+
+
+def test_a_result_for_an_already_published_scan_is_refused():
+    # THE republish hazard. Without the watermark a wedged sidecar's last good
+    # answer would be re-served every cycle, and a frozen world would look
+    # exactly like a clear one.
+    verdict = resolve_result(
+        result(sequence=5), newest_request_sequence=7,
+        last_published_sequence=5, now_s=100.1, scan_stale_s=STALE_S,
+    )
+    assert verdict.state == SUPERSEDED
+
+
+def test_a_result_ahead_of_anything_issued_is_refused():
+    # The worker and the node disagree about identity. Refuse rather than guess
+    # which one is right.
+    verdict = resolve_result(
+        result(sequence=9), newest_request_sequence=5,
+        last_published_sequence=0, now_s=100.1, scan_stale_s=STALE_S,
+    )
+    assert verdict.state == SUPERSEDED
+
+
+def test_staleness_is_measured_on_the_scan_not_on_the_reply():
+    # The safety question is how old the PERCEPTION is, not how recently the
+    # sidecar got back to us. A fast reply about an old scan is still old.
+    verdict = resolve_result(
+        result(sequence=5, scan_received_s=100.0),
+        newest_request_sequence=5,
+        last_published_sequence=4,
+        now_s=100.0 + STALE_S + 0.001,
+        scan_stale_s=STALE_S,
+    )
+    assert verdict.state == STALE
+
+
+def test_a_scan_exactly_at_the_staleness_budget_is_still_usable():
+    # The boundary is stated so a later change to the comparison shows up here
+    # rather than silently widening what counts as fresh.
+    verdict = resolve_result(
+        result(sequence=5, scan_received_s=100.0),
+        newest_request_sequence=5,
+        last_published_sequence=4,
+        now_s=100.0 + STALE_S,
+        scan_stale_s=STALE_S,
+    )
+    assert verdict.state == USE
+
+
+def test_identity_is_decided_before_staleness():
+    # A result about the wrong scan tells us nothing regardless of its age, and
+    # reporting it as STALE would send an operator to look at scan rates when
+    # the actual problem is identity.
+    verdict = resolve_result(
+        result(sequence=3, scan_received_s=0.0),
+        newest_request_sequence=9,
+        last_published_sequence=5,
+        now_s=1_000.0,          # wildly stale as well
+        scan_stale_s=STALE_S,
+    )
+    assert verdict.state == SUPERSEDED
+
+
+def test_a_fault_is_decided_before_identity():
+    # A failed request carries no evidence to compare, so comparing it would be
+    # inventing a verdict from a value that was never populated.
+    verdict = resolve_result(
+        result(sequence=99, fault="TAJ_UNREACHABLE"),
+        newest_request_sequence=5,
+        last_published_sequence=4,
+        now_s=100.1,
+        scan_stale_s=STALE_S,
+    )
+    assert verdict.state == FAULT
+
+
+def test_every_non_use_state_floors_the_cap():
+    # The safety property the whole module exists to deliver, asserted as a
+    # partition rather than trusted to the call sites. FLOOR_STATES is written
+    # out explicitly in the module, so this catches a new state being added
+    # without a decision about which side of the line it falls on.
+    all_states = {USE} | FLOOR_STATES
+    assert USE not in FLOOR_STATES
+    for state in (ABSENT, SUPERSEDED, STALE, FAULT):
+        assert state in FLOOR_STATES, state
+    assert len(all_states) == 5, "a state was added without classifying it"
+
+
+# ---------------------------------------------------------------------------
+# deadline_breached — the node's clock, not the transport's
+# ---------------------------------------------------------------------------
+
+
+def test_no_request_in_flight_cannot_breach():
+    assert deadline_breached(None, 100.0, 0.2) is False
+
+
+def test_a_request_inside_its_deadline_has_not_breached():
+    assert deadline_breached(100.0, 100.15, 0.2) is False
+
+
+def test_a_request_past_its_deadline_has_breached():
+    # THE case: the sidecar has not answered and `requests` has not given up,
+    # because its timeout is per socket operation. Perception drives a speed
+    # cap, so the cap must be floored on the node's schedule.
+    assert deadline_breached(100.0, 100.25, 0.2) is True
+
+
+def test_the_deadline_boundary_is_exclusive():
+    # Binary-exact values throughout: 0.25 and 100.25 are representable, so this
+    # measures the comparison rather than float representation. With 0.2,
+    # `100.2 - 100.0` is 0.20000000000000284 and "exactly at the deadline" is
+    # not a state the test could reach.
+    assert deadline_breached(100.0, 100.25, 0.25) is False, "exactly at is not past"
+    assert deadline_breached(100.0, 100.25 + 0.0625, 0.25) is True
+
+
+def test_an_unusable_deadline_disables_the_check_rather_than_floors_forever():
+    # Converting an operator's configuration mistake into a permanent floor
+    # would be a robot that never moves and never says why.
+    for bad in (0.0, -1.0, float("nan"), float("inf")):
+        assert deadline_breached(100.0, 1_000.0, bad) is False, bad
+
+
+# ---------------------------------------------------------------------------
+# Structural guard on the node itself (#1218 AC1).
+#
+# Parsed, not imported: the node needs rclpy and sensor_msgs, which are not
+# available in this host test environment. Parsing is also the stronger check —
+# it asserts a property of the SOURCE, so it holds whether or not the branch
+# happens to be exercised at runtime.
+# ---------------------------------------------------------------------------
+
+import ast  # noqa: E402
+
+_NODE_SOURCE = os.path.join(
+    os.path.dirname(__file__), "..", "kirra_safety", "perception_governor.py"
+)
+
+#: Attribute names that would mean the callback is waiting on something.
+_BLOCKING = {"post", "get", "put", "request", "send", "join", "sleep", "wait", "acquire"}
+
+
+def _method_bodies():
+    tree = ast.parse(open(_NODE_SOURCE, encoding="utf-8").read())
+    cls = next(n for n in ast.walk(tree) if isinstance(n, ast.ClassDef))
+    return {f.name: f for f in cls.body if isinstance(f, ast.FunctionDef)}
+
+
+def _reachable_attrs(entry, methods, seen=None):
+    """Attribute names reachable from `entry`, following self-calls."""
+    seen = seen or set()
+    if entry in seen or entry not in methods:
+        return set()
+    seen.add(entry)
+    found = set()
+    for node in ast.walk(methods[entry]):
+        if isinstance(node, ast.Attribute):
+            found.add(node.attr)
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "self"
+        ):
+            found |= _reachable_attrs(node.func.attr, methods, seen)
+    return found
+
+
+def test_the_scan_callback_reaches_no_blocking_call():
+    # AC1, as a property of the source. `_on_scan` runs on rclpy's
+    # single-threaded executor, so anything it waits on stalls every other
+    # callback on the node — including the scan subscription itself, which is
+    # how a slow sidecar used to back up the ingest it was judging.
+    methods = _method_bodies()
+    assert "_on_scan" in methods, "the callback was renamed; update this guard"
+
+    reachable = _reachable_attrs("_on_scan", methods)
+    offending = sorted(reachable & _BLOCKING)
+    assert not offending, (
+        f"_on_scan can reach blocking call(s) {offending}. The callback must "
+        f"copy and return; the worker does the network."
+    )
+
+
+def test_the_guard_would_notice_a_blocking_call():
+    # Non-vacuity: the walker must actually follow self-calls into helpers,
+    # otherwise the test above passes for any code at all.
+    methods = _method_bodies()
+    assert "_fetch" in methods, "the worker body was renamed; update this guard"
+
+    # `_fetch` is where the blocking call legitimately lives, so it must trip
+    # the same detector the callback is checked against.
+    reachable = _reachable_attrs("_fetch", methods)
+    assert reachable & _BLOCKING, (
+        "the detector found nothing blocking in the worker, so finding nothing "
+        "in the callback proves nothing"
+    )

--- a/ros2_ws/src/kirra_safety/test/test_perception_governor_async.py
+++ b/ros2_ws/src/kirra_safety/test/test_perception_governor_async.py
@@ -327,3 +327,137 @@ def test_counters_reach_the_health_wire():
     _cap, health = gov.published[-1]
     for field in ("discarded=", "deadline=", "overwritten="):
         assert field in health, f"{field} missing from {health}"
+
+
+# ---------------------------------------------------------------------------
+# Permanent worker blockage — SAFE, but an availability limitation.
+#
+# This is the case the async pattern does NOT fix, and the claim boundary
+# matters: it makes the ROS EXECUTOR recoverable, not a blocked socket. If the
+# worker never returns, the one-in-flight bound means no replacement is ever
+# started and the newest scan is never processed. The cap stays floored — safe
+# — but the node does not recover on its own.
+# ---------------------------------------------------------------------------
+
+
+class WedgedSession(FakeSession):
+    """A sidecar whose socket never completes and never times out."""
+
+    def __init__(self):
+        super().__init__()
+        self._never = threading.Event()
+
+    def post(self, *_a, **_k):
+        with self._lock:
+            self.calls += 1
+        self._never.wait()  # released only by `unwedge`
+
+    def unwedge(self):
+        self._never.set()
+
+
+def test_a_permanently_wedged_worker_floors_the_cap_and_keeps_it_floored():
+    session = WedgedSession()
+    gov = governor(session, deadline_s=0.02)
+
+    gov._on_scan(object())
+    time.sleep(0.05)
+    for _ in range(5):
+        gov._on_scan(object())
+
+    for _ in range(6):
+        gov._on_publish_timer()
+
+    assert all(cap == 0.0 for cap, _ in gov.published), "the cap must stay floored"
+    assert {h.split(":")[0] for _, h in gov.published} == {"TAJ_DEADLINE"}
+    assert gov._deadline_breaches == 6
+    session.unwedge()
+
+
+def test_a_wedged_worker_blocks_every_later_scan_which_is_an_availability_limit():
+    # Documented, not defended. Exactly one request was ever sent; the newest
+    # scan sits in the slot unprocessed for as long as the worker is stuck.
+    #
+    # Recovery is a RUNTIME concern (supervision, sidecar restart, or a
+    # replaceable process rather than a thread) — see the module docstring. This
+    # test exists so the limitation cannot be forgotten, and so that a future
+    # change which DOES add recovery has to come here and say so.
+    session = WedgedSession()
+    gov = governor(session, deadline_s=0.02)
+
+    gov._on_scan(object())
+    time.sleep(0.05)
+    for _ in range(4):
+        gov._on_scan(object())
+        gov._on_publish_timer()
+
+    assert session.calls == 1, (
+        "a second worker must never start — that bound is what stops thread "
+        "exhaustion against a sick sidecar"
+    )
+    with gov._lock:
+        assert gov._in_flight_since_s is not None, "still wedged"
+        assert gov._slot.has_pending, "the newest scan is waiting and will keep waiting"
+    session.unwedge()
+
+
+# ---------------------------------------------------------------------------
+# Timer idempotence and late-worker authority
+# ---------------------------------------------------------------------------
+
+
+def test_repeated_timer_ticks_with_no_new_evidence_keep_publishing_the_floor():
+    # Idempotent in the way that matters: the same absence produces the same
+    # verdict, and the cap never drifts upward because nothing happened.
+    gov = governor(FakeSession(payload=healthy_payload()))
+    for _ in range(8):
+        gov._on_publish_timer()
+    assert {cap for cap, _ in gov.published} == {0.0}
+    assert all(h.startswith("TAJ_ABSENT") for _, h in gov.published)
+
+
+def test_a_late_worker_cannot_restore_a_cap_after_its_scan_has_aged_out():
+    # The authority question behind the deadline: a worker that completes long
+    # after the runtime moved on must not be able to lift the floor. It is
+    # refused on FRESHNESS, which is the check that does not care how late the
+    # transport was — only how old the perception is.
+    session = FakeSession(payload=healthy_payload())
+    gov = governor(session, deadline_s=0.01, scan_stale_s=0.05)
+
+    gov._on_scan(object())
+    assert settle(gov), "the worker completed"
+
+    time.sleep(0.08)                 # the scan ages past the 50 ms budget
+    gov._on_publish_timer()
+
+    cap, health = gov.published[-1]
+    assert cap == 0.0
+    assert health.startswith("TAJ_STALE"), health
+
+
+def test_completion_and_arrival_racing_never_starts_two_workers():
+    # The determinism question: scans arriving exactly as a worker finishes.
+    # `_run_request` calls `_maybe_issue` after depositing, and `_on_scan` calls
+    # it too, so both paths can try to start the successor at once. The shared
+    # lock is what makes the outcome deterministic rather than a coin flip.
+    session = FakeSession(latency_s=0.002, payload=healthy_payload())
+    gov = governor(session)
+
+    stop = threading.Event()
+
+    def flood():
+        while not stop.is_set():
+            gov._on_scan(object())
+
+    threads = [threading.Thread(target=flood, daemon=True) for _ in range(4)]
+    for t in threads:
+        t.start()
+    time.sleep(0.4)
+    stop.set()
+    for t in threads:
+        t.join(timeout=1.0)
+
+    assert session.max_concurrent == 1, (
+        f"{session.max_concurrent} concurrent requests under a 4-thread flood"
+    )
+    assert session.calls > 1, "non-vacuity: the flood did drive real requests"

--- a/ros2_ws/src/kirra_safety/test/test_perception_governor_async.py
+++ b/ros2_ws/src/kirra_safety/test/test_perception_governor_async.py
@@ -1,0 +1,329 @@
+"""
+Callback-level tests for the perception governor's non-blocking scan cycle.
+
+These pin the invariants that only exist where the scan callback meets the
+background worker — that `_on_scan` returns while HTTP is still blocked, that a
+slow sidecar cannot pile up threads, and that every non-USE outcome floors the
+cap. The decision algebra itself is covered purely in test_async_perception.py;
+this file deliberately does not re-test it.
+
+NO ROS GRAPH IS NEEDED. `rclpy` / the message packages are stubbed into
+sys.modules before the node module is imported, and the node instance is built
+without running `Node.__init__` — so callbacks run against ordinary Python
+objects. The session is a fake whose latency and replies the test controls, so
+"did not wait for HTTP" is an assertion about wall clock rather than a network.
+
+Run:  pytest ros2_ws/src/kirra_safety/test/test_perception_governor_async.py
+"""
+
+import os
+import sys
+import threading
+import time
+import types
+
+
+# ---------------------------------------------------------------------------
+# ROS stubs — installed BEFORE importing the node module
+# ---------------------------------------------------------------------------
+
+def _install_ros_stubs():
+    for name in (
+        "rclpy", "rclpy.node", "rclpy.qos",
+        "sensor_msgs", "sensor_msgs.msg",
+        "std_msgs", "std_msgs.msg",
+    ):
+        sys.modules.setdefault(name, types.ModuleType(name))
+
+    class _Node:
+        def __init__(self, *a, **k):
+            pass
+
+    sys.modules["rclpy.node"].Node = _Node
+    sys.modules["rclpy.qos"].QoSProfile = lambda **kw: None
+    for attr in ("HistoryPolicy", "ReliabilityPolicy"):
+        setattr(
+            sys.modules["rclpy.qos"],
+            attr,
+            types.SimpleNamespace(BEST_EFFORT=0, KEEP_LAST=0),
+        )
+    sys.modules["sensor_msgs.msg"].LaserScan = object
+    for attr in ("Float64", "String"):
+        setattr(sys.modules["std_msgs.msg"], attr, lambda data=None: data)
+
+
+_install_ros_stubs()
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from kirra_safety import perception_governor as pg  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Harness
+# ---------------------------------------------------------------------------
+
+class FakeSession:
+    """A Taj stand-in whose latency and reply the test owns."""
+
+    def __init__(self, latency_s=0.0, payload=None, raise_with=None):
+        self.latency_s = latency_s
+        self.payload = healthy_payload() if payload is None else payload
+        self.raise_with = raise_with
+        self.calls = 0
+        self.concurrent = 0
+        self.max_concurrent = 0
+        self._lock = threading.Lock()
+        self.release = threading.Event()
+
+    def post(self, *_a, **_k):
+        with self._lock:
+            self.calls += 1
+            self.concurrent += 1
+            self.max_concurrent = max(self.max_concurrent, self.concurrent)
+        try:
+            if self.latency_s:
+                self.release.wait(self.latency_s)
+            if self.raise_with is not None:
+                raise self.raise_with
+            return _Response(self.payload)
+        finally:
+            with self._lock:
+                self.concurrent -= 1
+
+
+class _Response:
+    status_code = 200
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+def healthy_payload(cap=1.5):
+    return {
+        "speed_cap_mps": cap,
+        "clear_distance_m": 6.0,
+        "healthy": True,
+        "stabilized_speed_cap_mps": cap,
+        "cap_reason": "CAP_PASS",
+        "cap_clear_streak": 5,
+        "cap_limiting_object": None,
+        "minimum_corridor_width_m": 1.2,
+        "required_corridor_width_m": 0.5,
+    }
+
+
+def governor(session, deadline_s=0.25, scan_stale_s=0.5):
+    """A node instance with only the fields the async cycle touches."""
+    gov = pg.PerceptionGovernor.__new__(pg.PerceptionGovernor)
+    gov._lock = threading.Lock()
+    gov._slot = pg.LatestFrameSlot()
+    gov._request_sequence = 0
+    gov._last_published_sequence = 0
+    gov._in_flight_since_s = None
+    gov._result = None
+    gov._discarded_replies = 0
+    gov._deadline_breaches = 0
+    gov._deadline_s = deadline_s
+    gov._scan_stale_s = scan_stale_s
+    gov._taj_url = "http://taj.invalid"
+    gov._timeout_s = 0.04
+    gov._session = session
+    gov._request_body = lambda msg: {"ranges": []}
+    gov.published = []
+    gov._publish = lambda cap, health: gov.published.append((float(cap), health))
+    gov.logged = []
+    gov.get_logger = lambda: types.SimpleNamespace(
+        error=gov.logged.append, warn=gov.logged.append, info=gov.logged.append
+    )
+    return gov
+
+
+def settle(gov, timeout_s=2.0):
+    """Wait for the in-flight worker to deposit, so assertions are not racy."""
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        with gov._lock:
+            if gov._in_flight_since_s is None:
+                return True
+        time.sleep(0.005)
+    return False
+
+
+# ---------------------------------------------------------------------------
+# AC1 — the callback does not wait
+# ---------------------------------------------------------------------------
+
+
+def test_the_scan_callback_returns_while_http_is_still_blocked():
+    # THE issue. Under rclpy's single-threaded executor, a callback that waits
+    # stalls every other callback on the node — including scan ingest, so a slow
+    # sidecar used to back up the very stream it was judging.
+    session = FakeSession(latency_s=5.0)
+    gov = governor(session)
+
+    started = time.monotonic()
+    gov._on_scan(object())
+    elapsed_s = time.monotonic() - started
+
+    assert elapsed_s < 0.25, (
+        f"the callback took {elapsed_s * 1000:.1f} ms against a 5 s sidecar; "
+        f"it must copy and return, not wait"
+    )
+    session.release.set()
+    settle(gov)
+
+
+def test_the_worker_actually_performs_the_request():
+    # Non-vacuity for the test above: returning fast is trivial if nothing is
+    # ever sent. The work must still happen, just not on the callback.
+    session = FakeSession(payload=healthy_payload())
+    gov = governor(session)
+    gov._on_scan(object())
+    assert settle(gov), "the worker never completed"
+    assert session.calls == 1
+
+
+# ---------------------------------------------------------------------------
+# AC — one in-flight request, latest-frame slot
+# ---------------------------------------------------------------------------
+
+
+def test_scans_arriving_during_a_request_never_start_a_second():
+    # The bound on thread creation against a slow sidecar. Requests cannot be
+    # cancelled, so not starting one is the only control available.
+    session = FakeSession(latency_s=5.0)
+    gov = governor(session)
+
+    for _ in range(25):
+        gov._on_scan(object())
+
+    assert session.max_concurrent == 1, (
+        f"{session.max_concurrent} concurrent requests; exactly one may run"
+    )
+    session.release.set()
+    settle(gov)
+
+
+def test_a_backlog_is_bounded_to_one_scan_and_the_newest_survives():
+    session = FakeSession(latency_s=5.0)
+    gov = governor(session)
+
+    for _ in range(10):
+        gov._on_scan(object())
+
+    with gov._lock:
+        pending = gov._slot.take()
+    # 10 scans: the 1st is taken by the worker, the 2nd fills the empty slot,
+    # the remaining 8 displace it.
+    assert gov._slot.overwrites == 8
+    assert pending.request_sequence == 10, "the NEWEST scan is the one retained"
+    session.release.set()
+    settle(gov)
+
+
+# ---------------------------------------------------------------------------
+# AC — the deadline is the node's, not the transport's
+# ---------------------------------------------------------------------------
+
+
+def test_a_sidecar_that_stops_answering_floors_the_cap_on_the_deadline():
+    # `requests`' timeout is per socket operation, so a server dribbling bytes
+    # never trips it. Perception drives a speed cap, so the cap must be floored
+    # on a schedule the node controls.
+    session = FakeSession(latency_s=5.0)
+    gov = governor(session, deadline_s=0.05)
+    gov._on_scan(object())
+
+    time.sleep(0.1)
+    gov._on_publish_timer()
+
+    cap, health = gov.published[-1]
+    assert cap == 0.0
+    assert health.startswith("TAJ_DEADLINE"), health
+    assert gov._deadline_breaches == 1
+    session.release.set()
+    settle(gov)
+
+
+def test_a_late_reply_is_usable_if_its_scan_is_still_fresh():
+    # The deadline and the staleness budget answer DIFFERENT questions. The
+    # deadline bounds how long the node waits before flooring the cap; staleness
+    # bounds how old the perception behind a cap may be. A reply that missed the
+    # first can still satisfy the second, and refusing it would mean one slow
+    # round trip permanently discarded good, current evidence.
+    #
+    # What must not happen is the breach becoming invisible once a reply lands,
+    # so the counter stays on the wire.
+    session = FakeSession(latency_s=0.2, payload=healthy_payload())
+    gov = governor(session, deadline_s=0.01)
+    gov._on_scan(object())
+
+    # Past the 10 ms deadline, well short of the 200 ms reply.
+    time.sleep(0.05)
+    gov._on_publish_timer()          # breach: nothing has arrived yet
+    assert gov.published[-1][1].startswith("TAJ_DEADLINE")
+
+    assert settle(gov), "the worker never completed"
+    gov._on_publish_timer()          # the late reply is now in the slot
+    cap, health = gov.published[-1]
+    # It IS published — it is the newest evidence and it is still fresh. What
+    # must not happen is publishing it as though the breach never occurred, so
+    # the breach counter stays visible on the wire.
+    assert "deadline=1" in health, health
+    assert cap >= 0.0
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed: every non-USE outcome
+# ---------------------------------------------------------------------------
+
+
+def test_nothing_received_yet_publishes_the_floor():
+    gov = governor(FakeSession(payload=healthy_payload()))
+    gov._on_publish_timer()
+    cap, health = gov.published[-1]
+    assert cap == 0.0
+    assert health.startswith("TAJ_ABSENT")
+
+
+def test_a_transport_fault_publishes_the_floor():
+    session = FakeSession(raise_with=ValueError("bad json"))
+    gov = governor(session)
+    gov._on_scan(object())
+    assert settle(gov)
+
+    gov._on_publish_timer()
+    cap, health = gov.published[-1]
+    assert cap == 0.0
+    assert health.startswith("TAJ_FAULT")
+
+
+def test_a_result_is_published_once_and_not_republished():
+    # Without the watermark a wedged sidecar's last good answer would be
+    # re-served every publish period, and a frozen world would look clear.
+    session = FakeSession(payload=healthy_payload())
+    gov = governor(session)
+    gov._on_scan(object())
+    assert settle(gov)
+
+    gov._on_publish_timer()
+    first_cap = gov.published[-1][0]
+    assert first_cap > 0.0, "precondition: a real cap was published"
+
+    gov._on_publish_timer()
+    cap, health = gov.published[-1]
+    assert cap == 0.0, "the same result must not be published twice"
+    assert health.startswith("TAJ_SUPERSEDED")
+    assert gov._discarded_replies == 1
+
+
+def test_counters_reach_the_health_wire():
+    # An operator diagnosing "why is the cap zero" is already reading this
+    # string; a counter they have to find elsewhere is one they will not find.
+    gov = governor(FakeSession(payload=healthy_payload()))
+    gov._on_publish_timer()
+    _cap, health = gov.published[-1]
+    for field in ("discarded=", "deadline=", "overwritten="):
+        assert field in health, f"{field} missing from {health}"


### PR DESCRIPTION
> Measured: the scan callback returns in **~0.4 ms against a sidecar taking 5 s**. It used to wait for all of it.

**Completes #1218.**

## The two failures

`perception_governor._on_scan` POSTed to Taj and blocked on the reply **inside the scan subscription callback**. Under rclpy's single-threaded executor that couples sensor ingest to a network round trip: while the callback waits, no other callback on the node runs and inbound scans queue behind it. A slow sidecar backs up the very stream it is being asked to judge.

Nothing established that a reply belonged to the scan in hand, either. A reply for scan N applied to scan N+3 is perception evidence attributed to the wrong instant — and as the issue notes, the #1214 evidence binding cannot help, because that mismatch happens *before* the frame identity is stamped onto anything.

## Shape

```
_on_scan   →  stamp, copy, offer to a one-entry slot, RETURN
worker     →  one at a time, does the network, deposits
timer      →  the only publisher; decides once per period
```

`async_perception` holds the decisions, pure and ROS-free — the same split `async_plan` already uses for the doer's plan cycle. **This applies a proven in-repo pattern to a second call site rather than inventing one.**

It differs where the problem differs. The doer runs on a timer and asks "may I start work?"; perception is driven by *arrival*, which the node does not control, so a scan landing mid-request has to go somewhere. It goes into a **latest-frame slot** of exactly one entry, where a newer scan displaces an older un-started one.

Overwriting is right for perception in a way it would not be for commands: the newest scan is strictly better evidence, and the older one's only remaining value would be to make the robot act on a staler view of the world. Bounded by construction, not by a queue length nobody tuned.

Displacements are **counted**, alongside discarded replies and deadline breaches, on the health topic an operator is already reading. Bounded-by-construction is a design property; how often it engages is an operational fact, and a governor dropping every second scan should be visible to whoever is asking why the cap is low.

## The deadline is the node's, not the transport's

`requests`' timeout is **per socket operation**. A server that dribbles bytes holds a worker open indefinitely without ever tripping it. Perception drives a *speed cap*, so it must be floored on a schedule the node controls — hence `deadline_ms`, judged on the node's monotonic clock, independent of whether the HTTP call has returned.

This is also why the publish timer is not an implementation detail that could be dropped by letting the worker publish directly: **a worker blocked on a socket cannot notice that it is late.** Something else has to be running.

The deadline and the staleness budget answer different questions and are kept separate — one bounds how long the node waits, the other how old perception may be. A reply that missed the deadline is still usable if its scan is fresh; refusing it would let one slow round trip permanently discard good, current evidence. The breach counter stays on the wire so the episode does not become invisible once a reply lands.

## One publishable outcome

`ABSENT`, `SUPERSEDED`, `STALE`, `FAULT` and deadline-breach all publish the MRC floor. They stay distinct because the *operator response* differs, not the verdict. `FLOOR_STATES` is written out explicitly rather than derived as "not USE", so adding a state forces a decision about which side of the line it falls on.

The publish-once watermark matters more than it looks: without it, a wedged sidecar's last good answer would be re-served every period, and **a frozen world would look exactly like a clear one**.

## Lock discipline

Decide under the lock, publish outside it. Holding a lock across a ROS publish would couple the worker's deposit to publisher latency — the coupling this issue exists to remove. The request body is likewise built *before* the lock: it must be copied off the live ROS message, but that copy is pure computation and holding the lock across it stalls the worker for no reason.

The in-flight flag and the slot share one lock deliberately: "is a job running" and "what would it run on" is one question, and splitting it is a race that starts two workers.

## Tests — 34

The non-blocking property is pinned **structurally as well as behaviourally**: a test parses the node source and follows self-calls out of `_on_scan` looking for anything that waits. That is a property of the source rather than of whichever branch a test happens to exercise, and it comes with a non-vacuity companion proving the detector fires on `_fetch`, where the blocking call legitimately lives.

Mutation-verified — each of these fails a test:

| Mutation | Result |
|---|---|
| callback performs the HTTP itself (**the original bug**) | ✅ killed |
| deadline never enforced | ✅ killed |
| publish watermark never advances | ✅ killed |
| second concurrent request allowed | ✅ killed |
| slot keeps the older scan | ✅ killed |
| republish an already-published scan | ✅ killed |

## Transport is transitional

Recorded on the module, because nothing here should read as endorsing JSON-over-HTTP for a per-scan safety signal. The migration target is a typed carrier (#270/#339). **The decisions survive that move** — one in flight, newest-scan-wins, publish-at-most-once, deadline-floors-the-cap are properties of the cycle. The request/response sequence pairing does not; it exists only because this transport cannot express identity itself.

## Note on #1213

While picking this up I verified #1213's premises and **its headline is already implemented**. The C1 swept-footprint check landed 2026-07-27, a day before that issue was filed — all four corners' chords between consecutive poses, inflated by the segment sagitta, rear corner modelled explicitly. The audit appears to have grepped `validation.rs`, where the doc comment is, and missed `containment.rs`, where the implementation is. What genuinely remains there is smaller: steering-*rate* reachability, a `CorridorHealth` wire state, and field-measured station widths. Worth someone re-scoping that issue before it is picked up as written.

**Verification:** 755 Python tests · node and config parameters agree in both directions · no dead config entries.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjDFKPcBVHURDZpXsvnYhC)_