### PR TITLE
ci: make shellcheck failures and reports authoritative

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1573,11 +1573,46 @@ jobs:
             -A clippy::module_name_repetitions \
             -A clippy::must_use_candidate \
             2>&1 | tee clippy-report.txt
+      - name: ShellCheck gate self-test (the gate must be able to go red)
+        # Proves the step below actually GATES, rather than asserting it. Drives
+        # the same pipeline shape over a deliberately-bad throwaway script and
+        # requires a non-zero status; also requires a clean script to pass, an
+        # empty file list to FAIL rather than pass vacuously, and the report to
+        # still arrive intact through `tee`. Nothing in the tracked tree is
+        # modified. See scripts/test-shellcheck-gate.sh.
+        run: bash scripts/test-shellcheck-gate.sh
       - name: ShellCheck (shellcheck is preinstalled on the runner)
         # -S error: gate on real bugs, not style. The whole tracked script set is
         # error-clean today; a new error-level finding fails CI.
+        #
+        # GATING — three defects fixed together, because the first hid the others:
+        #
+        # 1. `set -o pipefail`. Without it the `| tee` pipeline returns TEE's
+        #    status and shellcheck's non-zero exit is discarded, so this step
+        #    could never go red. Measured on the pre-fix form: exit 0 on a tree
+        #    that had a real error-level finding. Same defect the #687 `cargo
+        #    audit` fix addressed; it was not applied here at the time.
+        # 2. One `shellcheck` invocation over the whole file list (`mapfile`, not
+        #    `xargs`), so the pipeline's status IS shellcheck's own — `xargs`
+        #    reports a generic 123 for "some child failed", which is red but
+        #    tells you nothing. An empty list is a hard failure, not a vacuous
+        #    pass: no tracked scripts means the glob or the checkout is wrong.
+        # 3. `LC_ALL=C.UTF-8`. shellcheck emits UTF-8; under a C/POSIX locale it
+        #    fails to write non-ASCII source lines to the pipe, TRUNCATING the
+        #    report and exiting 2. Observed in a `LANG=` environment. Pinning the
+        #    locale keeps the artifact readable wherever this runs.
+        #
+        # The report still goes through `tee` for the `if: always()` upload below.
         run: |
-          git ls-files -z -- '*.sh' | xargs -0 -r shellcheck -S error 2>&1 | tee shellcheck-report.txt
+          set -o pipefail
+          export LC_ALL=C.UTF-8
+          mapfile -d '' -t sh_files < <(git ls-files -z -- '*.sh')
+          if [ "${#sh_files[@]}" -eq 0 ]; then
+            echo "no tracked *.sh found — refusing to pass vacuously" >&2
+            exit 1
+          fi
+          echo "shellcheck -S error over ${#sh_files[@]} tracked script(s)"
+          shellcheck -S error "${sh_files[@]}" 2>&1 | tee shellcheck-report.txt
       - name: Install Helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
       - name: Lint the Helm chart

