### PR TITLE
feat(cycle-record): occy_doer + interceptor stage emitters, parameter-gated off (#1215)

### DIFF
--- a/ros2_ws/src/kirra_safety/kirra_safety/cmd_vel_interceptor.py
+++ b/ros2_ws/src/kirra_safety/kirra_safety/cmd_vel_interceptor.py
@@ -47,6 +47,7 @@ from kirra_safety.bound_proposal import parse_bound_proposal
 from kirra_safety.enforcement_decision import (
     decide_enforcement, Forward, wheelbase_consistent, release_frame,
 )
+from kirra_safety.cycle_events import CycleEventWriter, release_event_from_payload_hex
 from kirra_safety.perception_cap import apply_perception_cap, DISABLED
 
 try:
@@ -93,6 +94,14 @@ class CmdVelInterceptor(Node):
         # Ed25519 verify over exactly these bytes, plus its own evidence-
         # identity checks, are the trust path.
         self.declare_parameter('release_topic', '/kirra/release')
+        # #1215 cycle-record emission (OFF by default = byte-identical). This
+        # node witnesses the RELEASE stage: it decodes, read-only, the same
+        # 176-byte payload it already relays verbatim. Fail-soft + latching —
+        # recording can degrade, the relay cannot.
+        self.declare_parameter('cycle_record_path', '')
+        self._cycle_writer = CycleEventWriter(
+            self.get_parameter('cycle_record_path').value,
+            warn=lambda m: self.get_logger().warning(m))
 
         self._kirra_url = self.get_parameter('kirra_url').value
         self._kirra_token = self.get_parameter('kirra_token').value
@@ -333,12 +342,14 @@ class CmdVelInterceptor(Node):
         proposed['release_binding'] = release_binding
 
         try:
+            gw_t0 = time.monotonic()
             resp = requests.post(
                 f'{self._kirra_url}/actuator/motion/command',
                 headers=self._headers(),
                 json=proposed,
                 timeout=self._timeout_s,
             )
+            gw_ms = int((time.monotonic() - gw_t0) * 1000)
 
             if resp.status_code == 200:
                 # Parse defensively — a 200 with a non-JSON body is a fault.
@@ -357,6 +368,13 @@ class CmdVelInterceptor(Node):
                 # signer provisioned) → nothing to check; behavior unchanged.
                 release = parsed.get('release') if isinstance(parsed, dict) else None
                 if isinstance(release, dict):
+                    # Release stage witnessed: decoded read-only from the
+                    # exact payload bytes relayed below; the builder refuses
+                    # anything but 176 valid hex bytes, so a malformed
+                    # payload emits nothing rather than a guess.
+                    self._emit_cycle_event(release_event_from_payload_hex(
+                        release.get('payload_hex'),
+                        int(time.time() * 1000), gw_ms))
                     reported_wb = release.get('wheelbase_m')
                     if not wheelbase_consistent(self._wheelbase_m, reported_wb):
                         self._wheelbase_mismatch = True
@@ -454,6 +472,17 @@ class CmdVelInterceptor(Node):
         else:
             self._publish_stop('CONNECTION_ERROR')
             self._publish_action('CONNECTION_ERROR:STOP')
+
+
+    def _emit_cycle_event(self, event):
+        """#1215 emission chokepoint. A node built without the recorder (the
+        host tests construct via object.__new__, skipping __init__) simply
+        does not record — the missing-attribute case is DISABLED, not an
+        error, because the property is that recording can never alter
+        control behavior."""
+        writer = getattr(self, '_cycle_writer', None)
+        if writer is not None:
+            writer.emit(event)
 
     def _relay_release(self, release):
         """Republish the gateway 200's release object as the 272-byte V2 wire

--- a/ros2_ws/src/kirra_safety/kirra_safety/cycle_events.py
+++ b/ros2_ws/src/kirra_safety/kirra_safety/cycle_events.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""#1215 cycle-record stage-event emission — the pure half.
+
+No ROS, no requests, no clocks: every function takes explicit values and
+returns a dict shaped exactly like `kirra-cycle-record`'s `StageEvent` wire
+format (the Rust crate's serde JSONL is the contract; its tests own the shape,
+these mirror it).
+
+THE PROPERTY THIS MODULE EXISTS TO KEEP TRUE
+--------------------------------------------
+Each process emits only facts it can directly attest, using identifiers
+already carried by the authority chain, and disabling emission does not alter
+control behavior.
+
+Concretely:
+  * Builders return None rather than guessing when a response lacks the fields
+    an event needs. An event with an invented digest is worse than no event —
+    the joiner would happily chain it, and the artifact would lie.
+  * `CycleEventWriter` is FAIL-SOFT AND LATCHING: any I/O error disables
+    further emission for the process lifetime and the control path proceeds
+    untouched. The recorder degrades, never the loop. This is the exact
+    opposite polarity from every safety module in this package, and it is
+    correct here for the same reason those are fail-closed: authority and
+    observability must fail in opposite directions.
+  * Emission is OFF unless a path is configured. The default deployment is
+    byte-identical.
+
+THE RELEASE PAYLOAD DECODER
+---------------------------
+`release_event_from_payload_hex` decodes the 176-byte V2 payload the
+interceptor already relays (`payload(176) || token(96)`, see
+`enforcement_decision.release_frame`). This is READ-ONLY observability over
+bytes the node already carries verbatim — the trust path remains the motor
+consumer's Ed25519 verify over exactly these bytes, and nothing decoded here
+feeds back into any decision. Layout mirrors
+`kirra-release-token/src/ros_bound_command.rs::encode` (little-endian):
+
+    [0..8)    sequence u64        [8..16)   nonce u64
+    [16..24)  issued_at_ms u64    [24..32)  expires_at_ms u64
+    [32..40)  linear_mps f64      [40..48)  angular_rad_s f64
+    [48..56)  scan_sequence u64   [56]      camera flag (1 -> [64..72) u64)
+    [72..80)  tracker_generation  [80..112) profile_digest
+    [112..144) evidence_digest    [144..176) proposal_digest
+"""
+
+import json
+import struct
+
+RELEASE_PAYLOAD_LEN = 176
+
+
+def perception_event(taj, scan_sequence, t_wall_ms, stage_duration_ms):
+    """Build a perception stage event from a Taj `/perception` response.
+
+    Returns None when the response lacks the identity or cap fields — a
+    partial event would join as evidence the witness cannot actually attest.
+    """
+    if not isinstance(taj, dict):
+        return None
+    frame = taj.get('frame_id')
+    if not isinstance(frame, dict):
+        return None
+    evidence = frame.get('evidence_digest')
+    tracker = frame.get('tracker_generation')
+    raw_cap = taj.get('raw_speed_cap_mps')
+    stab_cap = taj.get('stabilized_speed_cap_mps')
+    if not isinstance(evidence, str) or not isinstance(tracker, int):
+        return None
+    if not isinstance(raw_cap, (int, float)) or not isinstance(stab_cap, (int, float)):
+        return None
+    objects = taj.get('objects')
+    return {
+        'stage': 'perception',
+        'scan_sequence': int(scan_sequence),
+        'camera_sequence': frame.get('camera_sequence'),
+        'tracker_generation': tracker,
+        'evidence_digest': evidence,
+        'raw_speed_cap_mps': float(raw_cap),
+        'stabilized_speed_cap_mps': float(stab_cap),
+        'object_count': len(objects) if isinstance(objects, list) else 0,
+        'camera_healthy': taj.get('camera_healthy'),
+        't_wall_ms': int(t_wall_ms),
+        'stage_duration_ms': int(stage_duration_ms),
+    }
+
+
+def proposal_event(plan, t_wall_ms, stage_duration_ms):
+    """Build a proposal stage event from a planner `/plan` response.
+
+    The scan sequence is taken from the planner's ECHOED frame id — the echo
+    is what the planner actually bound, and emitting the request's value
+    instead would attest something this witness did not observe the planner
+    accept.
+    """
+    if not isinstance(plan, dict):
+        return None
+    frame = plan.get('perception_frame_id')
+    digest = plan.get('proposal_digest')
+    verdict = plan.get('verdict')
+    admitted = plan.get('admitted')
+    if not isinstance(frame, dict) or not isinstance(digest, str):
+        return None
+    if not isinstance(verdict, str) or not isinstance(admitted, bool):
+        return None
+    scan = frame.get('scan_sequence')
+    evidence = frame.get('evidence_digest')
+    if not isinstance(scan, int) or not isinstance(evidence, str):
+        return None
+    return {
+        'stage': 'proposal',
+        'scan_sequence': scan,
+        'proposal_digest': digest,
+        'evidence_digest': evidence,
+        'verdict': verdict,
+        'admitted': admitted,
+        'reason_code': plan.get('reason_code'),
+        't_wall_ms': int(t_wall_ms),
+        'stage_duration_ms': int(stage_duration_ms),
+    }
+
+
+def release_event_from_payload_hex(payload_hex, t_wall_ms, stage_duration_ms):
+    """Decode a release stage event from the V2 payload hex the verifier's 200
+    carries (the same bytes `release_frame` relays verbatim).
+
+    Read-only observability; None on anything other than exactly 176 bytes of
+    valid hex — a truncated payload decoded "best effort" would attest fields
+    that were never signed.
+    """
+    if not isinstance(payload_hex, str):
+        return None
+    try:
+        payload = bytes.fromhex(payload_hex)
+    except ValueError:
+        return None
+    if len(payload) != RELEASE_PAYLOAD_LEN:
+        return None
+    (sequence, nonce, _issued_at_ms, expires_at_ms) = struct.unpack_from('<4Q', payload, 0)
+    (linear_mps, angular_rad_s) = struct.unpack_from('<2d', payload, 32)
+    (scan_sequence,) = struct.unpack_from('<Q', payload, 48)
+    evidence_digest = payload[112:144].hex()
+    proposal_digest = payload[144:176].hex()
+    return {
+        'stage': 'release',
+        'scan_sequence': scan_sequence,
+        'proposal_digest': proposal_digest,
+        'evidence_digest': evidence_digest,
+        'release_sequence': sequence,
+        'release_nonce': nonce,
+        'linear_mps': linear_mps,
+        'angular_rad_s': angular_rad_s,
+        'expires_at_ms': expires_at_ms,
+        't_wall_ms': int(t_wall_ms),
+        'stage_duration_ms': int(stage_duration_ms),
+    }
+
+
+class CycleEventWriter:
+    """Append-only JSONL emitter. FAIL-SOFT AND LATCHING.
+
+    Disabled when constructed with an empty/None path (the default
+    deployment). Any I/O or serialization error PERMANENTLY disables further
+    emission and is reported once via the supplied `warn` callable — the
+    control loop must be structurally incapable of being disturbed by its own
+    flight recorder, and a per-cycle retry against a full disk would trade
+    that for a warn storm.
+    """
+
+    def __init__(self, path, warn=None):
+        self._path = path or None
+        self._warn = warn or (lambda msg: None)
+        self._failed = False
+
+    @property
+    def enabled(self):
+        return self._path is not None and not self._failed
+
+    def emit(self, event):
+        """Append one event. `None` events (builder refusals) are counted as
+        no-ops — the builder already decided there was nothing attestable."""
+        if event is None or not self.enabled:
+            return
+        try:
+            line = json.dumps(event, separators=(',', ':'))
+            with open(self._path, 'a', encoding='utf-8') as f:
+                f.write(line + '\n')
+        except Exception as e:  # noqa: BLE001 — fail-soft is the contract here
+            self._failed = True
+            self._warn(
+                f'cycle-record emission disabled after error: {type(e).__name__}: {e} '
+                f'(control behavior unaffected; recording stops for this process)'
+            )

--- a/ros2_ws/src/kirra_safety/kirra_safety/occy_doer.py
+++ b/ros2_ws/src/kirra_safety/kirra_safety/occy_doer.py
@@ -85,6 +85,9 @@ from kirra_safety.camera_detect_core import (
     plan_object_goal_fields,
 )
 from kirra_safety.bound_proposal import build_release_binding, encode_bound_proposal
+from kirra_safety.cycle_events import (
+    CycleEventWriter, perception_event, proposal_event,
+)
 from kirra_safety.async_plan import (
     ANNOUNCE,
     AWAITING_GOAL,
@@ -162,6 +165,15 @@ class OccyDoer(Node):
         # receipt → odom), `hold` clears it. Mick publishes INTENTS, never
         # commands — this bridge is the only consumer.
         self.declare_parameter('mick_url', '')
+        # #1215 cycle-record emission (OFF by default = byte-identical). This
+        # node witnesses the perception and proposal stages; it emits ONLY
+        # facts it holds (the Taj/plan responses + its own POST timings). The
+        # writer is fail-soft and latching: recording can degrade, the plan
+        # loop cannot — see cycle_events.CycleEventWriter.
+        self.declare_parameter('cycle_record_path', '')
+        self._cycle_writer = CycleEventWriter(
+            self.get_parameter('cycle_record_path').value,
+            warn=lambda m: self.get_logger().warning(m))
         self.declare_parameter('odom_topic', '/odom')
         self.declare_parameter('goal_topic', '/goal_pose')
         self.declare_parameter('scan_topic', '/scan')
@@ -768,6 +780,17 @@ class OccyDoer(Node):
         ).start()
         return ISSUE
 
+
+    def _emit_cycle_event(self, event):
+        """#1215 emission chokepoint. A node built without the recorder (the
+        host tests construct via object.__new__, skipping __init__) simply
+        does not record — the missing-attribute case is DISABLED, not an
+        error, because the property is that recording can never alter
+        control behavior."""
+        writer = getattr(self, '_cycle_writer', None)
+        if writer is not None:
+            writer.emit(event)
+
     def _run_job(self, request):
         """WORKER THREAD. Computes, deposits, and touches nothing else."""
         result = self._execute_job(request)
@@ -793,9 +816,11 @@ class OccyDoer(Node):
 
         fields = request.plan_fields
         try:
+            taj_t0 = time.monotonic()
             taj = requests.post(
                 f'{request.taj_url}/perception',
                 timeout=request.timeout_s, json=request.perception).json()
+            taj_ms = int((time.monotonic() - taj_t0) * 1000)
             if not isinstance(taj, dict):
                 # Named explicitly rather than left to blow up on `.get` below,
                 # so the operator sees WHICH sidecar answered wrongly.
@@ -819,14 +844,26 @@ class OccyDoer(Node):
             }
             if fields['goal_fields']:
                 plan_req.update(fields['goal_fields'])
