### PR TITLE
fix(profiles): select the R2 class for R2 hardware, not the courier interim

### DIFF
--- a/docs/hardware/R2_LIVE_LOOP_BRINGUP.md
+++ b/docs/hardware/R2_LIVE_LOOP_BRINGUP.md
@@ -58,7 +58,7 @@ a different quantity from the motor consumer's physical
 `wheelbase_m` to the exact CLASS value.
 
 ⚠️ **The shipped config is wrong for courier:** `kirra_params.yaml` currently has
-`wheelbase_m: 0.2`. Under `KIRRA_VEHICLE_CLASS=courier` the verifier reports 0.5,
+`wheelbase_m: 0.2`. Under `KIRRA_VEHICLE_CLASS=r2` the verifier reports 0.229,
 so 0.2 ≠ 0.5 → instant latched stop. Change it to `0.5` (courier) — or pick the
 class whose contract wheelbase you set.
 
@@ -77,7 +77,7 @@ class whose contract wheelbase you set.
 |---|---|---|
 | Governor key | verifier `KIRRA_GOVERNOR_SIGNING_KEY_SOURCE=file:<2a seed>` | consumer `KIRRA_GOVERNOR_VK_HEX` (= pubkey 0x2a) |
 | `KIRRA_ADMIN_TOKEN` | verifier (required to boot) | interceptor `kirra_token` Bearer |
-| Vehicle class | verifier `KIRRA_VEHICLE_CLASS=courier` | fixes the contract wheelbase below |
+| Vehicle class | verifier `KIRRA_VEHICLE_CLASS=r2` | the R2's own envelope — courier assumes 2x braking (#1219) |
 | Interceptor `wheelbase_m` | `ros2_ws/.../config/kirra_params.yaml` | courier contract **0.5** (NOT 0.229) |
 | `ROS_DOMAIN_ID` | everywhere (consumer forces **28**) | 28 on the launch/robot side too |
 | Ports | verifier 8090 · planner 8100 · taj 8101 · mick 8102 · ollama 11434 | interceptor `kirra_url`, `planner_url`, `taj_url` match |
