### PR TITLE
feat(profiles): executable provenance verification for platform contracts (#1219 part 2)

### DIFF
--- a/docs/CONTRACT_PROFILES.md
+++ b/docs/CONTRACT_PROFILES.md
@@ -206,6 +206,101 @@ fail-closed guarantee lives at the binary startup boundary.)
 
 ---
 
+## Provenance coverage (#1219 part 2) — a derived view, not a second inventory
+
+The per-parameter status flags in the tables above are prose. `src/gateway/provenance.rs`
+makes them **executable**, under one property:
+
+> Every authority-relevant field and externally applied constraint has exactly one
+> provenance mapping; inherited mappings identify **and equal** their upstream source;
+> serialized representations remain derived from the Rust contract and existing reviewed
+> integrity pins.
+
+**It contains no numbers.** Records name a `Field`; values are read live from
+`contract_for` / `mrc_fallback_for` when a check or a serialization runs. A hand-authored
+"field → value → provenance" table would be a second numeric authority and would drift
+from `contract_profiles.rs` exactly as the R2 geometry literals drifted from the platform
+config. The one constant it names — the robotaxi external cap — is a reference to
+`ROBOTAXI_ODD_SPEED_CAP_MPS`, not a re-typed `22.35`.
+
+### Coverage is field-to-key, not key-set equality
+
+Tag granularity is deliberately non-uniform: `r2` splits `r2.overhangs` from `r2.footprint`
+*because their provenance differs* (body MEASURED, split ESTIMATE), while `courier` lumps
+all four geometry fields under one key. Computing an expected key set as classes × fields
+would force uniformity and erase that distinction. So the assertion is total coverage at
+the **field** level — every (class, profile, field) triple governed by exactly one record.
+
+That inversion is what found the live defect this work closed: `delivery_av_nominal`'s
+`length_m` and both overhangs carried no provenance, because the `(delivery-av.footprint)`
+tag was a *trailing* comment governing `width_m` alone. A "every key resolves" check passed
+on that tree — all 49 tags were valid and unique.
+
+### The four classifications, and two that are executed
+
+| Token | Meaning |
+|---|---|
+| `MEASURED` | Observed directly; cites the measurement. |
+| `ESTIMATE` | Calculated or approximated; states from what. |
+| `VALIDATION-PENDING` | Asserted, awaiting a named validation. |
+| `INHERITED` | Sourced from another key — which is **resolved and compared bit-for-bit**. |
+| `DERIVED-PRECONDITION` | Justified by an inequality that is **executed**. |
+
+`INHERITED` is not a politer word for unattributed. The 15 authored MRC relationships
+(3 classes × wheelbase + 4 footprint fields) previously asserted equality in prose;
+6 of them — the overhang pairs — were asserted nowhere, and those are the fields that
+place the swept-footprint corners in `containment.rs`.
+
+`DERIVED-PRECONDITION` covers the MRC `odd_speed_cap_mps: None` values, whose justification
+is `mrc.max_speed <= class ODD cap` (so `min()` selects the crawl). Executing that rule
+immediately rejected a mis-classification: robotaxi **nominal** also carries `None`, but its
+`max_speed` is 35.0, far *above* the 22.35 cap — its `None` is justified by the deployment
+applying the cap externally, a different claim with a different obligation. A prose
+rationale would have carried the wrong reason indefinitely.
+
+### Split authority is surfaced, not hidden
+
+`contract_for(Robotaxi)` returns the frozen instance with `odd_speed_cap_mps: None`, so the
+serialized contract alone derives a ceiling of **35.0 m/s** while the deployment enforces
+**22.35**. `ExternalConstraint` carries that cap as its own row — where it is applied, what
+supplies it, and whether it participates in the effective ceiling — and
+`effective_ceiling_mps` composes it. Only robotaxi needs one; the other three classes carry
+their caps in the contract, and a test refuses a phantom constraint on them.
+
+This also closed a latent gap: `mrc_leq_nominal_per_field_every_class` compares *mechanical*
+maxima, so a courier MRC crawl of 2.8 would pass (2.8 ≤ 3.0) while exceeding the class's own
+nominal **enforced** ceiling of 2.5 — more permissive in degraded posture than in nominal,
+in the only sense that reaches the wheels.
+
+### The frozen class, and the pin it binds to
+
+Robotaxi's numbers live in the byte-frozen talisman, where the git blob hash is the integrity
+pin, so provenance comments cannot be added beside them. Its records live in a sidecar valid
+**only** against that existing pin — `git hash-object` versus the hash in
+`docs/CAPTURE_PIPELINE_SPEC.md`, the same check `ci/build_safety_case.py` and the `ci.yml`
+rustfmt lane already run. A second hash pin would give the anti-drift mechanism its own drift
+problem. If the blob changes, the association fails closed until the sidecar is deliberately
+revisited.
+
+### The loop is closed
+
+`check_source_agreement` parses this file's sibling source with a **tag-led** grammar —
+locate the stable `(class.field)` tag, then read the classification only from its one
+permitted syntactic position — and asserts the table agrees with every tag it finds (52
+today: 49 field-dialect plus 3 const-dialect ODD caps). Without it the table would itself
+be a second authored inventory.
+
+The grammar is tag-led rather than classification-searching because each alternative fails
+cleanly-but-wrongly: `ESTIMATE (overhang split UNMEASURED)` contains `MEASURED` (a substring
+match promotes the one estimate to a measurement, optimistically); the ODD caps use a `///`
+dialect a field-dialect parser drops entirely; and narrative like "the FIRST profile with
+MEASURED geometry" would invent rows.
+
+Run: `cargo test --lib gateway::provenance` (42 tests; every positive assertion paired with a
+negative that proves it can fail).
+
+---
+
 ## Cross-references
 
 - `src/gateway/contract_profiles.rs` — the envelope family + `VehicleClass`

