### PR TITLE
proofs: pin K3b non-vacuity with reachable cover cases (#1242 follow-up)

### DIFF
--- a/docs/CAPTURE_PIPELINE_SPEC.md
+++ b/docs/CAPTURE_PIPELINE_SPEC.md
@@ -65,10 +65,36 @@ in `kirra_core::kinematics_contract` (relocated verbatim in de-monolith Stage 3;
 > implied acceleration, which is never emitted.
 >
 > EVIDENCE. `docs/safety/TALISMAN_CHANGE_PLAN_1242.md`,
-> `docs/safety/CLAMP_APPLICATION_INVENTORY.md`, Kani K6/K7 + their mirrors,
-> `crates/kirra-core/tests/speed_cap_lateral_envelope.rs`. K1–K5 mirrors green
-> (K3 intact by construction). Reviewer approval: **PENDING — must be recorded
-> here before merge.**
+> `docs/safety/CLAMP_APPLICATION_INVENTORY.md`, `MUTATION_BASELINE.md` §8,
+> Kani K3/K3b/K6 + K7's exhaustive grid mirror,
+> `crates/kirra-core/tests/speed_cap_lateral_envelope.rs`,
+> `crates/kirra-core/tests/rate_limit_epsilon_boundary.rs`.
+>
+> CORRECTION (post-merge). This note previously read "K1–K5 mirrors green (K3
+> intact by construction)". **K3 was NOT intact.** Widening which paths are
+> reachable put the P6 `tan` on the paths K3 quantifies over, and Kani fails a
+> harness whenever an unsupported foreign call is REACHABLE, whether or not an
+> assertion depends on its value — K3, K3b, K6 and K7 all failed with
+> `call to foreign "C" function 'tan' is not currently supported`, with no
+> assertion violated. Resolved by MODELLING `tan`/`atan`/`powi` in the proof
+> crate (axioms A1/A2/A3; the talisman is not modified for the prover), after
+> which 13/13 per-PR harnesses discharge. K7 is deferred to the weekly
+> `deep-proofs` lane WITHOUT a measured budget — it was stopped at 23 min of
+> CBMC time with no verdict — so its per-PR gate is a 306,180-point exhaustive
+> grid, not a proof. The residual honest exclusion is narrower than before: the
+> P6 numeric envelope VALUE is still not proved, because under the model the
+> proofs never evaluate a real `tan`.
+>
+> The generalizable lesson for the NEXT talisman amendment: ask not "does my new
+> property reach a construct CBMC cannot model?" but "does this change put such
+> a construct on any path an EXISTING harness quantifies over?"
+>
+> Reviewer approval: **NOT RECORDED. Still outstanding.** The amendment was
+> merged in PR #1244 with all 32 CI lanes green, but the named-reviewer approval
+> this note requires was never written here — so the gate was passed over, not
+> satisfied. Recording it retrospectively is the approver's action, not the
+> author's; this line is left open deliberately rather than closed to make the
+> record tidy.
 >
 > Any FURTHER change re-pins again + re-runs the
 > WCET/MC-DC/proptest gates.

--- a/verification/kani/src/proofs_kinematics.rs
+++ b/verification/kani/src/proofs_kinematics.rs
@@ -229,6 +229,37 @@ mod proofs {
         if let Some((linear, steering)) = executed_pair(&cmd, &action) {
             let linear_corrected = linear != cmd.linear_velocity_mps;
             let steering_corrected = steering != cmd.steering_angle_deg;
+
+            // NON-VACUITY. The assertion below is an IMPLICATION, so it holds
+            // trivially wherever its antecedent is unsatisfiable — and the
+            // antecedent is value-dependent, which under the #1242 solver model
+            // makes it a live concern rather than a theoretical one: `steering`
+            // comes from a nondeterministic `atan` restricted by axiom A3, and
+            // an A3 that over-restricted could collapse `steering_corrected` to
+            // false and turn this proof into a proof of nothing. It does not
+            // (both covers below are SATISFIED), but that is a measurement of
+            // today's model, not a property of the harness — a later change to
+            // A3, to `any_bounded_contract`, or to the kernel could remove it
+            // silently. Kani reports an unsatisfiable cover as a FAILURE, so
+            // these two lines are what make that silent.
+            //
+            // The SECOND cover is the load-bearing one, and it is not implied
+            // by the first: the antecedent could be reachable only on paths
+            // where the conclusion is forced for some unrelated reason, which
+            // would satisfy cover 1 while still exercising nothing about the
+            // composition rule. Requiring the antecedent to be reachable
+            // TOGETHER WITH `ClampBoth` pins the case the property is about.
+            kani::cover!(
+                linear_corrected && steering_corrected,
+                "K3b antecedent is satisfiable"
+            );
+            kani::cover!(
+                linear_corrected
+                    && steering_corrected
+                    && matches!(action, EnforceAction::ClampBoth { .. }),
+                "K3b antecedent is reachable together with the ClampBoth conclusion"
+            );
+
             if linear_corrected && steering_corrected {
                 assert!(
                     matches!(action, EnforceAction::ClampBoth { .. }),


### PR DESCRIPTION
Focused follow-up to #1244 (merged). One commit, no kernel change, **talisman blob untouched** — `talisman_gate` re-run and green on `6a61b74f`.

## 1. The covers

K3b asserts an **implication**, so it holds trivially wherever its antecedent is unsatisfiable. Under the #1242 solver model that is a live concern rather than a theoretical one: `steering` comes from a nondeterministic `atan` restricted by axiom **A3**, and an A3 that over-restricted could collapse `steering_corrected` to false and turn the proof into a proof of nothing.

It does not — but that was a measurement of one model at one commit, not a property of the harness. Kani reports an unsatisfiable cover as a **failure**, so committing the two covers is what makes a future regression loud instead of silent.

```rust
kani::cover!(linear_corrected && steering_corrected, ...);
kani::cover!(
    linear_corrected && steering_corrected
        && matches!(action, EnforceAction::ClampBoth { .. }), ...);
```

**The second cover is load-bearing and is not implied by the first.** The antecedent could be reachable only on paths where the conclusion is forced for some unrelated reason — satisfying cover 1 while exercising nothing about the composition rule. Requiring the antecedent to be reachable *together with* `ClampBoth` pins the case the property is actually about. The inline comment says so, so it does not get "simplified" away later.

Verified: `2 of 2 cover properties satisfied`, K3b still `SUCCESSFUL` (17 s), mirror tier 117 passed, fmt clean.

## 2. Two corrections to the #1242 re-pin note

`docs/CAPTURE_PIPELINE_SPEC.md` is the authoritative talisman pin record. Both of these merged unchanged in #1244 and are wrong on `main` today.

**a. "K1–K5 mirrors green (K3 intact by construction)" — K3 was NOT intact.** Widening which paths are reachable put the P6 `tan` on the paths K3 quantifies over, and Kani fails a harness whenever an unsupported foreign call is *reachable*, whether or not an assertion depends on its value. K3, K3b, K6 and K7 all failed with `call to foreign "C" function 'tan' is not currently supported`, **no assertion violated**. The note now records what actually happened, the resolution (modelling `tan`/`atan`/`powi` in the proof crate, axioms A1/A2/A3, talisman not modified for the prover), K7's deferral *without* a measured budget, and the narrower residual exclusion — the P6 numeric envelope value is still unproved, because under the model the proofs never evaluate a real `tan`.

It also records the generalizable lesson, since this will recur: ask not *"does my new property reach a construct CBMC cannot model?"* but *"does this change put such a construct on any path an **existing** harness quantifies over?"*

**b. "Reviewer approval: PENDING — must be recorded here before merge" survived the merge.** So the record simultaneously asserts a gate that must precede a merge which has already happened.

**I did not close this.** It is restated as `NOT RECORDED. Still outstanding.`, noting that the amendment merged with all 32 lanes green but no named approval written — i.e. the gate was **passed over, not satisfied**. Recording approval retrospectively is the approver's action, not the author's, and I have no name to write. Deleting the line would have made the record tidy and false; leaving it as "before merge" would have made it incoherent.

**If someone did approve out of band, that line is where their name belongs** — and that is the one reviewer action this PR actually asks for. If you would rather the wording were different, say so and I will change it; I have no attachment to the phrasing, only to it not reading as satisfied.

## Why this was not folded into #1244

Deliberately. #1244 was already before an independent reviewer for a talisman amendment; adding a third commit mid-review would have changed the evidence package after approval was requested, for something that does not alter the validity of any claim in it.

---
_Generated with [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01WjDFKPcBVHURDZpXsvnYhC

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjDFKPcBVHURDZpXsvnYhC)_