### PR TITLE
docs(safety): make the talisman separation-of-duties control achievable, and record #1242 as an exception

### DIFF
--- a/docs/CAPTURE_PIPELINE_SPEC.md
+++ b/docs/CAPTURE_PIPELINE_SPEC.md
@@ -89,12 +89,30 @@ in `kirra_core::kinematics_contract` (relocated verbatim in de-monolith Stage 3;
 > property reach a construct CBMC cannot model?" but "does this change put such
 > a construct on any path an EXISTING harness quantifies over?"
 >
-> Reviewer approval: **NOT RECORDED. Still outstanding.** The amendment was
-> merged in PR #1244 with all 32 CI lanes green, but the named-reviewer approval
-> this note requires was never written here — so the gate was passed over, not
-> satisfied. Recording it retrospectively is the approver's action, not the
-> author's; this line is left open deliberately rather than closed to make the
-> record tidy.
+> Reviewer approval: **RECORDED RETROSPECTIVELY — `justinlooney` (repository
+> owner), 2026-07-30.** Two qualifications belong in the record rather than in
+> the conversation that produced it:
+>
+> 1. **Retrospective, not pre-merge.** This note required the approval to be
+>    written here *before* merge. It was not: the amendment merged in PR #1244
+>    with all 32 CI lanes green and this line still reading PENDING. The gate was
+>    passed over and then closed after the fact. The change is not thereby
+>    unreviewed, but the sequencing control did not hold, and a future audit
+>    should read it as "approved late" rather than "approved on schedule".
+> 2. **Not independent of the author.** The requirement names an *independent*
+>    reviewer. PR #1244 was authored under the same account that approves it
+>    here, so author and approver are the same principal. That is a legitimate
+>    call for the accountable owner of a single-maintainer repository to make —
+>    it is not a substitute for a second pair of eyes, and it should not be cited
+>    as one in a certification context.
+>
+> What the approval covers: the Priority-2 accumulate change and its blob re-pin
+> `ed00f4da…` → `6a61b74f…`; the proof-crate transcendental model and its axioms
+> A1/A2/A3 (A3 being the load-bearing one — it is the assumption the deferred K7
+> P-RACK result rests on); K7's provisional, unbudgeted deferral to the weekly
+> lane; and the accepted `:544` equivalent mutant. It does NOT cover #1243, the
+> acceleration-enforcement gap, which is tracked separately with its own
+> evidence.
 >
 > Any FURTHER change re-pins again + re-runs the
 > WCET/MC-DC/proptest gates.

--- a/docs/CAPTURE_PIPELINE_SPEC.md
+++ b/docs/CAPTURE_PIPELINE_SPEC.md
@@ -89,30 +89,54 @@ in `kirra_core::kinematics_contract` (relocated verbatim in de-monolith Stage 3;
 > property reach a construct CBMC cannot model?" but "does this change put such
 > a construct on any path an EXISTING harness quantifies over?"
 >
-> Reviewer approval: **RECORDED RETROSPECTIVELY — `justinlooney` (repository
-> owner), 2026-07-30.** Two qualifications belong in the record rather than in
-> the conversation that produced it:
+> Independent approval: **NOT OBTAINED. This amendment proceeded under a
+> RECORDED EXCEPTION** to the separation-of-duties control, per
+> `docs/safety/TALISMAN_AMENDMENT_POLICY.md` §2.2. It is deliberately NOT
+> written as "approval with a caveat": a control that any caveat can satisfy is
+> not a control, and the author's own acknowledgement is not second-principal
+> approval. The five mandatory fields follow.
 >
-> 1. **Retrospective, not pre-merge.** This note required the approval to be
->    written here *before* merge. It was not: the amendment merged in PR #1244
->    with all 32 CI lanes green and this line still reading PENDING. The gate was
->    passed over and then closed after the fact. The change is not thereby
->    unreviewed, but the sequencing control did not hold, and a future audit
->    should read it as "approved late" rather than "approved on schedule".
-> 2. **Not independent of the author.** The requirement names an *independent*
->    reviewer. PR #1244 was authored under the same account that approves it
->    here, so author and approver are the same principal. That is a legitimate
->    call for the accountable owner of a single-maintainer repository to make —
->    it is not a substitute for a second pair of eyes, and it should not be cited
->    as one in a certification context.
+> 1. **Author of the change.** `justinlooney` (via Claude Code operating on that
+>    account) — commits on `claude/ros-bound-proposal-migration-nso5d2`, merged
+>    as PR #1244.
+> 2. **Why no eligible independent reviewer was available.** Structural: this is
+>    a single-maintainer repository with no second human principal holding
+>    review rights. No escalation path existed to attempt, which is itself the
+>    finding — the constraint is standing, not incidental to this change.
+> 3. **Who accepted the exception.** `justinlooney` (repository owner),
+>    2026-07-30, as the accountable authority owning the residual risk.
+> 4. **Evidence independently machine-checked.** This is what substitutes for
+>    the missing human, so it is named specifically rather than as "CI green":
+>    13/13 per-PR Kani harnesses discharged under the transcendental model
+>    (K1–K6 symbolic; K7 deferred, see the residual risk below); the 306,180-point
+>    exhaustive P-CAP/P-RACK grid; the mutation gate at 19 mutants / 18 caught /
+>    1 unviable / 0 missed, with the three tolerance-boundary kills verified by
+>    hand-applying each mutation; K3b non-vacuity proven by two `kani::cover!`
+>    properties; the `powi(2) == v * v` bit-identity measured across subnormals,
+>    exponent extremes and the operating range; and the four-location blob pin
+>    gate re-run against `6a61b74f`.
+> 5. **Residual risk from the absent human independence.** Machine checks
+>    establish that the stated properties hold; they cannot establish that they
+>    are the RIGHT properties, and nobody independent examined the judgement
+>    calls. Concretely: **axiom A3** — the inverse-monotone relation coupling
+>    the `tan`/`atan` model — is assumed, not proved, and the deferred K7 P-RACK
+>    result rests on it; a malformed A3 would not be caught by any gate here.
+>    K7's demotion to the weekly lane is provisional with no measured budget, so
+>    "deferred" could in principle become "never discharged" without anyone
+>    noticing. And the scope boundary below (that #1243 is excluded) is an
+>    author's judgement that no second party tested.
 >
-> What the approval covers: the Priority-2 accumulate change and its blob re-pin
-> `ed00f4da…` → `6a61b74f…`; the proof-crate transcendental model and its axioms
-> A1/A2/A3 (A3 being the load-bearing one — it is the assumption the deferred K7
-> P-RACK result rests on); K7's provisional, unbudgeted deferral to the weekly
-> lane; and the accepted `:544` equivalent mutant. It does NOT cover #1243, the
-> acceleration-enforcement gap, which is tracked separately with its own
-> evidence.
+> **Sequencing also failed, separately.** This note required the approval to be
+> written here BEFORE merge. It was not: #1244 merged with all 32 lanes green
+> and this line still reading PENDING; the exception was recorded afterwards. A
+> future audit should read this as "merged, then documented" — not "approved on
+> schedule".
+>
+> What the exception covers: the Priority-2 accumulate change and its blob
+> re-pin `ed00f4da…` → `6a61b74f…`; the proof-crate transcendental model and its
+> axioms A1/A2/A3; K7's provisional, unbudgeted deferral; and the accepted
+> `:544` equivalent mutant. It does NOT cover #1243, the acceleration-enforcement
+> gap, which is tracked separately with its own evidence.
 >
 > Any FURTHER change re-pins again + re-runs the
 > WCET/MC-DC/proptest gates.

--- a/docs/safety/CLAMP_APPLICATION_INVENTORY.md
+++ b/docs/safety/CLAMP_APPLICATION_INVENTORY.md
@@ -139,11 +139,14 @@ Talisman work, so the bar is higher than a normal fix:
       (4) the `rustfmt gate` workflow step, which HARDCODED the old prefix in its
       grep and so failed with an empty `pinned ` on the first legitimate re-pin —
       now anchored on the path instead of the value, matching (2)'s convention.
-      Reviewer approval **RECORDED RETROSPECTIVELY** — `justinlooney` (repository
-      owner), 2026-07-30, after the merge rather than before it, and not
-      independent of the author. Both qualifications are stated in the re-pin
-      note itself (`docs/CAPTURE_PIPELINE_SPEC.md`) so they travel with the
-      record rather than living only here;
+      Independent approval **NOT OBTAINED** — this amendment proceeded under a
+      **recorded exception** to the separation-of-duties control
+      (`docs/safety/TALISMAN_AMENDMENT_POLICY.md` §2.2), accepted by
+      `justinlooney` (repository owner) on 2026-07-30, and recorded after the
+      merge rather than before it. The five mandatory exception fields — author,
+      why no independent reviewer existed, who accepted, what was independently
+      machine-checked, and the residual risk — are in the re-pin note itself
+      (`docs/CAPTURE_PIPELINE_SPEC.md`) so they travel with the record;
 - [ ] FDIT matrix re-baseline for site 2 if released bytes change.
 
 The regression test uses the simulator's own formula and tolerance

--- a/docs/safety/CLAMP_APPLICATION_INVENTORY.md
+++ b/docs/safety/CLAMP_APPLICATION_INVENTORY.md
@@ -139,7 +139,11 @@ Talisman work, so the bar is higher than a normal fix:
       (4) the `rustfmt gate` workflow step, which HARDCODED the old prefix in its
       grep and so failed with an empty `pinned ` on the first legitimate re-pin —
       now anchored on the path instead of the value, matching (2)'s convention.
-      Reviewer approval remains **PENDING**;
+      Reviewer approval **RECORDED RETROSPECTIVELY** — `justinlooney` (repository
+      owner), 2026-07-30, after the merge rather than before it, and not
+      independent of the author. Both qualifications are stated in the re-pin
+      note itself (`docs/CAPTURE_PIPELINE_SPEC.md`) so they travel with the
+      record rather than living only here;
 - [ ] FDIT matrix re-baseline for site 2 if released bytes change.
 
 The regression test uses the simulator's own formula and tolerance

--- a/docs/safety/TALISMAN_AMENDMENT_POLICY.md
+++ b/docs/safety/TALISMAN_AMENDMENT_POLICY.md
@@ -1,0 +1,100 @@
+# Talisman amendment policy — separation of duties on the frozen kernel
+
+**Status:** normative. Applies to every change to the frozen kinematics talisman
+(`crates/kirra-core/src/kinematics_contract.rs`) and to its blob-hash re-pin.
+
+Scope note: this governs the **human control** around a talisman amendment. The
+mechanical procedure — what to record, which four pin locations must agree,
+which gates to re-run — is Step 6 of the change plan for the amendment in hand
+(`TALISMAN_CHANGE_PLAN_1242.md` §6 is the worked example). This document
+governs *who approves*, and what happens when nobody eligible exists.
+
+---
+
+## 1. Why this document exists
+
+The previous control read: *"reviewer approval, named"*, with the #1242 re-pin
+note requiring it to be recorded **before merge**. Both halves failed on first
+contact. #1242 merged with the approval line still reading `PENDING`, and the
+approval that was eventually recorded came from the same principal who authored
+the change.
+
+The tempting repair is to write "approval, with a caveat" and move on. That is
+the one repair that must not be made. A control which is *always* satisfied —
+because the caveat absorbs every failure — is not a control. It is a sentence.
+
+So the control is split into a normal path and an explicitly-flagged fallback,
+and a reviewer can now answer a **binary** question about any talisman
+amendment:
+
+> Does second-principal approval exist, **or** does a formally recorded
+> exception exist?
+
+There is no third answer. In particular, the author's own acknowledgement is
+**not** an answer — it is the fallback path, and the fallback path has
+mandatory content.
+
+## 2. The control
+
+> **Talisman blob changes require approval from a second named reviewer before
+> merge. If no eligible independent reviewer is available, the change must not
+> claim independent approval; instead, record the limitation, the attempted
+> escalation, and the named authority accepting the residual procedural risk.**
+
+### 2.1 Normal path — second-principal approval
+
+A named reviewer who is **not** the author of the change approves the amendment,
+and the approval is recorded in the re-pin note in
+`docs/CAPTURE_PIPELINE_SPEC.md` **before** the merge, not after.
+
+"Not the author" means a different human principal. An account that authored the
+commits — including one operating an automated assistant — is the author, not a
+reviewer, regardless of which of them typed the approval.
+
+### 2.2 Fallback path — a recorded exception
+
+If no eligible independent reviewer is available, the change proceeds **only** as
+a formally recorded **exception to the control**. It is not approval. The
+re-pin note must state, explicitly, that the control was not satisfied, and must
+carry all five of the following:
+
+| # | Field | Why it is mandatory |
+|---|---|---|
+| 1 | **Who authored the change** | Establishes the principal the reviewer would have had to be independent of. Without it "independent" is unverifiable. |
+| 2 | **Why no eligible independent reviewer was available** | Distinguishes a structural constraint (single-maintainer repository) from an avoidable one (nobody was asked, or the deadline was tight). Only the first is a legitimate standing reason. |
+| 3 | **Who accepted the exception** | A named authority owns the residual risk. An exception nobody owns is an excuse. |
+| 4 | **Exactly which evidence was independently machine-checked** | This is what actually substitutes for the missing human. Name the specific gates and their results, not "CI was green". Machine checks are independent of the author in a way the author's own reading is not. |
+| 5 | **What residual risk remains because human independence was unavailable** | Names what the machine checks cannot cover — typically judgement-shaped questions: is the property the right property, is an assumption sound, is the scope correctly drawn. |
+
+### 2.3 The fallback must stay rare and auditable
+
+Every exception is a debt against the safety case. Two consequences:
+
+- **Auditable.** Because the required fields are fixed, an auditor can grep the
+  pin history for exceptions and check each one has all five. A partially-filled
+  exception is a finding.
+- **Rare.** A repository where every amendment takes the fallback path has not
+  implemented separation of duties; it has documented that it lacks one. That
+  may be an acceptable state, but it should be visible as a standing gap rather
+  than rediscovered one exception at a time.
+
+## 3. What the exception explicitly does not license
+
+- It does **not** license claiming independent approval anywhere else — commit
+  messages, PR descriptions, release notes, or certification submissions.
+- It does **not** convert into approval later by the passage of time or by the
+  change proving uneventful in service.
+- It does **not** lower the evidence bar. Every mechanical gate in the change
+  plan's Step 6 still applies in full. The exception concerns *who signed*, not
+  *what was checked* — and since the machine-checked evidence is what carries
+  the weight when human independence is absent, weakening it under an exception
+  would be exactly backwards.
+
+## 4. Recorded exceptions
+
+| Amendment | Blob | Path taken | Where recorded |
+|---|---|---|---|
+| #1242 — Priority 2 accumulates past the speed ceiling | `ed00f4da…` → `6a61b74f…` | **Exception** (§2.2) — single-maintainer repository, author and accepting authority the same principal; additionally recorded *after* merge rather than before | `docs/CAPTURE_PIPELINE_SPEC.md`, re-pin note |
+
+This table is the audit entry point. Any future amendment taking the fallback
+path is appended here as well as recorded in the pin note.

--- a/docs/safety/TALISMAN_CHANGE_PLAN_1242.md
+++ b/docs/safety/TALISMAN_CHANGE_PLAN_1242.md
@@ -389,7 +389,11 @@ The re-pin is a deliberate act and must read as one. Record, in
   restated so the scope stays honest;
 - **regression results**, including the before/after of the previously-ignored
   test;
-- **reviewer approval**, named;
+- **approval**, per `docs/safety/TALISMAN_AMENDMENT_POLICY.md` — either a named
+  second-principal approval recorded BEFORE merge (§2.1), or a formally recorded
+  **exception** carrying all five mandatory fields (§2.2). "Named reviewer" alone
+  is no longer sufficient wording: it does not distinguish the two, and this
+  amendment is the case that showed why — it took the exception path;
 - an explicit statement that this re-pin acknowledges an **intentional kernel
   behaviour change** — commands on the speed-cap branch that previously returned
   `ClampLinear` now return `ClampBoth` — and is **not** formatting drift or an


### PR DESCRIPTION
Two commits, **docs only** — no code, talisman blob untouched, `talisman_gate` re-run green on `6a61b74f`.

> **Scope changed after this PR was opened.** It began as just the #1242 approval record. It now also defines the policy that record has to satisfy, because writing the record exposed that the control it was satisfying could not be satisfied. Flagging that explicitly since merge had been authorized for the narrower version.

## The problem

The old control read *"reviewer approval, named"*, required before merge. Both halves failed on first contact: #1242 merged with the line still reading `PENDING`, and the approval eventually recorded came from the same principal who authored the change.

The tempting repair is **"approval, with a caveat"** — which is what this PR's first commit did. That is the one repair that must not be made. A control that any caveat can satisfy is not a control; it is a sentence. Repeat it twice and it becomes a pattern that reads like separation of duties while providing none.

## The control, split so it is testable

A reviewer can now answer a **binary** question about any talisman amendment:

> Does second-principal approval exist, **or** does a formally recorded exception exist?

There is no third answer. The author's own acknowledgement is not one — it *is* the fallback path, and the fallback path has mandatory content.

**Normal path (§2.1)** — a named reviewer who is not the author approves, recorded **before** merge. "Not the author" means a different human principal; an account that authored the commits is the author regardless of which of them typed the approval.

**Fallback path (§2.2)** — an explicit **exception to the control**, never "approval with a caveat", carrying five mandatory fields:

| # | Field | Why mandatory |
|---|---|---|
| 1 | Who authored | Establishes who the reviewer had to be independent *of* |
| 2 | Why no eligible reviewer existed | Separates a structural constraint from an avoidable one |
| 3 | Who accepted the exception | An exception nobody owns is an excuse |
| 4 | Exactly which evidence was machine-checked | This is what substitutes for the missing human |
| 5 | Residual risk from the absent independence | Names what machines cannot cover |

The exception does not license claiming independent approval elsewhere, does not ripen into approval over time, and **does not lower the evidence bar** — since machine-checked evidence carries the weight when the human is absent, weakening it under an exception would be exactly backwards.

§4 is an audit entry point: a table of every amendment taking the fallback path. Fixed fields mean a partially-filled exception is a finding.

## #1242 reframed

The record previously read *"RECORDED RETROSPECTIVELY … two qualifications"* — precisely the shape the policy now forbids. It now reads **NOT OBTAINED**, proceeding under a recorded exception, with all five fields filled.

Field 4 names the specific checks rather than "CI was green", because those are what stand in for the missing reviewer: 13/13 Kani harnesses under the transcendental model, the 306,180-point exhaustive grid, the mutation gate at 0 missed with each boundary kill verified by hand-applying its mutation, K3b non-vacuity via two `cover!` properties, the `powi` bit-identity measurement, and the four-location pin gate.

Field 5 names what they cannot cover, and is the part worth reading:

- **axiom A3 is assumed, not proved**, and the deferred K7 P-RACK result rests on it — a malformed A3 would not be caught by any gate here;
- **K7's deferral is unbudgeted**, so "deferred" could become "never discharged" without anyone noticing;
- the **scope boundary excluding #1243** is an author's judgement that no second party tested.

Sequencing is recorded as having failed separately: merged first, documented after.

## Consistency

`CLAMP_APPLICATION_INVENTORY.md`'s closure checklist and `TALISMAN_CHANGE_PLAN_1242.md` §6 both now point at the policy, so the three cannot drift. §6's old wording — "reviewer approval, named" — is retired for being unable to distinguish the two paths.

#1243's evidence checklist already requires approval **before** merge; it will be updated to cite this policy once merged.

---
_Generated with [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01WjDFKPcBVHURDZpXsvnYhC