--- a/src/gateway/contract_profiles.rs
+++ b/src/gateway/contract_profiles.rs
@@ -339,7 +339,12 @@ fn delivery_av_nominal() -> VehicleKinematicsContract {
         min_follow_distance_m: 3.5, // VALIDATION-PENDING: ~0.3 s @ 11 m/s + reaction (delivery-av.follow)
         max_lateral_accel_mps2: 2.5, // VALIDATION-PENDING: between courier 1.5 and robotaxi 3.5 (delivery-av.lat_accel)
         wheelbase_m: 1.9,            // VALIDATION-PENDING: small road pod (delivery-av.wheelbase)
-        width_m: 1.1, // VALIDATION-PENDING: narrow pod footprint (delivery-av.footprint)
+        // VALIDATION-PENDING: narrow pod footprint; width/length/overhangs all
+        // positive. A LEADING block comment, deliberately: as a trailing comment
+        // on `width_m` it governed that one field and left length + both
+        // overhangs unattributed, which the #1219 coverage check now refuses.
+        // (delivery-av.footprint)
+        width_m: 1.1,
         length_m: 2.9,
         overhang_front_m: 0.5,
         overhang_rear_m: 0.5,

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -3,6 +3,7 @@
 pub mod contract_profiles;
 pub mod policy;
 pub mod policy_layer;
+pub mod provenance;
 
 #[cfg(test)]
 mod kinematics_proptest;

--- a/src/gateway/provenance.rs
+++ b/src/gateway/provenance.rs
@@ -96,9 +96,11 @@ pub const TALISMAN_PIN_DOC: &str = "docs/CAPTURE_PIPELINE_SPEC.md";
 /// Every authority-relevant field of [`VehicleKinematicsContract`].
 ///
 /// [`Field::ALL`] is the completeness denominator: a field added to the contract
-/// struct and not added here would silently escape coverage, so
-/// [`tests::every_contract_struct_field_appears_in_the_field_enum`] pins the
-/// count against the struct's own serialized shape.
+/// struct and not added here would silently escape coverage, so the test
+/// `every_contract_struct_field_appears_in_the_field_enum` pins this list
+/// against the struct's own serialized shape rather than against a hand-kept
+/// count. (Named, not linked: it is `#[cfg(test)]`, so an intra-doc link to it
+/// cannot resolve when rustdoc runs.)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Field {

--- a/src/gateway/provenance.rs
+++ b/src/gateway/provenance.rs
@@ -1,0 +1,1448 @@
+//! #1219 part 2 — provenance coverage over the canonical contract family.
+//!
+//! # The one property
+//!
+//! > Every authority-relevant field and externally applied constraint has
+//! > exactly one provenance mapping; inherited mappings identify **and equal**
+//! > their upstream source; serialized representations remain derived from the
+//! > Rust contract and existing reviewed integrity pins.
+//!
+//! # Why this is a view and not an inventory
+//!
+//! The load-bearing constraint on this module: **it contains no numbers.**
+//!
+//! A hand-authored table of "field → value → provenance" would be a second
+//! numeric authority, and would drift from `contract_profiles.rs` exactly as the
+//! geometry literals drifted from the platform config (#1219 part 1). So every
+//! record here names a [`Field`] and never a value. Values are read live from
+//! [`contract_for`] / [`mrc_fallback_for`] at the moment a check or a
+//! serialization runs. Change a contract number and this module reports the new
+//! number without being edited; change it *wrongly* and the relational checks
+//! below fail.
+//!
+//! The single exception is [`ExternalConstraint::value_mps`], and it is a
+//! reference rather than a literal — `ROBOTAXI_ODD_SPEED_CAP_MPS`, itself an
+//! alias of the talisman's `URBAN_ODD_SPEED_CAP_MPS`. Writing `22.35` there
+//! would have created the duplicate this module exists to prevent.
+//!
+//! # Why coverage is field-to-key, not key-set equality
+//!
+//! Tag granularity is deliberately non-uniform. `r2` splits `r2.overhangs` out
+//! from `r2.footprint` *because their provenance differs* — the footprint is
+//! MEASURED off the bench, the overhang split is an ESTIMATE. `courier` lumps
+//! all four geometry fields under `courier.footprint` because they share one
+//! provenance.
+//!
+//! Computing an expected key set as classes × fields would force a uniform
+//! granularity and destroy the r2 split, which is the one place the family
+//! currently distinguishes a measurement from an assumption. So the assertion is
+//! total coverage at the **field** level, with keys as coarse or fine as
+//! provenance requires: every (class, profile, field) triple is governed by
+//! exactly one record, and no triple by two.
+//!
+//! # Why `INHERITED` is executable
+//!
+//! `INHERITED` is not a politer word for unattributed. A record carrying it
+//! names its upstream key, and [`check_inheritance`] resolves that key and
+//! compares the two contracts' values **bit-for-bit**. The MRC footprint fields
+//! previously asserted their equality in prose ("Footprint IDENTICAL to r2
+//! nominal"); they now assert it in a test that fails when it stops being true.
+//!
+//! That is a stronger property than provenance coverage alone, and it closes a
+//! real gap: `mrc_leq_nominal_per_field_every_class` compares wheelbase, width
+//! and length but not the two overhangs, so 6 of the 15 inheritance claims were
+//! asserted nowhere — and the overhangs are the fields that place the
+//! swept-footprint corners in `containment.rs`.
+//!
+//! # Why the frozen class needs a sidecar
+//!
+//! The robotaxi contract lives in the byte-frozen kinematics talisman, whose git
+//! blob hash is its integrity pin. Provenance comments cannot be added beside
+//! those numbers without breaking the pin, so robotaxi's records live in
+//! [`ROBOTAXI_SIDECAR`] — bound to that same pin, not to a new one.
+//! [`validate_robotaxi_sidecar`] consumes the EXISTING authority (`git
+//! hash-object` against the hash recorded in `docs/CAPTURE_PIPELINE_SPEC.md`,
+//! the pin `ci/build_safety_case.py` and the `ci.yml` rustfmt lane already
+//! check). A second hash pin would give the anti-drift mechanism its own drift
+//! problem.
+//!
+//! The sidecar describes the frozen values. It never supplies or overrides them:
+//! its records name fields, like every other record here, and the values still
+//! come from the frozen instance.
+
+use std::path::Path;
+use std::process::Command;
+
+use serde::{Deserialize, Serialize};
+
+use kirra_core::kinematics_contract::VehicleKinematicsContract;
+
+use super::contract_profiles::{
+    contract_for, mrc_fallback_for, VehicleClass, COURIER_ODD_SPEED_CAP_MPS,
+    DELIVERY_AV_ODD_SPEED_CAP_MPS, R2_ODD_SPEED_CAP_MPS, ROBOTAXI_ODD_SPEED_CAP_MPS,
+};
+
+/// The frozen talisman, and the reviewed document that pins its blob hash. Both
+/// mirror `ci/build_safety_case.py`'s constants of the same name — deliberately,
+/// so the sidecar binds to the pin the safety case already gates on.
+pub const TALISMAN_PATH: &str = "crates/kirra-core/src/kinematics_contract.rs";
+/// The document holding the authoritative blob pin. See [`TALISMAN_PATH`].
+pub const TALISMAN_PIN_DOC: &str = "docs/CAPTURE_PIPELINE_SPEC.md";
+
+// ---------------------------------------------------------------------------
+// Fields
+// ---------------------------------------------------------------------------
+
+/// Every authority-relevant field of [`VehicleKinematicsContract`].
+///
+/// [`Field::ALL`] is the completeness denominator: a field added to the contract
+/// struct and not added here would silently escape coverage, so
+/// [`tests::every_contract_struct_field_appears_in_the_field_enum`] pins the
+/// count against the struct's own serialized shape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Field {
+    MaxSpeed,
+    MaxAccel,
+    MaxBrake,
+    MaxSteering,
+    MaxSteeringRate,
+    MinFollow,
+    MaxLateralAccel,
+    Wheelbase,
+    Width,
+    Length,
+    OverhangFront,
+    OverhangRear,
+    OddSpeedCap,
+}
+
+/// A field's live value, read from a real contract. `OptionalCap` keeps the
+/// absent-cap case distinguishable from a zero cap — `None` means "no ODD cap on
+/// this profile", which is a claim about authority, not a magnitude.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FieldValue {
+    Scalar(f64),
+    OptionalCap(Option<f64>),
+}
+
+impl Field {
+    /// Every field, in declaration order. The completeness denominator.
+    pub const ALL: &'static [Field] = &[
+        Field::MaxSpeed,
+        Field::MaxAccel,
+        Field::MaxBrake,
+        Field::MaxSteering,
+        Field::MaxSteeringRate,
+        Field::MinFollow,
+        Field::MaxLateralAccel,
+        Field::Wheelbase,
+        Field::Width,
+        Field::Length,
+        Field::OverhangFront,
+        Field::OverhangRear,
+        Field::OddSpeedCap,
+    ];
+
+    /// The struct field name, matching `VehicleKinematicsContract`'s serde shape.
+    #[must_use]
+    pub fn name(self) -> &'static str {
+        match self {
+            Field::MaxSpeed => "max_speed_mps",
+            Field::MaxAccel => "max_accel_mps2",
+            Field::MaxBrake => "max_brake_mps2",
+            Field::MaxSteering => "max_steering_deg",
+            Field::MaxSteeringRate => "max_steering_rate_deg_s",
+            Field::MinFollow => "min_follow_distance_m",
+            Field::MaxLateralAccel => "max_lateral_accel_mps2",
+            Field::Wheelbase => "wheelbase_m",
+            Field::Width => "width_m",
+            Field::Length => "length_m",
+            Field::OverhangFront => "overhang_front_m",
+            Field::OverhangRear => "overhang_rear_m",
+            Field::OddSpeedCap => "odd_speed_cap_mps",
+        }
+    }
+
+    /// Read this field LIVE from `c`. The only path by which a number enters
+    /// this module.
+    #[must_use]
+    pub fn read(self, c: &VehicleKinematicsContract) -> FieldValue {
+        match self {
+            Field::MaxSpeed => FieldValue::Scalar(c.max_speed_mps),
+            Field::MaxAccel => FieldValue::Scalar(c.max_accel_mps2),
+            Field::MaxBrake => FieldValue::Scalar(c.max_brake_mps2),
+            Field::MaxSteering => FieldValue::Scalar(c.max_steering_deg),
+            Field::MaxSteeringRate => FieldValue::Scalar(c.max_steering_rate_deg_s),
+            Field::MinFollow => FieldValue::Scalar(c.min_follow_distance_m),
+            Field::MaxLateralAccel => FieldValue::Scalar(c.max_lateral_accel_mps2),
+            Field::Wheelbase => FieldValue::Scalar(c.wheelbase_m),
+            Field::Width => FieldValue::Scalar(c.width_m),
+            Field::Length => FieldValue::Scalar(c.length_m),
+            Field::OverhangFront => FieldValue::Scalar(c.overhang_front_m),
+            Field::OverhangRear => FieldValue::Scalar(c.overhang_rear_m),
+            Field::OddSpeedCap => FieldValue::OptionalCap(c.odd_speed_cap_mps),
+        }
+    }
+}
+
+/// Which posture profile a record governs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Profile {
+    Nominal,
+    Mrc,
+}
+
+impl Profile {
+    pub const ALL: &'static [Profile] = &[Profile::Nominal, Profile::Mrc];
+
+    /// The live contract for `(class, self)`.
+    #[must_use]
+    pub fn contract(self, class: VehicleClass) -> VehicleKinematicsContract {
+        match self {
+            Profile::Nominal => contract_for(class),
+            Profile::Mrc => mrc_fallback_for(class),
+        }
+    }
+
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Profile::Nominal => "nominal",
+            Profile::Mrc => "mrc",
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Provenance
+// ---------------------------------------------------------------------------
+
+/// A machine-checkable precondition that justifies a value.
+///
+/// Distinct from a free-text rationale because it is *executed*. The three MRC
+/// `odd_speed_cap_mps: None` values are neither inherited nor unattributed:
+/// their justification is an inequality, and an inequality is better provenance
+/// than the prose it replaces.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PreconditionRule {
+    /// Leaving the MRC cap `None` is safe because the MRC crawl already sits at
+    /// or below the class's ODD cap, so `min()` selects the crawl either way.
+    ///
+    /// If that stopped holding, `None` would silently raise the MRC ceiling
+    /// ABOVE the class's own ODD cap — more permissive in degraded posture than
+    /// in nominal, in the only sense that reaches the wheels.
+    MrcCrawlAtOrBelowClassOddCap,
+    /// The contract carries no cap because the cap is applied OUTSIDE it.
+    ///
+    /// The robotaxi nominal case, and the reason this variant exists: its
+    /// `max_speed_mps` (35.0) is far ABOVE the class ODD cap (22.35), so the
+    /// crawl-below-cap rule emphatically does NOT justify its `None` — the
+    /// deployment applying the cap elsewhere does. Requires a registered
+    /// [`ExternalConstraint`] that participates in the effective ceiling and
+    /// actually binds.
+    ///
+    /// Discovered by this checker rejecting the wrong classification on the
+    /// first run, which is the argument for executing a precondition rather
+    /// than writing it down.
+    CapAppliedExternally,
+}
+
+/// How a value came to be what it is.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "class", rename_all = "SCREAMING-KEBAB-CASE")]
+pub enum Provenance {
+    /// Observed directly. `source` cites the measurement.
+    Measured { source: &'static str },
+    /// Calculated or approximated. `basis` states from what.
+    Estimate { basis: &'static str },
+    /// Asserted, awaiting a named validation. `owed` states which.
+    ValidationPending { owed: &'static str },
+    /// Sourced from another authoritative key. `upstream` MUST resolve, and the
+    /// values MUST compare equal — see [`check_inheritance`].
+    Inherited { upstream: &'static str },
+    /// Justified by a machine-checked precondition — see [`check_preconditions`].
+    DerivedPrecondition { rule: PreconditionRule },
+    /// No provenance. Present so an unattributed field is REPRESENTABLE and
+    /// therefore visible, rather than silently absent from the register.
+    Unattributed,
+}
+
+impl Provenance {
+    /// The stable classification token, for the serialized manifest and for
+    /// operators reading a rendered register.
+    #[must_use]
+    pub fn token(self) -> &'static str {
+        match self {
+            Provenance::Measured { .. } => "MEASURED",
+            Provenance::Estimate { .. } => "ESTIMATE",
+            Provenance::ValidationPending { .. } => "VALIDATION-PENDING",
+            Provenance::Inherited { .. } => "INHERITED",
+            Provenance::DerivedPrecondition { .. } => "DERIVED-PRECONDITION",
+            Provenance::Unattributed => "UNATTRIBUTED",
+        }
+    }
+
+    /// Whether the value has been validated against reality. Deliberately
+    /// conservative: only a measurement counts, and an inherited value defers to
+    /// its upstream rather than claiming validation of its own.
+    #[must_use]
+    pub fn is_validated(self) -> bool {
+        matches!(self, Provenance::Measured { .. })
+    }
+}
+
+/// One provenance record. Governs one or more FIELDS of one (class, profile).
+///
+/// Records name fields, never values. See the module docs.
+#[derive(Debug, Clone, Copy)]
+pub struct FieldProvenance {
+    /// Stable key, e.g. `"r2.footprint"` or `"courier.mrc.brake"`. Unique.
+    pub key: &'static str,
+    pub class: VehicleClass,
+    pub profile: Profile,
+    /// The fields this record governs. Coarse where provenance is shared, fine
+    /// where it differs.
+    pub fields: &'static [Field],
+    pub provenance: Provenance,
+}
+
+/// A limit applied somewhere OTHER than the contract struct.
+///
+/// The robotaxi case is why this type exists. `contract_for(Robotaxi)` returns
+/// the frozen instance with `odd_speed_cap_mps: None`, so the serialized
+/// contract derives an effective ceiling of 35.0 m/s while the deployment
+/// applies 22.35 elsewhere. A register that serialized only the contract would
+/// report the wrong ceiling — and "this class's cap is applied somewhere other
+/// than the contract" is precisely the split authority a manifest exists to
+/// expose.
+#[derive(Debug, Clone, Copy)]
+pub struct ExternalConstraint {
+    pub id: &'static str,
+    pub class: VehicleClass,
+    pub profile: Profile,
+    /// The contract field this constraint bounds.
+    pub constrains: Field,
+    /// Where the constraint is applied.
+    pub applied_at: &'static str,
+    /// The configuration or artifact that supplies it.
+    pub supplied_by: &'static str,
+    /// Whether it participates in the derived effective ceiling.
+    pub participates_in_effective_ceiling: bool,
+    pub provenance: Provenance,
+    /// A REFERENCE to the canonical constant, never a re-typed literal.
+    pub value_mps: f64,
+}
+
+// ---------------------------------------------------------------------------
+// The authored table — courier, delivery-av, r2
+// ---------------------------------------------------------------------------
+
+macro_rules! rec {
+    ($key:literal, $class:expr, $profile:expr, [$($f:expr),+ $(,)?], $prov:expr) => {
+        FieldProvenance {
+            key: $key,
+            class: $class,
+            profile: $profile,
+            fields: &[$($f),+],
+            provenance: $prov,
+        }
+    };
+}
+
+/// Shorthand for the most common classification. A macro rather than a `const
+/// fn` pointer because statics may not call function pointers.
+macro_rules! vp {
+    ($owed:literal) => {
+        Provenance::ValidationPending { owed: $owed }
+    };
+}
+
+/// Provenance for the three authored classes. Robotaxi lives in
+/// [`ROBOTAXI_SIDECAR`] because its numbers are byte-frozen.
+pub static AUTHORED_PROVENANCE: &[FieldProvenance] = &[
+    // --- courier nominal ---
+    rec!("courier.max_speed", VehicleClass::Courier, Profile::Nominal, [Field::MaxSpeed],
+         Provenance::ValidationPending { owed: "sidewalk operating-band survey; no bench measurement" }),
+    rec!("courier.accel", VehicleClass::Courier, Profile::Nominal, [Field::MaxAccel],
+         Provenance::ValidationPending { owed: "pedestrian-proximity comfort study" }),
+    rec!("courier.brake", VehicleClass::Courier, Profile::Nominal, [Field::MaxBrake],
+         Provenance::ValidationPending { owed: "service-brake deceleration measurement" }),
+    rec!("courier.steering", VehicleClass::Courier, Profile::Nominal, [Field::MaxSteering],
+         Provenance::ValidationPending { owed: "rack-limit measurement" }),
+    rec!("courier.steering_rate", VehicleClass::Courier, Profile::Nominal, [Field::MaxSteeringRate],
+         Provenance::ValidationPending { owed: "steering slew-rate measurement" }),
+    rec!("courier.follow", VehicleClass::Courier, Profile::Nominal, [Field::MinFollow],
+         Provenance::ValidationPending { owed: "headway derivation review" }),
+    rec!("courier.lat_accel", VehicleClass::Courier, Profile::Nominal, [Field::MaxLateralAccel],
+         Provenance::ValidationPending { owed: "lateral comfort / traction measurement" }),
+    rec!("courier.wheelbase", VehicleClass::Courier, Profile::Nominal, [Field::Wheelbase],
+         Provenance::ValidationPending { owed: "platform geometry measurement" }),
+    rec!("courier.footprint", VehicleClass::Courier, Profile::Nominal,
+         [Field::Width, Field::Length, Field::OverhangFront, Field::OverhangRear],
+         Provenance::ValidationPending { owed: "platform geometry measurement" }),
+    rec!("courier.odd_cap", VehicleClass::Courier, Profile::Nominal, [Field::OddSpeedCap],
+         Provenance::ValidationPending { owed: "ODD ceiling sign-off (docs/CONTRACT_PROFILES.md courier.odd_cap)" }),
+    // --- courier mrc ---
+    rec!("courier.mrc.max_speed", VehicleClass::Courier, Profile::Mrc, [Field::MaxSpeed],
+         Provenance::ValidationPending { owed: "degraded-crawl sign-off" }),
+    rec!("courier.mrc.accel", VehicleClass::Courier, Profile::Mrc, [Field::MaxAccel], vp!("degraded-envelope sign-off")),
+    rec!("courier.mrc.brake", VehicleClass::Courier, Profile::Mrc, [Field::MaxBrake], vp!("degraded-envelope sign-off")),
+    rec!("courier.mrc.steering", VehicleClass::Courier, Profile::Mrc, [Field::MaxSteering], vp!("degraded-envelope sign-off")),
+    rec!("courier.mrc.steering_rate", VehicleClass::Courier, Profile::Mrc, [Field::MaxSteeringRate], vp!("degraded-envelope sign-off")),
+    rec!("courier.mrc.follow", VehicleClass::Courier, Profile::Mrc, [Field::MinFollow], vp!("degraded-envelope sign-off")),
+    rec!("courier.mrc.lat_accel", VehicleClass::Courier, Profile::Mrc, [Field::MaxLateralAccel], vp!("degraded-envelope sign-off")),
+    rec!("courier.mrc.wheelbase", VehicleClass::Courier, Profile::Mrc, [Field::Wheelbase],
+         Provenance::Inherited { upstream: "courier.wheelbase" }),
+    rec!("courier.mrc.footprint", VehicleClass::Courier, Profile::Mrc,
+         [Field::Width, Field::Length, Field::OverhangFront, Field::OverhangRear],
+         Provenance::Inherited { upstream: "courier.footprint" }),
+    rec!("courier.mrc.odd_cap", VehicleClass::Courier, Profile::Mrc, [Field::OddSpeedCap],
+         Provenance::DerivedPrecondition { rule: PreconditionRule::MrcCrawlAtOrBelowClassOddCap }),
+
+    // --- delivery-av nominal ---
+    rec!("delivery-av.max_speed", VehicleClass::DeliveryAv, Profile::Nominal, [Field::MaxSpeed],
+         vp!("road-pod mechanical maximum measurement")),
+    rec!("delivery-av.accel", VehicleClass::DeliveryAv, Profile::Nominal, [Field::MaxAccel],
+         vp!("acceleration measurement; currently interpolated between courier and robotaxi")),
+    rec!("delivery-av.brake", VehicleClass::DeliveryAv, Profile::Nominal, [Field::MaxBrake],
+         vp!("service-brake deceleration measurement")),
+    rec!("delivery-av.steering", VehicleClass::DeliveryAv, Profile::Nominal, [Field::MaxSteering],
+         vp!("rack-limit measurement")),
+    rec!("delivery-av.steering_rate", VehicleClass::DeliveryAv, Profile::Nominal, [Field::MaxSteeringRate],
+         vp!("steering slew-rate measurement")),
+    rec!("delivery-av.follow", VehicleClass::DeliveryAv, Profile::Nominal, [Field::MinFollow],
+         vp!("headway derivation review")),
+    rec!("delivery-av.lat_accel", VehicleClass::DeliveryAv, Profile::Nominal, [Field::MaxLateralAccel],
+         vp!("lateral comfort / traction measurement")),
+    rec!("delivery-av.wheelbase", VehicleClass::DeliveryAv, Profile::Nominal, [Field::Wheelbase],
+         vp!("platform geometry measurement")),
+    // The record whose ABSENCE was the #1219 finding: the source comment tagged
+    // `width_m` as a trailing comment, leaving length + both overhangs with no
+    // provenance at all. Coverage is field-level precisely so this cannot recur.
+    rec!("delivery-av.footprint", VehicleClass::DeliveryAv, Profile::Nominal,
+         [Field::Width, Field::Length, Field::OverhangFront, Field::OverhangRear],
+         vp!("platform geometry measurement")),
+    rec!("delivery-av.odd_cap", VehicleClass::DeliveryAv, Profile::Nominal, [Field::OddSpeedCap],
+         vp!("ODD ceiling sign-off (docs/CONTRACT_PROFILES.md delivery-av.odd_cap)")),
+    // --- delivery-av mrc ---
+    rec!("delivery-av.mrc.max_speed", VehicleClass::DeliveryAv, Profile::Mrc, [Field::MaxSpeed], vp!("degraded-envelope sign-off")),
+    rec!("delivery-av.mrc.accel", VehicleClass::DeliveryAv, Profile::Mrc, [Field::MaxAccel], vp!("degraded-envelope sign-off")),
+    rec!("delivery-av.mrc.brake", VehicleClass::DeliveryAv, Profile::Mrc, [Field::MaxBrake], vp!("degraded-envelope sign-off")),
+    rec!("delivery-av.mrc.steering", VehicleClass::DeliveryAv, Profile::Mrc, [Field::MaxSteering], vp!("degraded-envelope sign-off")),
+    rec!("delivery-av.mrc.steering_rate", VehicleClass::DeliveryAv, Profile::Mrc, [Field::MaxSteeringRate], vp!("degraded-envelope sign-off")),
+    rec!("delivery-av.mrc.follow", VehicleClass::DeliveryAv, Profile::Mrc, [Field::MinFollow], vp!("degraded-envelope sign-off")),
+    rec!("delivery-av.mrc.lat_accel", VehicleClass::DeliveryAv, Profile::Mrc, [Field::MaxLateralAccel], vp!("degraded-envelope sign-off")),
+    rec!("delivery-av.mrc.wheelbase", VehicleClass::DeliveryAv, Profile::Mrc, [Field::Wheelbase],
+         Provenance::Inherited { upstream: "delivery-av.wheelbase" }),
+    rec!("delivery-av.mrc.footprint", VehicleClass::DeliveryAv, Profile::Mrc,
+         [Field::Width, Field::Length, Field::OverhangFront, Field::OverhangRear],
+         Provenance::Inherited { upstream: "delivery-av.footprint" }),
+    rec!("delivery-av.mrc.odd_cap", VehicleClass::DeliveryAv, Profile::Mrc, [Field::OddSpeedCap],
+         Provenance::DerivedPrecondition { rule: PreconditionRule::MrcCrawlAtOrBelowClassOddCap }),
+
+    // --- r2 nominal ---
+    rec!("r2.max_speed", VehicleClass::R2, Profile::Nominal, [Field::MaxSpeed],
+         vp!("bench max-speed run (one of the 4 remaining PLATFORM_R2_PENDING items)")),
+    rec!("r2.accel", VehicleClass::R2, Profile::Nominal, [Field::MaxAccel], vp!("bench acceleration run")),
+    rec!("r2.brake", VehicleClass::R2, Profile::Nominal, [Field::MaxBrake], vp!("bench braking run")),
+    rec!("r2.steering", VehicleClass::R2, Profile::Nominal, [Field::MaxSteering],
+         Provenance::Measured {
+             source: "protractor sweep at command ±45; robot/r2_drive_calibration_results.txt Phase C 2026-07-17",
+         }),
+    rec!("r2.steering_rate", VehicleClass::R2, Profile::Nominal, [Field::MaxSteeringRate],
+         vp!("servo slew rate — time a full −45→+45 sweep (PLATFORM_R2_PENDING; also gates #1213)")),
+    rec!("r2.follow", VehicleClass::R2, Profile::Nominal, [Field::MinFollow], vp!("headway derivation review")),
+    rec!("r2.lat_accel", VehicleClass::R2, Profile::Nominal, [Field::MaxLateralAccel], vp!("lateral comfort measurement")),
+    rec!("r2.wheelbase", VehicleClass::R2, Profile::Nominal, [Field::Wheelbase],
+         Provenance::Measured { source: "bench tape, front-to-rear ~9 in (CONFIRM still owed); KIRRA_R2_WHEELBASE_M" }),
+    // Split from the overhangs BECAUSE the provenance differs — the body was
+    // measured, the overhang split was not. A uniform key granularity would
+    // erase exactly this distinction.
+    rec!("r2.footprint", VehicleClass::R2, Profile::Nominal, [Field::Width, Field::Length],
+         Provenance::Measured { source: "bench tape: width 8 in = 0.203 m, length 13 in = 0.330 m" }),
+    rec!("r2.overhangs", VehicleClass::R2, Profile::Nominal, [Field::OverhangFront, Field::OverhangRear],
+         Provenance::Estimate {
+             basis: "(length − wheelbase)/2 assumed split evenly; UNMEASURED. Feeds the swept-footprint \
+                     corner placement in containment.rs — an under-estimated rear overhang under-covers the body",
+         }),
+    rec!("r2.odd_cap", VehicleClass::R2, Profile::Nominal, [Field::OddSpeedCap],
+         vp!("ODD ceiling sign-off (docs/CONTRACT_PROFILES.md r2.odd_cap)")),
+    // --- r2 mrc ---
+    rec!("r2.mrc.max_speed", VehicleClass::R2, Profile::Mrc, [Field::MaxSpeed], vp!("degraded-envelope sign-off")),
+    rec!("r2.mrc.accel", VehicleClass::R2, Profile::Mrc, [Field::MaxAccel], vp!("degraded-envelope sign-off")),
+    rec!("r2.mrc.brake", VehicleClass::R2, Profile::Mrc, [Field::MaxBrake], vp!("degraded-envelope sign-off")),
+    rec!("r2.mrc.steering", VehicleClass::R2, Profile::Mrc, [Field::MaxSteering], vp!("degraded-envelope sign-off")),
+    rec!("r2.mrc.steering_rate", VehicleClass::R2, Profile::Mrc, [Field::MaxSteeringRate], vp!("degraded-envelope sign-off")),
+    rec!("r2.mrc.follow", VehicleClass::R2, Profile::Mrc, [Field::MinFollow], vp!("degraded-envelope sign-off")),
+    rec!("r2.mrc.lat_accel", VehicleClass::R2, Profile::Mrc, [Field::MaxLateralAccel], vp!("degraded-envelope sign-off")),
+    rec!("r2.mrc.wheelbase", VehicleClass::R2, Profile::Mrc, [Field::Wheelbase],
+         Provenance::Inherited { upstream: "r2.wheelbase" }),
+    rec!("r2.mrc.footprint", VehicleClass::R2, Profile::Mrc, [Field::Width, Field::Length],
+         Provenance::Inherited { upstream: "r2.footprint" }),
+    rec!("r2.mrc.overhangs", VehicleClass::R2, Profile::Mrc, [Field::OverhangFront, Field::OverhangRear],
+         Provenance::Inherited { upstream: "r2.overhangs" }),
+    rec!("r2.mrc.odd_cap", VehicleClass::R2, Profile::Mrc, [Field::OddSpeedCap],
+         Provenance::DerivedPrecondition { rule: PreconditionRule::MrcCrawlAtOrBelowClassOddCap }),
+];
+
+/// Robotaxi provenance. Valid ONLY against the reviewed talisman blob pin — see
+/// [`validate_robotaxi_sidecar`] and the module docs.
+pub static ROBOTAXI_SIDECAR: &[FieldProvenance] = &[
+    rec!(
+        "robotaxi.max_speed",
+        VehicleClass::Robotaxi,
+        Profile::Nominal,
+        [Field::MaxSpeed],
+        vp!("frozen reference-deployment value; validation predates this register")
+    ),
+    rec!(
+        "robotaxi.accel",
+        VehicleClass::Robotaxi,
+        Profile::Nominal,
+        [Field::MaxAccel],
+        vp!("frozen reference-deployment value")
+    ),
+    rec!(
+        "robotaxi.brake",
+        VehicleClass::Robotaxi,
+        Profile::Nominal,
+        [Field::MaxBrake],
+        vp!("frozen reference-deployment value")
+    ),
+    rec!(
+        "robotaxi.steering",
+        VehicleClass::Robotaxi,
+        Profile::Nominal,
+        [Field::MaxSteering],
+        vp!("frozen reference-deployment value")
+    ),
+    rec!(
+        "robotaxi.steering_rate",
+        VehicleClass::Robotaxi,
+        Profile::Nominal,
+        [Field::MaxSteeringRate],
+        vp!("frozen reference-deployment value")
+    ),
+    rec!(
+        "robotaxi.follow",
+        VehicleClass::Robotaxi,
+        Profile::Nominal,
+        [Field::MinFollow],
+        vp!("frozen reference-deployment value")
+    ),
+    rec!(
+        "robotaxi.lat_accel",
+        VehicleClass::Robotaxi,
+        Profile::Nominal,
+        [Field::MaxLateralAccel],
+        vp!("frozen reference-deployment value")
+    ),
+    rec!(
+        "robotaxi.wheelbase",
+        VehicleClass::Robotaxi,
+        Profile::Nominal,
+        [Field::Wheelbase],
+        vp!("frozen reference-deployment value")
+    ),
+    rec!(
+        "robotaxi.footprint",
+        VehicleClass::Robotaxi,
+        Profile::Nominal,
+        [
+            Field::Width,
+            Field::Length,
+            Field::OverhangFront,
+            Field::OverhangRear
+        ],
+        vp!("frozen reference-deployment value")
+    ),
+    // The frozen instance carries `None` here ON PURPOSE — the deployment
+    // applies the ODD cap externally. That is why ROBOTAXI_ODD_CAP exists as an
+    // ExternalConstraint rather than as contract provenance.
+    rec!(
+        "robotaxi.odd_cap",
+        VehicleClass::Robotaxi,
+        Profile::Nominal,
+        [Field::OddSpeedCap],
+        Provenance::DerivedPrecondition {
+            rule: PreconditionRule::CapAppliedExternally
+        }
+    ),
+    rec!(
+        "robotaxi.mrc.max_speed",
+        VehicleClass::Robotaxi,
+        Profile::Mrc,
+        [Field::MaxSpeed],
+        vp!("frozen MRC value")
+    ),
+    rec!(
+        "robotaxi.mrc.accel",
+        VehicleClass::Robotaxi,
+        Profile::Mrc,
+        [Field::MaxAccel],
+        vp!("frozen MRC value")
+    ),
+    rec!(
+        "robotaxi.mrc.brake",
+        VehicleClass::Robotaxi,
+        Profile::Mrc,
+        [Field::MaxBrake],
+        vp!("frozen MRC value")
+    ),
+    rec!(
+        "robotaxi.mrc.steering",
+        VehicleClass::Robotaxi,
+        Profile::Mrc,
+        [Field::MaxSteering],
+        vp!("frozen MRC value")
+    ),
+    rec!(
+        "robotaxi.mrc.steering_rate",
+        VehicleClass::Robotaxi,
+        Profile::Mrc,
+        [Field::MaxSteeringRate],
+        vp!("frozen MRC value")
+    ),
+    rec!(
+        "robotaxi.mrc.follow",
+        VehicleClass::Robotaxi,
+        Profile::Mrc,
+        [Field::MinFollow],
+        vp!("frozen MRC value")
+    ),
+    rec!(
+        "robotaxi.mrc.lat_accel",
+        VehicleClass::Robotaxi,
+        Profile::Mrc,
+        [Field::MaxLateralAccel],
+        vp!("frozen MRC value")
+    ),
+    rec!(
+        "robotaxi.mrc.wheelbase",
+        VehicleClass::Robotaxi,
+        Profile::Mrc,
+        [Field::Wheelbase],
+        Provenance::Inherited {
+            upstream: "robotaxi.wheelbase"
+        }
+    ),
+    rec!(
+        "robotaxi.mrc.footprint",
+        VehicleClass::Robotaxi,
+        Profile::Mrc,
+        [
+            Field::Width,
+            Field::Length,
+            Field::OverhangFront,
+            Field::OverhangRear
+        ],
+        Provenance::Inherited {
+            upstream: "robotaxi.footprint"
+        }
+    ),
+    rec!(
+        "robotaxi.mrc.odd_cap",
+        VehicleClass::Robotaxi,
+        Profile::Mrc,
+        [Field::OddSpeedCap],
+        Provenance::DerivedPrecondition {
+            rule: PreconditionRule::MrcCrawlAtOrBelowClassOddCap
+        }
+    ),
+];
+
+/// Constraints applied OUTSIDE the contract struct.
+///
+/// Only the robotaxi ODD cap qualifies today: courier / delivery-av / r2 carry
+/// their caps inside `odd_speed_cap_mps`, so their effective ceiling is derivable
+/// from the serialized contract alone. Robotaxi's is not.
+pub static EXTERNAL_CONSTRAINTS: &[ExternalConstraint] = &[ExternalConstraint {
+    id: "robotaxi.external.odd_cap",
+    class: VehicleClass::Robotaxi,
+    profile: Profile::Nominal,
+    constrains: Field::MaxSpeed,
+    applied_at: "the deployment, not the contract — the frozen instance's odd_speed_cap_mps is None by design",
+    supplied_by: "ROBOTAXI_ODD_SPEED_CAP_MPS (= URBAN_ODD_SPEED_CAP_MPS, the frozen talisman constant); ADR-0001 / SPEED_ENVELOPE.md / KIRRA-OCCY-SPEED-VAL-001",
+    participates_in_effective_ceiling: true,
+    provenance: Provenance::ValidationPending {
+        owed: "carried from ADR-0001's RSS stopping-distance chain; re-validated unchanged in OCCY_SPEED_CAP_VALIDATION.md",
+    },
+    value_mps: ROBOTAXI_ODD_SPEED_CAP_MPS,
+}];
+
+/// Every provenance record, authored plus sidecar.
+#[must_use]
+pub fn all_records() -> Vec<FieldProvenance> {
+    AUTHORED_PROVENANCE
+        .iter()
+        .chain(ROBOTAXI_SIDECAR.iter())
+        .copied()
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Checks
+// ---------------------------------------------------------------------------
+
+/// A coverage defect. Every variant names the exact triple at fault so the
+/// failure is actionable rather than a bare count mismatch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CoverageError {
+    /// No record governs this field. THE defect #1219 found in the wild.
+    Uncovered {
+        class: &'static str,
+        profile: &'static str,
+        field: &'static str,
+    },
+    /// Two or more records govern it — provenance would be ambiguous.
+    DoubleCovered {
+        class: &'static str,
+        profile: &'static str,
+        field: &'static str,
+        keys: Vec<&'static str>,
+    },
+    /// Two records share a key.
+    DuplicateKey { key: &'static str },
+}
+
+/// Assert total field-level coverage over `classes`.
+///
+/// The completeness property, stated as code: every (class, profile, field)
+/// triple is governed by **exactly one** record. Not "every key resolves" —
+/// that direction only proves the table invented no keys, and says nothing
+/// about fields no record mentions, which is where the real defect lives.
+pub fn check_coverage(
+    records: &[FieldProvenance],
+    classes: &[VehicleClass],
+) -> Result<(), Vec<CoverageError>> {
+    let mut errors = Vec::new();
+
+    let mut seen_keys: Vec<&'static str> = Vec::new();
+    for r in records {
+        if seen_keys.contains(&r.key) {
+            errors.push(CoverageError::DuplicateKey { key: r.key });
+        }
+        seen_keys.push(r.key);
+    }
+
+    for &class in classes {
+        for &profile in Profile::ALL {
+            for &field in Field::ALL {
+                let owners: Vec<&'static str> = records
+                    .iter()
+                    .filter(|r| {
+                        r.class == class && r.profile == profile && r.fields.contains(&field)
+                    })
+                    .map(|r| r.key)
+                    .collect();
+                match owners.len() {
+                    1 => {}
+                    0 => errors.push(CoverageError::Uncovered {
+                        class: class.as_str(),
+                        profile: profile.as_str(),
+                        field: field.name(),
+                    }),
+                    _ => errors.push(CoverageError::DoubleCovered {
+                        class: class.as_str(),
+                        profile: profile.as_str(),
+                        field: field.name(),
+                        keys: owners,
+                    }),
+                }
+            }
+        }
+    }
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors)
+    }
+}
+
+/// An inheritance defect.
+#[derive(Debug, Clone, PartialEq)]
+pub enum InheritanceError {
+    /// The named upstream key does not exist — an unresolvable claim.
+    UpstreamMissing {
+        key: &'static str,
+        upstream: &'static str,
+    },
+    /// Upstream belongs to a different class. Inheritance is within a class;
+    /// crossing one would import another platform's geometry.
+    UpstreamWrongClass {
+        key: &'static str,
+        upstream: &'static str,
+    },
+    /// Upstream does not govern a field the downstream record claims to inherit.
+    UpstreamMissingField {
+        key: &'static str,
+        upstream: &'static str,
+        field: &'static str,
+    },
+    /// The values differ. The claim "IDENTICAL to nominal" is false.
+    ValueDiverged {
+        key: &'static str,
+        upstream: &'static str,
+        field: &'static str,
+        downstream: FieldValue,
+        upstream_value: FieldValue,
+    },
+}
+
+/// Assert every `INHERITED` record resolves to its upstream AND equals it.
+///
+/// This is the check that makes `INHERITED` more than a classification. Values
+/// are compared bit-for-bit (`f64::to_bits`) rather than with a tolerance: the
+/// claim is that the MRC profile carries the SAME value, and "same" admits no
+/// epsilon.
+pub fn check_inheritance(records: &[FieldProvenance]) -> Result<usize, Vec<InheritanceError>> {
+    let mut errors = Vec::new();
+    let mut verified = 0usize;
+
+    for r in records {
+        let Provenance::Inherited { upstream } = r.provenance else {
+            continue;
+        };
+        let Some(up) = records.iter().find(|c| c.key == upstream) else {
+            errors.push(InheritanceError::UpstreamMissing {
+                key: r.key,
+                upstream,
+            });
+            continue;
+        };
+        if up.class != r.class {
+            errors.push(InheritanceError::UpstreamWrongClass {
+                key: r.key,
+                upstream,
+            });
+            continue;
+        }
+
+        let down_contract = r.profile.contract(r.class);
+        let up_contract = up.profile.contract(up.class);
+
+        for &field in r.fields {
+            if !up.fields.contains(&field) {
+                errors.push(InheritanceError::UpstreamMissingField {
+                    key: r.key,
+                    upstream,
+                    field: field.name(),
+                });
+                continue;
+            }
+            let d = field.read(&down_contract);
+            let u = field.read(&up_contract);
+            if !field_values_identical(d, u) {
+                errors.push(InheritanceError::ValueDiverged {
+                    key: r.key,
+                    upstream,
+                    field: field.name(),
+                    downstream: d,
+                    upstream_value: u,
+                });
+            } else {
+                verified += 1;
+            }
+        }
+    }
+
+    if errors.is_empty() {
+        Ok(verified)
+    } else {
+        Err(errors)
+    }
+}
+
+/// Bit-identical comparison. `to_bits` rather than `==` so the check is exact
+/// and total (no NaN surprise, no epsilon creep).
+fn field_values_identical(a: FieldValue, b: FieldValue) -> bool {
+    match (a, b) {
+        (FieldValue::Scalar(x), FieldValue::Scalar(y)) => x.to_bits() == y.to_bits(),
+        (FieldValue::OptionalCap(None), FieldValue::OptionalCap(None)) => true,
+        (FieldValue::OptionalCap(Some(x)), FieldValue::OptionalCap(Some(y))) => {
+            x.to_bits() == y.to_bits()
+        }
+        _ => false,
+    }
+}
+
+/// A precondition defect: a justifying inequality that no longer holds.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PreconditionError {
+    pub key: &'static str,
+    pub rule: PreconditionRule,
+    pub detail: String,
+}
+
+/// The class ODD cap constant, by class. A REFERENCE table, not new numbers.
+#[must_use]
+pub fn class_odd_cap_mps(class: VehicleClass) -> f64 {
+    match class {
+        VehicleClass::Courier => COURIER_ODD_SPEED_CAP_MPS,
+        VehicleClass::DeliveryAv => DELIVERY_AV_ODD_SPEED_CAP_MPS,
+        VehicleClass::Robotaxi => ROBOTAXI_ODD_SPEED_CAP_MPS,
+        VehicleClass::R2 => R2_ODD_SPEED_CAP_MPS,
+    }
+}
+
+/// Execute every `DERIVED-PRECONDITION` record's rule.
+pub fn check_preconditions(records: &[FieldProvenance]) -> Result<usize, Vec<PreconditionError>> {
+    let mut errors = Vec::new();
+    let mut checked = 0usize;
+
+    for r in records {
+        let Provenance::DerivedPrecondition { rule } = r.provenance else {
+            continue;
+        };
+        match rule {
+            PreconditionRule::MrcCrawlAtOrBelowClassOddCap => {
+                let contract = r.profile.contract(r.class);
+                // The rule only justifies a cap that is actually absent. A
+                // record claiming it on a profile that HAS a cap is a
+                // mis-classification, not a satisfied precondition.
+                if contract.odd_speed_cap_mps.is_some() {
+                    errors.push(PreconditionError {
+                        key: r.key,
+                        rule,
+                        detail: format!(
+                            "{} carries an explicit ODD cap; the None-is-safe rule does not apply",
+                            r.key
+                        ),
+                    });
+                    continue;
+                }
+                let cap = class_odd_cap_mps(r.class);
+                if contract.max_speed_mps > cap {
+                    errors.push(PreconditionError {
+                        key: r.key,
+                        rule,
+                        detail: format!(
+                            "max_speed {} EXCEEDS the class ODD cap {cap}; leaving the cap None \
+                             raises this profile's enforced ceiling above the class ceiling",
+                            contract.max_speed_mps
+                        ),
+                    });
+                } else {
+                    checked += 1;
+                }
+            }
+            PreconditionRule::CapAppliedExternally => {
+                let contract = r.profile.contract(r.class);
+                if contract.odd_speed_cap_mps.is_some() {
+                    errors.push(PreconditionError {
+                        key: r.key,
+                        rule,
+                        detail: format!(
+                            "{} carries an explicit ODD cap; the applied-externally rule does not apply",
+                            r.key
+                        ),
+                    });
+                    continue;
+                }
+                // The claim is only honest if an external constraint actually
+                // exists AND actually binds. Otherwise "applied externally" is
+                // an assertion that nothing enforces the cap at all.
+                let external = EXTERNAL_CONSTRAINTS.iter().find(|c| {
+                    c.class == r.class
+                        && c.profile == r.profile
+                        && c.constrains == Field::MaxSpeed
+                        && c.participates_in_effective_ceiling
+                });
+                match external {
+                    None => errors.push(PreconditionError {
+                        key: r.key,
+                        rule,
+                        detail: format!(
+                            "{} claims its cap is applied externally, but no participating                              ExternalConstraint is registered — nothing caps this profile",
+                            r.key
+                        ),
+                    }),
+                    Some(c) if c.value_mps >= contract.max_speed_mps => {
+                        errors.push(PreconditionError {
+                            key: r.key,
+                            rule,
+                            detail: format!(
+                                "the external constraint {} ({}) does not bind below max_speed {}",
+                                c.id, c.value_mps, contract.max_speed_mps
+                            ),
+                        });
+                    }
+                    Some(_) => checked += 1,
+                }
+            }
+        }
+    }
+
+    if errors.is_empty() {
+        Ok(checked)
+    } else {
+        Err(errors)
+    }
+}
+
+/// The enforced speed ceiling for `(class, profile)`, composing the contract's
+/// own `effective_max_speed_mps()` with any participating [`ExternalConstraint`].
+///
+/// This is the function that makes robotaxi honest. `contract_for(Robotaxi)`
+/// alone derives 35.0 m/s, because the frozen instance's cap is `None` and the
+/// deployment applies 22.35 elsewhere. Serializing the contract without this
+/// composition would publish a ceiling 12.65 m/s above the one actually enforced.
+#[must_use]
+pub fn effective_ceiling_mps(class: VehicleClass, profile: Profile) -> f64 {
+    let mut ceiling = profile.contract(class).effective_max_speed_mps();
+    for c in EXTERNAL_CONSTRAINTS {
+        if c.class == class
+            && c.profile == profile
+            && c.participates_in_effective_ceiling
+            && c.value_mps < ceiling
+        {
+            ceiling = c.value_mps;
+        }
+    }
+    ceiling
+}
+
+// ---------------------------------------------------------------------------
+// The frozen sidecar's hash binding
+// ---------------------------------------------------------------------------
+
+/// Why a sidecar is not usable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SidecarError {
+    /// The pin document holds no hash for the talisman.
+    PinNotFound { doc: &'static str },
+    /// `git hash-object` could not be run. FAIL-CLOSED: an integrity gate that
+    /// skips when its tool is missing is worse than no gate, because it reports
+    /// success.
+    HashUnavailable { detail: String },
+    /// The talisman changed without a reviewed re-pin. The sidecar describes
+    /// numbers that may no longer be there.
+    PinMismatch { pinned: String, actual: String },
+}
+
+/// Read the reviewed blob pin out of [`TALISMAN_PIN_DOC`].
+///
+/// Parses the same `<path> = <40 hex>` shape `ci/build_safety_case.py` greps.
+/// No regex dependency; the shape is fixed and simple.
+fn read_pin(repo_root: &Path) -> Result<String, SidecarError> {
+    let doc = std::fs::read_to_string(repo_root.join(TALISMAN_PIN_DOC)).map_err(|_| {
+        SidecarError::PinNotFound {
+            doc: TALISMAN_PIN_DOC,
+        }
+    })?;
+    for line in doc.lines() {
+        let Some(after_path) = line.split_once(TALISMAN_PATH) else {
+            continue;
+        };
+        let rest = after_path.1;
+        let hex: String = rest
+            .chars()
+            .skip_while(|c| !c.is_ascii_hexdigit())
+            .take_while(char::is_ascii_hexdigit)
+            .collect();
+        if hex.len() == 40 {
+            return Ok(hex);
+        }
+    }
+    Err(SidecarError::PinNotFound {
+        doc: TALISMAN_PIN_DOC,
+    })
+}
+
+/// Validate the frozen sidecar against the EXISTING talisman pin.
+///
+/// Two conditions, both required:
+///
+/// 1. `git hash-object <talisman>` equals the hash recorded in the reviewed pin
+///    doc — the same check `ci/build_safety_case.py::talisman_gate` and the
+///    `ci.yml` rustfmt lane perform. Reused, not reimplemented.
+/// 2. The sidecar's records cover every field of every profile for its class —
+///    enforced by the caller via [`check_coverage`], so a sidecar cannot be
+///    partially populated and look complete.
+///
+/// If the blob changes, this fails and the provenance association is refused
+/// until the sidecar is deliberately revisited. That is the point: the sidecar
+/// DESCRIBES the frozen values, and a description of numbers that changed is
+/// worse than no description.
+pub fn validate_robotaxi_sidecar(repo_root: &Path) -> Result<String, SidecarError> {
+    let pinned = read_pin(repo_root)?;
+
+    let out = Command::new("git")
+        .args(["hash-object", TALISMAN_PATH])
+        .current_dir(repo_root)
+        .output()
+        .map_err(|e| SidecarError::HashUnavailable {
+            detail: format!("could not run `git hash-object`: {e}"),
+        })?;
+    if !out.status.success() {
+        return Err(SidecarError::HashUnavailable {
+            detail: format!(
+                "`git hash-object` failed: {}",
+                String::from_utf8_lossy(&out.stderr).trim()
+            ),
+        });
+    }
+    let actual = String::from_utf8_lossy(&out.stdout).trim().to_string();
+
+    if actual != pinned {
+        return Err(SidecarError::PinMismatch { pinned, actual });
+    }
+    Ok(actual)
+}
+
+// ---------------------------------------------------------------------------
+// The serialized manifest
+// ---------------------------------------------------------------------------
+
+/// One serialized field row: the live value plus its provenance.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ManifestField {
+    pub field: Field,
+    pub name: String,
+    pub value: FieldValue,
+    pub provenance_key: String,
+    pub provenance_class: String,
+    pub provenance_detail: String,
+    pub upstream: Option<String>,
+    pub validated: bool,
+}
+
+/// One serialized (class, profile) profile row.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ManifestProfile {
+    pub class: String,
+    pub profile: String,
+    /// The composed ceiling, INCLUDING external constraints. See
+    /// [`effective_ceiling_mps`].
+    pub effective_ceiling_mps: f64,
+    /// The ceiling derivable from the contract alone. Differs from the above
+    /// exactly when an external constraint participates — which is the split
+    /// authority the manifest exists to expose.
+    pub contract_only_ceiling_mps: f64,
+    pub fields: Vec<ManifestField>,
+}
+
+/// One serialized external-constraint row.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ManifestExternalConstraint {
+    pub id: String,
+    pub class: String,
+    pub profile: String,
+    pub constrains: String,
+    pub applied_at: String,
+    pub supplied_by: String,
+    pub participates_in_effective_ceiling: bool,
+    pub provenance_class: String,
+    pub value_mps: f64,
+}
+
+/// The serialized provenance manifest — a DERIVED view. Every number in it was
+/// read from a live contract or a canonical constant at render time.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ProvenanceManifest {
+    pub manifest_version: u32,
+    /// The talisman blob hash this render was validated against, when the
+    /// robotaxi sidecar was included.
+    pub talisman_blob: Option<String>,
+    pub profiles: Vec<ManifestProfile>,
+    pub external_constraints: Vec<ManifestExternalConstraint>,
+}
+
+/// The manifest schema version. Bump on a breaking shape change.
+pub const MANIFEST_VERSION: u32 = 1;
+
+fn provenance_detail(p: Provenance) -> String {
+    match p {
+        Provenance::Measured { source } => source.to_string(),
+        Provenance::Estimate { basis } => basis.to_string(),
+        Provenance::ValidationPending { owed } => owed.to_string(),
+        Provenance::Inherited { upstream } => format!("inherited from {upstream}"),
+        Provenance::DerivedPrecondition { rule } => format!("{rule:?}"),
+        Provenance::Unattributed => String::new(),
+    }
+}
+
+/// Render the manifest for `classes` from `records`.
+///
+/// Fails if coverage is incomplete: a manifest with a missing row would present
+/// as authoritative while being silently partial, which is the exact failure the
+/// completeness property exists to prevent.
+pub fn render_manifest(
+    records: &[FieldProvenance],
+    classes: &[VehicleClass],
+    talisman_blob: Option<String>,
+) -> Result<ProvenanceManifest, Vec<CoverageError>> {
+    check_coverage(records, classes)?;
+
+    let mut profiles = Vec::new();
+    for &class in classes {
+        for &profile in Profile::ALL {
+            let contract = profile.contract(class);
+            let mut fields = Vec::new();
+            for &field in Field::ALL {
+                let owner = records
+                    .iter()
+                    .find(|r| r.class == class && r.profile == profile && r.fields.contains(&field))
+                    .expect("coverage checked above");
+                fields.push(ManifestField {
+                    field,
+                    name: field.name().to_string(),
+                    value: field.read(&contract),
+                    provenance_key: owner.key.to_string(),
+                    provenance_class: owner.provenance.token().to_string(),
+                    provenance_detail: provenance_detail(owner.provenance),
+                    upstream: match owner.provenance {
+                        Provenance::Inherited { upstream } => Some(upstream.to_string()),
+                        _ => None,
+                    },
+                    validated: owner.provenance.is_validated(),
+                });
+            }
+            profiles.push(ManifestProfile {
+                class: class.as_str().to_string(),
+                profile: profile.as_str().to_string(),
+                effective_ceiling_mps: effective_ceiling_mps(class, profile),
+                contract_only_ceiling_mps: contract.effective_max_speed_mps(),
+                fields,
+            });
+        }
+    }
+
+    let external_constraints = EXTERNAL_CONSTRAINTS
+        .iter()
+        .filter(|c| classes.contains(&c.class))
+        .map(|c| ManifestExternalConstraint {
+            id: c.id.to_string(),
+            class: c.class.as_str().to_string(),
+            profile: c.profile.as_str().to_string(),
+            constrains: c.constrains.name().to_string(),
+            applied_at: c.applied_at.to_string(),
+            supplied_by: c.supplied_by.to_string(),
+            participates_in_effective_ceiling: c.participates_in_effective_ceiling,
+            provenance_class: c.provenance.token().to_string(),
+            value_mps: c.value_mps,
+        })
+        .collect();
+
+    Ok(ProvenanceManifest {
+        manifest_version: MANIFEST_VERSION,
+        talisman_blob,
+        profiles,
+        external_constraints,
+    })
+}
+
+/// Every class this register covers.
+pub const ALL_CLASSES: &[VehicleClass] = &[
+    VehicleClass::Courier,
+    VehicleClass::DeliveryAv,
+    VehicleClass::Robotaxi,
+    VehicleClass::R2,
+];
+
+#[cfg(test)]
+mod tests;
+
+// ---------------------------------------------------------------------------
+// Agreement with the source comments
+// ---------------------------------------------------------------------------
+
+/// A parsed provenance tag from `contract_profiles.rs`'s comments.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceTag {
+    pub key: String,
+    /// The classification token, read from the ONE permitted syntactic position.
+    pub token: String,
+}
+
+/// The classification vocabulary, longest-first so `VALIDATION-PENDING` is
+/// matched before any prefix of it could be.
+const CLASSIFICATION_TOKENS: &[&str] = &["VALIDATION-PENDING", "MEASURED", "ESTIMATE", "INHERITED"];
+
+/// Extract provenance tags from a `contract_profiles.rs`-shaped source.
+///
+/// The grammar is **tag-led**, and that is the whole safety property:
+///
+/// 1. locate a stable `(class.field)` tag,
+/// 2. read the classification ONLY from the permitted syntactic position — the
+///    first token of the comment block carrying the tag,
+/// 3. reject anything else.
+///
+/// Searching comments for the classification word instead would fail three ways,
+/// each producing a clean-looking but wrong result:
+///
+/// - **Substring**: `ESTIMATE (overhang split UNMEASURED)` contains `MEASURED`,
+///   so a naive `contains` promotes the one estimate in the file to a
+///   measurement — in the optimistic direction, on the field #1213 depends on.
+///   Matching only at the leading position makes that impossible.
+/// - **Single dialect**: the ODD caps live in `///` doc comments with the token
+///   bolded mid-sentence and the tag written ``(param `r2.odd_cap`)``. A parser
+///   written for the field dialect silently drops all four — and for the R2 the
+///   dropped row is the one that actually binds.
+/// - **Narrative**: comments like "the FIRST profile with MEASURED geometry"
+///   carry a token and no tag. Keying on the tag excludes them.
+#[must_use]
+pub fn extract_source_tags(source: &str) -> Vec<SourceTag> {
+    let mut out = Vec::new();
+    let lines: Vec<&str> = source.lines().collect();
+    let mut i = 0;
+
+    while i < lines.len() {
+        let trimmed = lines[i].trim();
+
+        // A contiguous comment block (either dialect).
+        if trimmed.starts_with("//") {
+            let start = i;
+            let mut body = String::new();
+            while i < lines.len() && lines[i].trim().starts_with("//") {
+                body.push(' ');
+                body.push_str(lines[i].trim().trim_start_matches('/').trim());
+                i += 1;
+            }
+            let is_doc = lines[start].trim().starts_with("///");
+            push_tag(&body, is_doc, &mut out);
+            continue;
+        }
+
+        // A trailing comment on a code line.
+        if let Some((code, comment)) = lines[i].split_once("//") {
+            if !code.trim().is_empty() {
+                push_tag(comment.trim(), false, &mut out);
+            }
+        }
+        i += 1;
+    }
+    out
+}
+
+/// The classification's permitted position differs by dialect, and only by
+/// dialect — never "anywhere in the text".
+fn classification_in(body: &str, is_doc: bool) -> Option<String> {
+    let cleaned = body.trim().trim_start_matches('*').trim();
+    if is_doc {
+        // Const dialect: the token is bolded. `**MEASURED.**` — permitted only
+        // inside the bold markers, not as loose prose.
+        for tok in CLASSIFICATION_TOKENS {
+            if cleaned.contains(&format!("**{tok}")) {
+                return Some((*tok).to_string());
+            }
+        }
+        return None;
+    }
+    // Field dialect: the token LEADS the block. Anchored, so `UNMEASURED`
+    // appearing later in the sentence can never match.
+    for tok in CLASSIFICATION_TOKENS {
+        if cleaned.starts_with(tok) {
+            return Some((*tok).to_string());
+        }
+    }
+    None
+}
+
+/// Pull the trailing stable tag: the last parenthesised `class.field` path.
+fn stable_tag_in(body: &str) -> Option<String> {
+    let mut found = None;
+    let bytes: Vec<char> = body.chars().collect();
+    let mut idx = 0;
+    while idx < bytes.len() {
+        if bytes[idx] == '(' {
+            let mut j = idx + 1;
+            let mut inner = String::new();
+            while j < bytes.len() && bytes[j] != ')' {
+                inner.push(bytes[j]);
+                j += 1;
+            }
+            if j < bytes.len() {
+                // Tolerates both `(r2.steering)` and
+                // ``(param `r2.odd_cap`)`` / `(CONTRACT_PROFILES.md courier.max_speed)`.
+                let candidate = inner
+                    .split_whitespace()
+                    .next_back()
+                    .unwrap_or("")
+                    .trim_matches('`');
+                if is_stable_tag(candidate) {
+                    found = Some(candidate.to_string());
+                }
+                idx = j;
+            }
+        }
+        idx += 1;
+    }
+    found
+}
+
+fn is_stable_tag(s: &str) -> bool {
+    let Some((class, rest)) = s.split_once('.') else {
+        return false;
+    };
+    if !matches!(class, "courier" | "delivery-av" | "r2" | "robotaxi") || rest.is_empty() {
+        return false;
+    }
+    rest.split('.')
+        .all(|seg| !seg.is_empty() && seg.chars().all(|c| c.is_ascii_lowercase() || c == '_'))
+}
+
+fn push_tag(body: &str, is_doc: bool, out: &mut Vec<SourceTag>) {
+    if let (Some(token), Some(key)) = (classification_in(body, is_doc), stable_tag_in(body)) {
+        out.push(SourceTag { key, token });
+    }
+}
+
+/// Disagreement between a source comment and the provenance table.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SourceAgreementError {
+    /// The comment classifies a key one way; the table another.
+    Divergent {
+        key: String,
+        comment_token: String,
+        table_token: &'static str,
+    },
+    /// The comment carries a tag no record claims.
+    UnknownKey { key: String },
+}
+
+/// Assert the table agrees with the comments it derives from.
+///
+/// Without this, the table would be a SECOND authored inventory of
+/// classifications, free to drift from the prose beside the numbers — the exact
+/// failure this register exists to prevent, reintroduced one level up.
+///
+/// Only keys that appear in BOTH are compared. `INHERITED` and
+/// `DERIVED-PRECONDITION` records have no comment tag (the source states those
+/// relationships as prose — "Footprint IDENTICAL to nominal"), so the table is
+/// where they become checkable; nothing is asserted about them here.
+pub fn check_source_agreement(
+    source: &str,
+    records: &[FieldProvenance],
+) -> Result<usize, Vec<SourceAgreementError>> {
+    let mut errors = Vec::new();
+    let mut agreed = 0usize;
+
+    for tag in extract_source_tags(source) {
+        let Some(record) = records.iter().find(|r| r.key == tag.key) else {
+            errors.push(SourceAgreementError::UnknownKey { key: tag.key });
+            continue;
+        };
+        let table_token = record.provenance.token();
+        if table_token == tag.token {
+            agreed += 1;
+        } else {
+            errors.push(SourceAgreementError::Divergent {
+                key: tag.key,
+                comment_token: tag.token,
+                table_token,
+            });
+        }
+    }
+
+    if errors.is_empty() {
+        Ok(agreed)
+    } else {
+        Err(errors)
+    }
+}

