### PR TITLE
feat(regions): typed geometry from the canonical contract + consumer conformance (#1215)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2549,6 +2549,8 @@ dependencies = [
  "kirra-policy-types",
  "kirra-release-token",
  "kirra-safety-authority",
+ "kirra-taj",
+ "kirra-trajectory",
  "parko-core",
  "parko-kirra",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,6 +182,10 @@ hyper = "1"
 hyper-util = { version = "0.1", features = ["server-auto", "tokio"] }
 
 [dev-dependencies]
+# #1215 consumer-geometry conformance (src/gateway/deployment_geometry): the root
+# crate sees both sides of every cited-copy boundary, so the checks live here.
+kirra-trajectory = { path = "crates/kirra-trajectory" }
+kirra-taj = { path = "crates/kirra-taj" }
 rand = "0.8"
 proptest = "1"
 # ADR-0035 slice 4: enable kirra-persistence's `test-support` feature for the root

--- a/crates/kirra-core/src/lib.rs
+++ b/crates/kirra-core/src/lib.rs
@@ -52,6 +52,12 @@ pub mod contract_consumer;
 /// existing path (the ROS2 adapter, the planner) holds.
 pub mod containment;
 
+/// #1215 — typed geometric regions (collision / corridor-observation /
+/// self-filter / turn-swept) derived from the canonical platform contract.
+/// Gives each region its meaning, its FRAME and an explicitly named margin, so
+/// a consumer can never independently re-derive a physical vehicle dimension.
+pub mod regions;
+
 /// The fail-closed frame-integrity gate (Stage S-FI1a, behind AOU-LOCALIZATION-001) —
 /// the graduated localization-trust verdict (`FrameIntegrity` / `FrameTrust` /
 /// `resolve_frame_trust` / `containment_margin_m`) that selects the SG2 containment

--- a/crates/kirra-core/src/regions.rs
+++ b/crates/kirra-core/src/regions.rs
@@ -1,0 +1,426 @@
+//! #1215 — typed geometric regions derived from the canonical platform contract.
+//!
+//! # The property
+//!
+//! > Every consumer geometry value is constructed from the canonical platform
+//! > profile plus an explicitly named margin or transformation; no consumer
+//! > independently re-derives physical vehicle dimensions.
+//!
+//! # Why types and not just a manifest
+//!
+//! #1219 can transport `length_m` and `width_m`. It cannot answer whether
+//! `0.11` means physical half-width, self-filter padding, proposal envelope, or
+//! observation clearance. Those are four different claims about the world, and
+//! before this module they were all spelled "some geometry number" and
+//! independently re-derived in four places:
+//!
+//! | Location | half-length | half-width | meaning (undeclared) |
+//! |---|---|---|---|
+//! | `contract_profiles.rs` | *length 0.330* | *width 0.203* | the physical body — the authority |
+//! | `kirra-trajectory` `config.rs::r2()` | 0.165 | 0.102 | checker collision extent |
+//! | `kirra_params.yaml` `occy_doer` | 0.17 | 0.11 | doer proposal envelope |
+//! | `kirra_params.yaml` `perception_governor` | — | `vehicle_width_m: 0.203` | **full** width, corridor input |
+//!
+//! The last row is the trap this module exists to prevent: `0.203` there is a
+//! FULL width feeding `required_corridor_width = vehicle_width + 2·clearance`,
+//! not a half-extent. Substituting it for a half-width would halve the corridor
+//! the ego demands. A type that carries its meaning cannot be swapped that way.
+//!
+//! # Margins are named, never accidental
+//!
+//! The doer's `0.17 × 0.11` is not a mistake to normalize away — it is a
+//! deliberate margin over the physical `0.165 × 0.1015`, in the conservative
+//! direction (the doer proposes within a larger body than the checker demands).
+//! What was missing is that nothing *said so*, and nothing bound the two: change
+//! `width_m` in the contract and neither followed.
+//!
+//! So every region is built as
+//!
+//! ```text
+//! physical footprint  +  explicitly named margin  =  region
+//! ```
+//!
+//! and the tests assert that RELATIONSHIP rather than an accidental equality.
+//! A region is never allowed to be smaller than the body it bounds.
+//!
+//! # Frames are load-bearing, and two conventions are in play
+//!
+//! This is the subtler half, and it is why every region carries a [`Frame`].
+//!
+//! `containment::footprint_corners` places the body at the **rear axle**:
+//! forward extent is `wheelbase + overhang_front`, rearward is `-overhang_rear`.
+//! An asymmetric body is described honestly there.
+//!
+//! The doer's `half_length_m` assumes a **geometric centre** origin: half the
+//! length each way, symmetric by construction.
+//!
+//! For the R2 those agree — but only because the overhang split is assumed
+//! even, and that split is an **ESTIMATE**, not a measurement (`r2.overhangs`,
+//! #1219; the measurement is owed under #1213). If the real split is uneven, a
+//! centre-origin symmetric half-length under-covers the longer end while
+//! reporting the same number. Nothing in the tree previously stated that
+//! coupling. [`PhysicalFootprint::centre_origin_is_exact`] makes it checkable.
+
+use crate::containment::VehicleFootprint;
+use crate::kinematics_contract::VehicleKinematicsContract;
+
+/// The coordinate frame a region's extents are expressed in.
+///
+/// Carried on every region because the same body has two valid descriptions and
+/// they are not interchangeable — see the module docs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Frame {
+    /// Origin at the **rear axle centre**, +x forward, +y left. The convention
+    /// `containment::footprint_corners` uses, and the only one that describes an
+    /// asymmetric body without loss.
+    RearAxleBody,
+    /// Origin at the **geometric centre** of the body, +x forward, +y left.
+    /// Symmetric by construction: exact only when the overhang split is even.
+    GeometricCentreBody,
+    /// The sensor's own origin. Self-filtering happens HERE, before any
+    /// transform, so a mount error cannot move the mask onto real returns
+    /// (#1210).
+    Sensor,
+}
+
+impl Frame {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Frame::RearAxleBody => "rear_axle_body",
+            Frame::GeometricCentreBody => "geometric_centre_body",
+            Frame::Sensor => "sensor",
+        }
+    }
+}
+
+/// An explicitly named, non-negative expansion of a region beyond the physical
+/// body.
+///
+/// Named because "why is this region bigger than the robot" is a safety
+/// question with a different answer per region, and an unnamed epsilon is
+/// indistinguishable from a rounding accident. The doer's extra ~8 mm and the
+/// checker's ~0.5 mm rounding were both of that kind before this type.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Margin {
+    /// Why this margin exists. Not decoration — it is the field a reviewer reads
+    /// to decide whether the margin is still justified.
+    pub reason: &'static str,
+    pub longitudinal_m: f64,
+    pub lateral_m: f64,
+}
+
+/// A margin was not usable as declared.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MarginError {
+    /// Negative margins would SHRINK a region below the body it bounds.
+    /// Refused rather than clamped: a negative margin is a statement someone
+    /// meant to make, and silently zeroing it hides the intent.
+    Negative,
+    /// Non-finite margins propagate into every downstream comparison.
+    NotFinite,
+    /// A margin with no stated reason is an unexplained expansion.
+    Unnamed,
+}
+
+impl Margin {
+    /// The zero margin — a region exactly the size of the body.
+    pub const NONE: Margin = Margin {
+        reason: "no expansion: the region is exactly the physical body",
+        longitudinal_m: 0.0,
+        lateral_m: 0.0,
+    };
+
+    /// Construct a validated margin. FAIL-CLOSED on negative, non-finite, or
+    /// unnamed.
+    pub fn new(
+        reason: &'static str,
+        longitudinal_m: f64,
+        lateral_m: f64,
+    ) -> Result<Self, MarginError> {
+        if reason.trim().is_empty() {
+            return Err(MarginError::Unnamed);
+        }
+        if !longitudinal_m.is_finite() || !lateral_m.is_finite() {
+            return Err(MarginError::NotFinite);
+        }
+        if longitudinal_m < 0.0 || lateral_m < 0.0 {
+            return Err(MarginError::Negative);
+        }
+        Ok(Margin {
+            reason,
+            longitudinal_m,
+            lateral_m,
+        })
+    }
+}
+
+/// The physical vehicle body. **The one thing every region derives from.**
+///
+/// Constructed only from a [`VehicleKinematicsContract`], so a consumer cannot
+/// introduce a body dimension the contract does not know about.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PhysicalFootprint {
+    pub length_m: f64,
+    pub width_m: f64,
+    pub wheelbase_m: f64,
+    pub overhang_front_m: f64,
+    pub overhang_rear_m: f64,
+}
+
+impl PhysicalFootprint {
+    /// Derive from the canonical contract. The ONLY constructor — there is
+    /// deliberately no way to hand-build one from loose numbers.
+    #[must_use]
+    pub fn from_contract(c: &VehicleKinematicsContract) -> Self {
+        Self {
+            length_m: c.length_m,
+            width_m: c.width_m,
+            wheelbase_m: c.wheelbase_m,
+            overhang_front_m: c.overhang_front_m,
+            overhang_rear_m: c.overhang_rear_m,
+        }
+    }
+
+    /// Half the body width. The value a consumer means by "half_width_m".
+    #[must_use]
+    pub fn half_width_m(&self) -> f64 {
+        self.width_m * 0.5
+    }
+
+    /// Half the body length, in the GEOMETRIC CENTRE convention.
+    ///
+    /// Exact only when the overhang split is even — see
+    /// [`Self::centre_origin_is_exact`].
+    #[must_use]
+    pub fn half_length_m(&self) -> f64 {
+        self.length_m * 0.5
+    }
+
+    /// Forward extent from the REAR AXLE. The honest description of an
+    /// asymmetric body.
+    #[must_use]
+    pub fn forward_extent_from_rear_axle_m(&self) -> f64 {
+        self.wheelbase_m + self.overhang_front_m
+    }
+
+    /// Rearward extent from the rear axle (a positive distance).
+    #[must_use]
+    pub fn rearward_extent_from_rear_axle_m(&self) -> f64 {
+        self.overhang_rear_m
+    }
+
+    /// Whether a symmetric centre-origin description loses nothing.
+    ///
+    /// True exactly when the overhangs are equal. When false, a consumer using
+    /// `half_length_m` describes the body as symmetric when it is not, and
+    /// **under-covers the longer end** while reporting a plausible number.
+    ///
+    /// For the R2 this is true only because the overhang split is an assumed
+    /// even division of `(length − wheelbase)`; the measurement is owed under
+    /// #1213 and the assumption is registered as `r2.overhangs` ESTIMATE in the
+    /// #1219 provenance table.
+    #[must_use]
+    pub fn centre_origin_is_exact(&self) -> bool {
+        (self.overhang_front_m - self.overhang_rear_m).abs() <= f64::EPSILON
+    }
+
+    /// How much a symmetric centre-origin description under-covers the longer
+    /// end. Zero when [`Self::centre_origin_is_exact`].
+    #[must_use]
+    pub fn centre_origin_shortfall_m(&self) -> f64 {
+        ((self.overhang_front_m - self.overhang_rear_m) * 0.5).abs()
+    }
+}
+
+impl From<&PhysicalFootprint> for VehicleFootprint {
+    fn from(p: &PhysicalFootprint) -> Self {
+        VehicleFootprint {
+            width_m: p.width_m,
+            length_m: p.length_m,
+            overhang_front_m: p.overhang_front_m,
+            overhang_rear_m: p.overhang_rear_m,
+            wheelbase_m: p.wheelbase_m,
+        }
+    }
+}
+
+/// **"Would the ego contact this object?"**
+///
+/// The region an object must lie inside to count as a collision candidate.
+/// Half-extents, because the question is symmetric about the ego's own axis.
+///
+/// Absorbs: `kirra-trajectory` `config.rs`'s `half_length_m` / `half_width_m`,
+/// and `kirra_params.yaml` `occy_doer`'s same-named pair. Those differed
+/// (0.165/0.102 vs 0.17/0.11) with no stated relationship; they are now the same
+/// construction with different named margins.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CollisionRegion {
+    pub frame: Frame,
+    pub half_length_m: f64,
+    pub half_width_m: f64,
+    pub margin: Margin,
+    /// The body this was derived from, retained so the relationship stays
+    /// checkable after construction.
+    pub physical: PhysicalFootprint,
+}
+
+impl CollisionRegion {
+    /// Build from the canonical footprint plus a named margin, in the
+    /// centre-origin convention.
+    #[must_use]
+    pub fn centre_origin(physical: PhysicalFootprint, margin: Margin) -> Self {
+        Self {
+            frame: Frame::GeometricCentreBody,
+            half_length_m: physical.half_length_m() + margin.longitudinal_m,
+            half_width_m: physical.half_width_m() + margin.lateral_m,
+            margin,
+            physical,
+        }
+    }
+
+    /// Whether an object at `(x, y)` in this region's frame is a collision
+    /// candidate.
+    #[must_use]
+    pub fn contains(&self, x_m: f64, y_m: f64) -> bool {
+        x_m.is_finite()
+            && y_m.is_finite()
+            && x_m.abs() <= self.half_length_m
+            && y_m.abs() <= self.half_width_m
+    }
+
+    /// A region must never be smaller than the body it bounds. Holds by
+    /// construction given a validated [`Margin`]; asserted anyway, because
+    /// "holds by construction" is a claim that survives only until someone adds
+    /// a constructor.
+    #[must_use]
+    pub fn covers_physical_body(&self) -> bool {
+        self.half_length_m >= self.physical.half_length_m()
+            && self.half_width_m >= self.physical.half_width_m()
+    }
+}
+
+/// **"How much room must the corridor provide?"**
+///
+/// Deliberately NOT a half-extent. This carries the **full** vehicle width plus
+/// clearance on each side, matching
+/// `required_corridor_width = vehicle_width + 2·clearance` in the Taj sidecar.
+///
+/// Absorbs `kirra_params.yaml` `perception_governor`'s `vehicle_width_m: 0.203`
+/// and `lateral_clearance_m`. The type exists chiefly so that value cannot be
+/// mistaken for a half-width — doing so would halve the corridor the ego demands.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CorridorObservationRegion {
+    pub frame: Frame,
+    /// FULL body width, not halved.
+    pub vehicle_width_m: f64,
+    /// Clearance demanded on EACH side.
+    pub clearance_each_side_m: f64,
+    pub physical: PhysicalFootprint,
+}
+
+impl CorridorObservationRegion {
+    #[must_use]
+    pub fn new(physical: PhysicalFootprint, clearance: Margin) -> Self {
+        Self {
+            frame: Frame::GeometricCentreBody,
+            vehicle_width_m: physical.width_m,
+            clearance_each_side_m: clearance.lateral_m,
+            physical,
+        }
+    }
+
+    /// The total corridor width the ego requires.
+    #[must_use]
+    pub fn required_width_m(&self) -> f64 {
+        self.vehicle_width_m + 2.0 * self.clearance_each_side_m
+    }
+
+    /// Half the required width — the comparison a lane-gate half-extent must
+    /// satisfy. Provided so a caller never has to halve by hand, which is where
+    /// the full-vs-half confusion enters.
+    #[must_use]
+    pub fn required_half_width_m(&self) -> f64 {
+        self.required_width_m() * 0.5
+    }
+}
+
+/// **"Returns inside this are the robot itself."**
+///
+/// Sensor frame, always. #1210's argument runs backwards from every other
+/// region here: this is the one operation that REMOVES evidence, so its bound
+/// limits how much a mask may destroy rather than how much space the ego needs.
+///
+/// The vertex radius derives from the body's own diagonal — a mask may not
+/// reach beyond the robot it is masking.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SelfFilterRegion {
+    pub frame: Frame,
+    /// No mask vertex may sit further from the sensor origin than this.
+    pub max_vertex_radius_m: f64,
+    pub physical: PhysicalFootprint,
+}
+
+impl SelfFilterRegion {
+    /// The body's half-diagonal: the furthest any point of the robot can be from
+    /// its own centre. A mask vertex beyond this is masking something that is
+    /// not the robot.
+    #[must_use]
+    pub fn from_footprint(physical: PhysicalFootprint) -> Self {
+        let hl = physical.half_length_m();
+        let hw = physical.half_width_m();
+        Self {
+            frame: Frame::Sensor,
+            max_vertex_radius_m: (hl * hl + hw * hw).sqrt(),
+            physical,
+        }
+    }
+}
+
+/// **"What does the body sweep through a turn?"**
+///
+/// A NAMED VIEW over the existing containment geometry, not a second
+/// implementation. `containment::footprint_corners` already places the swept
+/// corners at `(wheelbase + overhang_front, ±width/2)` and `(−overhang_rear,
+/// ±width/2)` from the rear axle; this type gives that placement a name, a
+/// frame, and a home, so a reader can find out what "the swept region" means
+/// without reading the containment internals.
+///
+/// Deliberately carries no margin: the swept region is the body's actual
+/// excursion, and the safety margin against the corridor is applied separately
+/// by the containment check (`CONTAINMENT_LATERAL_MARGIN_M`). Folding a margin
+/// in here would double-count it.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct TurnSweptRegion {
+    pub frame: Frame,
+    pub forward_extent_m: f64,
+    pub rearward_extent_m: f64,
+    pub half_width_m: f64,
+    pub physical: PhysicalFootprint,
+}
+
+impl TurnSweptRegion {
+    /// Rear-axle frame, matching `containment::footprint_corners` exactly.
+    #[must_use]
+    pub fn rear_axle_origin(physical: PhysicalFootprint) -> Self {
+        Self {
+            frame: Frame::RearAxleBody,
+            forward_extent_m: physical.forward_extent_from_rear_axle_m(),
+            rearward_extent_m: physical.rearward_extent_from_rear_axle_m(),
+            half_width_m: physical.half_width_m(),
+            physical,
+        }
+    }
+
+    /// Total longitudinal extent. Equals `length_m` exactly when
+    /// `wheelbase + overhang_front + overhang_rear == length` — the family
+    /// invariant `every_profile_footprint_positive` assumes and this makes
+    /// checkable.
+    #[must_use]
+    pub fn total_length_m(&self) -> f64 {
+        self.forward_extent_m + self.rearward_extent_m
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/kirra-core/src/regions.rs
+++ b/crates/kirra-core/src/regions.rs
@@ -257,7 +257,13 @@ impl From<&PhysicalFootprint> for VehicleFootprint {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct CollisionRegion {
     pub frame: Frame,
-    pub half_length_m: f64,
+    /// Forward extent from the frame origin. Kept SEPARATE from the rearward
+    /// extent so an asymmetric body (robotaxi: overhangs 0.9 / 1.1) is never
+    /// silently averaged into a symmetric one — the average under-covers the
+    /// longer end while reporting a plausible number.
+    pub front_extent_m: f64,
+    /// Rearward extent from the frame origin (a positive distance).
+    pub rear_extent_m: f64,
     pub half_width_m: f64,
     pub margin: Margin,
     /// The body this was derived from, retained so the relationship stays
@@ -267,35 +273,82 @@ pub struct CollisionRegion {
 
 impl CollisionRegion {
     /// Build from the canonical footprint plus a named margin, in the
-    /// centre-origin convention.
+    /// centre-origin convention. Front and rear extents are each `length/2`
+    /// BY DEFINITION of the geometric centre — the asymmetry hazard for this
+    /// constructor lives in where the ORIGIN is placed, not in the extents;
+    /// see [`PhysicalFootprint::centre_origin_is_exact`].
     #[must_use]
     pub fn centre_origin(physical: PhysicalFootprint, margin: Margin) -> Self {
         Self {
             frame: Frame::GeometricCentreBody,
-            half_length_m: physical.half_length_m() + margin.longitudinal_m,
+            front_extent_m: physical.half_length_m() + margin.longitudinal_m,
+            rear_extent_m: physical.half_length_m() + margin.longitudinal_m,
             half_width_m: physical.half_width_m() + margin.lateral_m,
             margin,
             physical,
         }
     }
 
+    /// Build in the rear-axle convention, preserving the body's true
+    /// asymmetry: forward is `wheelbase + overhang_front`, rearward is
+    /// `overhang_rear`. The honest description of an asymmetric body, and the
+    /// only correct one for the robotaxi class.
+    #[must_use]
+    pub fn rear_axle_origin(physical: PhysicalFootprint, margin: Margin) -> Self {
+        Self {
+            frame: Frame::RearAxleBody,
+            front_extent_m: physical.forward_extent_from_rear_axle_m() + margin.longitudinal_m,
+            rear_extent_m: physical.rearward_extent_from_rear_axle_m() + margin.longitudinal_m,
+            half_width_m: physical.half_width_m() + margin.lateral_m,
+            margin,
+            physical,
+        }
+    }
+
+    /// The symmetric half-length as a DELIBERATELY CONSERVATIVE derived bound:
+    /// `max(front_extent, rear_extent)`, never the average.
+    ///
+    /// A consumer that structurally requires one symmetric number (the doer's
+    /// `half_length_m` parameter) must take it from here. The average would
+    /// under-cover the longer end of an asymmetric body — for the robotaxi's
+    /// 0.9 / 1.1 overhang split, by a real margin — while reporting a value
+    /// that looks right. `max` over-covers the shorter end instead, which is
+    /// the only acceptable direction for a bound.
+    #[must_use]
+    pub fn conservative_symmetric_half_length_m(&self) -> f64 {
+        self.front_extent_m.max(self.rear_extent_m)
+    }
+
     /// Whether an object at `(x, y)` in this region's frame is a collision
-    /// candidate.
+    /// candidate. `+x` forward, so the rearward test is against
+    /// `-rear_extent_m`.
     #[must_use]
     pub fn contains(&self, x_m: f64, y_m: f64) -> bool {
         x_m.is_finite()
             && y_m.is_finite()
-            && x_m.abs() <= self.half_length_m
+            && x_m <= self.front_extent_m
+            && x_m >= -self.rear_extent_m
             && y_m.abs() <= self.half_width_m
     }
 
-    /// A region must never be smaller than the body it bounds. Holds by
-    /// construction given a validated [`Margin`]; asserted anyway, because
-    /// "holds by construction" is a claim that survives only until someone adds
-    /// a constructor.
+    /// A region must never be smaller than the body it bounds — checked in the
+    /// region's OWN frame, since the extents mean different things in each.
+    /// Holds by construction given a validated [`Margin`]; asserted anyway,
+    /// because "holds by construction" survives only until someone adds a
+    /// constructor.
     #[must_use]
     pub fn covers_physical_body(&self) -> bool {
-        self.half_length_m >= self.physical.half_length_m()
+        let (body_front, body_rear) = match self.frame {
+            Frame::GeometricCentreBody => {
+                (self.physical.half_length_m(), self.physical.half_length_m())
+            }
+            Frame::RearAxleBody | Frame::Sensor => (
+                self.physical.forward_extent_from_rear_axle_m(),
+                self.physical.rearward_extent_from_rear_axle_m(),
+            ),
+        };
+        self.front_extent_m >= body_front
+            && self.rear_extent_m >= body_rear
             && self.half_width_m >= self.physical.half_width_m()
     }
 }

--- a/crates/kirra-core/src/regions/tests.rs
+++ b/crates/kirra-core/src/regions/tests.rs
@@ -1,0 +1,423 @@
+//! #1215 region tests.
+//!
+//! The acceptance property under test:
+//!
+//! > Every consumer geometry value is constructed from the canonical platform
+//! > profile plus an explicitly named margin or transformation; no consumer
+//! > independently re-derives physical vehicle dimensions.
+//!
+//! Relationships are asserted, never accidental equalities — a test that passes
+//! because two numbers happen to match today proves nothing about tomorrow.
+
+use super::*;
+
+/// A stand-in for the R2 contract. Uses the same shape as the real `r2` profile
+/// so the derivations below exercise the real arithmetic; the VALUES are
+/// deliberately arbitrary in the regression test further down, to prove the
+/// regions follow the contract rather than these particular numbers.
+fn r2_like() -> VehicleKinematicsContract {
+    VehicleKinematicsContract {
+        max_speed_mps: 1.5,
+        max_accel_mps2: 0.5,
+        max_brake_mps2: 1.5,
+        max_steering_deg: 39.0,
+        max_steering_rate_deg_s: 30.0,
+        min_follow_distance_m: 0.5,
+        max_lateral_accel_mps2: 1.0,
+        wheelbase_m: 0.229,
+        width_m: 0.203,
+        length_m: 0.330,
+        overhang_front_m: 0.0505,
+        overhang_rear_m: 0.0505,
+        odd_speed_cap_mps: Some(1.0),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Margins are named, validated, and never shrink a region
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_negative_margin_is_refused_rather_than_clamped() {
+    assert_eq!(
+        Margin::new("proposal envelope", -0.01, 0.0),
+        Err(MarginError::Negative),
+        "a negative margin would shrink the region below the body; clamping it \
+         to zero would hide an intent someone meant to express"
+    );
+}
+
+#[test]
+fn a_non_finite_margin_is_refused() {
+    assert_eq!(
+        Margin::new("bad", f64::NAN, 0.0),
+        Err(MarginError::NotFinite)
+    );
+    assert_eq!(
+        Margin::new("bad", 0.0, f64::INFINITY),
+        Err(MarginError::NotFinite)
+    );
+}
+
+#[test]
+fn an_unnamed_margin_is_refused() {
+    assert_eq!(Margin::new("   ", 0.01, 0.01), Err(MarginError::Unnamed));
+}
+
+#[test]
+fn a_valid_margin_records_its_reason() {
+    let m = Margin::new(
+        "doer proposal envelope over the physical body",
+        0.005,
+        0.0085,
+    )
+    .expect("valid");
+    assert!(!m.reason.is_empty());
+    assert!(m.longitudinal_m >= 0.0 && m.lateral_m >= 0.0);
+}
+
+// ---------------------------------------------------------------------------
+// The relationship, not an equality
+// ---------------------------------------------------------------------------
+
+/// The doer's `0.17 × 0.11` is not an error to normalize away — it is a
+/// deliberate margin over the physical `0.165 × 0.1015`, in the conservative
+/// direction. What was missing is that nothing SAID so.
+#[test]
+fn a_region_is_never_smaller_than_the_body_it_bounds() {
+    let physical = PhysicalFootprint::from_contract(&r2_like());
+
+    for (reason, lon, lat) in [
+        ("no expansion", 0.0, 0.0),
+        ("checker rounding headroom", 0.0, 0.0005),
+        ("doer proposal envelope", 0.005, 0.0085),
+    ] {
+        let margin = Margin::new(reason, lon, lat).expect("valid margin");
+        let region = CollisionRegion::centre_origin(physical, margin);
+
+        assert!(
+            region.covers_physical_body(),
+            "{reason}: region {}x{} does not cover the body {}x{}",
+            region.half_length_m,
+            region.half_width_m,
+            physical.half_length_m(),
+            physical.half_width_m()
+        );
+        assert!(region.half_length_m >= physical.half_length_m());
+        assert!(region.half_width_m >= physical.half_width_m());
+    }
+}
+
+/// The doer and checker regions differ, and the difference is now a stated
+/// margin rather than two independent derivations that happen not to match.
+#[test]
+fn the_doer_envelope_is_the_checker_envelope_plus_a_named_margin() {
+    let physical = PhysicalFootprint::from_contract(&r2_like());
+
+    let checker = CollisionRegion::centre_origin(physical, Margin::NONE);
+    let doer = CollisionRegion::centre_origin(
+        physical,
+        Margin::new(
+            "doer proposal envelope; propose within a body larger than the checker demands",
+            0.005,
+            0.0085,
+        )
+        .expect("valid"),
+    );
+
+    assert!(
+        doer.half_length_m > checker.half_length_m,
+        "the doer envelope must be strictly more conservative longitudinally"
+    );
+    assert!(
+        doer.half_width_m > checker.half_width_m,
+        "the doer envelope must be strictly more conservative laterally"
+    );
+    // Both still describe the SAME body.
+    assert_eq!(doer.physical, checker.physical);
+}
+
+// ---------------------------------------------------------------------------
+// THE regression for the defect shape that motivated #1215
+// ---------------------------------------------------------------------------
+
+/// Changing the contract's width or length changes every derived region, while
+/// preserving each region's declared margin policy.
+///
+/// This is the property whose ABSENCE was the finding: four consumers
+/// independently re-derived the R2 footprint, so a contract change would have
+/// updated none of them.
+#[test]
+fn changing_the_contract_changes_every_derived_region_and_preserves_each_margin() {
+    let before = PhysicalFootprint::from_contract(&r2_like());
+
+    let mut grown = r2_like();
+    grown.width_m *= 2.0;
+    grown.length_m *= 2.0;
+    // Keep the body self-consistent: wheelbase + overhangs == length.
+    grown.wheelbase_m = grown.length_m - grown.overhang_front_m - grown.overhang_rear_m;
+    let after = PhysicalFootprint::from_contract(&grown);
+
+    let margin = Margin::new("doer proposal envelope", 0.005, 0.0085).expect("valid");
+
+    let collision_before = CollisionRegion::centre_origin(before, margin);
+    let collision_after = CollisionRegion::centre_origin(after, margin);
+    assert!(
+        collision_after.half_width_m > collision_before.half_width_m,
+        "the collision region did not follow the contract width"
+    );
+    assert!(
+        collision_after.half_length_m > collision_before.half_length_m,
+        "the collision region did not follow the contract length"
+    );
+    // The MARGIN POLICY is preserved — the region grew by the body's growth, not
+    // by an arbitrary amount, and the declared expansion is unchanged.
+    assert_eq!(collision_after.margin, collision_before.margin);
+    assert_eq!(
+        collision_after.half_width_m - after.half_width_m(),
+        collision_before.half_width_m - before.half_width_m(),
+        "the declared lateral margin changed when only the body should have"
+    );
+    assert_eq!(
+        collision_after.half_length_m - after.half_length_m(),
+        collision_before.half_length_m - before.half_length_m(),
+        "the declared longitudinal margin changed when only the body should have"
+    );
+
+    let clearance = Margin::new("required clearance each side", 0.0, 0.15).expect("valid");
+    let corridor_before = CorridorObservationRegion::new(before, clearance);
+    let corridor_after = CorridorObservationRegion::new(after, clearance);
+    assert!(
+        corridor_after.required_width_m() > corridor_before.required_width_m(),
+        "the corridor requirement did not follow the contract width"
+    );
+    assert_eq!(
+        corridor_after.clearance_each_side_m, corridor_before.clearance_each_side_m,
+        "the clearance policy changed when only the body should have"
+    );
+
+    let self_filter_before = SelfFilterRegion::from_footprint(before);
+    let self_filter_after = SelfFilterRegion::from_footprint(after);
+    assert!(
+        self_filter_after.max_vertex_radius_m > self_filter_before.max_vertex_radius_m,
+        "the self-filter bound did not follow the body"
+    );
+
+    let swept_before = TurnSweptRegion::rear_axle_origin(before);
+    let swept_after = TurnSweptRegion::rear_axle_origin(after);
+    assert!(
+        swept_after.total_length_m() > swept_before.total_length_m(),
+        "the swept region did not follow the contract length"
+    );
+    assert!(swept_after.half_width_m > swept_before.half_width_m);
+}
+
+// ---------------------------------------------------------------------------
+// Full width is not a half-extent
+// ---------------------------------------------------------------------------
+
+/// The trap this type exists to prevent. `perception_governor`'s
+/// `vehicle_width_m: 0.203` is a FULL width feeding
+/// `required_corridor_width = vehicle_width + 2·clearance`. Substituting a
+/// half-width there would halve the corridor the ego demands.
+#[test]
+fn the_corridor_region_carries_a_full_width_not_a_half_extent() {
+    let physical = PhysicalFootprint::from_contract(&r2_like());
+    let corridor = CorridorObservationRegion::new(
+        physical,
+        Margin::new("required clearance each side", 0.0, 0.15).expect("valid"),
+    );
+
+    assert_eq!(
+        corridor.vehicle_width_m, physical.width_m,
+        "the corridor region must carry the FULL width"
+    );
+    assert!(
+        corridor.vehicle_width_m > physical.half_width_m(),
+        "a full width must be distinguishable from a half-extent"
+    );
+    assert_eq!(
+        corridor.required_width_m(),
+        physical.width_m + 2.0 * 0.15,
+        "must match the Taj sidecar's required_corridor_width formula exactly"
+    );
+    assert_eq!(
+        corridor.required_half_width_m() * 2.0,
+        corridor.required_width_m(),
+        "the halving helper must round-trip, so callers never halve by hand"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Membership is monotonic in the widening dimension
+// ---------------------------------------------------------------------------
+
+#[test]
+fn collision_membership_is_monotonic_in_the_margin() {
+    let physical = PhysicalFootprint::from_contract(&r2_like());
+    let tight = CollisionRegion::centre_origin(physical, Margin::NONE);
+    let loose =
+        CollisionRegion::centre_origin(physical, Margin::new("wider", 0.10, 0.10).expect("valid"));
+
+    // Every point inside the tighter region is inside the looser one. Sampled on
+    // a grid spanning well beyond both.
+    for i in 0..40 {
+        for j in 0..40 {
+            let x = -0.4 + f64::from(i) * 0.02;
+            let y = -0.4 + f64::from(j) * 0.02;
+            if tight.contains(x, y) {
+                assert!(
+                    loose.contains(x, y),
+                    "({x}, {y}) is inside the tight region but not the loose one"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn collision_membership_refuses_non_finite_coordinates() {
+    let region =
+        CollisionRegion::centre_origin(PhysicalFootprint::from_contract(&r2_like()), Margin::NONE);
+    for bad in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+        assert!(!region.contains(bad, 0.0));
+        assert!(!region.contains(0.0, bad));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Frames: the two conventions, and where they stop agreeing
+// ---------------------------------------------------------------------------
+
+#[test]
+fn regions_declare_the_frame_they_are_expressed_in() {
+    let physical = PhysicalFootprint::from_contract(&r2_like());
+    assert_eq!(
+        CollisionRegion::centre_origin(physical, Margin::NONE).frame,
+        Frame::GeometricCentreBody
+    );
+    assert_eq!(
+        TurnSweptRegion::rear_axle_origin(physical).frame,
+        Frame::RearAxleBody
+    );
+    assert_eq!(
+        SelfFilterRegion::from_footprint(physical).frame,
+        Frame::Sensor,
+        "self-filtering happens in the SENSOR frame, before any transform (#1210)"
+    );
+}
+
+/// The R2's symmetric centre-origin description is exact — but only because the
+/// overhang split is an assumed even division. That assumption is an ESTIMATE
+/// (`r2.overhangs`, #1219), and its measurement is owed under #1213.
+#[test]
+fn the_r2_centre_origin_description_is_exact_only_because_the_split_is_assumed_even() {
+    let physical = PhysicalFootprint::from_contract(&r2_like());
+    assert!(physical.centre_origin_is_exact());
+    assert_eq!(physical.centre_origin_shortfall_m(), 0.0);
+    assert_eq!(
+        physical.overhang_front_m, physical.overhang_rear_m,
+        "the exactness rests entirely on this equality, which is assumed, not measured"
+    );
+}
+
+/// The coupling nobody had stated: if the real split is uneven, a symmetric
+/// half-length UNDER-COVERS the longer end while reporting a plausible number.
+#[test]
+fn an_uneven_overhang_split_makes_the_symmetric_description_under_cover() {
+    let mut uneven = r2_like();
+    // Same total length, shifted split: more overhang at the front.
+    uneven.overhang_front_m = 0.08;
+    uneven.overhang_rear_m = 0.02;
+    let physical = PhysicalFootprint::from_contract(&uneven);
+
+    assert!(
+        !physical.centre_origin_is_exact(),
+        "an uneven split must not report as exact"
+    );
+    assert!(
+        physical.centre_origin_shortfall_m() > 0.0,
+        "the shortfall must be quantified, not merely flagged"
+    );
+
+    // The concrete consequence: the symmetric forward reach is short of the
+    // body's true forward reach measured from the rear axle.
+    let symmetric_forward_from_axle = physical.wheelbase_m * 0.5 + physical.half_length_m();
+    assert!(
+        symmetric_forward_from_axle < physical.forward_extent_from_rear_axle_m(),
+        "the symmetric description should fall short of the true forward extent"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Agreement with the geometry that already ships
+// ---------------------------------------------------------------------------
+
+/// `TurnSweptRegion` is a NAMED VIEW over `containment::footprint_corners`, not
+/// a second implementation. This pins the extents to the same arithmetic that
+/// function performs, so the two cannot drift into disagreeing about where the
+/// body is.
+#[test]
+fn the_swept_region_matches_the_containment_corner_placement() {
+    let physical = PhysicalFootprint::from_contract(&r2_like());
+    let swept = TurnSweptRegion::rear_axle_origin(physical);
+
+    // containment::footprint_corners places body-frame corners at
+    // (wheelbase + overhang_front, ±width/2) and (−overhang_rear, ±width/2).
+    assert_eq!(
+        swept.forward_extent_m,
+        physical.wheelbase_m + physical.overhang_front_m
+    );
+    assert_eq!(swept.rearward_extent_m, physical.overhang_rear_m);
+    assert_eq!(swept.half_width_m, physical.width_m * 0.5);
+}
+
+/// The family invariant the swept extents assume: the body's parts add up to its
+/// length. Checked here rather than assumed, because the swept region is where a
+/// violation would silently mis-place a corner.
+#[test]
+fn the_swept_extents_sum_to_the_contract_length() {
+    let physical = PhysicalFootprint::from_contract(&r2_like());
+    let swept = TurnSweptRegion::rear_axle_origin(physical);
+    assert!(
+        (swept.total_length_m() - physical.length_m).abs() < 1e-9,
+        "wheelbase {} + overhangs {}/{} = {} != length {}",
+        physical.wheelbase_m,
+        physical.overhang_front_m,
+        physical.overhang_rear_m,
+        swept.total_length_m(),
+        physical.length_m
+    );
+}
+
+/// A `PhysicalFootprint` converts to the `VehicleFootprint` the containment
+/// check already consumes, so a region and the shipped containment path cannot
+/// describe different bodies.
+#[test]
+fn the_physical_footprint_converts_to_the_containment_footprint_losslessly() {
+    let contract = r2_like();
+    let physical = PhysicalFootprint::from_contract(&contract);
+    let vf: VehicleFootprint = (&physical).into();
+
+    assert_eq!(vf.width_m, contract.width_m);
+    assert_eq!(vf.length_m, contract.length_m);
+    assert_eq!(vf.wheelbase_m, contract.wheelbase_m);
+    assert_eq!(vf.overhang_front_m, contract.overhang_front_m);
+    assert_eq!(vf.overhang_rear_m, contract.overhang_rear_m);
+}
+
+/// The self-filter bound may not reach beyond the robot it is masking.
+#[test]
+fn the_self_filter_radius_is_the_body_half_diagonal() {
+    let physical = PhysicalFootprint::from_contract(&r2_like());
+    let region = SelfFilterRegion::from_footprint(physical);
+
+    let hl = physical.half_length_m();
+    let hw = physical.half_width_m();
+    assert!((region.max_vertex_radius_m - (hl * hl + hw * hw).sqrt()).abs() < 1e-12);
+
+    // Strictly beyond either half-extent alone (it is a diagonal), and finite.
+    assert!(region.max_vertex_radius_m > hl);
+    assert!(region.max_vertex_radius_m > hw);
+    assert!(region.max_vertex_radius_m.is_finite());
+}

--- a/crates/kirra-core/src/regions/tests.rs
+++ b/crates/kirra-core/src/regions/tests.rs
@@ -97,13 +97,15 @@ fn a_region_is_never_smaller_than_the_body_it_bounds() {
 
         assert!(
             region.covers_physical_body(),
-            "{reason}: region {}x{} does not cover the body {}x{}",
-            region.half_length_m,
+            "{reason}: region {}/{}x{} does not cover the body {}x{}",
+            region.front_extent_m,
+            region.rear_extent_m,
             region.half_width_m,
             physical.half_length_m(),
             physical.half_width_m()
         );
-        assert!(region.half_length_m >= physical.half_length_m());
+        assert!(region.front_extent_m >= physical.half_length_m());
+        assert!(region.rear_extent_m >= physical.half_length_m());
         assert!(region.half_width_m >= physical.half_width_m());
     }
 }
@@ -126,7 +128,7 @@ fn the_doer_envelope_is_the_checker_envelope_plus_a_named_margin() {
     );
 
     assert!(
-        doer.half_length_m > checker.half_length_m,
+        doer.front_extent_m > checker.front_extent_m && doer.rear_extent_m > checker.rear_extent_m,
         "the doer envelope must be strictly more conservative longitudinally"
     );
     assert!(
@@ -167,7 +169,8 @@ fn changing_the_contract_changes_every_derived_region_and_preserves_each_margin(
         "the collision region did not follow the contract width"
     );
     assert!(
-        collision_after.half_length_m > collision_before.half_length_m,
+        collision_after.front_extent_m > collision_before.front_extent_m
+            && collision_after.rear_extent_m > collision_before.rear_extent_m,
         "the collision region did not follow the contract length"
     );
     // The MARGIN POLICY is preserved — the region grew by the body's growth, not
@@ -179,8 +182,8 @@ fn changing_the_contract_changes_every_derived_region_and_preserves_each_margin(
         "the declared lateral margin changed when only the body should have"
     );
     assert_eq!(
-        collision_after.half_length_m - after.half_length_m(),
-        collision_before.half_length_m - before.half_length_m(),
+        collision_after.front_extent_m - after.half_length_m(),
+        collision_before.front_extent_m - before.half_length_m(),
         "the declared longitudinal margin changed when only the body should have"
     );
 
@@ -420,4 +423,101 @@ fn the_self_filter_radius_is_the_body_half_diagonal() {
     assert!(region.max_vertex_radius_m > hl);
     assert!(region.max_vertex_radius_m > hw);
     assert!(region.max_vertex_radius_m.is_finite());
+}
+
+// ---------------------------------------------------------------------------
+// Asymmetry: the robotaxi shape, and the rule max-never-average
+// ---------------------------------------------------------------------------
+
+/// The frozen reference class's actual shape: wheelbase 2.8, overhangs 0.9 /
+/// 1.1 — ASYMMETRIC. The class with the most authority is precisely where a
+/// symmetric description under-covers.
+fn robotaxi_like() -> VehicleKinematicsContract {
+    VehicleKinematicsContract {
+        max_speed_mps: 35.0,
+        max_accel_mps2: 2.5,
+        max_brake_mps2: 6.0,
+        max_steering_deg: 35.0,
+        max_steering_rate_deg_s: 45.0,
+        min_follow_distance_m: 5.0,
+        max_lateral_accel_mps2: 3.5,
+        wheelbase_m: 2.8,
+        width_m: 1.9,
+        length_m: 4.8,
+        overhang_front_m: 0.9,
+        overhang_rear_m: 1.1,
+        odd_speed_cap_mps: None,
+    }
+}
+
+/// A symmetric abstraction may exist only as a deliberately conservative
+/// derived bound: `max(front_extent, rear_extent)`, never the average.
+///
+/// For the robotaxi in the rear-axle frame the difference is not subtle —
+/// front extent 3.7, rear extent 1.1. The average (2.4) under-covers the front
+/// by 1.3 m while looking like a plausible half-length (it equals length/2).
+#[test]
+fn the_symmetric_bound_is_the_max_of_the_extents_never_the_average() {
+    let physical = PhysicalFootprint::from_contract(&robotaxi_like());
+    let region = CollisionRegion::rear_axle_origin(physical, Margin::NONE);
+
+    assert_eq!(region.front_extent_m, 2.8 + 0.9);
+    assert_eq!(region.rear_extent_m, 1.1);
+
+    let symmetric = region.conservative_symmetric_half_length_m();
+    assert_eq!(
+        symmetric,
+        region.front_extent_m.max(region.rear_extent_m),
+        "the symmetric bound must be the max of the extents"
+    );
+
+    let average = (region.front_extent_m + region.rear_extent_m) / 2.0;
+    assert!(
+        symmetric > average,
+        "for an asymmetric body the max must exceed the average — if these are \
+         equal the body is symmetric and this test's premise has changed"
+    );
+    // The average is exactly the trap: it equals length/2, which LOOKS right.
+    assert!((average - physical.half_length_m()).abs() < 1e-12);
+    // The max covers both real extents; the average does not cover the front.
+    assert!(symmetric >= region.front_extent_m && symmetric >= region.rear_extent_m);
+    assert!(average < region.front_extent_m);
+}
+
+/// The longer extent is never reduced by taking the symmetric bound — the
+/// robotaxi-specific regression the asymmetry finding called for.
+#[test]
+fn the_robotaxi_longer_extent_survives_the_symmetric_abstraction() {
+    let physical = PhysicalFootprint::from_contract(&robotaxi_like());
+    let region = CollisionRegion::rear_axle_origin(physical, Margin::NONE);
+
+    assert!(
+        region.conservative_symmetric_half_length_m() >= region.front_extent_m,
+        "the symmetric bound reduced the longer (front) extent"
+    );
+    assert!(
+        !physical.centre_origin_is_exact(),
+        "robotaxi's overhangs are asymmetric; if this becomes exact the shape changed"
+    );
+    // And the shortfall a naive symmetric-about-the-axle description would
+    // carry is quantified, not merely flagged.
+    assert!((physical.centre_origin_shortfall_m() - 0.1).abs() < 1e-12);
+}
+
+/// The rear-axle collision region covers the physical body in ITS OWN frame —
+/// the centre-origin cover check would be the wrong comparison here.
+#[test]
+fn the_rear_axle_region_covers_the_asymmetric_body() {
+    let physical = PhysicalFootprint::from_contract(&robotaxi_like());
+    for margin in [
+        Margin::NONE,
+        Margin::new("proposal envelope", 0.05, 0.03).expect("valid"),
+    ] {
+        let region = CollisionRegion::rear_axle_origin(physical, margin);
+        assert!(region.covers_physical_body(), "margin {:?}", margin.reason);
+        // Membership at the true corners, which a symmetric-average region
+        // would reject at the front.
+        assert!(region.contains(physical.forward_extent_from_rear_axle_m(), 0.0));
+        assert!(region.contains(-physical.rearward_extent_from_rear_axle_m(), 0.0));
+    }
 }

--- a/crates/kirra-trajectory/src/config.rs
+++ b/crates/kirra-trajectory/src/config.rs
@@ -266,6 +266,13 @@ impl VehicleConfig {
     pub fn r2() -> Self {
         Self {
             // MEASURED ~9 in front-to-rear (KIRRA_R2_WHEELBASE_M). (r2.wheelbase)
+            // GEOMETRY IS A CHECKED COPY (#1215): this crate cannot import the
+            // root's `contract_for`, so these values are cited copies — and the
+            // root-crate conformance test
+            // `deployment_geometry::the_checker_r2_config_is_the_contract_plus_its_declared_margin`
+            // asserts each equals the canonical contract plus the DECLARED
+            // margin (`CHECKER_R2_COLLISION_MARGIN`: lateral +0.0005 rounding
+            // headroom, longitudinal none). Edit the contract, not these.
             wheelbase_m: 0.229,
             // VALIDATION-PENDING: wheel track NOT bench-measured; estimate < body width.
             track_width_m: 0.16,

--- a/ros2_ws/src/kirra_safety/config/kirra_params.yaml
+++ b/ros2_ws/src/kirra_safety/config/kirra_params.yaml
@@ -99,9 +99,16 @@ occy_doer:
     # braking, 2.5x speed ceiling). The explicit numbers below still win for the
     # fields they name; this selects the band for the fields they do not.
     vehicle_class: "r2"                         # doer RSS-band label; numbers below win
-    wheelbase_m: 0.229                          # MEASURED ~9 in (front-to-rear CONFIRM pending)
-    half_length_m: 0.17                         # MEASURED body 13 in=0.330 m -> half 0.165 + margin
-    half_width_m: 0.11                          # MEASURED body 8 in=0.203 m -> half 0.102 + margin
+    # #1215: these three are CHECKED COPIES of the r2 contract. The margin is no
+    # longer anonymous — it is DOER_R2_PROPOSAL_MARGIN (src/gateway/
+    # deployment_geometry.rs): +0.005 m longitudinal, +0.0085 m lateral over the
+    # physical half-extents, so the doer proposes within a larger body than the
+    # checker demands. A root-crate test parses THIS file and fails if these
+    # values stop equalling contract + that margin. Edit the contract (and the
+    # declared margin if the policy changes), not these numbers.
+    wheelbase_m: 0.229                          # MEASURED ~9 in == contract (also the #1219 latch value)
+    half_length_m: 0.17                         # = contract half 0.165 + 0.005 declared margin
+    half_width_m: 0.11                          # = contract half 0.1015 + 0.0085 declared margin
     max_steering_deg: 39.0                      # MEASURED full lock ~39 deg (0.68 rad) @ cmd +/-45 (calib Phase C)
     lateral_clearance_target_m: 0.15            # robot-scale (was courier 0.6)
     rss_lateral_alignment_tolerance_m: 0.15     # robot-scale (was courier 0.6)
@@ -124,7 +131,9 @@ perception_governor:
     decel_mps2: 1.5              # assumed comfortable brake for the ACD cap
     margin_m: 0.4                # standoff distance (matches the checker's lateral margin)
     lane_half_m: 0.26            # scalar forward-object lane gate
-    vehicle_width_m: 0.203       # measured R2 body width
+    vehicle_width_m: 0.203       # FULL contract width (NOT a half-extent — feeds
+                                 # required_corridor_width = width + 2*clearance;
+                                 # checked against the contract by #1215 conformance)
     lateral_clearance_m: 0.15    # required clearance on each side
     confidence_floor: 0.5        # below this -> unhealthy -> 0.0 cap
     # #1212: cap_rise_rate_mps_per_s / cap_restriction_epsilon_mps /

--- a/src/gateway/contract_profiles.rs
+++ b/src/gateway/contract_profiles.rs
@@ -409,11 +409,17 @@ fn r2_nominal() -> VehicleKinematicsContract {
         // (r2.footprint)
         width_m: 0.203,
         length_m: 0.330,
-        // ESTIMATE (overhang split UNMEASURED): (length − wheelbase)/2 ≈ 0.05 m
-        // each → front+rear+wheelbase ≈ length. Firm up per PLATFORM_R2_PENDING.
+        // ESTIMATE (overhang split UNMEASURED): (length − wheelbase)/2 =
+        // (0.330 − 0.229)/2 = 0.0505 m each → front+rear+wheelbase = length
+        // EXACTLY. The stated formula, not a rounding of it: at 0.05 the parts
+        // summed to 0.329 against a measured length of 0.330, so
+        // `containment::footprint_corners` placed the swept body 1 mm SHORTER
+        // than the robot — the unsafe direction, and the one #1215's closure
+        // test now refuses. The split itself is still assumed even; the
+        // measurement is owed per PLATFORM_R2_PENDING / #1213.
         // (r2.overhangs)
-        overhang_front_m: 0.05,
-        overhang_rear_m: 0.05,
+        overhang_front_m: 0.0505,
+        overhang_rear_m: 0.0505,
         // The bench-robot ODD ceiling (sibling of COURIER_ODD_SPEED_CAP_MPS).
         odd_speed_cap_mps: Some(R2_ODD_SPEED_CAP_MPS),
     }
@@ -432,8 +438,8 @@ fn r2_mrc() -> VehicleKinematicsContract {
         wheelbase_m: 0.229,
         width_m: 0.203,
         length_m: 0.330,
-        overhang_front_m: 0.05,
-        overhang_rear_m: 0.05,
+        overhang_front_m: 0.0505,
+        overhang_rear_m: 0.0505,
         // MRC crawl (0.5) is already below the R2 ODD cap; leave None so min()
         // selects 0.5 (the frozen-MRC idiom).
         odd_speed_cap_mps: None,

--- a/src/gateway/deployment_geometry.rs
+++ b/src/gateway/deployment_geometry.rs
@@ -1,0 +1,116 @@
+//! #1215 consumer wiring — every deployed geometry value is the canonical
+//! contract plus a NAMED policy, and the relationship is asserted, not assumed.
+//!
+//! # The two wiring shapes, and why both exist
+//!
+//! The rule for this slice: *replace literals with canonical geometry plus
+//! explicit policy, not with opaque generated numbers.* The repo's dependency
+//! structure forces that rule into two shapes:
+//!
+//! - **Construct**, where an import edge exists. `kirra-core::regions` is the
+//!   constructive path: a consumer that can see the contract builds its region
+//!   from [`kirra_core::regions::PhysicalFootprint`] and a [`Margin`].
+//!
+//! - **Validate**, where one does not. `kirra-trajectory` cannot import
+//!   `contract_for` (the profile family lives in this root crate, above it),
+//!   and `kirra_params.yaml` is consumed by Python nodes that cannot import
+//!   Rust at all. Those carry the repo's existing **cited-copy discipline**
+//!   (CONTRACT_PROFILES.md): the copy is deliberate and cited — and, as of
+//!   this module, *checked*. The root crate sees both sides of every such
+//!   boundary, so the conformance tests live here.
+//!
+//! A copy that is cited but unchecked is how the four-way footprint divergence
+//! happened (#1215's motivating finding: checker 0.165/0.102, doer 0.17/0.11,
+//! contract 0.330×0.203, all claiming the same robot).
+//!
+//! # The margins, declared once
+//!
+//! The named policies below are THE declarations of each consumer's expansion
+//! over the physical body. The YAML and the checker config are mirrors of
+//! `contract + policy`; if either drifts, the tests in `tests.rs` name the
+//! value and the policy it violated.
+
+use kirra_core::regions::Margin;
+
+/// The slow-loop checker's collision extents (`kirra_trajectory::VehicleConfig::r2`).
+///
+/// Longitudinal: none — `half_length_m: 0.165` is exactly `0.330 / 2`.
+/// Lateral: `half_width_m: 0.102` sits 0.5 mm over the physical `0.1015`; that
+/// was an undeclared rounding-up before this constant existed. Keeping it (and
+/// naming it) rather than tightening to the physical value: it is conservative,
+/// shipped, and the point of this module is to make expansions DECLARED, not to
+/// re-tune them.
+pub const CHECKER_R2_COLLISION_MARGIN: Margin = Margin {
+    reason: "slow-loop checker rounding headroom: half_width carried 0.102 (vs physical 0.1015) \
+             since its introduction; retained and declared rather than silently re-tuned",
+    longitudinal_m: 0.0,
+    lateral_m: 0.0005,
+};
+
+/// The doer's proposal envelope (`kirra_params.yaml` `occy_doer`
+/// `half_length_m` / `half_width_m`).
+///
+/// The YAML says "+ margin" and never said how much. This is how much: 5 mm
+/// longitudinal, 8.5 mm lateral over the physical half-extents. Conservative
+/// direction — the doer proposes within a larger body than the checker demands,
+/// so a proposal that fits the doer's envelope has headroom at the checker.
+pub const DOER_R2_PROPOSAL_MARGIN: Margin = Margin {
+    reason: "doer proposal envelope: propose within a body larger than the checker demands, \
+             so admissible proposals carry headroom at the checker (kirra_params.yaml occy_doer)",
+    longitudinal_m: 0.005,
+    lateral_m: 0.0085,
+};
+
+/// The perception governor's required lateral clearance on EACH side of the
+/// body (`kirra_params.yaml` `perception_governor` `lateral_clearance_m`),
+/// feeding `required_corridor_width = vehicle_width + 2 · clearance` in the Taj
+/// sidecar.
+pub const PERCEPTION_R2_CLEARANCE: Margin = Margin {
+    reason: "required clearance each side of the body before a corridor admits the ego \
+             (kirra_params.yaml perception_governor lateral_clearance_m)",
+    longitudinal_m: 0.0,
+    lateral_m: 0.15,
+};
+
+/// The relative path of the deployed ROS parameter file this module's tests
+/// validate. One definition so the tests and any future tooling agree on which
+/// file is the deployed one.
+pub const R2_PARAMS_YAML: &str = "ros2_ws/src/kirra_safety/config/kirra_params.yaml";
+
+/// Read a `key: value` scalar out of a flat ROS params YAML section.
+///
+/// Deliberately not a YAML library: the file is flat `key: value  # comment`
+/// under two-level indentation, the root crate carries no YAML dependency, and
+/// a parser that handled more would invite the config to grow shapes this
+/// validation cannot see. Fails loudly (None) on absence so a renamed key
+/// cannot silently pass.
+#[must_use]
+pub fn yaml_scalar(source: &str, section: &str, key: &str) -> Option<f64> {
+    let mut in_section = false;
+    for line in source.lines() {
+        let trimmed = line.trim_end();
+        // A section header is a top-level `name:` line.
+        if !trimmed.starts_with(' ') && trimmed.ends_with(':') {
+            in_section = trimmed.trim_end_matches(':') == section;
+            continue;
+        }
+        if !in_section {
+            continue;
+        }
+        let inner = trimmed.trim_start();
+        let Some(rest) = inner.strip_prefix(key) else {
+            continue;
+        };
+        let Some(value_part) = rest.trim_start().strip_prefix(':') else {
+            continue;
+        };
+        let value_text = value_part.split('#').next().unwrap_or("").trim();
+        if let Ok(v) = value_text.parse::<f64>() {
+            return Some(v);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/gateway/deployment_geometry/tests.rs
+++ b/src/gateway/deployment_geometry/tests.rs
@@ -1,0 +1,303 @@
+//! #1215 consumer conformance — the deployed values equal contract + policy.
+//!
+//! Each test names the consumer, the value, and the policy. A failure reads as
+//! "this consumer no longer derives from the contract", not as a bare number
+//! mismatch.
+
+use std::path::PathBuf;
+
+use kirra_core::regions::{
+    CollisionRegion, CorridorObservationRegion, PhysicalFootprint, SelfFilterRegion,
+};
+
+use super::*;
+use crate::gateway::contract_profiles::{contract_for, VehicleClass};
+
+fn r2_physical() -> PhysicalFootprint {
+    PhysicalFootprint::from_contract(&contract_for(VehicleClass::R2))
+}
+
+fn params_yaml() -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(R2_PARAMS_YAML);
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("deployed params file {} unreadable: {e}", path.display()))
+}
+
+const EPS: f64 = 1e-9;
+
+// ---------------------------------------------------------------------------
+// The rounding-drift regression (the 0.0505 correction, pinned by formula)
+// ---------------------------------------------------------------------------
+
+/// The body closes: `wheelbase + overhang_front + overhang_rear == length`,
+/// for EVERY class and BOTH profiles — asserted against the real contracts,
+/// not fixtures.
+///
+/// The R2 shipped violating this: its overhangs were the estimate's formula
+/// `(length − wheelbase)/2 = 0.0505` rounded to `0.05`, so
+/// `containment::footprint_corners` placed the swept body 1 mm SHORTER than
+/// the measured robot — the unsafe direction. The fix (0f513407) is a
+/// **reviewed safety-value correction**, and this test is what stops the next
+/// edit from silently reintroducing rounding drift.
+#[test]
+fn every_class_body_closes_exactly() {
+    use crate::gateway::contract_profiles::mrc_fallback_for;
+    for class in [
+        VehicleClass::Courier,
+        VehicleClass::DeliveryAv,
+        VehicleClass::Robotaxi,
+        VehicleClass::R2,
+    ] {
+        for (label, c) in [
+            ("nominal", contract_for(class)),
+            ("mrc", mrc_fallback_for(class)),
+        ] {
+            let parts = c.wheelbase_m + c.overhang_front_m + c.overhang_rear_m;
+            assert!(
+                (parts - c.length_m).abs() < EPS,
+                "{class:?} {label}: wheelbase {} + overhangs {}/{} = {parts} != length {} — \
+                 the swept body and the measured body disagree about where the robot ends",
+                c.wheelbase_m,
+                c.overhang_front_m,
+                c.overhang_rear_m,
+                c.length_m
+            );
+        }
+    }
+}
+
+/// The R2 overhang IS its stated formula, not a rounding of it.
+#[test]
+fn the_r2_overhang_is_the_formula_from_the_canonical_dimensions() {
+    let c = contract_for(VehicleClass::R2);
+    let formula = (c.length_m - c.wheelbase_m) / 2.0;
+    assert!(
+        (c.overhang_front_m - formula).abs() < EPS && (c.overhang_rear_m - formula).abs() < EPS,
+        "r2 overhangs {}/{} != (length − wheelbase)/2 = {formula}; the ESTIMATE's own \
+         derivation has drifted",
+        c.overhang_front_m,
+        c.overhang_rear_m
+    );
+}
+
+// ---------------------------------------------------------------------------
+// kirra-trajectory (the slow-loop checker) — VALIDATE across the crate boundary
+// ---------------------------------------------------------------------------
+
+/// `kirra_trajectory::VehicleConfig::r2()` cannot import `contract_for` (the
+/// profile family lives above it), so its geometry is a cited copy. This test
+/// is the check the citation never had: every geometric field equals the
+/// canonical contract plus [`CHECKER_R2_COLLISION_MARGIN`].
+#[test]
+fn the_checker_r2_config_is_the_contract_plus_its_declared_margin() {
+    let config = kirra_trajectory::config::VehicleConfig::r2();
+    let physical = r2_physical();
+    let region = CollisionRegion::centre_origin(physical, CHECKER_R2_COLLISION_MARGIN);
+
+    assert!(
+        (config.wheelbase_m - physical.wheelbase_m).abs() < EPS,
+        "checker wheelbase {} != contract {}",
+        config.wheelbase_m,
+        physical.wheelbase_m
+    );
+    assert!(
+        (config.half_length_m - region.front_extent_m).abs() < EPS,
+        "checker half_length {} != contract half-length {} + declared margin {}",
+        config.half_length_m,
+        physical.half_length_m(),
+        CHECKER_R2_COLLISION_MARGIN.longitudinal_m
+    );
+    assert!(
+        (config.half_width_m - region.half_width_m).abs() < EPS,
+        "checker half_width {} != contract half-width {} + declared margin {}",
+        config.half_width_m,
+        physical.half_width_m(),
+        CHECKER_R2_COLLISION_MARGIN.lateral_m
+    );
+    // The dynamic limits are the same cited copies; geometry is this slice's
+    // scope, but the wheelbase-adjacent kinematic terms ride along cheaply.
+    let contract = contract_for(VehicleClass::R2);
+    assert!((config.max_speed_mps - contract.max_speed_mps).abs() < EPS);
+    assert!(
+        (config.max_steering_rad - contract.max_steering_deg.to_radians()).abs() < EPS,
+        "checker max_steering {} rad != contract {}°",
+        config.max_steering_rad,
+        contract.max_steering_deg
+    );
+    assert_eq!(config.odd_speed_cap_mps, contract.odd_speed_cap_mps);
+}
+
+// ---------------------------------------------------------------------------
+// kirra_params.yaml occy_doer — VALIDATE across the language boundary
+// ---------------------------------------------------------------------------
+
+/// The doer's YAML said "MEASURED … + margin" without saying how much. The
+/// margin is now [`DOER_R2_PROPOSAL_MARGIN`], and the YAML is a checked mirror
+/// of `contract + that margin`.
+#[test]
+fn the_doer_yaml_is_the_contract_plus_its_declared_margin() {
+    let yaml = params_yaml();
+    let physical = r2_physical();
+    let region = CollisionRegion::centre_origin(physical, DOER_R2_PROPOSAL_MARGIN);
+
+    let wheelbase = yaml_scalar(&yaml, "occy_doer", "wheelbase_m").expect("occy_doer.wheelbase_m");
+    let half_length =
+        yaml_scalar(&yaml, "occy_doer", "half_length_m").expect("occy_doer.half_length_m");
+    let half_width =
+        yaml_scalar(&yaml, "occy_doer", "half_width_m").expect("occy_doer.half_width_m");
+
+    assert!(
+        (wheelbase - physical.wheelbase_m).abs() < EPS,
+        "doer wheelbase {wheelbase} != contract {} — this is also the #1219 latch value",
+        physical.wheelbase_m
+    );
+    assert!(
+        (half_length - region.front_extent_m).abs() < EPS,
+        "doer half_length {half_length} != contract {} + declared margin {} = {}",
+        physical.half_length_m(),
+        DOER_R2_PROPOSAL_MARGIN.longitudinal_m,
+        region.front_extent_m
+    );
+    assert!(
+        (half_width - region.half_width_m).abs() < EPS,
+        "doer half_width {half_width} != contract {} + declared margin {} = {}",
+        physical.half_width_m(),
+        DOER_R2_PROPOSAL_MARGIN.lateral_m,
+        region.half_width_m
+    );
+}
+
+/// The interceptor's wheelbase — the value the #1219 `wheelbase_consistent`
+/// latch compares against the verifier's active contract — is the contract
+/// value exactly.
+#[test]
+fn the_interceptor_wheelbase_is_the_contract_wheelbase() {
+    let yaml = params_yaml();
+    let wheelbase = yaml_scalar(&yaml, "cmd_vel_interceptor", "wheelbase_m")
+        .expect("cmd_vel_interceptor.wheelbase_m");
+    assert!(
+        (wheelbase - r2_physical().wheelbase_m).abs() < EPS,
+        "interceptor wheelbase {wheelbase} != contract — the #1219 latch would trip at runtime"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// kirra_params.yaml perception_governor — full width is not a half-extent
+// ---------------------------------------------------------------------------
+
+/// `vehicle_width_m` is semantically the FULL body width feeding the Taj
+/// sidecar's `required_corridor_width = vehicle_width + 2·clearance`. It must
+/// equal the contract width exactly — not the half-width, which would halve
+/// the corridor the ego demands.
+#[test]
+fn the_perception_vehicle_width_is_the_full_contract_width() {
+    let yaml = params_yaml();
+    let physical = r2_physical();
+    let width = yaml_scalar(&yaml, "perception_governor", "vehicle_width_m")
+        .expect("perception_governor.vehicle_width_m");
+
+    assert!(
+        (width - physical.width_m).abs() < EPS,
+        "perception vehicle_width {width} != contract FULL width {}",
+        physical.width_m
+    );
+    // The guard the type system provides in Rust, asserted for the YAML:
+    // the value is unambiguously a full width, not a half-extent.
+    assert!(
+        (width - physical.half_width_m()).abs() > 0.05,
+        "perception vehicle_width {width} is suspiciously close to the HALF width {} — \
+         a half-extent here would halve the corridor the ego demands",
+        physical.half_width_m()
+    );
+}
+
+/// The lane gate admits the corridor the region demands: the deployed
+/// `lane_half_m` and `lateral_clearance_m` satisfy the same inequality the Taj
+/// sidecar enforces at request time (`LaneNarrowerThanRequiredCorridor`), so a
+/// config edit cannot ship a lane the sidecar will refuse.
+#[test]
+fn the_deployed_lane_gate_admits_the_required_corridor() {
+    let yaml = params_yaml();
+    let physical = r2_physical();
+
+    let lane_half = yaml_scalar(&yaml, "perception_governor", "lane_half_m").expect("lane_half_m");
+    let clearance = yaml_scalar(&yaml, "perception_governor", "lateral_clearance_m")
+        .expect("lateral_clearance_m");
+
+    assert!(
+        (clearance - PERCEPTION_R2_CLEARANCE.lateral_m).abs() < EPS,
+        "deployed clearance {clearance} != declared policy {}",
+        PERCEPTION_R2_CLEARANCE.lateral_m
+    );
+
+    let region = CorridorObservationRegion::new(physical, PERCEPTION_R2_CLEARANCE);
+    assert!(
+        lane_half >= region.required_half_width_m(),
+        "lane_half {lane_half} < required half-width {} (= (width {} + 2×clearance {}) / 2) — \
+         the Taj sidecar would refuse every request from this config",
+        region.required_half_width_m(),
+        region.vehicle_width_m,
+        region.clearance_each_side_m
+    );
+}
+
+// ---------------------------------------------------------------------------
+// kirra-taj self-filter — the mask bound follows the body
+// ---------------------------------------------------------------------------
+
+/// `SelfFilterBounds::for_footprint(width, length, …)` takes the body
+/// dimensions as parameters — the caller supplies them from the contract. This
+/// pins the two crates' arithmetic together: the taj bound for the contract
+/// body stays within the region type's half-diagonal-derived cap, and both
+/// stay under the crate's hard backstop.
+#[test]
+fn the_taj_self_filter_bound_and_the_region_agree_on_the_contract_body() {
+    let physical = r2_physical();
+    let region = SelfFilterRegion::from_footprint(physical);
+
+    let taj_bounds = kirra_taj::self_filter::SelfFilterBounds::for_footprint(
+        physical.width_m,
+        physical.length_m,
+        &kirra_taj::self_filter::SensorMount::ASSUMED_IDENTITY,
+    );
+
+    // The region's radius is the half-diagonal; taj's bound must admit exactly
+    // the vertices the half-diagonal admits (its own construction adds mount
+    // slack on top, so >=), and never exceed the crate's absolute backstop.
+    assert!(
+        taj_bounds.max_vertex_radius_m >= region.max_vertex_radius_m,
+        "taj self-filter radius {} rejects vertices on the body's own half-diagonal {}",
+        taj_bounds.max_vertex_radius_m,
+        region.max_vertex_radius_m
+    );
+    assert!(
+        taj_bounds.max_vertex_radius_m <= kirra_taj::self_filter::MAX_SELF_MASK_VERTEX_RADIUS_M,
+        "taj self-filter radius exceeds the crate backstop"
+    );
+    assert!(region.max_vertex_radius_m <= kirra_taj::self_filter::MAX_SELF_MASK_VERTEX_RADIUS_M);
+}
+
+// ---------------------------------------------------------------------------
+// Non-vacuity: the YAML parser actually reads the deployed file
+// ---------------------------------------------------------------------------
+
+/// A parser that silently returned None for everything would make every
+/// YAML-validating test above fail loudly (expect panics) — but a parser that
+/// read the WRONG section would not. Pin the section discrimination.
+#[test]
+fn the_yaml_scalar_reader_discriminates_sections() {
+    let sample = "\
+alpha:\n  ros__parameters:\n    key_a: 1.5\nbeta:\n  ros__parameters:\n    key_a: 2.5\n";
+    assert_eq!(yaml_scalar(sample, "alpha", "key_a"), Some(1.5));
+    assert_eq!(yaml_scalar(sample, "beta", "key_a"), Some(2.5));
+    assert_eq!(yaml_scalar(sample, "gamma", "key_a"), None);
+    assert_eq!(yaml_scalar(sample, "alpha", "key_b"), None);
+}
+
+/// Comments after values are stripped; a renamed key is an error, not a
+/// default.
+#[test]
+fn the_yaml_scalar_reader_strips_trailing_comments() {
+    let sample = "s:\n  ros__parameters:\n    k: 0.229   # MEASURED wheelbase\n";
+    assert_eq!(yaml_scalar(sample, "s", "k"), Some(0.229));
+}

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -1,6 +1,8 @@
 // src/gateway/mod.rs
 
 pub mod contract_profiles;
+#[cfg(test)]
+pub mod deployment_geometry;
 pub mod policy;
 pub mod policy_layer;
 pub mod provenance;

--- a/src/gateway/provenance.rs
+++ b/src/gateway/provenance.rs
@@ -469,7 +469,9 @@ pub static AUTHORED_PROVENANCE: &[FieldProvenance] = &[
     rec!("r2.overhangs", VehicleClass::R2, Profile::Nominal, [Field::OverhangFront, Field::OverhangRear],
          Provenance::Estimate {
              basis: "(length − wheelbase)/2 assumed split evenly; UNMEASURED. Feeds the swept-footprint \
-                     corner placement in containment.rs — an under-estimated rear overhang under-covers the body",
+                     corner placement in containment.rs — an under-estimated rear overhang under-covers the body. \
+                     Rounding this estimate to 0.05 left the parts 1 mm short of the measured length, placing the \
+                     swept body inside the real one (#1215)",
          }),
     rec!("r2.odd_cap", VehicleClass::R2, Profile::Nominal, [Field::OddSpeedCap],
          vp!("ODD ceiling sign-off (docs/CONTRACT_PROFILES.md r2.odd_cap)")),


### PR DESCRIPTION
> Platform geometry remains authored in the canonical contracts. Consumers construct typed regions directly where dependency edges allow it, and copied configuration is verified at a root-level conformance seam where direct construction is impossible.

Closes the geometry-types half of #1215: the four region types the issue names (`CollisionRegion`, `CorridorObservationRegion`, `SelfFilterRegion`, `TurnSweptRegion`), each carrying its frame and an explicitly named margin, plus the consumer wiring that makes the property true rather than merely naming it.

**Ownership boundary against #1219, so neither issue over-claims:** #1215 defines the geometric *concepts* — what a number means, in which frame, with what margin. #1219 remains responsible for proving serialized/deployed consumer configuration is generated from or validated against the same contract. A manifest can transport `length_m`; it cannot answer whether `0.11` means physical half-width, self-filter padding, proposal envelope, or observation clearance.

## Four review-sensitive changes

### 1. `CollisionRegion` preserves front/rear asymmetry

The type carries `front_extent_m` / `rear_extent_m` / `half_width_m` — never a bare symmetric half-length. A symmetric abstraction exists only as `conservative_symmetric_half_length_m() = max(front, rear)`, never the average.

The robotaxi regression shows why this is not pedantry: the frozen reference class has **asymmetric overhangs (0.9 / 1.1)**. In the rear-axle frame its extents are 3.7 / 1.1, and the average — 2.4 — *equals `length/2`*, so it looks like a plausible half-length while under-covering the front by **1.3 m**. A robotaxi-specific test proves the longer extent survives the abstraction.

### 2. Consumer margins are explicit named policies, not anonymous literals

The doer's `0.17 × 0.11` was not an error — it was deliberate conservatism over the physical `0.165 × 0.1015` that nothing declared and nothing bound. Historical conservatism is **named, not erased**:

| Policy | Value | Reconciles |
|---|---|---|
| `CHECKER_R2_COLLISION_MARGIN` | lateral +0.0005 | `kirra-trajectory`'s 0.102 vs physical 0.1015 — an undeclared round-up since introduction, retained and declared |
| `DOER_R2_PROPOSAL_MARGIN` | +0.005 lon / +0.0085 lat | the YAML's anonymous "+ margin" now has a number and a reason |
| `PERCEPTION_R2_CLEARANCE` | 0.15 each side | the Taj sidecar's `required_corridor_width = width + 2·clearance` |

`Margin::new` fails closed on negative (would shrink a region below the body), non-finite, or unnamed.

### 3. Copied configuration is continuously checked against canonical geometry

The four-way footprint divergence that motivated #1215 (contract 0.330×0.203; checker 0.165/0.102; doer 0.17/0.11; perception 0.203-full-width) happened because the copies were cited but **unchecked**. Two wiring shapes, forced by the dependency structure:

- **Construct** where an import edge exists — `kirra_core::regions` is the constructive path (`PhysicalFootprint::from_contract` is the *only* constructor; no hand-building from loose numbers).
- **Validate** where one does not — `kirra-trajectory` cannot import `contract_for` (the profile family lives above it) and `kirra_params.yaml` is consumed by Python. The root crate sees both sides of every such boundary, so the conformance seam lives there: `src/gateway/deployment_geometry`, ten tests, each naming the consumer, the value, and the policy it must satisfy.

Beyond arithmetic agreement, the lane-gate test proves **deployability**: the deployed `lane_half_m` / `lateral_clearance_m` must satisfy the same inequality the Taj sidecar enforces at request time (`LaneNarrowerThanRequiredCorridor`), so a config edit cannot ship a lane the sidecar will refuse on the first request. The `vehicle_width_m` test additionally guards the full-width-vs-half-extent trap explicitly — a half-width there would halve the corridor the ego demands.

Each consumer file now cites its check in place ("edit the contract, not these numbers", with its margin named).

### 4. R2 overhangs change 0.05 → 0.0505 — a reviewed safety-value correction, not cleanup

The region types' closure test failed on first run against the shipped tree:

```
wheelbase 0.229 + overhangs 0.05/0.05 = 0.329   vs   length 0.330
```

`containment::footprint_corners` places the swept body at `wheelbase + overhang_front` forward and `−overhang_rear` back, so the containment check evaluated a body **1 mm shorter than the measured robot** — the unsafe direction, on exactly the rear-corner placement #1213 concerns. Root cause: the estimate's own stated formula `(length − wheelbase)/2` gives **0.0505**; the shipped value rounded it to 0.05.

Verified before changing anything: **courier, delivery-av and robotaxi all close exactly** — only the R2 didn't. The correction matches the documented formula, moves the envelope conservatively, and leaves the even-split *assumption* untouched (still an ESTIMATE; measurement owed under #1213). Two regressions pin it against the real contracts, not fixtures: `every_class_body_closes_exactly` (all four classes, both profiles) and `the_r2_overhang_is_the_formula_from_the_canonical_dimensions`, so the next edit cannot silently reintroduce rounding drift.

## Dependency note

**This PR adds dev-dependencies only** (`kirra-trajectory`, `kirra-taj` in the root crate's `[dev-dependencies]`) and creates **no new runtime dependency direction**. The conformance module is `#[cfg(test)]` — it has no runtime surface at all. The constructive path (`kirra_core::regions`) sits in a crate every consumer already depends on.

## Verification

652 root lib tests · 234 kirra-core (20 region) · 255 kirra-trajectory · full workspace green before the final doc-comment touches · `cargo fmt --check` clean · clippy clean · `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --lib --locked` clean (the lane that caught #1235's first push) · safety-constants gate green (19 constants).

| File | Change |
|---|---|
| `crates/kirra-core/src/regions.rs` + `regions/tests.rs` | **new** — the four region types, `Frame`, `Margin`, `PhysicalFootprint`; 20 tests |
| `src/gateway/deployment_geometry.rs` + `tests.rs` | **new** — named margin policies + the 10-test conformance seam (`cfg(test)`) |
| `src/gateway/contract_profiles.rs` | R2 overhangs 0.05 → 0.0505 (item 4) |
| `src/gateway/provenance.rs` | `r2.overhangs` ESTIMATE basis records the rounding finding |
| `crates/kirra-trajectory/src/config.rs` | comment only — cites its conformance check |
| `ros2_ws/src/kirra_safety/config/kirra_params.yaml` | comments only — names the margins, cites the checks; **no deployed value changed** |
| `Cargo.toml` / `Cargo.lock` | dev-deps for the conformance seam |

Refs #1215 (geometry half; the joined cycle record remains), #1219 (ownership boundary), #1213 (the overhang measurement both findings point at).

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjDFKPcBVHURDZpXsvnYhC)_