@@ -141,7 +141,7 @@ this over SSH-only** — you need eyes on the robot and a hand on the e-stop.
 7. **Verifier** (mints; 2a key so the consumer accepts it):
    ```bash
    export KIRRA_ADMIN_TOKEN=<pick-a-token>
-   export KIRRA_VEHICLE_CLASS=courier
+   export KIRRA_VEHICLE_CLASS=r2
    export KIRRA_GOVERNOR_SIGNING_KEY_SOURCE=file:/etc/kirra/gov_2a.seed
    cargo run --bin kirra_verifier_service --release      # listens 0.0.0.0:8090
    curl -s localhost:8090/health

--- a/installer/platform_map.toml
+++ b/installer/platform_map.toml
@@ -24,18 +24,18 @@ required_car_type = 5          # board must report CARTYPE_R2; wrong mode → RE
 # (one-wheel drive — findings doc). The installer VERIFIES mode 5 and working
 # metadata; it cannot create the R2 base image.
 base_image = "yahboom-r2 (vendor artifact — operator-flashed; see docs/hardware/R2_GOLDEN_BUILD.md)"
-# INTERIM until the measurement-gated `r2` contract profile lands (Track-A A2):
-# courier is the closest reviewed class; the demo envelope stays the backstop.
-# profile_class = "courier"
-# ── R2-CLASS FLIP (draft, GATED — 1 of 3 uncomment sites) ─────────────────────
-# The `r2` kinematic + SG6 classes now EXIST (src/gateway/contract_profiles.rs +
-# parko impact.rs; measured footprint + full-lock steering). To retire the
-# courier interim: comment the `profile_class = "courier"` line above and
-# uncomment the line below — but ONLY AFTER the 4 remaining bench captures land
-# (front-to-rear wheelbase confirm, servo slew rate, overhang split, track width)
-# AND the r2 DYNAMIC limits are benched. Flip all THREE sites together (see
-# robot/install/PLATFORM_R2_PENDING.md "THE FLIP"): this, the verifier's
-# KIRRA_VEHICLE_CLASS, and the interceptor wheelbase_m (→ 0.229).
+# #1219: `r2`, not the former `courier` interim. The interim borrowed the
+# "closest reviewed class" while the r2 dynamic limits were VALIDATION-PENDING —
+# preferring a REVIEWED envelope over UNVALIDATED numbers. That is the wrong
+# ordering rule for a safety envelope: what matters is which values are more
+# conservative, and courier's are not. courier assumes 3.0 m/s2 of braking
+# against the R2 contract's 1.5, and permits 2.5 m/s against 1.0. Over-estimating
+# available brake under-estimates stopping distance directly.
+#
+# The r2 dynamic limits remain VALIDATION-PENDING (4 bench captures still owed:
+# front-to-rear wheelbase confirm, servo slew rate, overhang split, track width).
+# They are nonetheless the safer selection — if both are estimates, the lower one
+# is. See src/gateway/contract_profiles.rs tests for the pinned property.
 profile_class = "r2"
 motor_port = "/dev/myserial"
 [platform.r2.lidar]

--- a/installer/test_installer.py
+++ b/installer/test_installer.py
@@ -96,6 +96,25 @@ def main() -> int:
               f"the class profile / deployment review, never the installer")
     print("(6) rendered config: select-not-infer holds (class name + mapping values only)")
 
+    # (6b) #1219 — the R2 renders the R2 class, and each platform renders its
+    #      OWN class. Only x3 was checked before, so nothing asserted that an R2
+    #      install selects the R2 envelope rather than borrowing another
+    #      platform's. courier assumes 2x the braking (3.0 vs 1.5 m/s2) and 2.5x
+    #      the speed ceiling, and over-estimating available brake under-estimates
+    #      stopping distance directly.
+    r2_cfg = "\n".join(render_config("r2", platforms["r2"]).values())
+    check("KIRRA_VEHICLE_CLASS=r2" in r2_cfg,
+          "(6b) an R2 install must select the r2 class, not borrow another platform's")
+    check("KIRRA_VEHICLE_CLASS=courier" not in r2_cfg,
+          "(6b) an R2 install must NOT select courier")
+    check("KIRRA_EXPECTED_CAR_TYPE=5" in r2_cfg,
+          "(6b) R2 expected car type from the mapping")
+    # …and the classes are genuinely distinct, so the check above is not
+    # satisfied by every platform rendering the same string.
+    check("KIRRA_VEHICLE_CLASS=courier" in joined,
+          "(6b) non-vacuity: x3 still renders its own (different) class")
+    print("(6b) each platform renders its OWN class (r2 -> r2, x3 -> courier)")
+
     # (7) detect_board_mode never invents a name for an unknown register value.
     check(detect_board_mode(lambda: 99)["mode_name"] is None,
           "(7) unknown car-type value must map to None (refused upstream)")

--- a/robot/install/PLATFORM_R2_PENDING.md
+++ b/robot/install/PLATFORM_R2_PENDING.md
@@ -104,7 +104,7 @@ steering, dynamic limits VALIDATION-PENDING). The deployment switch is drafted a
 
 | # | File | Change |
 |---|------|--------|
-| 1 | `installer/platform_map.toml` | `profile_class = "courier"` → `"r2"` |
+| 1 | `installer/platform_map.toml` | ✅ DONE — `profile_class = "r2"` (#1219) |
 | 2 | `ros2_ws/src/kirra_safety/config/kirra_params.yaml` | interceptor `wheelbase_m: 0.2` → `0.229` (r2 contract == physical) |
 | 3 | `robot/install/env.template` (verifier env) | uncomment `KIRRA_VEHICLE_CLASS=r2`; on the R2 image also `KIRRA_EXPECTED_CAR_TYPE=5` |
 

--- a/robot/install/README.md
+++ b/robot/install/README.md
@@ -101,8 +101,26 @@ it generates the secrets (`deploy/systemd/install.sh:61-79`) but NOT
 **fails closed at startup** until you append it to `/etc/kirra/kirra.env`:
 
 ```bash