--- a/src/gateway/provenance/tests.rs
+++ b/src/gateway/provenance/tests.rs
@@ -1,0 +1,984 @@
+//! #1219 part 2 test surface.
+//!
+//! Every test here exists to make one clause of the property executable:
+//!
+//! > Every authority-relevant field and externally applied constraint has
+//! > exactly one provenance mapping; inherited mappings identify and equal their
+//! > upstream source; serialized representations remain derived from the Rust
+//! > contract and existing reviewed integrity pins.
+//!
+//! Several assertions pass on the current tree, so each is paired with a
+//! NEGATIVE that proves the assertion can fail. An always-green check is not
+//! evidence — it is decoration.
+
+use std::path::PathBuf;
+
+use super::*;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+// ---------------------------------------------------------------------------
+// The denominator itself
+// ---------------------------------------------------------------------------
+
+/// `Field::ALL` is what every coverage claim is measured against, so a field
+/// added to the contract struct and not added here would let the whole register
+/// report complete while silently ignoring it.
+///
+/// Anchored to the struct's own serde shape rather than to a hand-kept count.
+#[test]
+fn every_contract_struct_field_appears_in_the_field_enum() {
+    let json = serde_json::to_value(contract_for(VehicleClass::R2)).expect("contract serializes");
+    let obj = json.as_object().expect("contract is a JSON object");
+
+    let mut struct_fields: Vec<&str> = obj.keys().map(String::as_str).collect();
+    struct_fields.sort_unstable();
+
+    let mut enum_fields: Vec<&str> = Field::ALL.iter().map(|f| f.name()).collect();
+    enum_fields.sort_unstable();
+
+    assert_eq!(
+        struct_fields, enum_fields,
+        "VehicleKinematicsContract's fields and Field::ALL have diverged — a field \
+         missing from Field::ALL escapes every coverage check in this module"
+    );
+}
+
+#[test]
+fn field_names_are_unique() {
+    let mut names: Vec<&str> = Field::ALL.iter().map(|f| f.name()).collect();
+    names.sort_unstable();
+    let before = names.len();
+    names.dedup();
+    assert_eq!(before, names.len(), "duplicate Field::name()");
+}
+
+// ---------------------------------------------------------------------------
+// 1 + 2 — coverage: exactly one record per (class, profile, field)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn every_field_of_every_profile_has_exactly_one_provenance_record() {
+    let records = all_records();
+    if let Err(errors) = check_coverage(&records, ALL_CLASSES) {
+        panic!("provenance coverage is incomplete or ambiguous: {errors:#?}");
+    }
+}
+
+/// The denominator, stated explicitly so a silent change to the class or field
+/// list shows up as a number nobody meant to change.
+#[test]
+fn coverage_spans_the_expected_number_of_field_assignments() {
+    let expected = ALL_CLASSES.len() * Profile::ALL.len() * Field::ALL.len();
+    assert_eq!(expected, 4 * 2 * 13);
+
+    let records = all_records();
+    let mut covered = 0usize;
+    for &class in ALL_CLASSES {
+        for &profile in Profile::ALL {
+            for &field in Field::ALL {
+                covered += records
+                    .iter()
+                    .filter(|r| {
+                        r.class == class && r.profile == profile && r.fields.contains(&field)
+                    })
+                    .count();
+            }
+        }
+    }
+    assert_eq!(
+        covered, expected,
+        "field assignments covered ({covered}) != field assignments that exist ({expected})"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 3 — non-vacuity: the check catches the omission that actually shipped
+// ---------------------------------------------------------------------------
+
+/// The `delivery_av_nominal` defect, reconstructed.
+///
+/// Before this work, the source comment tagged `(delivery-av.footprint)` as a
+/// TRAILING comment on `width_m`, so it governed that one field and left
+/// `length_m`, `overhang_front_m` and `overhang_rear_m` with no provenance at
+/// all. Crucially, a "every key resolves to a known field" check PASSED on that
+/// tree — all 49 tags were valid and unique. Only field-level coverage sees it.
+///
+/// This reconstructs the narrow record and asserts the checker names all three
+/// missing fields.
+#[test]
+fn the_coverage_check_catches_the_delivery_av_omission_that_shipped() {
+    let narrow = FieldProvenance {
+        key: "delivery-av.footprint",
+        class: VehicleClass::DeliveryAv,
+        profile: Profile::Nominal,
+        // The bug: width only, exactly as a trailing comment would have bound it.
+        fields: &[Field::Width],
+        provenance: Provenance::ValidationPending {
+            owed: "platform geometry measurement",
+        },
+    };
+
+    let records: Vec<FieldProvenance> = all_records()
+        .into_iter()
+        .map(|r| if r.key == narrow.key { narrow } else { r })
+        .collect();
+
+    let errors = check_coverage(&records, ALL_CLASSES)
+        .expect_err("a table missing three fields must NOT report complete");
+
+    for missing in ["length_m", "overhang_front_m", "overhang_rear_m"] {
+        assert!(
+            errors.contains(&CoverageError::Uncovered {
+                class: "delivery-av",
+                profile: "nominal",
+                field: missing,
+            }),
+            "coverage check did not report {missing} as uncovered; got {errors:#?}"
+        );
+    }
+    assert_eq!(
+        errors.len(),
+        3,
+        "exactly the three known-missing fields should fail; got {errors:#?}"
+    );
+}
+
+/// The other direction: two records governing one field is also a defect,
+/// because provenance would be ambiguous — a reader could not say which
+/// classification applies.
+#[test]
+fn the_coverage_check_catches_a_double_covered_field() {
+    let mut records = all_records();
+    records.push(FieldProvenance {
+        key: "r2.wheelbase.duplicate",
+        class: VehicleClass::R2,
+        profile: Profile::Nominal,
+        fields: &[Field::Wheelbase],
+        provenance: Provenance::Estimate {
+            basis: "a second, conflicting claim",
+        },
+    });
+
+    let errors = check_coverage(&records, ALL_CLASSES).expect_err("double coverage must fail");
+    assert!(
+        errors.iter().any(|e| matches!(
+            e,
+            CoverageError::DoubleCovered {
+                field: "wheelbase_m",
+                class: "r2",
+                ..
+            }
+        )),
+        "expected a DoubleCovered report for r2 wheelbase_m; got {errors:#?}"
+    );
+}
+
+#[test]
+fn the_coverage_check_catches_a_duplicate_key() {
+    let mut records = all_records();
+    let first = records[0];
+    records.push(FieldProvenance {
+        // Same key, different (unused) field set — the key is the identity.
+        fields: &[],
+        ..first
+    });
+
+    let errors = check_coverage(&records, ALL_CLASSES).expect_err("duplicate keys must fail");
+    assert!(
+        errors.contains(&CoverageError::DuplicateKey { key: first.key }),
+        "expected DuplicateKey for {}; got {errors:#?}",
+        first.key
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 4 — inheritance resolves AND compares equal
+// ---------------------------------------------------------------------------
+
+#[test]
+fn every_inherited_record_resolves_and_equals_its_upstream() {
+    let records = all_records();
+    match check_inheritance(&records) {
+        Ok(verified) => assert!(verified > 0, "no inheritance relationships were verified"),
+        Err(errors) => panic!("inheritance claims are false or unresolvable: {errors:#?}"),
+    }
+}
+
+/// The authored classes carry exactly 15 inheritance relationships: three
+/// classes × (wheelbase + the four footprint fields).
+///
+/// Six of them — the two overhangs on each class — were asserted NOWHERE before
+/// this module. `mrc_leq_nominal_per_field_every_class` compares wheelbase,
+/// width and length under a comment claiming the whole footprint is identical.
+/// The overhangs are the fields that place the swept-footprint corners in
+/// `containment.rs`.
+#[test]
+fn the_authored_classes_carry_fifteen_verified_inheritance_relationships() {
+    let verified = check_inheritance(AUTHORED_PROVENANCE).expect("authored inheritance holds");
+    assert_eq!(
+        verified, 15,
+        "expected 15 authored inheritance field-comparisons"
+    );
+}
+
+#[test]
+fn the_overhangs_are_among_the_inheritance_relationships_now_verified() {
+    let inherits_overhangs = |class: VehicleClass| {
+        AUTHORED_PROVENANCE.iter().any(|r| {
+            r.class == class
+                && r.profile == Profile::Mrc
+                && matches!(r.provenance, Provenance::Inherited { .. })
+                && r.fields.contains(&Field::OverhangFront)
+                && r.fields.contains(&Field::OverhangRear)
+        })
+    };
+    for class in [
+        VehicleClass::Courier,
+        VehicleClass::DeliveryAv,
+        VehicleClass::R2,
+    ] {
+        assert!(
+            inherits_overhangs(class),
+            "{} MRC overhangs carry no verified inheritance claim",
+            class.as_str()
+        );
+    }
+}
+
+/// NON-VACUITY for the inheritance check.
+///
+/// All 15 relationships hold today, so the positive test above would pass even
+/// if the comparison were a no-op. This constructs a record whose claimed
+/// upstream genuinely differs — courier MRC `max_speed` is 1.0, courier nominal
+/// is 3.0 — and asserts the check reports the divergence.
+#[test]
+fn the_inheritance_comparison_actually_compares_values() {
+    let mut records = all_records();
+    // Replace the courier MRC max-speed record with a false inheritance claim.
+    for r in &mut records {
+        if r.key == "courier.mrc.max_speed" {
+            r.provenance = Provenance::Inherited {
+                upstream: "courier.max_speed",
+            };
+        }
+    }
+
+    let errors = check_inheritance(&records).expect_err("a false inheritance claim must fail");
+    assert!(
+        errors.iter().any(|e| matches!(
+            e,
+            InheritanceError::ValueDiverged {
+                key: "courier.mrc.max_speed",
+                field: "max_speed_mps",
+                ..
+            }
+        )),
+        "expected a ValueDiverged report; got {errors:#?}"
+    );
+}
+
+#[test]
+fn an_unresolvable_upstream_is_reported_not_ignored() {
+    let mut records = all_records();
+    for r in &mut records {
+        if r.key == "r2.mrc.wheelbase" {
+            r.provenance = Provenance::Inherited {
+                upstream: "r2.no-such-key",
+            };
+        }
+    }
+    let errors = check_inheritance(&records).expect_err("a dangling upstream must fail");
+    assert!(
+        errors.contains(&InheritanceError::UpstreamMissing {
+            key: "r2.mrc.wheelbase",
+            upstream: "r2.no-such-key",
+        }),
+        "expected UpstreamMissing; got {errors:#?}"
+    );
+}
+
+/// Inheritance is within a class. Crossing one would import another platform's
+/// geometry under the label "inherited", which is how a courier wheelbase ends
+/// up on an R2.
+#[test]
+fn inheritance_across_classes_is_refused() {
+    let mut records = all_records();
+    for r in &mut records {
+        if r.key == "r2.mrc.wheelbase" {
+            r.provenance = Provenance::Inherited {
+                upstream: "courier.wheelbase",
+            };
+        }
+    }
+    let errors = check_inheritance(&records).expect_err("cross-class inheritance must fail");
+    assert!(
+        errors.contains(&InheritanceError::UpstreamWrongClass {
+            key: "r2.mrc.wheelbase",
+            upstream: "courier.wheelbase",
+        }),
+        "expected UpstreamWrongClass; got {errors:#?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 5 — the `None` MRC caps carry a precondition, and it holds
+// ---------------------------------------------------------------------------
+
+#[test]
+fn every_none_cap_precondition_holds() {
+    let records = all_records();
+    let checked = check_preconditions(&records).expect("precondition rules hold");
+    assert!(checked > 0, "no preconditions were actually executed");
+}
+
+/// The three MRC `None` caps are neither inherited nor unattributed: leaving the
+/// cap absent is safe only because the crawl already sits at or below the class
+/// ODD cap, so `min()` selects the crawl either way.
+///
+/// The inequality holds for every class today and was asserted nowhere.
+#[test]
+fn the_mrc_crawl_sits_at_or_below_the_class_odd_cap_for_every_class() {
+    for &class in ALL_CLASSES {
+        let mrc = mrc_fallback_for(class);
+        let cap = class_odd_cap_mps(class);
+        assert!(
+            mrc.max_speed_mps <= cap,
+            "{}: MRC crawl {} exceeds the class ODD cap {cap} — leaving odd_speed_cap_mps None \
+             would raise the degraded ceiling above the nominal one",
+            class.as_str(),
+            mrc.max_speed_mps
+        );
+    }
+}
+
+/// NON-VACUITY for the precondition check: claiming the rule on a profile that
+/// actually carries a cap is a mis-classification, and must be reported rather
+/// than silently counted as satisfied.
+#[test]
+fn claiming_the_none_rule_on_a_profile_that_has_a_cap_is_refused() {
+    let mut records = all_records();
+    for r in &mut records {
+        // r2 NOMINAL carries Some(1.0) — the rule does not apply there.
+        if r.key == "r2.odd_cap" {
+            r.provenance = Provenance::DerivedPrecondition {
+                rule: PreconditionRule::MrcCrawlAtOrBelowClassOddCap,
+            };
+        }
+    }
+    let errors = check_preconditions(&records).expect_err("a misapplied rule must fail");
+    assert!(
+        errors.iter().any(|e| e.key == "r2.odd_cap"),
+        "expected r2.odd_cap to be reported; got {errors:#?}"
+    );
+}
+
+/// Regression pin for a mis-classification this checker caught on its first run.
+///
+/// `robotaxi.odd_cap` was initially written as
+/// `MrcCrawlAtOrBelowClassOddCap` — the same rule the three MRC caps use. It is
+/// wrong: robotaxi NOMINAL `max_speed_mps` is 35.0, far ABOVE the 22.35 class
+/// cap, so "the crawl already sits below the cap" justifies nothing there. Its
+/// `None` is justified by the deployment applying the cap externally, which is a
+/// different claim with a different obligation attached.
+///
+/// A prose rationale would have carried the wrong reason indefinitely. Executing
+/// the rule rejected it immediately.
+#[test]
+fn the_crawl_below_cap_rule_does_not_justify_the_robotaxi_nominal_none() {
+    let mut records = all_records();
+    for r in &mut records {
+        if r.key == "robotaxi.odd_cap" {
+            r.provenance = Provenance::DerivedPrecondition {
+                rule: PreconditionRule::MrcCrawlAtOrBelowClassOddCap,
+            };
+        }
+    }
+    let errors =
+        check_preconditions(&records).expect_err("the wrong rule must not justify this value");
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.key == "robotaxi.odd_cap" && e.detail.contains("EXCEEDS")),
+        "expected the exceeds-the-cap detail; got {errors:#?}"
+    );
+}
+
+/// The externally-applied claim carries an obligation: a participating
+/// constraint must exist AND bind. Otherwise "applied externally" is an
+/// assertion that nothing caps the profile at all — the most dangerous shape a
+/// provenance record could take, because it reads as deliberate.
+#[test]
+fn claiming_external_application_on_a_profile_that_has_its_own_cap_is_refused() {
+    let mut records = all_records();
+    for r in &mut records {
+        // r2 nominal carries Some(1.0) in the contract — nothing is external.
+        if r.key == "r2.odd_cap" {
+            r.provenance = Provenance::DerivedPrecondition {
+                rule: PreconditionRule::CapAppliedExternally,
+            };
+        }
+    }
+    let errors = check_preconditions(&records).expect_err("a misapplied rule must fail");
+    assert!(
+        errors.iter().any(|e| e.key == "r2.odd_cap"),
+        "expected r2.odd_cap to be reported; got {errors:#?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 6 — all four ODD caps present
+// ---------------------------------------------------------------------------
+
+#[test]
+fn all_four_odd_caps_have_provenance() {
+    let records = all_records();
+    for &class in ALL_CLASSES {
+        let owner = records
+            .iter()
+            .find(|r| {
+                r.class == class
+                    && r.profile == Profile::Nominal
+                    && r.fields.contains(&Field::OddSpeedCap)
+            })
+            .unwrap_or_else(|| {
+                panic!(
+                    "{} nominal ODD cap has no provenance record",
+                    class.as_str()
+                )
+            });
+        assert_ne!(
+            owner.provenance.token(),
+            "UNATTRIBUTED",
+            "{} ODD cap is unattributed",
+            class.as_str()
+        );
+    }
+}
+
+/// The caps live in a different comment dialect (`///` doc comments on the
+/// constants) from the per-field records, which is exactly why a generator
+/// written against one dialect drops them. For the R2 the dropped row would have
+/// been the one that actually binds: the cap is BELOW `max_speed_mps`, so it is
+/// the effective ceiling.
+#[test]
+fn the_r2_odd_cap_is_the_binding_ceiling_not_its_max_speed() {
+    let r2 = contract_for(VehicleClass::R2);
+    assert!(
+        r2.odd_speed_cap_mps.expect("r2 carries an ODD cap") < r2.max_speed_mps,
+        "the R2 ODD cap no longer binds; this test's premise has changed"
+    );
+    assert_eq!(
+        effective_ceiling_mps(VehicleClass::R2, Profile::Nominal),
+        r2.odd_speed_cap_mps.unwrap()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 7 — robotaxi's external cap participates in the derived ceiling
+// ---------------------------------------------------------------------------
+
+/// The asymmetry the manifest must not hide.
+///
+/// `contract_for(Robotaxi)` returns the frozen instance with
+/// `odd_speed_cap_mps: None`, because the deployment applies the ODD cap
+/// elsewhere. A register that serialized only the contract would publish a
+/// ceiling far above the enforced one.
+#[test]
+fn the_robotaxi_ceiling_is_not_derivable_from_the_contract_alone() {
+    let contract = contract_for(VehicleClass::Robotaxi);
+    assert!(
+        contract.odd_speed_cap_mps.is_none(),
+        "the frozen robotaxi instance now carries a cap; this test's premise has changed"
+    );
+
+    let contract_only = contract.effective_max_speed_mps();
+    let composed = effective_ceiling_mps(VehicleClass::Robotaxi, Profile::Nominal);
+
+    assert!(
+        composed < contract_only,
+        "the external cap must TIGHTEN the ceiling: composed {composed} !< contract-only {contract_only}"
+    );
+    assert_eq!(
+        composed, ROBOTAXI_ODD_SPEED_CAP_MPS,
+        "the composed ceiling must be the externally applied cap"
+    );
+}
+
+#[test]
+fn the_robotaxi_external_constraint_is_represented_with_its_source() {
+    let c = EXTERNAL_CONSTRAINTS
+        .iter()
+        .find(|c| c.class == VehicleClass::Robotaxi)
+        .expect("the robotaxi external cap is registered");
+
+    assert!(c.participates_in_effective_ceiling);
+    assert_eq!(c.constrains, Field::MaxSpeed);
+    assert_eq!(c.value_mps, ROBOTAXI_ODD_SPEED_CAP_MPS);
+    assert!(
+        !c.applied_at.is_empty(),
+        "where it is applied must be recorded"
+    );
+    assert!(
+        !c.supplied_by.is_empty(),
+        "what supplies it must be recorded"
+    );
+}
+
+/// The classes whose caps DO live in the contract must not acquire a phantom
+/// external constraint — their ceiling is derivable from the serialized contract
+/// alone, and saying otherwise would misrepresent where authority sits.
+#[test]
+fn only_robotaxi_needs_an_external_constraint() {
+    for class in [
+        VehicleClass::Courier,
+        VehicleClass::DeliveryAv,
+        VehicleClass::R2,
+    ] {
+        assert!(
+            !EXTERNAL_CONSTRAINTS.iter().any(|c| c.class == class),
+            "{} should carry its cap in the contract, not externally",
+            class.as_str()
+        );
+        assert_eq!(
+            effective_ceiling_mps(class, Profile::Nominal),
+            contract_for(class).effective_max_speed_mps(),
+            "{}'s ceiling must be derivable from its contract alone",
+            class.as_str()
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 8 — MRC-effective <= Nominal-effective (the gap the register closes)
+// ---------------------------------------------------------------------------
+
+/// `mrc_leq_nominal_per_field_every_class` compares `mrc.max_speed_mps` against
+/// `nom.max_speed_mps` — the MECHANICAL maxima. But Nominal's enforced ceiling
+/// is `min(max_speed, odd_cap)`, and MRC has no cap.
+///
+/// A courier MRC crawl of 2.8 would pass that assertion (2.8 <= 3.0) while
+/// exceeding the class's own nominal enforced ceiling of 2.5 — more permissive
+/// in degraded posture than in nominal, in the only sense that reaches the
+/// wheels. Nothing asserted the effective comparison until now.
+#[test]
+fn mrc_effective_ceiling_never_exceeds_nominal_effective_ceiling() {
+    for &class in ALL_CLASSES {
+        let nominal = effective_ceiling_mps(class, Profile::Nominal);
+        let mrc = effective_ceiling_mps(class, Profile::Mrc);
+        assert!(
+            mrc <= nominal,
+            "{}: MRC effective ceiling {mrc} exceeds nominal effective ceiling {nominal} — \
+             degraded posture would be more permissive than nominal at the wheels",
+            class.as_str()
+        );
+    }
+}
+
+/// The gap is real, not hypothetical: for at least one class the nominal
+/// MECHANICAL maximum is strictly above the nominal ENFORCED ceiling, which is
+/// the room in which an MRC crawl could hide.
+#[test]
+fn the_mechanical_maximum_exceeds_the_enforced_ceiling_somewhere() {
+    let gap_exists = ALL_CLASSES.iter().any(|&class| {
+        let c = contract_for(class);
+        c.effective_max_speed_mps() < c.max_speed_mps
+    });
+    assert!(
+        gap_exists,
+        "no class has a binding ODD cap, so the effective-vs-mechanical distinction \
+         this test guards would be vacuous"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 9 — the sidecar is valid only against the EXISTING talisman pin
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_robotaxi_sidecar_validates_against_the_reviewed_talisman_pin() {
+    match validate_robotaxi_sidecar(&repo_root()) {
+        Ok(blob) => assert_eq!(blob.len(), 40, "a git blob hash is 40 hex chars"),
+        Err(e) => panic!(
+            "the robotaxi provenance sidecar is not valid against the reviewed pin in {}: {e:?}",
+            TALISMAN_PIN_DOC
+        ),
+    }
+}
+
+/// The sidecar binds to the pin `ci/build_safety_case.py` and the `ci.yml`
+/// rustfmt lane already gate on — the same path, the same document. A second
+/// pin would give the anti-drift mechanism its own drift problem.
+#[test]
+fn the_sidecar_binds_to_the_same_artifacts_the_safety_case_gates_on() {
+    let ci = std::fs::read_to_string(repo_root().join("ci/build_safety_case.py"))
+        .expect("the safety-case builder is readable");
+    assert!(
+        ci.contains(TALISMAN_PATH),
+        "build_safety_case.py no longer references {TALISMAN_PATH}; the sidecar and the \
+         safety case have diverged on which file is frozen"
+    );
+    assert!(
+        ci.contains(TALISMAN_PIN_DOC),
+        "build_safety_case.py no longer references {TALISMAN_PIN_DOC}; the sidecar and the \
+         safety case have diverged on where the pin lives"
+    );
+}
+
+/// The sidecar must describe the frozen class COMPLETELY. A partially-populated
+/// sidecar that still reported valid would be the "looks complete while empty"
+/// failure the field-level inversion exists to prevent.
+#[test]
+fn the_sidecar_covers_every_field_of_the_frozen_class() {
+    check_coverage(ROBOTAXI_SIDECAR, &[VehicleClass::Robotaxi])
+        .expect("the robotaxi sidecar must cover every field of both profiles");
+}
+
+#[test]
+fn a_sidecar_missing_a_field_is_refused() {
+    let short: Vec<FieldProvenance> = ROBOTAXI_SIDECAR
+        .iter()
+        .copied()
+        .filter(|r| r.key != "robotaxi.mrc.follow")
+        .collect();
+    let errors = check_coverage(&short, &[VehicleClass::Robotaxi])
+        .expect_err("a sidecar with a hole must not validate");
+    assert!(
+        errors.contains(&CoverageError::Uncovered {
+            class: "robotaxi",
+            profile: "mrc",
+            field: "min_follow_distance_m",
+        }),
+        "expected the missing field to be named; got {errors:#?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 10 — unattributed values are visible, not absent
+// ---------------------------------------------------------------------------
+
+/// Nothing in the shipped table is unattributed. The point of the test is that
+/// an unattributed value would be REPRESENTABLE and therefore VISIBLE — the
+/// failure mode being guarded against is a field disappearing from the register
+/// rather than appearing in it with an honest empty classification.
+#[test]
+fn nothing_in_the_shipped_table_is_unattributed() {
+    let offenders: Vec<&str> = all_records()
+        .iter()
+        .filter(|r| matches!(r.provenance, Provenance::Unattributed))
+        .map(|r| r.key)
+        .collect();
+    assert!(
+        offenders.is_empty(),
+        "unattributed provenance records: {offenders:?}"
+    );
+}
+
+#[test]
+fn an_unattributed_field_renders_visibly_rather_than_vanishing() {
+    let records: Vec<FieldProvenance> = all_records()
+        .into_iter()
+        .map(|mut r| {
+            if r.key == "r2.follow" {
+                r.provenance = Provenance::Unattributed;
+            }
+            r
+        })
+        .collect();
+
+    let manifest =
+        render_manifest(&records, &[VehicleClass::R2], None).expect("coverage is still total");
+    let row = manifest
+        .profiles
+        .iter()
+        .find(|p| p.profile == "nominal")
+        .expect("r2 nominal")
+        .fields
+        .iter()
+        .find(|f| f.field == Field::MinFollow)
+        .expect("the field is still present");
+
+    assert_eq!(row.provenance_class, "UNATTRIBUTED");
+    assert!(
+        !row.validated,
+        "an unattributed value must not read as validated"
+    );
+    assert!(
+        matches!(row.value, FieldValue::Scalar(_)),
+        "the VALUE is still reported — it is the provenance that is absent, not the number"
+    );
+}
+
+/// A manifest must never render over an incomplete table: a missing row would
+/// present as authoritative while being silently partial.
+#[test]
+fn rendering_refuses_an_incomplete_table() {
+    let short: Vec<FieldProvenance> = all_records()
+        .into_iter()
+        .filter(|r| r.key != "r2.overhangs")
+        .collect();
+    render_manifest(&short, ALL_CLASSES, None)
+        .expect_err("a manifest must not render over a hole in the table");
+}
+
+// ---------------------------------------------------------------------------
+// 11 — serialization: derived, and lossless over the provenance metadata
+// ---------------------------------------------------------------------------
+
+#[test]
+fn provenance_class_source_status_and_upstream_survive_a_round_trip() {
+    let blob = validate_robotaxi_sidecar(&repo_root()).ok();
+    let manifest =
+        render_manifest(&all_records(), ALL_CLASSES, blob).expect("the shipped table is complete");
+
+    let json = serde_json::to_string(&manifest).expect("manifest serializes");
+    let back: ProvenanceManifest = serde_json::from_str(&json).expect("manifest deserializes");
+
+    assert_eq!(manifest, back, "the manifest is not round-trip stable");
+
+    // Spot-check the four things the property names, on rows that exercise each.
+    let r2_nominal = back
+        .profiles
+        .iter()
+        .find(|p| p.class == "r2" && p.profile == "nominal")
+        .expect("r2 nominal survives");
+
+    let steering = r2_nominal
+        .fields
+        .iter()
+        .find(|f| f.field == Field::MaxSteering)
+        .expect("steering survives");
+    assert_eq!(steering.provenance_class, "MEASURED");
+    assert!(steering.validated, "validation status survives");
+    assert!(
+        steering.provenance_detail.contains("Phase C"),
+        "the source citation survives: {}",
+        steering.provenance_detail
+    );
+
+    let overhangs = r2_nominal
+        .fields
+        .iter()
+        .find(|f| f.field == Field::OverhangFront)
+        .expect("overhang survives");
+    assert_eq!(overhangs.provenance_class, "ESTIMATE");
+    assert!(!overhangs.validated, "an estimate is not validated");
+
+    let r2_mrc = back
+        .profiles
+        .iter()
+        .find(|p| p.class == "r2" && p.profile == "mrc")
+        .expect("r2 mrc survives");
+    let inherited = r2_mrc
+        .fields
+        .iter()
+        .find(|f| f.field == Field::Wheelbase)
+        .expect("wheelbase survives");
+    assert_eq!(inherited.provenance_class, "INHERITED");
+    assert_eq!(
+        inherited.upstream.as_deref(),
+        Some("r2.wheelbase"),
+        "the upstream relationship survives"
+    );
+}
+
+/// The manifest is DERIVED. Every number in it must equal what the live contract
+/// says right now — not a value transcribed into this module.
+#[test]
+fn every_manifest_number_comes_from_the_live_contract() {
+    let manifest = render_manifest(&all_records(), ALL_CLASSES, None).expect("complete");
+
+    for p in &manifest.profiles {
+        let class = p
+            .class
+            .parse::<VehicleClass>()
+            .expect("the manifest's class id round-trips through from_str");
+        let profile = if p.profile == "nominal" {
+            Profile::Nominal
+        } else {
+            Profile::Mrc
+        };
+        let contract = profile.contract(class);
+
+        for f in &p.fields {
+            assert!(
+                field_values_identical(f.value, f.field.read(&contract)),
+                "{}/{} {} diverged from the live contract",
+                p.class,
+                p.profile,
+                f.name
+            );
+        }
+        assert_eq!(
+            p.contract_only_ceiling_mps,
+            contract.effective_max_speed_mps()
+        );
+        assert_eq!(
+            p.effective_ceiling_mps,
+            effective_ceiling_mps(class, profile)
+        );
+    }
+}
+
+/// The one number this module names is a REFERENCE to the canonical constant.
+/// Writing `22.35` here instead would recreate the duplicate-authority problem
+/// the whole register exists to prevent.
+#[test]
+fn the_external_constraint_value_is_the_canonical_constant_not_a_literal() {
+    let c = EXTERNAL_CONSTRAINTS
+        .iter()
+        .find(|c| c.class == VehicleClass::Robotaxi)
+        .expect("registered");
+    assert_eq!(c.value_mps.to_bits(), ROBOTAXI_ODD_SPEED_CAP_MPS.to_bits());
+}
+
+/// The manifest records the talisman blob it was validated against, so a
+/// rendered register is traceable to the frozen artifact it describes.
+#[test]
+fn the_manifest_records_the_talisman_blob_it_was_validated_against() {
+    let blob = validate_robotaxi_sidecar(&repo_root()).expect("pin matches");
+    let manifest =
+        render_manifest(&all_records(), ALL_CLASSES, Some(blob.clone())).expect("complete");
+    assert_eq!(manifest.talisman_blob.as_deref(), Some(blob.as_str()));
+}
+
+// ---------------------------------------------------------------------------
+// Closing the loop — the table must AGREE with the comments it derives from
+// ---------------------------------------------------------------------------
+
+fn contract_profiles_source() -> String {
+    std::fs::read_to_string(repo_root().join("src/gateway/contract_profiles.rs"))
+        .expect("contract_profiles.rs is readable")
+}
+
+/// Without this test the table is a SECOND authored inventory of
+/// classifications, free to drift from the prose sitting beside the numbers.
+/// That is the failure this whole register exists to prevent, reintroduced one
+/// level up.
+#[test]
+fn the_table_agrees_with_the_source_comments_it_derives_from() {
+    let source = contract_profiles_source();
+    match check_source_agreement(&source, &all_records()) {
+        // `check_source_agreement` errors on any tag it cannot match, so Ok(n)
+        // already means every extracted tag was compared. The floor guards the
+        // other direction: a parser that silently stopped matching would return
+        // Ok(0) and this check would pass while asserting nothing. 52 tags
+        // extract today — 49 field-dialect plus the 3 const-dialect ODD caps.
+        Ok(agreed) => assert!(
+            agreed >= 50,
+            "only {agreed} tags were compared — the parser has probably stopped \
+             matching the source, which would make this check silently vacuous"
+        ),
+        Err(errors) => panic!("table and source comments disagree: {errors:#?}"),
+    }
+}
+
+/// THE substring hazard, pinned.
+///
+/// `r2.overhangs` is tagged `ESTIMATE (overhang split UNMEASURED)`. `UNMEASURED`
+/// contains `MEASURED`, so a `contains`-based parser classifies the one estimate
+/// in the file as a measurement — in the OPTIMISTIC direction, on the field that
+/// places the swept-footprint corners.
+#[test]
+fn unmeasured_prose_never_classifies_a_row_as_measured() {
+    let tags = extract_source_tags(&contract_profiles_source());
+    let overhangs = tags
+        .iter()
+        .find(|t| t.key == "r2.overhangs")
+        .expect("the r2 overhang tag is present in the source");
+    assert_eq!(
+        overhangs.token, "ESTIMATE",
+        "the anchored parser must read the LEADING token, not any occurrence"
+    );
+
+    // And the naive parser really would get it wrong — so the anchoring is
+    // load-bearing rather than defensive.
+    let naive_line = "ESTIMATE (overhang split UNMEASURED): (length - wheelbase)/2";
+    assert!(
+        naive_line.contains("MEASURED"),
+        "the hazard this test guards has disappeared from the source; re-check the premise"
+    );
+}
+
+/// Both dialects must be recognised. The ODD caps live in `///` doc comments
+/// with the token bolded mid-sentence; a parser written only for the field
+/// dialect drops all four, and the R2's is the effective ceiling.
+#[test]
+fn both_comment_dialects_are_recognised_including_all_four_odd_caps() {
+    let tags = extract_source_tags(&contract_profiles_source());
+
+    for key in ["courier.odd_cap", "delivery-av.odd_cap", "r2.odd_cap"] {
+        assert!(
+            tags.iter().any(|t| t.key == key),
+            "{key} was not extracted — the const dialect is being dropped"
+        );
+    }
+    // Field dialect, for contrast.
+    for key in ["r2.steering", "r2.wheelbase", "courier.brake"] {
+        assert!(
+            tags.iter().any(|t| t.key == key),
+            "{key} was not extracted — the field dialect is being dropped"
+        );
+    }
+}
+
+/// Narrative mentions carry a classification word and no stable tag. Keying on
+/// the tag excludes them; keying on the classification would invent rows.
+#[test]
+fn narrative_mentions_produce_no_rows() {
+    let narrative = "\
+// The FIRST profile with MEASURED geometry. Footprint + full-lock steering are
+// bench numbers; the DYNAMIC limits and the overhang split are still
+// VALIDATION-PENDING estimates.
+";
+    assert!(
+        extract_source_tags(narrative).is_empty(),
+        "prose with no stable tag must not produce a provenance row"
+    );
+}
+
+/// NON-VACUITY for the agreement check: a divergence must be reported, not
+/// quietly tolerated.
+#[test]
+fn a_comment_that_disagrees_with_the_table_is_reported() {
+    // The source says MEASURED for r2.steering; claim ESTIMATE in the table.
+    let records: Vec<FieldProvenance> = all_records()
+        .into_iter()
+        .map(|mut r| {
+            if r.key == "r2.steering" {
+                r.provenance = Provenance::Estimate {
+                    basis: "a claim the source contradicts",
+                };
+            }
+            r
+        })
+        .collect();
+
+    let errors = check_source_agreement(&contract_profiles_source(), &records)
+        .expect_err("a divergence must fail");
+    assert!(
+        errors.iter().any(|e| matches!(
+            e,
+            SourceAgreementError::Divergent { key, table_token: "ESTIMATE", .. } if key == "r2.steering"
+        )),
+        "expected a Divergent report for r2.steering; got {errors:#?}"
+    );
+}
+
+/// A tag in the source that no record claims means the table has a hole the
+/// coverage check cannot see — coverage is measured over FIELDS, and a stray tag
+/// names a key.
+#[test]
+fn a_source_tag_with_no_matching_record_is_reported() {
+    let source = "        // MEASURED: something new. (r2.brand_new_thing)\n";
+    let errors =
+        check_source_agreement(source, &all_records()).expect_err("an unknown key must fail");
+    assert_eq!(
+        errors,
+        vec![SourceAgreementError::UnknownKey {
+            key: "r2.brand_new_thing".to_string()
+        }]
+    );
+}


### PR DESCRIPTION
This PR introduces **executable provenance verification for platform contracts**. Numeric values remain authored solely in the Rust contract; provenance, validation status, inheritance and externally applied constraints are *derived from* and *verified against* that authority. The implementation proves complete field coverage, agreement with source annotations, inheritance correctness, and fail-closed handling of frozen artifacts.

The property, stated once:

> Every authority-relevant field and externally applied constraint has exactly one provenance mapping; inherited mappings identify **and equal** their upstream source; serialized representations remain derived from the Rust contract and existing reviewed integrity pins.

## The design constraint everything follows from

**The module contains no numbers.** Records name a `Field`; values are read live from `contract_for` / `mrc_fallback_for` whenever a check or a serialization runs. A hand-authored field→value→provenance table would be a second numeric authority and would drift from `contract_profiles.rs` exactly as the R2 geometry literals drifted from the platform config in part 1. The one constant named is a *reference* to `ROBOTAXI_ODD_SPEED_CAP_MPS`, and a test compares bit patterns to prove it was not re-typed as `22.35`.

Coverage is asserted at the **field** level, not as key-set equality. Tag granularity is deliberately non-uniform — `r2` splits `r2.overhangs` from `r2.footprint` *because their provenance differs* (body MEASURED, split ESTIMATE), while `courier` shares one key across all four geometry fields. Forcing uniform granularity would erase the one place the family currently distinguishes a measurement from an assumption.

## Findings — evidence the checks are doing work

**1. An attribution gap was detected and fixed.** `delivery_av_nominal`'s `length_m` and both overhangs carried no provenance at all: the `(delivery-av.footprint)` tag was a *trailing* comment governing `width_m` alone. A "every key resolves to a known field" check passed on that tree — all 49 tags were valid and unique. Only field-level coverage sees it. Fixed by converting to a leading block comment, and the omission is reconstructed as a non-vacuity test so it cannot recur silently.

**2. The robotaxi ODD-cap rationale was rejected until modeled as an external constraint.** This is the episode that most argues for the approach. I classified `robotaxi.odd_cap` with the same `MrcCrawlAtOrBelowClassOddCap` rule the three MRC caps use. The *data* was right — `None` is correct there — but the *reason* was wrong: robotaxi nominal `max_speed` is 35.0, far above the 22.35 cap, so "the crawl already sits below the cap" justifies nothing. Its `None` is justified by the deployment applying the cap externally, which is a different claim carrying a different obligation. Executing the rule rejected it on the first run; a prose rationale would have carried the wrong reason indefinitely. `CapAppliedExternally` now requires a registered constraint that both exists *and* binds, and the mis-classification is pinned as a regression test.

**3. Parser hazards are permanently pinned.** `check_source_agreement` reads the source with a **tag-led** grammar — locate the stable `(class.field)` tag, then read the classification only from its one permitted syntactic position. Each alternative fails cleanly-but-wrongly, and each now has a test: `ESTIMATE (overhang split UNMEASURED)` contains `MEASURED`, so a substring match promotes the file's one estimate to a measurement *in the optimistic direction*, on the field that places the swept-footprint corners; the ODD caps use a `///` dialect a field-dialect parser drops entirely, and for the R2 the dropped row is the one that actually binds; narrative like "the FIRST profile with MEASURED geometry" would invent rows.

## Two latent gaps closed as a side effect

**`INHERITED` is now executable.** The upstream key is resolved and values compared bit-for-bit. Of the 15 authored relationships, 6 — the overhang pairs — were asserted nowhere: `mrc_leq_nominal_per_field_every_class` compares wheelbase, width and length under a comment claiming the whole footprint is identical. The overhangs are the fields that place the swept-footprint corners in `containment.rs`.

**MRC-effective ≤ Nominal-effective is now asserted.** The existing test compares *mechanical* maxima, so a courier MRC crawl of 2.8 would pass (2.8 ≤ 3.0) while exceeding the class's nominal *enforced* ceiling of 2.5 — more permissive in degraded posture than in nominal, in the only sense that reaches the wheels. No live violation; no guard either, until now.

## Split authority is surfaced rather than hidden

`contract_for(Robotaxi)` returns the frozen instance with `odd_speed_cap_mps: None`, so the serialized contract alone derives a ceiling of 35.0 m/s while 22.35 is enforced. `ExternalConstraint` carries that cap as its own row — where it is applied, what supplies it, whether it participates in the effective ceiling — and `effective_ceiling_mps` composes it. Only robotaxi needs one; a test refuses a phantom constraint on the other three, whose ceilings *are* derivable from the serialized contract alone.

## The frozen class binds to the existing pin

Robotaxi's numbers live in the byte-frozen talisman where the git blob hash is the integrity pin, so provenance comments cannot be added beside them. Its records live in a sidecar valid **only** when `git hash-object` matches the hash in `docs/CAPTURE_PIPELINE_SPEC.md` — the same check `ci/build_safety_case.py` and the `ci.yml` rustfmt lane already run. Reused deliberately: a second hash pin would give the anti-drift mechanism its own drift problem. It fails closed when `git` is unavailable, because an integrity gate that skips when its tool is missing is worse than no gate — it reports success.

## Review asks

1. Is the no-numbers boundary actually held? The failure mode would be a value transcribed into a record's prose where a `Field` reference belongs.
2. Is the tag-led grammar right, or is there a fourth parser hazard the three pinned tests miss?
3. `CapAppliedExternally` requires a participating constraint that binds. Is that the correct obligation, or should it also require the constraint to be *reachable* from the enforcement path rather than merely registered?

## Verification

`cargo test --lib gateway::provenance` — 42 tests, every positive assertion paired with a negative proving it can fail. Full workspace green (189 test binaries, zero failures); `cargo fmt --check` clean; `cargo clippy --lib --tests` clean; `ci/check_safety_constants.py` green; safety-case bundle rebuilds.

| File | |
|---|---|
| `src/gateway/provenance.rs` | **new** — the table, the checks, the manifest, the source-agreement parser |
| `src/gateway/provenance/tests.rs` | **new** — the 42-test surface |
| `src/gateway/contract_profiles.rs` | the `delivery-av` footprint comment fix |
| `src/gateway/mod.rs` | module registration |
| `docs/CONTRACT_PROFILES.md` | the provenance-coverage section |

Refs #1219. Does not close it — the manifest's consumer-configuration half is a separate slice.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjDFKPcBVHURDZpXsvnYhC)_