### PR TITLE
fix(release-token): close the lifetime-scaled restart replay window (#1230 Part B)

### DIFF
--- a/crates/kirra-actuation-consumer/src/lib.rs
+++ b/crates/kirra-actuation-consumer/src/lib.rs
@@ -238,6 +238,12 @@ pub struct BoundRefusalBreakdown {
     pub signature_invalid: u64,
     pub undecodable: u64,
     pub future_issued: u64,
+    /// #1230 Part B: tokens minted before this process booted (a restart is a
+    /// new trust epoch). Counted separately from `expired` because the two
+    /// answer different operator questions: expired = the loop is slow;
+    /// predates-boot = a restart happened and pre-boot traffic is being
+    /// correctly discarded.
+    pub token_predates_boot: u64,
     pub expired: u64,
     pub lifetime_too_long: u64,
     pub sequence_not_advanced: u64,
@@ -258,6 +264,7 @@ impl BoundRefusalBreakdown {
             }
             RosBoundCommandRefusal::Undecodable(_) => self.undecodable += 1,
             RosBoundCommandRefusal::FutureIssued { .. } => self.future_issued += 1,
+            RosBoundCommandRefusal::TokenPredatesBoot { .. } => self.token_predates_boot += 1,
             RosBoundCommandRefusal::Expired { .. } => self.expired += 1,
             RosBoundCommandRefusal::LifetimeTooLong { .. } => self.lifetime_too_long += 1,
             RosBoundCommandRefusal::SequenceNotAdvanced { .. } => self.sequence_not_advanced += 1,
@@ -539,6 +546,7 @@ impl<S: MotorSerial> BoundMotorConsumer<S> {
         governor_vk: VerifyingKey,
         expected_profile_digest: [u8; 32],
         maximum_token_lifetime_ms: u64,
+        boot_wall_ms: u64,
         cfg: ConsumerConfig,
         serial: S,
     ) -> Result<Self, ConfigError> {
@@ -554,6 +562,7 @@ impl<S: MotorSerial> BoundMotorConsumer<S> {
                 governor_vk,
                 expected_profile_digest,
                 maximum_token_lifetime_ms,
+                boot_wall_ms,
             ),
             serial,
             cfg,
@@ -782,6 +791,10 @@ mod tests {
             sk().verifying_key(),
             TEST_PROFILE_DIGEST,
             200,
+            // Boot epoch 0: admits every test token, so the existing scenario
+            // matrix keeps exercising the checks it was written for. The
+            // predates-boot behavior has its own dedicated tests.
+            0,
             cfg(),
             RecordingSerial::default(),
         )

--- a/crates/kirra-consumer-ffi/src/lib.rs
+++ b/crates/kirra-consumer-ffi/src/lib.rs
@@ -240,6 +240,11 @@ const BOUND_REF_SEQUENCE_NOT_ADVANCED: i32 = 107;
 const BOUND_REF_NONCE_NOT_ADVANCED: i32 = 108;
 const BOUND_REF_PROFILE_DIGEST_MISMATCH: i32 = 109;
 const BOUND_REF_PERCEPTION_FRAME_SUPERSEDED: i32 = 110;
+/// #1230 Part B: the token was minted before this consumer process booted.
+/// Distinct from EXPIRED (105) because the operator responses differ: 105
+/// means the loop is slow; 111 means a restart happened and pre-boot traffic
+/// is being correctly discarded.
+const BOUND_REF_TOKEN_PREDATES_BOOT: i32 = 111;
 
 fn bound_refusal_code(refusal: &RosBoundCommandRefusal) -> i32 {
     match refusal {
@@ -250,6 +255,7 @@ fn bound_refusal_code(refusal: &RosBoundCommandRefusal) -> i32 {
         }
         RosBoundCommandRefusal::Undecodable(_) => BOUND_REF_UNDECODABLE,
         RosBoundCommandRefusal::FutureIssued { .. } => BOUND_REF_FUTURE_ISSUED,
+        RosBoundCommandRefusal::TokenPredatesBoot { .. } => BOUND_REF_TOKEN_PREDATES_BOOT,
         RosBoundCommandRefusal::Expired { .. } => BOUND_REF_EXPIRED,
         RosBoundCommandRefusal::LifetimeTooLong { .. } => BOUND_REF_LIFETIME_TOO_LONG,
         RosBoundCommandRefusal::SequenceNotAdvanced { .. } => BOUND_REF_SEQUENCE_NOT_ADVANCED,
@@ -334,6 +340,7 @@ pub unsafe extern "C" fn kirra_bound_consumer_new(
     vk: *const u8,
     expected_profile_digest: *const u8,
     maximum_token_lifetime_ms: u64,
+    boot_wall_ms: u64,
     control_period_ms: u64,
     missed_periods: u32,
     stop_decel_mps2: f64,
@@ -388,6 +395,7 @@ pub unsafe extern "C" fn kirra_bound_consumer_new(
         governor_vk,
         profile_digest,
         maximum_token_lifetime_ms,
+        boot_wall_ms,
         cfg,
         serial,
     ) {
@@ -946,6 +954,7 @@ mod tests {
             sk().verifying_key().as_bytes().as_ptr(),
             PROFILE_DIGEST.as_ptr(),
             200,
+            0, // boot epoch 0 admits every test token; predates-boot has its own test
             100,
             3,
             1.0,

--- a/crates/kirra-release-token/src/ros_bound_command.rs
+++ b/crates/kirra-release-token/src/ros_bound_command.rs
@@ -283,6 +283,15 @@ pub enum RosBoundCommandRefusal {
         issued_at_ms: u64,
         now_ms: u64,
     },
+    /// #1230 Part B: the token was minted before this consumer process
+    /// booted. A restart is a new trust epoch; pre-boot tokens are refused
+    /// regardless of how much signed lifetime they have left, so the
+    /// post-restart replay window no longer scales with
+    /// `KIRRA_FRESHNESS_WINDOW_MS`.
+    TokenPredatesBoot {
+        issued_at_ms: u64,
+        boot_wall_ms: u64,
+    },
 
     /// The signed command has reached or passed its explicit expiration.
     Expired {
@@ -339,6 +348,16 @@ pub struct RosBoundCommandGate {
     governor_vk: VerifyingKey,
     expected_profile_digest: [u8; 32],
     maximum_lifetime_ms: u64,
+    /// #1230 Part B — the consumer's boot instant (wall ms). Tokens ISSUED
+    /// before this are refused regardless of remaining lifetime: a restart is
+    /// a new trust epoch, and a pre-boot mint belongs to the previous one.
+    /// Interim, deliberately: same-host clock domain on the ADR-0033 topology
+    /// makes the comparison sound in the common case, but a backward wall
+    /// step DURING the restart re-opens the window — the structural fix (a
+    /// boot epoch bound into the signed payload, Part A) is the ADR revision
+    /// tracked on the issue. Strict `<`: a token minted at the boot instant
+    /// is admitted.
+    boot_wall_ms: u64,
 
     last_released_sequence: Option<u64>,
     last_released_nonce: Option<u64>,
@@ -351,11 +370,13 @@ impl RosBoundCommandGate {
         governor_vk: VerifyingKey,
         expected_profile_digest: [u8; 32],
         maximum_lifetime_ms: u64,
+        boot_wall_ms: u64,
     ) -> Self {
         Self {
             governor_vk,
             expected_profile_digest,
             maximum_lifetime_ms,
+            boot_wall_ms,
             last_released_sequence: None,
             last_released_nonce: None,
             latest_perception_frame: None,
@@ -389,6 +410,16 @@ impl RosBoundCommandGate {
             return Err(RosBoundCommandRefusal::FutureIssued {
                 issued_at_ms: payload.issued_at_ms,
                 now_ms,
+            });
+        }
+
+        // #1230 Part B: refuse anything minted before this process booted —
+        // a restart is a new trust epoch, and expiry alone made the replay
+        // window exactly as wide as the configurable token lifetime.
+        if payload.issued_at_ms < self.boot_wall_ms {
+            return Err(RosBoundCommandRefusal::TokenPredatesBoot {
+                issued_at_ms: payload.issued_at_ms,
+                boot_wall_ms: self.boot_wall_ms,
             });
         }
 
@@ -509,7 +540,7 @@ mod tests {
     }
 
     fn gate() -> RosBoundCommandGate {
-        RosBoundCommandGate::new(signing_key().verifying_key(), [0x11; 32], 200)
+        RosBoundCommandGate::new(signing_key().verifying_key(), [0x11; 32], 200, 0)
     }
 
     fn signed(payload: &RosBoundCommandPayload) -> ReleaseToken {

--- a/crates/kirra-release-token/tests/restart_trust_epoch.rs
+++ b/crates/kirra-release-token/tests/restart_trust_epoch.rs
@@ -1,31 +1,26 @@
-//! #1214 — what a consumer restart does to replay protection.
+//! #1230 — what a consumer restart does to replay protection.
 //!
-//! The intended assertion for this test was:
+//! HISTORY: this file originally pinned the UNDESIRED behaviour — a restarted
+//! consumer accepted any pre-restart token still inside its own wall-clock
+//! lifetime, because all three gate watermarks are in-memory and expiry was
+//! the only refusal left standing. That made the post-restart replay window
+//! exactly `maximum_lifetime_ms` wide, i.e. a function of the CONFIGURABLE
+//! `KIRRA_FRESHNESS_WINDOW_MS` rather than of restart itself.
 //!
-//!     mint a token under epoch A → restart the consumer →
-//!     present the epoch-A token → REJECTED
+//! #1230 Part B closes that coupling: the gate now carries `boot_wall_ms`,
+//! and any token ISSUED before this process booted is refused with the
+//! distinct `TokenPredatesBoot` — regardless of how much signed lifetime it
+//! has left. A restart is a new trust epoch; pre-boot mints belong to the
+//! previous one.
 //!
-//! **The protocol cannot make that assertion true today**, and this file pins
-//! what actually happens instead. Writing the aspirational assertion and marking
-//! it ignored would be worse than useless: it would read as a covered case.
-//!
-//! The gate's three watermarks — `last_released_sequence`, `last_released_nonce`
-//! and `latest_perception_frame` — are in-memory. A restarted consumer therefore
-//! accepts any sequence, any nonce and any perception frame. The ONLY thing that
-//! refuses a pre-restart token is its own wall-clock lifetime, so the exposure
-//! window is exactly `maximum_lifetime_ms` wide and closes by expiry rather than
-//! by any restart-aware rule.
-//!
-//! In the shipped configuration that lifetime is 200 ms
-//! (`ROS_BOUND_RELEASE_LIFETIME_MS`) and a real process restart takes far
-//! longer, so this is not exploitable as configured. That is a **timing
-//! accident, not a designed invariant** — it depends on restart duration
-//! exceeding a configurable token lifetime, and a backward wall-clock step
-//! during the restart widens it further.
-//!
-//! The structural fix (a boot/session epoch bound into evidence identity and
-//! release tokens, so pre-restart tokens are invalid by construction) is
-//! tracked separately. See the issue cited in the tests below.
+//! HONEST SCOPE (why #1230 stays open): this is the INTERIM, not the
+//! structural fix. The comparison is same-clock-domain — sound on the
+//! ADR-0033 single-host topology — but time-anchored, so a backward wall
+//! step DURING the restart re-opens the window; that remainder is pinned
+//! below rather than hidden, exactly as this file once pinned the original
+//! gap. The structural fix (Part A: a boot epoch bound into the SIGNED
+//! payload, wire V3, refusal `TokenEpochMismatch`) is the ADR-0033 revision
+//! tracked on #1230.
 
 use ed25519_dalek::SigningKey;
 use kirra_release_token::ros_bound_command::{
@@ -57,104 +52,61 @@ fn payload() -> RosBoundCommandPayload {
     }
 }
 
-/// A restarted consumer is a NEW gate: same key, same pinned profile, no
-/// watermarks. This is what "restart" means throughout this file.
-fn restarted_consumer() -> RosBoundCommandGate {
-    RosBoundCommandGate::new(key().verifying_key(), PROFILE, MAXIMUM_LIFETIME_MS)
+/// A consumer process with a stated boot instant: same key, same pinned
+/// profile, no watermarks. This is what "restart" means throughout this file —
+/// every in-memory watermark is gone, and only `boot_wall_ms` distinguishes
+/// the new epoch from the old.
+fn consumer_booted_at(boot_wall_ms: u64) -> RosBoundCommandGate {
+    RosBoundCommandGate::new(
+        key().verifying_key(),
+        PROFILE,
+        MAXIMUM_LIFETIME_MS,
+        boot_wall_ms,
+    )
 }
 
-/// Documents the gap: a pre-restart token IS accepted after a restart while it
-/// remains inside its own wall-clock lifetime.
+/// THE FLIP (#1230 acceptance): a pre-restart token is refused after restart
+/// REGARDLESS of its remaining lifetime, with the distinct predates-boot code
+/// — not incidentally by expiry.
 ///
-/// This test asserts behaviour the project does not want. It exists so the gap
-/// is visible in the test suite rather than only in prose, and so that
-/// implementing epoch binding forces a deliberate edit here rather than silently
-/// leaving a stale expectation.
+/// This test previously asserted the opposite, deliberately, so that the fix
+/// would force this edit rather than leave a stale expectation.
 #[test]
-fn a_pre_restart_token_is_still_accepted_after_restart_within_its_lifetime() {
+fn a_pre_restart_token_is_refused_after_restart_despite_remaining_lifetime() {
     let payload = payload();
     let token = issue_ros_bound_command_release(&payload, &key());
     let bytes = payload.encode();
 
-    let mut before = restarted_consumer();
+    // Epoch A: consumer booted before the mint; releases normally.
+    let mut before = consumer_booted_at(9_000);
     before
         .release(&bytes, Some(&token), 10_050)
         .expect("released normally under epoch A");
 
-    // The consumer restarts. Every watermark is gone.
-    let mut after = restarted_consumer();
+    // Restart at 10_055 — AFTER the mint. The token still has ~140 ms of
+    // signed lifetime at now=10_060; that lifetime no longer matters.
+    let mut after = consumer_booted_at(10_055);
     let replayed = after.release(&bytes, Some(&token), 10_060);
 
-    assert!(
-        replayed.is_ok(),
-        "EXPECTED-BUT-UNDESIRED: a pre-restart token is accepted after restart. \
-         If this now fails, epoch binding has been implemented — update this test \
-         and the restart section of docs/safety/EVIDENCE_BINDING.md."
-    );
-}
-
-/// The only thing that closes the window: the token's own expiry.
-#[test]
-fn the_exposure_window_is_closed_by_expiry_not_by_any_restart_rule() {
-    let payload = payload();
-    let token = issue_ros_bound_command_release(&payload, &key());
-    let bytes = payload.encode();
-
-    let mut after = restarted_consumer();
-    let refused = after.release(&bytes, Some(&token), payload.expires_at_ms);
-
     assert_eq!(
-        refused,
-        Err(RosBoundCommandRefusal::Expired {
-            expires_at_ms: payload.expires_at_ms,
-            now_ms: payload.expires_at_ms,
+        replayed,
+        Err(RosBoundCommandRefusal::TokenPredatesBoot {
+            issued_at_ms: 10_000,
+            boot_wall_ms: 10_055,
         }),
-        "expiry is the sole bound on post-restart replay"
+        "a restart is a new trust epoch: pre-boot mints are refused at the \
+         boundary, not by waiting out their expiry"
     );
 }
 
-/// States the exposure numerically: the window is exactly the token lifetime,
-/// and it is a function of a CONFIGURABLE value rather than of restart itself.
-///
-/// This is the assertion that makes the risk legible. A deployment that raises
-/// `KIRRA_FRESHNESS_WINDOW_MS` widens the post-restart replay window by the same
-/// amount, which is not obvious from either the variable's name or its
-/// documentation.
+/// No bootstrap deadlock (#1230 acceptance): the first legitimately fresh
+/// token after a restart — minted at or after the boot instant — is admitted
+/// on the first cycle, and the gate then enforces its watermarks normally
+/// within the new epoch (non-vacuity: the refusals above must not be a gate
+/// that refuses everything).
 #[test]
-fn the_exposure_window_equals_the_token_lifetime() {
-    let payload = payload();
-    let token = issue_ros_bound_command_release(&payload, &key());
-    let bytes = payload.encode();
-
-    // Accepted at the last instant before expiry…
-    let mut just_inside = restarted_consumer();
-    assert!(just_inside
-        .release(&bytes, Some(&token), payload.expires_at_ms - 1)
-        .is_ok());
-
-    // …and refused at expiry. The window is [issued_at, expires_at).
-    let mut just_outside = restarted_consumer();
-    assert!(just_outside
-        .release(&bytes, Some(&token), payload.expires_at_ms)
-        .is_err());
-
-    assert_eq!(
-        payload.expires_at_ms - payload.issued_at_ms,
-        MAXIMUM_LIFETIME_MS,
-        "the exposure window IS the token lifetime, so raising the configured \
-         lifetime widens post-restart replay by the same amount"
-    );
-}
-
-/// The post-restart epoch does re-establish normally: a fresh token under new
-/// evidence is accepted, and the restarted gate then enforces its watermarks
-/// from that point.
-///
-/// Non-vacuity for the tests above — they must not be passing because the
-/// restarted gate accepts everything unconditionally.
-#[test]
-fn a_restarted_consumer_re_establishes_and_then_enforces_normally() {
-    let mut after = restarted_consumer();
+fn a_fresh_post_restart_token_is_admitted_and_the_epoch_then_enforces_normally() {
+    let mut consumer = consumer_booted_at(10_055);
 
     let mut fresh = payload();
     fresh.sequence = 500;
@@ -165,24 +117,102 @@ fn a_restarted_consumer_re_establishes_and_then_enforces_normally() {
     fresh.expires_at_ms = 50_000 + MAXIMUM_LIFETIME_MS;
     let fresh_token = issue_ros_bound_command_release(&fresh, &key());
 
-    after
+    consumer
         .release(&fresh.encode(), Some(&fresh_token), 50_050)
-        .expect("the new epoch's first token is accepted");
+        .expect("the new epoch's first token is accepted — no deadlock");
 
-    // …and the watermark is live again: the same frame replayed is refused.
+    // The watermark is live again: the same frame replayed is refused.
     assert!(
-        after
+        consumer
             .release(&fresh.encode(), Some(&fresh_token), 50_060)
             .is_err(),
         "the restarted gate must enforce replay protection within its own epoch"
     );
+}
 
-    // A pre-restart token from the OLD epoch is now refused too — but by the
-    // sequence watermark the new epoch established, not by anything that knows
-    // a restart happened. Had it arrived first, it would have been accepted.
-    let stale = payload();
-    let stale_token = issue_ros_bound_command_release(&stale, &key());
-    assert!(after
-        .release(&stale.encode(), Some(&stale_token), 50_070)
-        .is_err());
+/// The boundary is strict `<`: a token minted at EXACTLY the boot instant is
+/// admitted. The verifier minting in the same millisecond the consumer comes
+/// up is the current epoch, not the previous one.
+#[test]
+fn a_token_minted_at_the_boot_instant_is_admitted() {
+    let mut consumer = consumer_booted_at(10_000);
+    let p = payload(); // issued_at_ms == 10_000 == boot
+    let token = issue_ros_bound_command_release(&p, &key());
+    consumer
+        .release(&p.encode(), Some(&token), 10_050)
+        .expect("issued_at == boot is the current epoch");
+}
+
+/// A token that is BOTH pre-boot and expired is refused on every path.
+/// Pinned so a future reordering of the gate's checks cannot silently admit
+/// one of the two cases.
+#[test]
+fn a_pre_boot_and_expired_token_is_refused() {
+    let p = payload();
+    let token = issue_ros_bound_command_release(&p, &key());
+    let mut consumer = consumer_booted_at(10_055);
+    let refused = consumer.release(&p.encode(), Some(&token), p.expires_at_ms + 10);
+    assert!(refused.is_err(), "no path admits it: {refused:?}");
+}
+
+/// The exposure statement, updated: the window no longer scales with the
+/// configured token lifetime. Pre-Part-B, "one ms before expiry" was the
+/// just-inside acceptance that made the window equal the lifetime; now the
+/// boot instant refuses it however much lifetime remains — including under a
+/// ten-fold longer configured lifetime.
+#[test]
+fn the_exposure_window_no_longer_scales_with_the_configured_lifetime() {
+    let p = payload();
+    let token = issue_ros_bound_command_release(&p, &key());
+    let mut just_after_boot = consumer_booted_at(p.issued_at_ms + 1);
+    assert!(matches!(
+        just_after_boot.release(&p.encode(), Some(&token), p.expires_at_ms - 1),
+        Err(RosBoundCommandRefusal::TokenPredatesBoot { .. })
+    ));
+
+    let mut long = payload();
+    long.expires_at_ms = long.issued_at_ms + 10 * MAXIMUM_LIFETIME_MS;
+    let long_token = issue_ros_bound_command_release(&long, &key());
+    let mut consumer = RosBoundCommandGate::new(
+        key().verifying_key(),
+        PROFILE,
+        10 * MAXIMUM_LIFETIME_MS,
+        long.issued_at_ms + 1,
+    );
+    assert!(matches!(
+        consumer.release(&long.encode(), Some(&long_token), long.issued_at_ms + 500),
+        Err(RosBoundCommandRefusal::TokenPredatesBoot { .. })
+    ));
+}
+
+/// THE HONEST REMAINDER (Part A's justification, kept visible): a backward
+/// wall-clock step DURING the restart re-opens the window. If the clock steps
+/// back far enough that the consumer's recorded boot instant precedes the
+/// token's mint time, the predates-boot rule is blind by construction and
+/// only expiry is left — the pre-Part-B behaviour, restored by the clock
+/// rather than by any code change.
+///
+/// This test asserts behaviour the project does not want, exactly as this
+/// file's original test did for the un-guarded gate: the gap stays visible in
+/// the suite until Part A (the boot epoch in the SIGNED payload, which no
+/// clock step can forge) closes it. When `TokenEpochMismatch` exists, this
+/// test flips.
+#[test]
+fn a_backward_clock_step_across_restart_reopens_the_window() {
+    let p = payload(); // minted at 10_000
+    let token = issue_ros_bound_command_release(&p, &key());
+
+    // The restart happens after the mint, but the wall clock stepped back:
+    // the consumer records boot at 9_990 — BEFORE the mint it is trying to
+    // fence off.
+    let mut consumer = consumer_booted_at(9_990);
+    let replayed = consumer.release(&p.encode(), Some(&token), 10_050);
+
+    assert!(
+        replayed.is_ok(),
+        "EXPECTED-BUT-UNDESIRED: a backward clock step across the restart \
+         defeats the time-anchored boot fence. If this now fails, Part A \
+         (structural epoch binding) has landed — update this test and \
+         docs/safety/EVIDENCE_BINDING.md §4.7."
+    );
 }

--- a/docs/safety/EVIDENCE_BINDING.md
+++ b/docs/safety/EVIDENCE_BINDING.md
@@ -178,23 +178,28 @@ after restart, a token is minted against it, startup generation and frame
 identity are nonzero and accepted by the full chain (#1214), and the gate
 enforces its watermarks from the first post-restart release.
 
-**One requirement does not hold.** A pre-restart token is still accepted after a
-restart if it remains inside its own wall-clock lifetime. Nothing refuses it on
-the grounds that a restart happened — the sequence and nonce that would have
-refused it were cleared, and only expiry closes the window.
+**One requirement holds only at the interim tier (#1230 Part B).** The gate now
+carries the consumer's boot instant (`boot_wall_ms`, captured once at process
+start), and any token MINTED before it is refused with the distinct
+`TokenPredatesBoot` (FFI code 111) — regardless of remaining signed lifetime.
+The post-restart replay window therefore no longer scales with the configurable
+`KIRRA_FRESHNESS_WINDOW_MS`: with a correctly recorded boot instant it is zero,
+and the historical coupling (raise the lifetime, widen the replay window by the
+same amount) is severed. The boundary is strict — a token minted at exactly the
+boot instant is the current epoch — and re-establishment stays deadlock-free:
+the first post-boot mint is admitted on the first cycle.
 
-The exposure is exactly `maximum_lifetime_ms` wide: 200 ms as shipped, against a
-real restart that takes far longer. That is a **timing accident, not a designed
-invariant** — it depends on restart duration exceeding a *configurable* lifetime,
-and a backward clock step during the restart widens it further, with the clock
-guard unable to help because its hold died with the process.
-
-Tracked as **#1230**, with a boot/session epoch bound into evidence identity and
-the signed payload as the preferred fix, so pre-restart tokens become
-structurally invalid rather than invalid-by-timeout. Pinned meanwhile by
-`crates/kirra-release-token/tests/restart_trust_epoch.rs`, which asserts the
-undesired behaviour deliberately so that implementing the fix forces an edit
-rather than leaving a stale expectation.
+**The honest remainder, which is why #1230 stays open.** The comparison is
+time-anchored on the shared host clock (sound on the ADR-0033 single-host
+topology, where verifier and consumer share one clock domain). A backward wall
+step DURING the restart can place the recorded boot instant before the mint it
+should fence, restoring the pre-Part-B behaviour — pinned as an
+expected-but-undesired test exactly as the original gap was. The structural fix
+(Part A) binds a per-boot epoch into the SIGNED payload, which no clock step
+can forge: wire revision V3 per ADR-0033, a new consumer-published epoch
+channel attached by the interceptor, refusal `TokenEpochMismatch`. Until it
+lands, `restart_trust_epoch.rs` carries both the flipped assertions and the
+remaining-gap pin.
 
 **Operational consequences.**
 

--- a/robot/bound_consumer_test.py
+++ b/robot/bound_consumer_test.py
@@ -465,7 +465,7 @@ def test_bound_consumer_refuses_bad_key_and_digest_before_calling_c():
     from kirra_ffi import BoundKirraConsumer
 
     good_kwargs = dict(
-        maximum_token_lifetime_ms=200, control_period_ms=100, missed_periods=3,
+        maximum_token_lifetime_ms=200, boot_wall_ms=0, control_period_ms=100, missed_periods=3,
         stop_decel_mps2=1.0, vx_max=0.15, vz_max=0.4,
         lib_path="/nonexistent/libkirra_consumer_ffi.so",
     )
@@ -516,8 +516,9 @@ def test_bound_consumer_passes_the_pinned_profile_bytes_to_the_constructor():
         digest = bytes.fromhex(PROFILE_HEX)
         consumer = kirra_ffi.BoundKirraConsumer(
             vk, digest,
-            maximum_token_lifetime_ms=200, control_period_ms=100, missed_periods=3,
-            stop_decel_mps2=1.0, vx_max=0.15, vz_max=0.4, lib_path="ignored",
+            maximum_token_lifetime_ms=200, boot_wall_ms=0, control_period_ms=100,
+            missed_periods=3, stop_decel_mps2=1.0, vx_max=0.15, vz_max=0.4,
+            lib_path="ignored",
         )
         assert seen["vk"] == vk
         assert seen["digest"] == digest, "the pinned profile digest must pass through byte-for-byte"
@@ -550,7 +551,7 @@ def test_bound_consumer_treats_null_handle_as_fail_closed():
     try:
         kirra_ffi.BoundKirraConsumer(
             b"\x01" * VK_LEN, b"\x02" * DIGEST_LEN,
-            maximum_token_lifetime_ms=200, control_period_ms=100, missed_periods=3,
+            maximum_token_lifetime_ms=200, boot_wall_ms=0, control_period_ms=100, missed_periods=3,
             stop_decel_mps2=1.0, vx_max=0.15, vz_max=0.4, lib_path="ignored",
         )
     except ValueError as e:

--- a/robot/ffi_smoke_test.py
+++ b/robot/ffi_smoke_test.py
@@ -211,8 +211,8 @@ def main() -> int:
 
     def new_bound(vk_bytes=vk, digest=profile_digest, **over):
         kwargs = dict(
-            maximum_token_lifetime_ms=200, control_period_ms=100, missed_periods=3,
-            stop_decel_mps2=1.0, vx_max=VX_MAX, vz_max=VZ_MAX,
+            maximum_token_lifetime_ms=200, boot_wall_ms=0, control_period_ms=100,
+            missed_periods=3, stop_decel_mps2=1.0, vx_max=VX_MAX, vz_max=VZ_MAX,
         )
         kwargs.update(over)
         return BoundKirraConsumer(vk_bytes, digest, **kwargs)

--- a/robot/kirra_ffi.py
+++ b/robot/kirra_ffi.py
@@ -296,6 +296,7 @@ def _bind_bound(lib: ctypes.CDLL) -> ctypes.CDLL:
         ctypes.c_char_p,   # vk (32 bytes)
         ctypes.c_char_p,   # expected_profile_digest (32 bytes)
         ctypes.c_uint64,   # maximum_token_lifetime_ms
+        ctypes.c_uint64,   # boot_wall_ms (#1230 Part B: pre-boot tokens refused)
         ctypes.c_uint64,   # control_period_ms
         ctypes.c_uint32,   # missed_periods
         ctypes.c_double,   # stop_decel_mps2
@@ -428,6 +429,7 @@ class BoundKirraConsumer:
         expected_profile_digest: bytes,
         *,
         maximum_token_lifetime_ms: int,
+        boot_wall_ms: int,
         control_period_ms: int,
         missed_periods: int,
         stop_decel_mps2: float,
@@ -458,6 +460,7 @@ class BoundKirraConsumer:
             bytes(governor_vk),
             bytes(expected_profile_digest),
             ctypes.c_uint64(maximum_token_lifetime_ms),
+            ctypes.c_uint64(boot_wall_ms),
             ctypes.c_uint64(control_period_ms),
             ctypes.c_uint32(missed_periods),
             ctypes.c_double(stop_decel_mps2),

--- a/robot/kirra_motor_consumer.py
+++ b/robot/kirra_motor_consumer.py
@@ -44,6 +44,13 @@ Config — ALL required, NO defaults (fail-closed; a missing var aborts):
                                be driven under another platform's envelope.
                                Missing/uppercase/non-hex/wrong-length → abort.
     KIRRA_FRESHNESS_WINDOW_MS  MAXIMUM token lifetime (ms) the core will accept.
+                               NOTE (#1230): before Part B this value was ALSO
+                               the post-restart replay window — a pre-restart
+                               token stayed acceptable for its whole remaining
+                               lifetime after a restart cleared the watermarks.
+                               The boot fence (TokenPredatesBoot) removed that
+                               second role; keep it small anyway — it still
+                               bounds in-epoch token lifetime.
                                V2 enforces the signed `expires_at_ms`; this is
                                the upper bound on how long a mint may be valid
                                (a signer cannot hand itself an eternal token).
@@ -496,10 +503,19 @@ def main() -> int:
     topic = os.environ.get("KIRRA_RELEASE_TOPIC", "/kirra/release")
 
     # The evidence-bound V2 verify core (fail-closed: raises on a NULL handle).
+    # #1230 Part B: this process's boot instant, captured ONCE. The verify
+    # core refuses any token MINTED before it (TokenPredatesBoot, code 111) —
+    # a restart is a new trust epoch, so the post-restart replay window no
+    # longer scales with KIRRA_FRESHNESS_WINDOW_MS. Same-host clock domain
+    # per ADR-0033; the structural (clock-independent) epoch binding is
+    # Part A on the issue.
+    boot_wall_ms = int(time.time() * 1000)
+
     consumer = BoundKirraConsumer(
         governor_vk,
         profile_digest,
         maximum_token_lifetime_ms=maximum_token_lifetime_ms,
+        boot_wall_ms=boot_wall_ms,
         control_period_ms=control_period_ms,
         missed_periods=missed_periods,
         stop_decel_mps2=stop_decel_mps2,

--- a/src/bin/kirra_verifier_service/ros_release_mint_tests.rs
+++ b/src/bin/kirra_verifier_service/ros_release_mint_tests.rs
@@ -159,7 +159,7 @@ async fn enforced_200_mints_a_token_that_verifies_over_exactly_the_enforced_byte
     let token = kirra_verifier::governor_release::ReleaseToken::from_bytes(&token_bytes);
 
     // The SAME evidence-bound gate the V2 motor consumer runs.
-    let mut gate = RosBoundCommandGate::new(vk, [0x11; 32], 200);
+    let mut gate = RosBoundCommandGate::new(vk, [0x11; 32], 200, 0);
     let released = gate
         .release(
             &payload_bytes,


### PR DESCRIPTION
**Closes the lifetime-scaled restart replay window while preserving the clock-step remainder.** This is #1230's interim tier, not the epoch solution — Part A (structural binding) remains the ADR-0033 revision, and the issue stays open.

## What this establishes, and what it does not

> **Establishes:** under a monotonic-enough wall clock across restart, pre-boot tokens are rejected independently of their configured lifetime.

> **Does NOT establish:** restart trust is structurally bound to the new boot epoch.

So the acceptance criterion *"refusal is structural (epoch mismatch), not incidental"* stays unchecked until `TokenEpochMismatch` lands.

## The problem this removes

Before: the only thing refusing a pre-restart token was its own expiry, because all three gate watermarks are in-memory and a restart clears them. That made the post-restart replay window exactly `maximum_lifetime_ms` wide — a function of the **configurable** `KIRRA_FRESHNESS_WINDOW_MS` rather than of restart itself. A timing accident, not a designed invariant.

After: `RosBoundCommandGate` carries `boot_wall_ms`, captured once at process start, and refuses any token **minted** before it with the distinct `TokenPredatesBoot`. Raising the configured lifetime ten-fold now widens nothing — tested.

## ⚠ The assurance limit reviewers should hold

**`boot_wall_ms` is a captured process-start boundary, not a trusted hardware boot measurement.** The name is reasonable in context but the limit is real: a backward wall-clock step during the restart can place an old mint on the *apparent current side* of that boundary, and the fence is blind by construction. That is precisely why Part A remains necessary — a boot epoch inside the **signed** payload cannot be forged by a clock.

That bypass is pinned as a live expected-but-undesired test (`a_backward_clock_step_across_restart_reopens_the_window`), exactly as this file originally pinned the un-fenced gap, so it flips visibly when Part A lands rather than being remembered from prose.

The comparison is same-clock-domain, which is sound on the ADR-0033 single-host topology where verifier and consumer share one clock.

## Why a distinct refusal code, not a reuse of `Expired`

The two demand different operator actions, and collapsing them would erase that:

| Refusal | What to inspect |
|---|---|
| `Expired` (105) | timing, latency, token lifetime — the loop is slow |
| `TokenPredatesBoot` (111) | restart/replay behaviour — a restart happened and pre-boot traffic is being correctly discarded |

Carried through as a separate `token_predates_boot` counter in `BoundRefusalBreakdown` too, so telemetry can distinguish them without parsing.

## End-to-end ABI change, not a one-layer patch

`RosBoundCommandGate::new` → `BoundMotorConsumer::new` → `kirra_bound_consumer_new` (new `u64` param) → `kirra_ffi.py` `argtypes` in lockstep → `kirra_motor_consumer.py` capturing boot at startup. The `.so` and the Python binding ship together, so there is no version skew window. Both exhaustive `match`es on `RosBoundCommandRefusal` forced the new variant to be handled — those matches doing their job.

## Test changes

`restart_trust_epoch.rs` flips, as the file itself demanded:

- the deliberate expected-but-undesired assertion → the desired `TokenPredatesBoot` refusal, with ~140 ms of signed lifetime remaining;
- the exposure test → *"the window no longer scales with the configured lifetime"*, proven under a ten-fold lifetime;
- bootstrap proven deadlock-free: the first post-boot mint is admitted on the first cycle, and watermarks are live immediately after (non-vacuity — the refusals above must not be a gate that refuses everything);
- the strict `<` boundary pinned: minted-at-the-boot-instant is the current epoch;
- both-pre-boot-and-expired pinned, so a future reordering of the gate's checks cannot silently admit one case.

## Documentation

`KIRRA_FRESHNESS_WINDOW_MS`'s second role is documented **and retired** in the consumer docstring (it still bounds in-epoch token lifetime; it no longer bounds post-restart replay). `EVIDENCE_BINDING.md` §4.7 rewritten from "the gap" to the interim invariant plus the named Part A remainder.

## Verification

release-token 25 (7 restart) · actuation-consumer 74 · consumer-ffi 18 · robot host suites 32/32, 53/53, 8/8, 13/13 · `cargo fmt --check` and clippy clean. Re-run after rebasing onto the merged #1238.

Refs #1230 — **does not close it.** Part A (wire V3, consumer-published epoch channel attached by the interceptor, `TokenEpochMismatch`) is the ADR amendment tracked there.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjDFKPcBVHURDZpXsvnYhC)_