-echo 'KIRRA_VEHICLE_CLASS=courier' | sudo tee -a /etc/kirra/kirra.env  # interim reviewed class, installer/platform_map.toml:29
+echo 'KIRRA_VEHICLE_CLASS=r2' | sudo tee -a /etc/kirra/kirra.env  # matches installer/platform_map.toml
 ```
+
+> **Why `r2` and not `courier` (#1219).** `courier` was borrowed as the
+> "closest reviewed class" while the r2 dynamic limits were VALIDATION-PENDING.
+> That preferred a *reviewed* envelope over *unvalidated* numbers — the wrong
+> ordering rule for a safety envelope, where what matters is which values are
+> more conservative. A reviewed optimistic constant is still optimistic.
+>
+> `courier` assumes **3.0 m/s² of braking** against the R2 contract's **1.5**,
+> and permits **2.5 m/s** against the R2's **1.0**. Braking is the sharpest of
+> those: it is what every stopping-distance computation divides by, so assuming
+> more deceleration than the platform has under-estimates stopping distance
+> directly. courier's larger footprint is geometrically conservative, but a
+> bigger box does nothing for stopping distance.
+>
+> The R2's dynamic limits remain VALIDATION-PENDING — but they are uniformly
+> *lower*, and if both are estimates the lower one is the safe choice. The
+> automated installer already selects `r2`
+> (`installer/platform_map.toml`); this manual step now matches it.
 
 Minting (needed for the live loop) additionally requires
 `KIRRA_GOVERNOR_SIGNING_KEY_SOURCE` (+ `KIRRA_GOVERNOR_SIGNING_KEY_ALLOW_DEV=1`

--- a/robot/install/preflight_autostart.sh
+++ b/robot/install/preflight_autostart.sh
@@ -79,8 +79,17 @@ else
       # A WARN rather than a failure: R2 hardware running the vendor X3 image is
       # a real configuration, and courier is the right class there. Only the
       # operator knows which image is flashed.
-      warn "KIRRA_VEHICLE_CLASS = $kcls (not r2) — a MORE PERMISSIVE envelope for R2 hardware"
-      fix "set KIRRA_VEHICLE_CLASS=r2 unless this robot is running the vendor X3 image (see #1219)"
+      warn "KIRRA_VEHICLE_CLASS = $kcls (not r2) — MORE PERMISSIVE envelope for R2 hardware:"
+      warn "  $kcls assumes more braking than the R2 contract declares, and"
+      warn "  over-estimating brake UNDER-estimates stopping distance."
+      warn "  It ALSO mismatches the interceptor wheelbase: kirra_params.yaml sets"
+      warn "  0.229 (the R2's measured value) and the verifier reports this class's"
+      warn "  own wheelbase — enforcement_decision.wheelbase_consistent then latches"
+      warn "  a PERMANENT stop, so the live loop will not run."
+      fix "set KIRRA_VEHICLE_CLASS=r2 — UNLESS this robot is flashed with the vendor"
+      fix "  X3 image, where $kcls is correct and the interceptor wheelbase must"
+      fix "  match that class instead. Only you can tell which image is flashed;"
+      fix "  this check cannot. (#1219)"
     fi
   else
     bad "KIRRA_VEHICLE_CLASS unset/invalid (verifier + parko fail-closed abort)"

--- a/robot/install/preflight_autostart.sh
+++ b/robot/install/preflight_autostart.sh
@@ -67,10 +67,25 @@ else
   grep -qE '^KIRRA_ADMIN_TOKEN=.+' <<<"$kenv" && ok "KIRRA_ADMIN_TOKEN set" || { bad "KIRRA_ADMIN_TOKEN empty (verifier 503s)"; fix "re-run deploy/systemd/install.sh"; }
   grep -qE '^KIRRA_SUPERVISOR_RESET_KEY=.+' <<<"$kenv" && ok "KIRRA_SUPERVISOR_RESET_KEY set" || bad "KIRRA_SUPERVISOR_RESET_KEY empty"
   if grep -qE '^KIRRA_VEHICLE_CLASS=(courier|delivery-av|robotaxi|r2)$' <<<"$kenv"; then
-    ok "KIRRA_VEHICLE_CLASS = $(grep -oE '^KIRRA_VEHICLE_CLASS=.*' <<<"$kenv" | cut -d= -f2)"
+    kcls="$(grep -oE '^KIRRA_VEHICLE_CLASS=.*' <<<"$kenv" | cut -d= -f2)"
+    if [[ "$kcls" == "r2" ]]; then
+      ok "KIRRA_VEHICLE_CLASS = r2"
+    else
+      # #1219: parseable but not this platform's class. Every non-r2 class is a
+      # MORE PERMISSIVE envelope on the dynamics — courier alone assumes 2x the
+      # braking (3.0 vs 1.5 m/s2) and 2.5x the speed ceiling. Over-estimating
+      # available brake under-estimates stopping distance directly.
+      #
+      # A WARN rather than a failure: R2 hardware running the vendor X3 image is
+      # a real configuration, and courier is the right class there. Only the
+      # operator knows which image is flashed.
+      warn "KIRRA_VEHICLE_CLASS = $kcls (not r2) — a MORE PERMISSIVE envelope for R2 hardware"
+      fix "set KIRRA_VEHICLE_CLASS=r2 unless this robot is running the vendor X3 image (see #1219)"
+    fi
   else
     bad "KIRRA_VEHICLE_CLASS unset/invalid (verifier + parko fail-closed abort)"
-    fix "set KIRRA_VEHICLE_CLASS=courier (interim) or r2 in $KENV"
+    fix "set KIRRA_VEHICLE_CLASS=r2 in $KENV (courier is the X3 class and is a \
+MORE PERMISSIVE envelope for an R2 — 2x assumed braking; see #1219)"
   fi
   if grep -qE '^KIRRA_GOVERNOR_SIGNING_KEY_SOURCE=.+' <<<"$kenv"; then
     ok "KIRRA_GOVERNOR_SIGNING_KEY_SOURCE set"

--- a/ros2_ws/src/kirra_safety/config/kirra_params.yaml
+++ b/ros2_ws/src/kirra_safety/config/kirra_params.yaml
@@ -4,19 +4,15 @@ cmd_vel_interceptor:
     kirra_token: ""              # Set via environment variable KIRRA_ADMIN_TOKEN or launch arg
     kirra_client_id: "ros2-interceptor-01"
     wheelbase_m: 0.229             # Hiwonder ROSOrin wheelbase (meters)
-    # ── R2-CLASS FLIP (draft, GATED — 2 of 3 uncomment sites) ─────────────────
-    # The interceptor cross-checks wheelbase_m against the wheelbase the verifier
-    # reports for its ACTIVE class contract; a mismatch (>1e-6) latches a
-    # PERMANENT stop (enforcement_decision.py WHEELBASE_TOLERANCE_M). The active
-    # class's contract wheelbase must be matched EXACTLY:
-    #   • courier interim → 0.5   • r2 class → 0.229 (== the physical, measured)
-    # When you flip to r2 (KIRRA_VEHICLE_CLASS=r2 + platform_map profile_class="r2"),
-    # comment the 0.2 line above and uncomment the r2 line below. Flip all THREE
-    # sites together — robot/install/PLATFORM_R2_PENDING.md "THE FLIP".
-    # NOTE: the current 0.2 matches NEITHER class — it is safe only while no
-    # verifier is in the loop (Stage-1 doer dry run); a Stage-2 courier run needs
-    # 0.5, a Stage-2 r2 run needs 0.229.
-    # wheelbase_m: 0.229         # r2 contract wheelbase (== physical, measured)
+    # #1219: the interceptor cross-checks this against the wheelbase the verifier
+    # reports for its ACTIVE class contract; a mismatch >1e-6 latches a PERMANENT
+    # stop (enforcement_decision.py `wheelbase_consistent`). So this value and
+    # KIRRA_VEHICLE_CLASS are one decision, not two:
+    #   • r2 class      → 0.229  (== the physical, MEASURED wheelbase)  ← current
+    #   • courier class → 0.5
+    # With KIRRA_VEHICLE_CLASS=courier this 0.229 would MISMATCH and latch the
+    # stop, so the class flip is required for the live loop to run at all — not
+    # only for the envelope to be right.
     max_speed_mps: 1.8           # ROSOrin spec max speed (m/s)
     input_topic: "/cmd_vel"
     output_topic: "/cmd_vel_safe"
@@ -98,7 +94,11 @@ occy_doer:
     # owed). Origin-offset / overhangs unmeasured -> the corridor_back
     # extension (0.5 m) covers the rear; half_length assumes a roughly-front
     # origin (lidar at base). Firm both up per PLATFORM_R2_PENDING.
-    vehicle_class: "courier"                    # doer RSS-band label; numbers below win
+    # #1219: r2, not the courier interim. `VehicleConfig::for_class` knows "r2",
+    # and courier is a MORE PERMISSIVE envelope for this platform (2x assumed
+    # braking, 2.5x speed ceiling). The explicit numbers below still win for the
+    # fields they name; this selects the band for the fields they do not.
+    vehicle_class: "r2"                         # doer RSS-band label; numbers below win
     wheelbase_m: 0.229                          # MEASURED ~9 in (front-to-rear CONFIRM pending)
     half_length_m: 0.17                         # MEASURED body 13 in=0.330 m -> half 0.165 + margin
     half_width_m: 0.11                          # MEASURED body 8 in=0.203 m -> half 0.102 + margin

--- a/src/gateway/contract_profiles.rs
+++ b/src/gateway/contract_profiles.rs
@@ -443,6 +443,168 @@ fn r2_mrc() -> VehicleKinematicsContract {
 mod tests {
     use super::*;
 
+    // -----------------------------------------------------------------------
+    // #1219 — the R2 must not be run under a more permissive class.
+    //
+    // `courier` was borrowed as an interim "closest reviewed class" while the
+    // r2 dynamic limits stayed VALIDATION-PENDING. The reasoning preferred a
+    // REVIEWED envelope over UNVALIDATED numbers, which is the wrong ordering
+    // rule for a safety envelope: the question is which values are more
+    // conservative, not which were reviewed. A reviewed optimistic constant is
+    // still optimistic.
+    //
+    // These tests pin the property that replaces that judgement call:
+    //
+    //   The default and documented profile for the R2 must not assume more
+    //   braking, speed, or steering-rate authority than the R2 contract
+    //   declares.
+    // -----------------------------------------------------------------------
+
+    /// The authority-relevant terms, and the direction that is UNSAFE to
+    /// increase. Steering ANGLE is deliberately absent — see the test below.
+    fn authority_terms(c: &VehicleKinematicsContract) -> [(&'static str, f64); 4] {
+        [
+            ("effective_max_speed_mps", c.effective_max_speed_mps()),
+            ("max_brake_mps2", c.max_brake_mps2),
+            ("max_accel_mps2", c.max_accel_mps2),
+            ("max_steering_rate_deg_s", c.max_steering_rate_deg_s),
+        ]
+    }
+
+    /// The R2 contract is no more permissive than `courier` on any term where
+    /// being more permissive would be unsafe.
+    ///
+    /// Braking is the sharpest of these. `max_brake_mps2` is what every
+    /// stopping-distance computation divides by, so assuming more deceleration
+    /// than the platform has UNDER-estimates stopping distance directly — and
+    /// courier assumes 3.0 m/s² against the R2 contract's 1.5.
+    #[test]
+    fn the_r2_profile_claims_no_more_authority_than_the_courier_interim() {
+        let r2 = contract_for(VehicleClass::R2);
+        let courier = contract_for(VehicleClass::Courier);
+
+        for ((name, r2_value), (_, courier_value)) in authority_terms(&r2)
+            .iter()
+            .zip(authority_terms(&courier).iter())
+        {
+            assert!(
+                r2_value <= courier_value,
+                "{name}: r2 claims {r2_value} vs courier {courier_value} — running \
+                 the R2 under its own class must not WIDEN any authority term, or \
+                 the flip away from the courier interim is not a safety improvement"
+            );
+        }
+    }
+
+    /// Non-vacuity: courier really is the more permissive envelope, so the
+    /// assertion above is doing work rather than comparing a profile to itself.
+    ///
+    /// Without this, `authority_terms` returning identical values for both
+    /// classes would satisfy the test while proving nothing.
+    #[test]
+    fn the_courier_interim_really_was_more_permissive() {
+        let r2 = contract_for(VehicleClass::R2);
+        let courier = contract_for(VehicleClass::Courier);
+
+        assert!(
+            courier.max_brake_mps2 > r2.max_brake_mps2,
+            "courier assumes {} m/s2 of braking against the R2's {} — if this \
+             ever becomes equal, the whole argument for the flip has changed and \
+             the reasoning above needs revisiting",
+            courier.max_brake_mps2,
+            r2.max_brake_mps2,
+        );
+        assert!(
+            courier.effective_max_speed_mps() > r2.effective_max_speed_mps(),
+            "courier permits {} m/s against the R2's {}",
+            courier.effective_max_speed_mps(),
+            r2.effective_max_speed_mps(),
+        );
+    }
+
+    /// The ONE term where r2 exceeds courier, stated explicitly so it is a
+    /// recorded decision rather than an oversight.
+    ///
+    /// `max_steering_deg` is 39 on the R2 versus courier's 30 — and the R2's
+    /// value is MEASURED (full-lock road-wheel angle, bench Phase C), not an
+    /// estimate. A larger steering ANGLE does not grant authority in the way a
+    /// larger brake or speed figure does: the per-pose kinematics check bounds
+    /// what a command may request, and every downstream geometric check
+    /// (containment, swept footprint) evaluates the resulting path on its own
+    /// terms. Running the R2 under courier's 30 deg would REFUSE steering the
+    /// robot can physically perform — an availability cost, not a safety one.
+    #[test]
+    fn steering_angle_is_the_documented_exception_and_is_measured() {
+        let r2 = contract_for(VehicleClass::R2);
+        let courier = contract_for(VehicleClass::Courier);
+
+        assert!(
+            r2.max_steering_deg > courier.max_steering_deg,
+            "if the R2 no longer steers further than courier, this exception is \
+             stale and should be folded back into the general rule"
+        );
+        // …and it is not a back door into more speed or brake.
+        assert!(r2.effective_max_speed_mps() <= courier.effective_max_speed_mps());
+        assert!(r2.max_brake_mps2 <= courier.max_brake_mps2);
+    }
+
+    /// The deployed interceptor wheelbase and the selected class must agree, or
+    /// the live loop latches a permanent stop before any envelope question
+    /// arises.
+    ///
+    /// `enforcement_decision.wheelbase_consistent` compares the interceptor's
+    /// configured `wheelbase_m` against the wheelbase the verifier reports for
+    /// its ACTIVE class, with a 1e-6 m tolerance, and a mismatch is a permanent
+    /// stop — executed yaw would not be the yaw Kirra approved.
+    ///
+    /// `kirra_params.yaml` configures 0.229, the R2's measured wheelbase. That
+    /// makes the class selection and the interceptor wheelbase ONE decision:
+    /// under `courier` the verifier reports 0.5 and the two disagree. So the
+    /// flip away from the courier interim is not only the more conservative
+    /// envelope, it is required for the loop to run.
+    #[test]
+    fn the_r2_contract_wheelbase_matches_the_deployed_interceptor_configuration() {
+        // The value in ros2_ws/src/kirra_safety/config/kirra_params.yaml.
+        const DEPLOYED_INTERCEPTOR_WHEELBASE_M: f64 = 0.229;
+        const TOLERANCE_M: f64 = 1e-6; // enforcement_decision.WHEELBASE_TOLERANCE_M
+
+        let r2 = contract_for(VehicleClass::R2);
+        assert!(
+            (r2.wheelbase_m - DEPLOYED_INTERCEPTOR_WHEELBASE_M).abs() <= TOLERANCE_M,
+            "r2 contract wheelbase {} does not match the deployed interceptor \
+             configuration {} — the live loop would latch a permanent stop",
+            r2.wheelbase_m,
+            DEPLOYED_INTERCEPTOR_WHEELBASE_M,
+        );
+
+        // Non-vacuity: the interim class genuinely would NOT have matched, so
+        // this test is about agreement rather than about any two floats.
+        let courier = contract_for(VehicleClass::Courier);
+        assert!(
+            (courier.wheelbase_m - DEPLOYED_INTERCEPTOR_WHEELBASE_M).abs() > TOLERANCE_M,
+            "courier wheelbase now matches the deployed interceptor too, so this \
+             test no longer distinguishes the classes"
+        );
+    }
+
+    /// The MRC envelope must satisfy the same property: falling back to the R2
+    /// MRC may not claim more authority than falling back to courier's.
+    #[test]
+    fn the_mrc_fallback_holds_the_same_property() {
+        let r2 = mrc_fallback_for(VehicleClass::R2);
+        let courier = mrc_fallback_for(VehicleClass::Courier);
+
+        for ((name, r2_value), (_, courier_value)) in authority_terms(&r2)
+            .iter()
+            .zip(authority_terms(&courier).iter())
+        {
+            assert!(
+                r2_value <= courier_value,
+                "MRC {name}: r2 {r2_value} vs courier {courier_value}"
+            );
+        }
+    }
+
     /// Every family member, Nominal + MRC, as (name, nominal, mrc).
     fn family() -> Vec<(
         VehicleClass,


### PR DESCRIPTION
> `courier` assumes **3.0 m/s² of braking**. The R2's own contract says **1.5**. Over-estimating available brake under-estimates stopping distance directly.

**Part 1 of #1219.** A live safety-envelope correction, not cleanup. Manifest serialization is deliberately **not** in this change.

## The argument

`courier` was borrowed as the "closest reviewed class" while the r2 dynamic limits were `VALIDATION-PENDING`. That reasoning preferred a *reviewed* envelope over *unvalidated* numbers — **the wrong ordering rule for a safety envelope.** What matters is which values are more conservative, not which were reviewed. A reviewed optimistic constant is still optimistic.

| term | courier | r2 |
|---|---|---|
| effective ceiling `min(max_speed, odd_cap)` | **2.5 m/s** | **1.0 m/s** |
| `max_brake_mps2` | **3.0** | **1.5** |
| `max_accel_mps2` | 1.0 | 0.5 |
| `wheelbase_m` | 0.5 | 0.229 |
| footprint W×L | 0.6 × 0.9 | 0.203 × 0.330 |

Braking is the sharpest. courier's larger footprint *is* geometrically conservative — a bigger box is harder to fit through a corridor — but **a bigger box does nothing for stopping distance.**

The r2 dynamic limits remain `VALIDATION-PENDING`. They are nonetheless the safer selection: if both are estimates, the lower one is.

## A second reason, arguably decisive

Found while verifying. The interceptor is already configured at `wheelbase_m: 0.229`, and `enforcement_decision.wheelbase_consistent` latches a **PERMANENT stop** when that disagrees with the wheelbase the verifier reports for its active class (tolerance 1e-6).

Under `courier` the verifier reports **0.5**.

So the class selection and the interceptor wheelbase are **one decision, not two** — and the configuration as it stood could not have run a live Stage-2 loop at all. The flip was already half-done in the interceptor.

## Scope correction

My gate comment on #1219 implied the installer path was affected. **It was not.** `installer/platform_map.toml` already maps `r2 → r2`; the `courier` there belongs to `[platform.x3]`, a genuinely different platform (mecanum drive). Verified by rendering both configs.

The exposure was in the **manual and documented paths**:

- `robot/install/README.md` — the systemd install instruction (needed because `install.sh` doesn't generate the var; a documented known gap)
- `robot/install/preflight_autostart.sh` — offered `courier` as the fix
- `docs/hardware/R2_LIVE_LOOP_BRINGUP.md` — three sites
- `ros2_ws/.../kirra_params.yaml` — the doer-side class label

Preflight now also **warns when an R2 runs a non-r2 class**. A warning rather than a failure: R2 hardware running the vendor X3 image is a real configuration where `courier` is correct, and only the operator knows which image is flashed.

## The one term where r2 is larger

`max_steering_deg` is 39 on the R2 versus courier's 30 — stated explicitly as a recorded decision rather than left to be discovered.

That value is **MEASURED** (full-lock road-wheel angle, bench Phase C). A larger steering *angle* does not grant authority the way a larger brake or speed figure does: the per-pose kinematics check bounds what a command may request, and every downstream geometric check evaluates the resulting path on its own terms. Running under courier's 30° would **refuse steering the robot can physically perform** — an availability cost, not a safety one. A test asserts it is not a back door into more speed or brake.

## Acceptance property

> The default and documented profile for the R2 must not assume more braking, speed, or steering-rate authority than the R2 contract declares.

Pinned, with non-vacuity throughout:

- `the_r2_profile_claims_no_more_authority_than_the_courier_interim` — the property itself
- `the_courier_interim_really_was_more_permissive` — otherwise the above could compare a profile to itself
- `steering_angle_is_the_documented_exception_and_is_measured`
- `the_mrc_fallback_holds_the_same_property` — the fallback envelope too
- `the_r2_contract_wheelbase_matches_the_deployed_interceptor_configuration` — with non-vacuity that courier would *not* have matched
- `installer test (6b)` — each platform renders its **own** class; only x3 was checked before, so nothing asserted that an R2 install selects the R2 envelope

## Verification

Mutation-verified — each fails a test:

| Mutation | |
|---|---|
| r2 brake raised to courier's | ✅ killed (3 tests) |
| r2 wheelbase moved off the deployed 0.229 | ✅ killed (3 tests) |
| installer maps r2 → courier again | ✅ killed (2 checks) |

600 Rust tests · 329 ROS tests · installer suite · fmt clean · shell syntax checked.

## Not in this change

Manifest serialization, consumer-config generation, extended digest enforcement, and the `R2_PERCEPTION_BASELINE` artifact — #1219 parts 2 and 3. This lands the immediate exposure fix alone; the baseline needs hardware.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjDFKPcBVHURDZpXsvnYhC)_