--- a/scripts/test-shellcheck-gate.sh
+++ b/scripts/test-shellcheck-gate.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# test-shellcheck-gate.sh — prove the CI ShellCheck step can actually go RED.
+#
+# A lint gate that cannot fail is worse than no gate: it reports green forever
+# and everyone stops looking. This repository shipped exactly that — the step ran
+# `… | tee shellcheck-report.txt` with no `set -o pipefail`, so the pipeline
+# returned TEE's status and shellcheck's non-zero exit was discarded. Measured on
+# the pre-fix form: exit 0 on a tree that had a real error-level SC2148 finding.
+# The same defect was fixed for `cargo audit` in #687 but never applied here.
+#
+# So this asserts the PROPERTY, not the wording: run the gate's pipeline shape
+# over a deliberately-bad throwaway script and require a non-zero status.
+#
+# Everything is generated under `mktemp -d`. Nothing tracked is written, and no
+# bad script is committed — a committed bad script would break the real gate,
+# which is the thing under test.
+#
+# Run: bash scripts/test-shellcheck-gate.sh   (exit 0 = the gate is real)
+set -euo pipefail
+
+# NOTE: the tool emits UTF-8; under a C/POSIX locale it cannot write non-ASCII
+# source lines to a pipe and TRUNCATES its report (exiting 2). The CI step pins
+# this for the same reason — see the comment on the ShellCheck step in ci.yml.
+# (This comment deliberately does not begin with the tool's name: a comment
+# starting `# shellcheck …` is parsed as a DIRECTIVE, which is SC1072/SC1073 at
+# error level. The fixed gate caught exactly that here.)
+export LC_ALL=C.UTF-8
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PASS=0
+FAIL=0
+
+ok() { printf '  ok   - %s\n' "$1"; PASS=$((PASS + 1)); }
+bad() { printf '  FAIL - %s\n' "$1"; FAIL=$((FAIL + 1)); }
+check() { if [ "$1" -eq 0 ]; then ok "$2"; else bad "$2"; fi; }
+
+command -v shellcheck >/dev/null 2>&1 || {
+    echo "test-shellcheck-gate: shellcheck not installed — cannot verify the gate" >&2
+    echo "(install it, or run this on the CI runner where it is preinstalled)" >&2
+    exit 2
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# ── the gate's pipeline shape, isolated ──────────────────────────────────────
+# Deliberately mirrors the CI step: pipefail + one invocation + tee. If the CI
+# step's shape changes, P7 below catches the divergence.
+run_gate() {
+    local report="$1"
+    shift
+    (
+        set -o pipefail
+        shellcheck -S error "$@" 2>&1 | tee "$report" >/dev/null
+    )
+}
+
+echo "== P1-P2: a real finding must produce a real failure =="
+
+# An error-level finding with no ambiguity: a sourced fragment with no shebang
+# and no shell directive is SC2148 (error) — the exact class this repo tripped.
+cat >"$WORK/bad_fragment.sh" <<'FRAGMENT'
+# no shebang, no shell directive: SC2148 at error level
+SOME_VALUE=1
+FRAGMENT
+
+set +e
+run_gate "$WORK/bad.txt" "$WORK/bad_fragment.sh"
+BAD_RC=$?
+set -e
+[ "$BAD_RC" -ne 0 ]
+check $? "P1. a script with an error-level finding FAILS the gate (exit $BAD_RC)"
+
+grep -q 'SC2148' "$WORK/bad.txt"
+check $? "P2. the finding still reaches the report through tee"
+
+echo "== P3: the historical bug is really a bug =="
+# The pre-fix pipeline shape, run over the SAME bad script. If this ever starts
+# failing, the masking has gone away on its own and this test's premise needs
+# revisiting — but until then it documents WHY pipefail is load-bearing.
+set +e
+bash -c 'shellcheck -S error "$1" 2>&1 | tee "$2" >/dev/null' _ \
+    "$WORK/bad_fragment.sh" "$WORK/masked.txt"
+MASKED_RC=$?
+set -e
+[ "$MASKED_RC" -eq 0 ]
+check $? "P3. WITHOUT pipefail the same finding exits 0 — the masking is real (got $MASKED_RC)"
+
+echo "== P4-P5: a clean script must still pass, and emptiness must not =="
+
+cat >"$WORK/clean.sh" <<'CLEAN'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "nothing to complain about"
+CLEAN
+
+set +e
+run_gate "$WORK/clean.txt" "$WORK/clean.sh"
+CLEAN_RC=$?
+set -e
+[ "$CLEAN_RC" -eq 0 ]
+check $? "P4. a clean script PASSES the gate (exit $CLEAN_RC)"
+
+# An empty file list must be a hard failure. `xargs -r` silently skips, which
+# would turn a broken glob or a bad checkout into a green run.
+set +e
+(
+    set -o pipefail
+    mapfile -d '' -t files < <(printf '')
+    if [ "${#files[@]}" -eq 0 ]; then exit 1; fi
+    shellcheck -S error "${files[@]}"
+)
+EMPTY_RC=$?
+set -e
+[ "$EMPTY_RC" -ne 0 ]
+check $? "P5. an EMPTY file list fails rather than passing vacuously (exit $EMPTY_RC)"
+
+echo "== P6: the sourced fragment is checked AS a fragment =="
+
+FRAG="$REPO_ROOT/tools/qnx-rtm-harness/judge_build_flags.sh"
+set +e
+run_gate "$WORK/frag.txt" "$FRAG"
+FRAG_RC=$?
+set -e
+[ "$FRAG_RC" -eq 0 ]
+check $? "P6a. judge_build_flags.sh passes the gate (exit $FRAG_RC)"
+
+grep -q '^# shellcheck shell=bash' "$FRAG"
+check $? "P6b. …because it DECLARES its dialect with a shell directive"
+
+! head -n 1 "$FRAG" | grep -q '^#!'
+check $? "P6c. …and NOT by gaining a shebang it does not deserve"
+
+[ ! -x "$FRAG" ]
+check $? "P6d. …and it is still not executable (it is sourced, never run)"
+
+# The fix must not have been achieved by muting the check everywhere. This file
+# is excluded because it necessarily contains the string it searches for — a
+# scanner that matches its own needle only ever finds itself.
+SELF="$(basename "${BASH_SOURCE[0]}")"
+if grep -rl 'disable=SC2148' "$REPO_ROOT/scripts" "$REPO_ROOT/tools" 2>/dev/null \
+        | grep -qv "/$SELF\$"; then
+    bad "P6e. SC2148 is blanket-disabled somewhere (that would hide real cases)"
+else
+    ok "P6e. SC2148 is not blanket-disabled anywhere"
+fi
+
+echo "== P7: the CI step still has the shape this test verifies =="
+
+CI="$REPO_ROOT/.github/workflows/ci.yml"
+# Comment lines are stripped before matching: the step's own comments explain WHY
+# it does not use xargs, and prose about a command must never be mistaken for the
+# command. Only the executable lines are inspected.
+CI_STEP="$(awk '/name: ShellCheck \(shellcheck is preinstalled/,/name: Install Helm/' "$CI" \
+    | grep -v '^[[:space:]]*#')"
+for needle in 'set -o pipefail' 'LC_ALL=C.UTF-8' 'mapfile -d' \
+              'tee shellcheck-report.txt' 'refusing to pass vacuously'; do
+    if printf '%s\n' "$CI_STEP" | grep -q -- "$needle"; then
+        ok "P7. the CI ShellCheck step still runs: $needle"
+    else
+        bad "P7. the CI ShellCheck step no longer runs: $needle"
+    fi
+done
+if printf '%s\n' "$CI_STEP" | grep -q 'xargs'; then
+    bad "P7. the CI step reverted to xargs (status would be xargs's 123, not shellcheck's)"
+else
+    ok "P7. the CI step does not route through xargs"
+fi
+
+echo "== P8: the whole tracked tree is error-clean under the fixed gate =="
+
+cd "$REPO_ROOT"
+mapfile -d '' -t tracked < <(git ls-files -z -- '*.sh')
+[ "${#tracked[@]}" -gt 0 ]
+check $? "P8a. the tracked script set is non-empty (${#tracked[@]} scripts)"
+
+set +e
+run_gate "$WORK/tree.txt" "${tracked[@]}"
+TREE_RC=$?
+set -e
+[ "$TREE_RC" -eq 0 ]
+check $? "P8b. every tracked script passes -S error (exit $TREE_RC)"
+[ "$TREE_RC" -eq 0 ] || sed -n '1,40p' "$WORK/tree.txt"
+
+echo
+if [ "$FAIL" -ne 0 ]; then
+    echo "== shellcheck gate self-test: $FAIL FAILED, $PASS passed =="
+    exit 1
+fi
+echo "== shellcheck gate self-test: all $PASS checks passed =="

--- a/tools/qnx-rtm-harness/judge_build_flags.sh
+++ b/tools/qnx-rtm-harness/judge_build_flags.sh
@@ -1,3 +1,12 @@
+# shellcheck shell=bash
+#
+# The directive above is how a SOURCED FRAGMENT declares its dialect. It is not a
+# shebang and does not make this file executable: the file has no shebang, is not
+# +x, and is only ever `source`d (see the two consumers below). Without it
+# ShellCheck cannot know the target shell and reports SC2148 at error level —
+# adding a shebang instead would assert this file can be run on its own, which is
+# false, and would invite someone to run it.
+#
 # judge_build_flags.sh — the SINGLE SOURCE for the QNX governor-judge codegen
 # flags (#790 F6). This file is `source`d by BOTH judge-build recipes:
 #   - scripts/build_qnx_judge_artifact.sh — the shipped-artifact cargo/build-std recipe
@@ -11,6 +20,8 @@
 # Treat it as a safety change — re-run the FDIT/RTM matrix (QNX_MAPPING.md).
 #
 # Not executable and has no shebang on purpose: it only assigns shell variables.
+# Its dialect is declared by the `# shellcheck shell=bash` directive at the top —
+# the array assignment below is bash, not POSIX sh.
 
 # Canonical scalar values (the ONE place these numbers live).
 KIRRA_JUDGE_EDITION=2021


### PR DESCRIPTION
The `Static Analysis (ISO 26262)` ShellCheck step could not fail. It has been
reporting green unconditionally since it was added, which is worse than having no
gate: a check that cannot go red stops being read.

Measured on the pre-fix form, verbatim from `ci.yml`:

```
$ git ls-files -z -- '*.sh' | xargs -0 -r shellcheck -S error 2>&1 \
      | tee shellcheck-report.txt
exit 0
```

Zero — on a tree that had a real error-level SC2148 finding.

## Three coupled defects

They are fixed together because the first hid the other two. Landing only the
first would knowingly turn CI red; suppressing SC2148 generically would hide
legitimate instances elsewhere.

**1. `tee` masked shellcheck's failure status.**
`tee` is the last command in the pipeline, so without `set -o pipefail` its exit
status *is* the pipeline's and shellcheck's is discarded. This is the identical
defect fixed for `cargo audit` in #687; it was never applied to this step.

**2. `xargs` collapsed shellcheck's status into a generic 123.**
Even with `pipefail`, routing through `xargs` reports 123 for "some child
failed" — red, but uninformative, and it conflates a lint finding with a
dispatch problem. The step now runs ONE `shellcheck` invocation over a
`mapfile`-collected file list, so the pipeline's status is shellcheck's own.
An empty file list is now a hard failure rather than an `xargs -r` no-op, so a
broken glob or an incomplete checkout cannot produce a vacuous green.

**3. A POSIX locale could truncate non-ASCII findings and return 2.**
shellcheck emits UTF-8. Under a C/POSIX locale it fails writing non-ASCII source
lines to the pipe, truncating the report and exiting 2. Observed in a `LANG=`
environment, where the artifact read `# judge_build_flags.sh For more
information:` with the finding itself eaten. `LC_ALL=C.UTF-8` pins it. A gate
whose diagnostics can be truncated, or whose status can be replaced by an
encoding error, does not reliably preserve its own evidence — so this is part of
making the gate truthful, not unrelated cleanup.

## The finding the broken gate was hiding

`tools/qnx-rtm-harness/judge_build_flags.sh` tripped SC2148 at error level.

It remains **intentionally source-only** and is now checked in its correct Bash
fragment context: a `# shellcheck shell=bash` directive declares its dialect. It
gains no shebang, stays non-executable, and is still only ever `source`d — by
`scripts/build_qnx_judge_artifact.sh` and `tools/qnx-rtm-harness/run_qnx_fdit.sh`,
both of which already carry `# shellcheck source=` directives. Adding a shebang
would assert the file can be run standalone, which is false and would invite
someone to try.

Its SC2034 findings are warning-level, below the `-S error` gate, and are
correct — those variables are consumed by the sourcing scripts. They are
deliberately left alone.

## Proving the gate can fail

`scripts/test-shellcheck-gate.sh` — 18 checks, wired in as a CI step immediately
before the gate itself, so this is a standing regression test rather than a
one-off demonstration.

| | |
|---|---|
| P1/P2 | a script with an error-level finding FAILS, and the finding still reaches the report through `tee` |
| P3 | the **pre-fix** pipeline shape exits 0 on that same script — the masking is reproduced, so the reason `pipefail` is load-bearing cannot be lost to a future cleanup |
| P4/P5 | a clean script passes; an EMPTY file list fails rather than passing |
| P6 | `judge_build_flags.sh` passes, and does so via a shell directive — no shebang, still non-executable, SC2148 not blanket-disabled anywhere |
| P7 | the CI step still runs `pipefail` / `LC_ALL` / `mapfile` / `tee`, and does NOT route through `xargs`. Comment lines are stripped before matching, so prose *about* a command is never mistaken for the command |
| P8 | all 52 tracked scripts pass `-S error` |

Everything is generated under `mktemp -d`. No bad script is committed — a
committed bad script would break the very gate under test.

## Verification

- The workflow's `run:` body executed verbatim: **exit 0** on the clean tree,
  **exit 1** with one deliberately-broken tracked script added.
- Both profiles of the self-test pass: 18/18.
- The fixed gate immediately caught a defect **in this patch**: a comment in the
  new test beginning `# shellcheck …` parses as a *directive* (SC1072/SC1073,
  error level). It passed locally only because the file was not yet tracked;
  once committed, CI would have gone red. Reworded, with the trap documented in
  place.

No unrelated shell findings are swept in: the tracked set was already
error-clean apart from the one fragment, and the severity threshold is unchanged.

## Review order

This PR is independent and sits directly on `main`. It should land **first** —
it improves the reliability of the CI evidence every later branch depends on.
Three further branches follow as a stack, each retargeted or rebased as its
dependency lands: `feat/robot-command-language` → `feat/kirra-engineering-assistant`
→ `feat/gemma-assistant-contract`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HaTMYY54Z5Gc4TryvETrum

---
_Generated by [Claude Code](https://claude.ai/code/session_01HaTMYY54Z5Gc4TryvETrum)_