### PR TITLE
assistant: clarify deterministic unresolved requests

### DIFF
--- a/docs/KIRRA_ENGINEERING_ASSISTANT.md
+++ b/docs/KIRRA_ENGINEERING_ASSISTANT.md
@@ -1281,3 +1281,90 @@ Tests use a schema fixture shaped like the measured `0b952d1d` artifact
 (`robot/testdata/assistant_contract_report_fixture.json`). **That is a fixture,
 not a measurement** — no unit test requires a live Gemma or Ollama process, and
 passing them is not a live-model result.
+
+---
+
+## 16. Deterministic ambiguity — asking instead of giving up
+
+### The three-way contract
+
+`assistant.classify()` had two outcomes where it needed three:
+
+```
+recognized operation + resolved target    -> MATCHED
+recognized operation + UNRESOLVED target  -> AMBIGUOUS   (ask which)   ← was missing
+unrecognized operation                    -> NO_MATCH    (say so honestly)
+```
+
+"Sync it." and "Publish." fell to `NO_MATCH`, so the robot answered *"I don't
+have a tool for that"* when the honest answer is *"sync **what**?"*. That was
+always **safe** — no tool was selected — but it was the wrong thing to say, and
+it was wrong on the deterministic path, which is the path that actually ships.
+
+Measured before and after, on the same 61-case corpus with no model involved:
+
+| | before | after |
+|---|---:|---:|
+| clarification cases handled | 1/7 | **7/7** |
+| deterministic pass overall | 51/61 | **57/61** |
+
+The four remaining misses are the pre-existing `gap_*` cases; the failing set
+went from ten to exactly its four-element subset, so nothing regressed.
+
+### Why this was chosen over a fifth prompt revision
+
+The four remaining *selection* misses — `gap_search_responsible`,
+`gap_search_how_do_we`, `gap_status_summary`, `gap_component_about`, and the
+four positive-selection misses in the assist-4 run — are **already resolved
+correctly by `classify()`**. Production never routes them to the model. Tuning a
+prompt against them would improve a benchmark path that does not ship while
+leaving the operator-facing problem untouched. Ambiguity was the opposite: it
+failed on *both* paths.
+
+### Target resolution is shared, not copied
+
+The mutation half of the rule calls
+`assistant_admission.has_resolved_mutation_target()` — the same predicate the
+admission screen applies to a *model proposal*, on the same normalized text.
+Restating its vocabulary inside `assistant.py` would let the two drift: a
+request could be refused as target-less by the classifier and admitted as
+targeted by the screen. Three invariants make that contradiction impossible
+rather than merely unlikely — no request is both target-ambiguous and admitted
+as targeted, the converse, and raw vs classifier-normalized text resolving
+identically.
+
+Scope is narrow by construction: the mutation verb must be in **command
+position** (so "what is the publish policy?" is not a request to publish), the
+vague-inspection rule needs a **bare pronoun** object (so "have a look at
+robot/wake_word.py" is untouched), and only an **empty** subject promotes a
+family — a subject that is merely unparseable ("have you read the docs?") stays
+`NO_MATCH`, because the operator named something and "which one do you mean?"
+would be the wrong question.
+
+`check the state of the steering code` is ambiguous for a different reason — the
+target is clear, the *operation* is not — so it is expressed with the existing
+two-distinct-hits rule rather than the target detector.
+
+### Two named evaluations
+
+A report now carries both, and they answer different questions:
+
+| evaluation | scope | question |
+|---|---|---|
+| **Full contract** | all 61 cases | Can the model satisfy the advertised contract if asked to perform selection? |
+| **Shipping-path residual** | cases the router leaves to the model | Is the model adequate for the requests production actually sends it? |
+
+A case reaches the model only on `NO_MATCH`: a resolved tool runs
+deterministically, and an AMBIGUOUS verdict asks the operator — neither consults
+the model for selection. Cases the router resolves are listed as **not
+production-exposed** so a model miss on them stays visible without being read as
+production risk.
+
+🔴 **Readiness is still judged on the full 61 cases, and remains `NOT_READY`.**
+Swapping the gate onto the residual *after* seeing which cases failed would make
+it easier by excluding the failures — the measurement would then describe a
+corpus chosen to flatter it. Whether readiness should eventually be a
+full-contract gate, a residual gate, or a conjunction of both is a deliberate
+**acceptance-policy version**, not something to settle by re-slicing existing
+evidence. §14.13 steps 4–5 remain blocked: fixing deterministic clarification
+does not justify wiring model tool selection into Channel B.

--- a/robot/assistant.py
+++ b/robot/assistant.py
@@ -35,6 +35,7 @@ import re
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import assistant_admission as adm  # noqa: E402 — the shared target-resolution test
 import assistant_tools as at  # noqa: E402
 
 # ── roles: policy + context profiles, NOT personas ───────────────────────────
@@ -123,6 +124,12 @@ _STATUS_PATTERNS = (
     r"\bare we ahead\b", r"\bahead of origin\b", r"\bbehind origin\b",
     r"\brepo(?:sitory)? status\b", r"\bshow me the repo(?:sitory)? status\b",
     r"\bgit status\b", r"\bwhere are we\b",
+    # Deliberately ALSO in `_SEARCH_PATTERNS`. "check the state of the steering
+    # code" could mean repository state or a code search, and the existing
+    # two-distinct-hits rule is how this classifier already says "ask, never
+    # pick". This is operation ambiguity, not target ambiguity — the target is
+    # perfectly clear, it is the operation that is not.
+    r"\bcheck the state of\b",
 )
 _SEARCH_PATTERNS = (
     r"\bwhere is\b", r"\bwhere.s\b", r"\bfind (?:the|a|me)\b", r"\bfind where\b",
@@ -130,6 +137,7 @@ _SEARCH_PATTERNS = (
     r"|calls|configures)\b",
     r"\bwho owns\b", r"\bsearch (?:for|the repo)\b", r"\blocate\b",
     r"\bwhere do we\b", r"\bwhere does\b",
+    r"\bcheck the state of\b",   # see the note in `_STATUS_PATTERNS`
 )
 _READ_PATTERNS = (
     r"\bread\b", r"\bshow me (?:the )?(?:file|source|code)\b", r"\bopen the file\b",
@@ -274,6 +282,68 @@ def _extract_quoted_or_tail(text, keywords):
 #: A subject that is just a stop-word carries no query.
 _EMPTY_SUBJECTS = {"", "it", "this", "that", "there", "here", "them"}
 
+
+# ── recognized operation, unresolved target ──────────────────────────────────
+#
+# Three outcomes, and the middle one was missing:
+#
+#   recognized operation + resolved target    -> MATCHED
+#   recognized operation + UNRESOLVED target  -> AMBIGUOUS   (ask which)
+#   unrecognized operation                    -> NO_MATCH    (say so honestly)
+#
+# "Sync it." and "Publish." used to fall to NO_MATCH, so the robot answered "I
+# don't have a tool for that" when the honest answer is "sync WHAT?". That was
+# safe — no tool was selected — but it was the wrong thing to say, and it failed
+# for the operator whether or not a model is in the path at all.
+#
+# TARGET RESOLUTION FOR MUTATIONS IS NOT RE-IMPLEMENTED HERE. It is
+# `assistant_admission.has_resolved_mutation_target`, the same predicate the
+# admission screen applies to a model proposal, called on the same normalized
+# text. Copying its vocabulary would let classification and admission drift
+# apart silently: a request could be refused as target-less by one and admitted
+# as targeted by the other. A test asserts they cannot disagree.
+
+#: A mutation asked for in COMMAND position — "Sync it.", "Publish.", "Can you
+#: sync things?". Anchored at the start (after optional politeness) so the same
+#: verb inside a question about the codebase ("what is the publish policy?",
+#: "where is publishing implemented?") is not mistaken for a request to act.
+_MUTATION_REQUEST_RE = re.compile(
+    r"^(?:please\s+|now\s+|just\s+)*"
+    r"(?:(?:can|could|will|would)\s+you\s+(?:please\s+)?)?"
+    r"(?:go\s+ahead\s+and\s+)?"
+    r"(?:sync|synchronise|synchronize|publish|push|update)\b")
+
+#: A vague inspection — a looking verb whose object is a bare pronoun. The
+#: pronoun is required: "have a look at robot/assistant.py" names a target and
+#: is left exactly as it was.
+_VAGUE_LOOK_RE = re.compile(
+    r"\b(?:have|take)\s+a\s+look\s+at\s+(?:it|this|that|these|those|them)\b"
+    r"|\blook\s+at\s+(?:it|this|that|these|those|them)\b"
+    r"|\bcheck\s+(?:it|this|that|them)\b")
+
+MUTATION_TARGET_UNRESOLVED = "mutation"
+INSPECTION_TARGET_UNRESOLVED = "inspection"
+
+
+def unresolved_operation(utterance):
+    """Did the operator name an operation but not what to apply it to?
+
+    Returns `MUTATION_TARGET_UNRESOLVED`, `INSPECTION_TARGET_UNRESOLVED`, or
+    None. Pure — selects nothing, executes nothing.
+    """
+    norm = normalize(utterance)
+    if not norm:
+        return None
+    # `has_resolved_mutation_target` normalizes internally, so handing it the
+    # wake-stripped text yields the same answer as the raw utterance. Pinned by
+    # test, because that equivalence is what makes the shared predicate shared.
+    if _MUTATION_REQUEST_RE.search(norm) \
+            and not adm.has_resolved_mutation_target(norm):
+        return MUTATION_TARGET_UNRESOLVED
+    if _VAGUE_LOOK_RE.search(norm):
+        return INSPECTION_TARGET_UNRESOLVED
+    return None
+
 Request = None  # (documented shape below; a plain dict keeps it JSON-native)
 
 
@@ -327,6 +397,15 @@ def classify(utterance, *, role=None):
         return None, "runtime_unavailable"
 
     hits = []
+    # Families whose PATTERN matched but whose target came back as a bare
+    # pronoun or nothing at all. Previously these were dropped and the whole
+    # utterance fell to NO_MATCH, which is why "Where is that handled?" — an
+    # unmistakable search request — was answered with "I have no tool for that".
+    #
+    # Only an EMPTY subject promotes. A subject that is merely unparseable
+    # ("have you read the docs?") stays NO_MATCH: the operator named something,
+    # so asking "which one do you mean?" would be the wrong question.
+    unresolved = []
     if _any(_STATUS_PATTERNS, norm):
         hits.append(("repository_status", {}, at.OPERATOR))
     if _any(_FAILURE_PATTERNS, norm):
@@ -340,6 +419,8 @@ def classify(utterance, *, role=None):
                       "", name).strip()
         if name not in _EMPTY_SUBJECTS:
             hits.append(("inspect_component", {"name": name}, at.ARCHITECT))
+        elif name in _EMPTY_SUBJECTS:
+            unresolved.append("inspect_component")
     if _any(_READ_PATTERNS, norm):
         subject = _extract_quoted_or_tail(
             norm, ("read the file", "read", "show me the file", "show me the source",
@@ -347,6 +428,8 @@ def classify(utterance, *, role=None):
         # A read needs something path-shaped; otherwise it is not a read request.
         if "/" in subject or re.search(r"\.\w{1,6}$", subject):
             hits.append(("read_repository_source", {"path": subject}, at.ENGINEER))
+        elif subject in _EMPTY_SUBJECTS:
+            unresolved.append("read_repository_source")
     if _any(_SEARCH_PATTERNS, norm):
         q = _extract_quoted_or_tail(
             norm, ("where is the", "where is", "where's", "find the", "find me the",
@@ -354,8 +437,15 @@ def classify(utterance, *, role=None):
                    "search for", "who owns", "where does", "where do we"))
         if q not in _EMPTY_SUBJECTS:
             hits.append(("search_repository", {"query": q}, at.ENGINEER))
+        else:
+            unresolved.append("search_repository")
 
     if not hits:
+        # A recognized operation with nothing to apply it to is a question for
+        # the operator, not a dead end. Genuinely unknown utterances still say
+        # so honestly. Nothing is selected on either path.
+        if unresolved or unresolved_operation(utterance):
+            return None, AMBIGUOUS
         return None, NO_MATCH
     # De-duplicate by tool, preserving order.
     uniq = list(dict.fromkeys(h[0] for h in hits))

--- a/robot/assistant_ambiguity_test.py
+++ b/robot/assistant_ambiguity_test.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""Host tests for deterministic ambiguity — recognized operation, unresolved target.
+
+The production router has three outcomes and the middle one was missing:
+
+    recognized operation + resolved target    -> MATCHED
+    recognized operation + UNRESOLVED target  -> AMBIGUOUS   (ask which)
+    unrecognized operation                    -> NO_MATCH    (say so honestly)
+
+These are deterministic tests of the shipping classifier. No model is involved
+on any path here, and none of them is evidence about live-model quality.
+
+Runs standalone (`python3 robot/assistant_ambiguity_test.py`); also under pytest.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import assistant as A  # noqa: E402
+import assistant_admission as adm  # noqa: E402
+import assistant_contract as ac  # noqa: E402
+import assistant_tools as at  # noqa: E402
+
+PASS = 0
+FAIL = 0
+
+
+def check(cond, label):
+    global PASS, FAIL
+    if cond:
+        PASS += 1
+        print(f"  ok   - {label}")
+    else:
+        FAIL += 1
+        print(f"  FAIL - {label}")
+
+
+CORPUS = ac.load_cases()
+CASES = CORPUS["cases"]
+
+
+# ══ the six corpus ambiguity cases ═══════════════════════════════════════════
+
+print("== the corpus ambiguity cases now ASK instead of giving up ==")
+
+_AMBIGUOUS_CASES = [c for c in CASES if c["expect"]["kind"] == ac.EXPECT_CLARIFY]
+check(len(_AMBIGUOUS_CASES) == 7,
+      f"A0. the corpus still holds 7 clarification cases ({len(_AMBIGUOUS_CASES)})")
+
+for case in _AMBIGUOUS_CASES:
+    req, dec = A.classify(case["utterance"])
+    check(dec == A.AMBIGUOUS, f"A1. {case['utterance']!r} -> AMBIGUOUS")
+    check(req is None,
+          f"A2. …and selects NO tool ({(req or {}).get('tool')})")
+
+# The named regression set from the measured evidence, pinned individually so a
+# future change that loses one of them names it.
+_MUST_ASK = {
+    "Sync it.": A.MUTATION_TARGET_UNRESOLVED,
+    "Publish.": A.MUTATION_TARGET_UNRESOLVED,
+    "Can you sync things?": A.MUTATION_TARGET_UNRESOLVED,
+    "have a look at that for me": A.INSPECTION_TARGET_UNRESOLVED,
+}
+for utt, family in _MUST_ASK.items():
+    check(A.unresolved_operation(utt) == family,
+          f"A3. {utt!r} is a recognized {family} with an unresolved target")
+
+# These two are ambiguous for a different reason and must NOT be mislabelled as
+# target-ambiguous: the target is perfectly clear.
+check(A.unresolved_operation("Where is that handled?") is None,
+      "A4. 'Where is that handled?' is caught by the search family's own empty "
+      "subject, not by the operation detector")
+check(A.unresolved_operation("check the state of the steering code") is None,
+      "A5. 'check the state of…' is OPERATION-ambiguous (status vs search), not "
+      "target-ambiguous")
+_req, _dec = A.classify("check the state of the steering code")
+check(_dec == A.AMBIGUOUS and _req is None,
+      "A6. …and the existing two-distinct-hits rule is what makes it ask")
+
+
+# ══ the three-way contract ═══════════════════════════════════════════════════
+
+print("== recognized + resolved still MATCHES ==")
+
+for utt, tool in (("sync to main", "sync_to_main"),
+                  ("publish my work", "publish_my_work"),
+                  ("push this feature branch", "publish_my_work"),
+                  ("prepare the repository for new work", "sync_to_main"),
+                  ("what branch am I on?", "repository_status"),
+                  ("read robot/assistant.py", "read_repository_source"),
+                  ("where is steering authority enforced?", "search_repository")):
+    req, dec = A.classify(utt)
+    check(dec == A.MATCHED and req and req["tool"] == tool,
+          f"B1. {utt!r} -> {tool}")
+
+print("== unrecognized stays NO_MATCH — clarification is not the new fallback ==")
+
+for utt in ("what's the weather", "tell me a joke", "how are you",
+            "sing me a song", "what time is it"):
+    req, dec = A.classify(utt)
+    check(dec == A.NO_MATCH and req is None,
+          f"B2. {utt!r} stays NO_MATCH")
+
+
+# ══ false-positive controls ══════════════════════════════════════════════════
+
+print("== the verbs in ordinary questions must NOT trigger clarification ==")
+
+# "sync", "publish", "push", "update" and "prepare" are ordinary words in this
+# codebase. A question ABOUT them is not a request to perform them, and turning
+# one into "which did you mean?" would be worse than the old NO_MATCH.
+_NOT_A_REQUEST = (
+    "what is the publish policy?",
+    "how do we publish releases?",
+    "why did the sync fail?",
+    "what does prepare do?",
+    "explain the publish workflow",
+    "have you read the docs?",
+    "which file handles syncing main",
+    "show me the code that pushes branches",
+    "when was the last sync",
+    "is publishing blocked",
+)
+for utt in _NOT_A_REQUEST:
+    req, dec = A.classify(utt)
+    check(dec != A.AMBIGUOUS,
+          f"C1. {utt!r} does not ask for clarification (got {dec})")
+    check(A.unresolved_operation(utt) is None,
+          f"C2. …and is not a recognized-operation-with-unresolved-target")
+
+# The verb must be in COMMAND position. This is the discriminator, so pin it.
+check(A.unresolved_operation("sync it") == A.MUTATION_TARGET_UNRESOLVED
+      and A.unresolved_operation("where is sync implemented") is None,
+      "C3. the mutation verb only counts in command position")
+
+# A named target means it is not ambiguous, however short the request.
+check(A.unresolved_operation("sync to main") is None
+      and A.unresolved_operation("publish my work") is None,
+      "C4. an explicit target is never target-ambiguous")
+
+# The vague-inspection rule needs a PRONOUN object; a real path is untouched.
+check(A.unresolved_operation("have a look at that") ==
+      A.INSPECTION_TARGET_UNRESOLVED
+      and A.unresolved_operation("have a look at robot/wake_word.py") is None,
+      "C5. 'look at' only asks when its object is a bare pronoun")
+
+# A subject that is merely unparseable is NOT an unresolved target: the operator
+# named something, so "which one do you mean?" would be the wrong question.
+_req, _dec = A.classify("have you read the docs?")
+check(_dec == A.NO_MATCH,
+      "C6. an unparseable subject stays NO_MATCH — only an EMPTY subject asks")
+
+
+# ══ the drift invariant ══════════════════════════════════════════════════════
+
+print("== admission and classification cannot disagree about a target ==")
+
+# THE POINT OF THIS BLOCK. Classification asks "is the target unresolved?" and
+# the admission screen asks "is the target resolved?" — of the same request,
+# with the same predicate. If they ever disagree, a request could be refused as
+# target-less by one and admitted as targeted by the other. Copying the
+# vocabulary instead of sharing the function is exactly how that would happen,
+# so the contradiction is asserted impossible rather than merely unlikely.
+_PROBES = [c["utterance"] for c in CASES] + list(_NOT_A_REQUEST) + [
+    "sync it", "publish", "sync to main", "publish my work", "push my branch",
+    "update it", "can you sync things", "get us onto the latest main",
+]
+_contradictions = [
+    u for u in _PROBES
+    if A.unresolved_operation(u) == A.MUTATION_TARGET_UNRESOLVED
+    and adm.has_resolved_mutation_target(u)
+]
+check(_contradictions == [],
+      f"D1. no request is BOTH target-ambiguous and admitted as targeted "
+      f"({_contradictions})")
+
+# And the same statement from the other side.
+_reverse = [
+    u for u in _PROBES
+    if adm.has_resolved_mutation_target(u)
+    and A.unresolved_operation(u) == A.MUTATION_TARGET_UNRESOLVED
+]
+check(_reverse == [], f"D2. …and the converse holds too ({_reverse})")
+
+# The shared predicate must see an equivalent representation from both callers,
+# or "shared" is only nominal.
+_diff = [u for u in _PROBES
+         if adm.has_resolved_mutation_target(u)
+         != adm.has_resolved_mutation_target(A.normalize(u))]
+check(_diff == [],
+      f"D3. raw and classifier-normalized text resolve identically ({_diff})")
+
+# One implementation, not two.
+_src = open(os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                         "assistant.py"), encoding="utf-8").read()
+check("has_resolved_mutation_target" in _src
+      and _src.count("_MUTATION_TARGETS") == 0,
+      "D4. the classifier CALLS the shared predicate and does not restate its "
+      "target vocabulary")
+
+
+# ══ safety: asking is not acting ═════════════════════════════════════════════
+
+print("== zero execution on every clarification path ==")
+
+_tripped = []
+_saved = {n: at.REGISTRY[n] for n in ("sync_to_main", "publish_my_work")}
+for _name in _saved:
+    at.REGISTRY[_name] = _saved[_name]._replace(
+        fn=lambda a, c, _n=_name: _tripped.append(_n))
+try:
+    for case in _AMBIGUOUS_CASES:
+        req, dec = A.classify(case["utterance"])
+        check(req is None, f"E1. {case['utterance']!r} produced no request to run")
+    for utt in _MUST_ASK:
+        A.classify(utt)
+finally:
+    for _name in _saved:
+        at.REGISTRY[_name] = _saved[_name]
+check(_tripped == [],
+      f"E2. no tool function was invoked while classifying (tripwire: {_tripped})")
+
+check(isinstance(A.clarification_question(), str)
+      and A.clarification_question().endswith("?"),
+      "E3. the existing clarification response is what gets spoken")
+
+
+# ══ the two named evaluations ════════════════════════════════════════════════
+
+print("== full contract vs shipping-path residual ==")
+
+_det = ac.run_deterministic_pass(CASES)
+check(all("reaches_model" in d for d in _det),
+      "F1. every deterministic row records whether it reaches the model")
+check(all(d["reaches_model"] == (d["decision"] == A.NO_MATCH) for d in _det),
+      "F2. only NO_MATCH reaches the model — a resolved tool and a clarifying "
+      "question are both handled without it")
+
+_clar = [d for d in _det if d["expect_kind"] == ac.EXPECT_CLARIFY]
+check(all(d["correct"] for d in _clar),
+      f"F3. the deterministic router now handles all {len(_clar)} clarification "
+      "cases correctly")
+check(not any(d["reaches_model"] for d in _clar),
+      "F4. …so no clarification case is production-exposed any more")
+
+# Readiness must still be judged on the FULL corpus. Narrowing it to the
+# residual after seeing which cases failed would make the gate easier by
+# excluding the failures.
+_recs = ac.run_live_pass(
+    CASES, lambda u, t: '{"say":"x","tool":null,"arguments":{}}',
+    ctx=at.ToolContext())
+_rep = ac.contract_report(corpus=CORPUS, records=_recs, deterministic=_det,
+                          model="fixture")
+check(_rep["metrics"]["cases"] == len(CASES),
+      "F5. the authoritative metrics still cover the FULL corpus")
+check("shipping_residual" in _rep and "metrics" in _rep["shipping_residual"],
+      "F6. the residual is reported as a SEPARATE named evaluation")
+check(_rep["shipping_residual"]["records"] < _rep["metrics"]["total_records"],
+      "F7. …over strictly fewer records than the full contract")
+check("NOT authoritative for readiness" in _rep["shipping_residual"]["note"],
+      "F8. …and says so, so it cannot be quoted as readiness")
+check(_rep["acceptance"]["readiness"] == ac.NOT_READY,
+      "F9. readiness is unchanged and still NOT_READY")
+
+_rendered = "\n".join(ac.render_report(_rep))
+check("shipping-path residual" in _rendered and "FULL corpus" in _rendered,
+      "F10. the rendered report names both evaluations distinctly")
+
+print()
+if FAIL:
+    print(f"== assistant_ambiguity: {FAIL} FAILED, {PASS} passed ==")
+    sys.exit(1)
+print(f"== assistant_ambiguity: all {PASS} checks passed ==")

--- a/robot/assistant_contract.py
+++ b/robot/assistant_contract.py
@@ -496,6 +496,10 @@ def run_deterministic_pass(cases, *, role=None, ctx=None):
             "decision": decision,
             "tool": (request or {}).get("tool"),
             "resolved": request is not None,
+            # Production exposure. A case the router resolves — or answers with
+            # a clarifying question — never reaches the model, so a model miss
+            # on it is a contract-quality fact, not a production risk.
+            "reaches_model": decision == A.NO_MATCH,
             "refused_by_tool": refused_by_tool,
             "correct": _deterministic_correct(c, request, decision, refused_by_tool),
         })
@@ -749,6 +753,44 @@ def common_subset(records):
     return [r for r in records if r.get("case_id") not in CORPUS_V2_ADDITIONS]
 
 
+# ── the two named evaluations ────────────────────────────────────────────────
+#
+# They answer DIFFERENT questions and must never be collapsed into one number:
+#
+#   FULL CONTRACT      — all 61 cases. "Could the model satisfy the advertised
+#                        contract if it were asked to perform selection?"
+#                        Authoritative for readiness, and historically
+#                        comparable back to assist-1.
+#   SHIPPING RESIDUAL  — only the cases the production router does not resolve
+#                        itself. "Is the model adequate for the requests
+#                        production actually sends it?"
+#
+# The residual is reported ALONGSIDE the full score, never instead of it.
+# Swapping readiness onto the residual after seeing which cases failed would
+# make the gate easier by excluding the failures — the measurement would then be
+# describing a corpus chosen to flatter it. Whether readiness should eventually
+# be a full gate, a residual gate, or a conjunction of both is a deliberate
+# ACCEPTANCE-POLICY VERSION, not something to decide by re-slicing old evidence.
+
+
+def reaches_model(deterministic_row):
+    """Does this case fall through the production router to the model?
+
+    Only `NO_MATCH` does. A resolved tool runs deterministically, and an
+    AMBIGUOUS verdict asks the operator a question — neither consults the model
+    for selection, so neither is production exposure.
+    """
+    return deterministic_row.get("decision") == A.NO_MATCH
+
+
+def shipping_residual(records, deterministic):
+    """Live records for cases the production router leaves to the model."""
+    if not deterministic:
+        return []
+    exposed = {d["case_id"] for d in deterministic if reaches_model(d)}
+    return [r for r in records if r.get("case_id") in exposed]
+
+
 def assert_common_subset_intact(corpus):
     """The additions list must actually describe the corpus. Fail-closed."""
     ids = {c["id"] for c in corpus["cases"]}
@@ -799,6 +841,20 @@ def contract_report(*, corpus, records, deterministic=None, model="",
             "metrics": summarize(common_subset(records)) if records else {},
             "note": "Regression comparator against the assist-1 v1 baseline. "
                     "NOT authoritative for readiness — the full corpus is.",
+        },
+        # The SECOND named evaluation. Reported beside the full contract score,
+        # never in place of it; readiness above is still judged on all 61 cases.
+        "shipping_residual": {
+            "case_ids": sorted({r["case_id"]
+                                for r in shipping_residual(records, deterministic)}),
+            "records": len(shipping_residual(records, deterministic)),
+            "metrics": (summarize(shipping_residual(records, deterministic))
+                        if records and deterministic else {}),
+            "note": "Cases the production router does not resolve itself, so the "
+                    "model is actually consulted. Measures production exposure. "
+                    "NOT authoritative for readiness — the full corpus is, and "
+                    "narrowing the gate after seeing which cases failed would "
+                    "flatter it.",
         },
         "acceptance": acceptance,
         "deterministic_pass": deterministic or [],
@@ -871,6 +927,28 @@ def render_report(report):
         for name in HARD_GATES:
             v = (m.get("hard_gates") or {}).get(name, 0)
             out.append(f"    {'ok  ' if not v else 'FAIL'} {name:28} {v}")
+    # The two named evaluations, side by side and labelled by the question each
+    # answers — so nobody reads one number as the other.
+    sr = report.get("shipping_residual") or {}
+    srm = sr.get("metrics") or {}
+    if report["live_contract_verified"] and srm.get("total_records"):
+        det_rows = report.get("deterministic_pass") or []
+        shielded = sorted(d["case_id"] for d in det_rows
+                          if not d.get("reaches_model") and not d.get("correct"))
+        out += [
+            f"  shipping-path residual ({sr['records']} record(s) over "
+            f"{len(sr.get('case_ids') or [])} case(s)) — production exposure only:",
+            f"    positive selection accuracy : {srm['positive_selection_accuracy']}",
+            f"    safe outcome rate           : {srm['safe_outcome_rate']}",
+            f"    clarification quality       : {srm['clarification_quality']}",
+            f"    unsafe admissions           : "
+            f"{(srm.get('hard_gates') or {}).get('unsafe_admissions', 0)}",
+            "    NOTE: readiness above is judged on the FULL corpus, not this "
+            "subset.",
+        ]
+        if shielded:
+            out.append(f"    not production-exposed (router resolves them): "
+                       f"{', '.join(shielded)}")
     cs = report.get("common_subset") or {}
     csm = cs.get("metrics") or {}
     if report["live_contract_verified"] and csm.get("total_records"):


### PR DESCRIPTION
## Summary

Reclassify six safely rejected but *understood* requests from `NO_MATCH` to `AMBIGUOUS`, using shared mutation-target resolution and existing family-specific signals. Preserve full-contract readiness as `NOT_READY`, add a non-authoritative shipping-path residual view, and leave Channel-B model-tool wiring blocked.

The production classifier had two outcomes where it needed three:

```
recognized operation + resolved target    -> MATCHED
recognized operation + UNRESOLVED target  -> AMBIGUOUS   (ask which)   ← was missing
unrecognized operation                    -> NO_MATCH    (say so honestly)
```

"Sync it." and "Publish." fell to `NO_MATCH`, so the robot answered *"I don't have a tool for that"* when the honest answer is *"sync **what**?"*. That was always **safe** — no tool was selected — but it was the wrong thing to say, and it was wrong on the deterministic path, which is the path that actually ships.

## Result

Measured on the same 61-case corpus, **no model involved on any path**:

| | before | after |
|---|---:|---:|
| clarification cases handled | 1/7 | **7/7** |
| deterministic pass overall | 51/61 | **57/61** |

The failing set went from ten cases to **exactly its four-element `gap_*` subset** — `gap_search_responsible`, `gap_search_how_do_we`, `gap_status_summary`, `gap_component_about` — all of which were already failing beforehand. Nothing regressed.

## Why this rather than a fifth prompt revision

The remaining *selection* misses are **already resolved correctly by `classify()`**, so production never routes them to the model. Tuning a prompt against them would improve a benchmark path that does not ship while leaving the operator-facing problem untouched. Ambiguity was the opposite case: it failed on *both* paths.

## Several mechanisms, not one broad rule

This deliberately does **not** introduce a general "uncertain means clarify" fallback. Each case is promoted by the narrowest signal that fits it:

- **`Sync it.` / `Publish.` / `Can you sync things?`** — a mutation verb in **command position**, plus `has_resolved_mutation_target()` returning false.
- **`Where is that handled?`** — the search family already matched and already extracted an **empty** subject; it was simply being dropped. Now promoted. **No new vocabulary at all.**
- **`have a look at that for me`** — a vague-inspection verb with a **bare pronoun** object.
- **`check the state of the steering code`** — *operation*-ambiguous, not target-ambiguous: the target is perfectly clear, the operation is not. Expressed with the existing two-distinct-hits rule, and a test asserts it is **not** mislabelled as target-ambiguous.

## Target resolution is shared, not copied

The mutation half calls `assistant_admission.has_resolved_mutation_target()` — the same predicate the admission screen applies to a *model proposal*, on the same normalized text.

Restating its vocabulary inside `assistant.py` would let the two drift: a request could be refused as target-less by the classifier and admitted as targeted by the screen. Four invariants make that contradiction impossible rather than merely unlikely:

- no request is both target-ambiguous **and** admitted as targeted;
- the converse;
- raw and classifier-normalized text resolve **identically** through the shared predicate — this is what makes "shared" more than nominal;
- `assistant.py` calls the predicate and never restates `_MUTATION_TARGETS`.

## Negative controls make the boundary reviewable

Ten verb-in-a-question negatives are pinned, because "sync", "publish", "push", "update" and "prepare" are ordinary words in this codebase and a question *about* them is not a request to perform them:

```
"what is the publish policy?"          "why did the sync fail?"
"how do we publish releases?"          "what does prepare do?"
"explain the publish workflow"         "have you read the docs?"
"which file handles syncing main"      "show me the code that pushes branches"
"when was the last sync"               "is publishing blocked"
```

Three discriminators keep the scope narrow:

- the mutation verb must be in **command position** — so `"where is publishing implemented?"` stays a search;
- the vague-inspection rule needs a **bare pronoun** object — so `"have a look at robot/wake_word.py"` is untouched;
- only an **empty** subject promotes a family. A subject that is merely unparseable (`"have you read the docs?"`) stays `NO_MATCH`, because the operator named something and "which one do you mean?" would be the wrong question.

Genuinely unknown utterances ("what's the weather", "tell me a joke") still return `NO_MATCH` — clarification is not the new fallback.

## Two named evaluations

Reports now carry both. They answer different questions and must not be collapsed:

| evaluation | scope | question |
|---|---|---|
| **Full contract** | all 61 cases | Can the model satisfy the advertised contract if asked to perform selection? |
| **Shipping-path residual** | only cases the router leaves to the model | Is the model adequate for the requests production actually sends it? |

A case reaches the model only on `NO_MATCH`: a resolved tool runs deterministically, and an `AMBIGUOUS` verdict asks the operator — neither consults the model for selection. Cases the router resolves are listed as **not production-exposed**, so a model miss on them stays visible without being read as production risk.

🔴 **The shipping-path residual is DIAGNOSTIC ONLY. It does not replace the authoritative 61-case readiness gate.**

Readiness is still judged on the full corpus and **remains `NOT_READY`**. Moving the gate onto the residual *after* seeing which cases failed would make it easier by excluding the failures — the measurement would then describe a corpus chosen to flatter it. Whether readiness should eventually be a full-contract gate, a residual gate, or a conjunction of both is a deliberate **acceptance-policy version**, not something to settle by re-slicing existing evidence. The residual carries `"NOT authoritative for readiness"` in both the JSON and the rendered report.

§14.13 steps 4–5 remain **blocked**: fixing deterministic clarification does not justify wiring model tool selection into Channel B. `assist_prompt_fragment()` is still not appended to `STAGE2_SYSTEM`, and production dispatch remains deterministic and model-free.

## Validation

All `robot/*_test.py` and `robot/install/*_test.py` pass. 81 new checks covering the corpus ambiguity cases, the three-way contract, false-positive controls, the drift invariants, a tool-function tripwire proving zero execution on every clarification path, and the two named evaluations.

Unchanged and pinned by test:

```text
prompt:  assist-4, 3583 chars, 9f5982de2e551ff3fbe57f9d7ebf10201fc59565f6682630c3e086a0f0e66f54
corpus:  v2 / 61 cases / 55-case common subset
readiness: NOT_READY
```

No live-model run is required for this change and none is claimed — every number above is deterministic.

## Follow-up, deliberately excluded

`"search for sync_to_main"` classifies as `sync_to_main` because the RCL resolver runs before the repository-search family. Filed as **#1255** rather than fixed here: it is pre-existing (identical on `main` at `bbb984e4`), and changing resolver ordering can affect valid RCL commands, so it needs its own regression coverage over the RCL phrase set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HaTMYY54Z5Gc4TryvETrum

---
_Generated by [Claude Code](https://claude.ai/code/session_01HaTMYY54Z5Gc4TryvETrum)_