+            # Perception stage witnessed (emitted before the plan POST so a
+            # planner fault cannot erase the perception evidence).
+            self._emit_cycle_event(perception_event(
+                taj, request.scan_sequence, int(time.time() * 1000), taj_ms))
+            plan_t0 = time.monotonic()
             plan = requests.post(
                 f'{request.planner_url}/plan',
                 timeout=request.timeout_s, json=plan_req).json()
+            plan_ms = int((time.monotonic() - plan_t0) * 1000)
         except Exception as e:  # noqa: BLE001 — any fault holds (fail-soft)
             return faulted(f'service-error:{type(e).__name__}')
 
         if not isinstance(plan, dict):
             return faulted('planner-response-not-an-object')
+
+        # Proposal + verdict stage witnessed (the scan comes from the
+        # planner's ECHOED frame id inside the builder — the echo is what the
+        # planner actually bound).
+        self._emit_cycle_event(proposal_event(
+            plan, int(time.time() * 1000), plan_ms))
 
         taj_seq, plan_seq = evidence_sequences(taj, plan)
         return JobResult(

--- a/ros2_ws/src/kirra_safety/test/test_cycle_events.py
+++ b/ros2_ws/src/kirra_safety/test/test_cycle_events.py
@@ -1,0 +1,180 @@
+"""Host tests for cycle_events — the pure emission half of #1215.
+
+The property under test: each builder emits only facts the witness can
+directly attest (None on anything else), and the writer's failure can never
+reach the control path (fail-soft, latching, off by default).
+
+The wire shape's authority is the Rust crate (`kirra-cycle-record`); the
+round-trip test here encodes a payload byte-for-byte per
+`ros_bound_command.rs::encode` so the Python decoder cannot drift from the
+signed layout without this failing.
+"""
+
+import json
+import struct
+import unittest
+
+from kirra_safety.cycle_events import (
+    CycleEventWriter,
+    perception_event,
+    proposal_event,
+    release_event_from_payload_hex,
+)
+
+
+def taj_response(**overrides):
+    base = {
+        'frame_id': {
+            'scan_sequence': 7,
+            'camera_sequence': 70,
+            'tracker_generation': 1,
+            'evidence_digest': 'aa' * 32,
+        },
+        'raw_speed_cap_mps': 0.9,
+        'stabilized_speed_cap_mps': 0.8,
+        'objects': [{}, {}, {}],
+        'camera_healthy': True,
+    }
+    base.update(overrides)
+    return base
+
+
+def plan_response(**overrides):
+    base = {
+        'perception_frame_id': {
+            'scan_sequence': 7,
+            'evidence_digest': 'aa' * 32,
+        },
+        'proposal_digest': 'bb' * 32,
+        'verdict': 'Accept',
+        'admitted': True,
+        'reason_code': None,
+    }
+    base.update(overrides)
+    return base
+
+
+def encode_payload(sequence=100, nonce=700, issued=1000, expires=2007,
+                   linear=0.4, angular=0.0, scan=7, camera=70,
+                   tracker=1):
+    """Byte-for-byte mirror of ros_bound_command.rs::encode."""
+    out = bytearray(176)
+    struct.pack_into('<4Q', out, 0, sequence, nonce, issued, expires)
+    struct.pack_into('<2d', out, 32, linear, angular)
+    struct.pack_into('<Q', out, 48, scan)
+    if camera is not None:
+        out[56] = 1
+        struct.pack_into('<Q', out, 64, camera)
+    struct.pack_into('<Q', out, 72, tracker)
+    out[80:112] = bytes.fromhex('cc' * 32)   # profile digest
+    out[112:144] = bytes.fromhex('aa' * 32)  # evidence digest
+    out[144:176] = bytes.fromhex('bb' * 32)  # proposal digest
+    return bytes(out).hex()
+
+
+class PerceptionBuilder(unittest.TestCase):
+    def test_a_full_response_builds_the_event(self):
+        ev = perception_event(taj_response(), 7, 1007, 12)
+        self.assertEqual(ev['stage'], 'perception')
+        self.assertEqual(ev['scan_sequence'], 7)
+        self.assertEqual(ev['evidence_digest'], 'aa' * 32)
+        self.assertEqual(ev['raw_speed_cap_mps'], 0.9)
+        self.assertEqual(ev['stabilized_speed_cap_mps'], 0.8)
+        self.assertEqual(ev['object_count'], 3)
+
+    def test_a_response_missing_identity_or_caps_builds_nothing(self):
+        # Only facts the witness can attest: no frame id, no event; no cap
+        # pair, no event. A partial event would join as false evidence.
+        self.assertIsNone(perception_event({'objects': []}, 7, 0, 0))
+        broken = taj_response()
+        del broken['stabilized_speed_cap_mps']
+        self.assertIsNone(perception_event(broken, 7, 0, 0))
+        self.assertIsNone(perception_event('not a dict', 7, 0, 0))
+
+
+class ProposalBuilder(unittest.TestCase):
+    def test_the_scan_comes_from_the_planner_echo(self):
+        # The echo is what the planner actually bound; a request-side value
+        # would attest something this witness did not observe accepted.
+        plan = plan_response()
+        plan['perception_frame_id']['scan_sequence'] = 9
+        ev = proposal_event(plan, 1027, 25)
+        self.assertEqual(ev['scan_sequence'], 9)
+        self.assertEqual(ev['proposal_digest'], 'bb' * 32)
+        self.assertTrue(ev['admitted'])
+
+    def test_a_refusal_carries_its_reason_code(self):
+        plan = plan_response(verdict='MRCFallback', admitted=False,
+                             reason_code='TRAJECTORY_CORRIDOR_BREACH')
+        ev = proposal_event(plan, 0, 0)
+        self.assertFalse(ev['admitted'])
+        self.assertEqual(ev['reason_code'], 'TRAJECTORY_CORRIDOR_BREACH')
+
+    def test_a_response_without_echo_or_digest_builds_nothing(self):
+        plan = plan_response()
+        del plan['perception_frame_id']
+        self.assertIsNone(proposal_event(plan, 0, 0))
+        plan = plan_response(proposal_digest=None)
+        self.assertIsNone(proposal_event(plan, 0, 0))
+
+
+class ReleaseDecoder(unittest.TestCase):
+    def test_the_decoder_round_trips_the_rust_layout(self):
+        ev = release_event_from_payload_hex(encode_payload(), 1047, 8)
+        self.assertEqual(ev['stage'], 'release')
+        self.assertEqual(ev['release_sequence'], 100)
+        self.assertEqual(ev['release_nonce'], 700)
+        self.assertEqual(ev['scan_sequence'], 7)
+        self.assertEqual(ev['linear_mps'], 0.4)
+        self.assertEqual(ev['expires_at_ms'], 2007)
+        self.assertEqual(ev['evidence_digest'], 'aa' * 32)
+        self.assertEqual(ev['proposal_digest'], 'bb' * 32)
+
+    def test_anything_but_exactly_176_valid_hex_bytes_decodes_to_nothing(self):
+        # A best-effort decode of a truncated payload would attest fields
+        # that were never signed.
+        full = encode_payload()
+        self.assertIsNone(release_event_from_payload_hex(full[:-2], 0, 0))
+        self.assertIsNone(release_event_from_payload_hex(full + 'ff', 0, 0))
+        self.assertIsNone(release_event_from_payload_hex('zz' + full[2:], 0, 0))
+        self.assertIsNone(release_event_from_payload_hex(None, 0, 0))
+
+
+class Writer(unittest.TestCase):
+    def test_off_by_default_and_none_events_are_no_ops(self):
+        w = CycleEventWriter('')
+        self.assertFalse(w.enabled)
+        w.emit({'stage': 'perception'})  # must not raise, must not write
+        w2 = CycleEventWriter(None)
+        self.assertFalse(w2.enabled)
+
+    def test_events_append_as_jsonl(self):
+        import tempfile, os
+        path = os.path.join(tempfile.mkdtemp(), 'cycle.jsonl')
+        w = CycleEventWriter(path)
+        ev = perception_event(taj_response(), 7, 1007, 12)
+        w.emit(ev)
+        w.emit(None)  # builder refusal: a counted no-op
+        w.emit(proposal_event(plan_response(), 1027, 25))
+        with open(path, encoding='utf-8') as f:
+            lines = [json.loads(l) for l in f.read().splitlines()]
+        self.assertEqual(len(lines), 2)
+        self.assertEqual(lines[0]['stage'], 'perception')
+        self.assertEqual(lines[1]['stage'], 'proposal')
+
+    def test_an_io_failure_latches_off_and_never_raises(self):
+        # A directory path cannot be opened for append: the first emit fails,
+        # warns ONCE, latches off, and every later emit is a silent no-op.
+        warnings = []
+        w = CycleEventWriter('/', warn=warnings.append)
+        self.assertTrue(w.enabled)
+        w.emit({'stage': 'perception'})  # must not raise
+        self.assertFalse(w.enabled)
+        self.assertEqual(len(warnings), 1)
+        self.assertIn('control behavior unaffected', warnings[0])
+        w.emit({'stage': 'proposal'})  # latched: no second warning
+        self.assertEqual(len(warnings), 1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The Python emitter half of #1215's joined cycle record — deliberately separated from the merged Rust core (#1237) because live process instrumentation is a different risk class from artifact semantics. The property this PR proves:

> Each process emits only facts it can directly attest, using identifiers already carried by the authority chain, and disabling emission does not alter control behavior.

## Shape

One shared pure module, `kirra_safety/cycle_events.py` (no ROS, no `requests`, no clocks), plus minimal wiring in the two witnesses:

| Witness | Emits | From |
|---|---|---|
| `occy_doer` | perception + proposal events | the Taj and plan responses it already holds, with its own measured POST durations |
| `cmd_vel_interceptor` | release events | a **read-only decode** of the 176-byte V2 payload it already relays verbatim |

Both gated on a new `cycle_record_path` parameter, **default `''` = off = byte-identical deployment**.

## Only attestable facts

- Builders return `None` rather than guess when a response lacks the identity or cap fields — an event with an invented digest is worse than no event, because the joiner would happily chain it.
- The proposal's scan sequence comes from the planner's **echoed** frame id: the echo is what the planner actually bound; the request-side value would attest something this witness never observed accepted.
- The release decoder mirrors `ros_bound_command.rs::encode` byte-for-byte and refuses anything but exactly 176 valid hex bytes — a best-effort decode of a truncated payload would attest fields that were never signed. The trust path remains the motor consumer's Ed25519 verify over these same bytes; nothing decoded here feeds any decision.

## Emission cannot disturb control — proven at suite scale, not asserted

`CycleEventWriter` is **fail-soft and latching**: any I/O error warns once, permanently disables emission for the process, and the control path proceeds. This is the deliberate *opposite* polarity from every safety module in this package, and correct for the same reason those fail closed — authority and observability must fail in opposite directions.

The wiring goes through one `_emit_cycle_event` chokepoint per node, which treats a **missing** writer as disabled rather than an error. Worth the review minute: the first wiring attempt turned emission into a plan fault through the node's broad fault handler, because the host tests construct nodes via `object.__new__` with no `__init__` — 20 async tests went red. The fix is also the property's proof: **the entire async control suite now runs against nodes with no recorder at all and behaves identically**, which is "disabling emission does not alter control behavior" tested across 339 cases rather than claimed in one.

## Cross-language wire compatibility — proven live

Events emitted by this module were rejoined under the merged Rust joiner and verified through `kirra-replay --joined` (exit 0, `Partial { missing: [Actuation] }` exactly as expected with the consumer emitter deferred). The test suite additionally round-trips a payload encoded byte-for-byte per the Rust layout through the Python decoder, so the two cannot drift without a red test.

## Verification

339 `kirra_safety` host tests (10 new in `test_cycle_events.py`) · both nodes `ast.parse` clean · no Rust changes.

| File | Change |
|---|---|
| `ros2_ws/src/kirra_safety/kirra_safety/cycle_events.py` | **new** — pure builders + fail-soft writer |
| `ros2_ws/src/kirra_safety/test/test_cycle_events.py` | **new** — 10 tests incl. the Rust-layout round-trip |
| `kirra_safety/occy_doer.py` | param + writer + two emit calls + the chokepoint |
| `kirra_safety/cmd_vel_interceptor.py` | param + writer + one emit call + the chokepoint |

Refs #1215. Remaining after this: the motor-consumer emitter and a real on-hardware incident capture, with Rev A (#1216).

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjDFKPcBVHURDZpXsvnYhC)_