### PR TITLE
install: deploy the Engineering Assistant flag in the file the units load

### DIFF
--- a/robot/install/deployment_verify_test.py
+++ b/robot/install/deployment_verify_test.py
@@ -124,6 +124,72 @@ def test_verification_is_read_only():
     check(not mutating, f"verification must be read-only, found: {mutating}")
 
 
+# ── the voice layer is actually deployed ─────────────────────────────────────
+#
+# The defect these guard against: `assistant.classify()` returned a correct
+# typed request, `assistant.handle()` returned None, and the code was fine —
+# `KIRRA_ASSIST_ENABLED` was simply absent from the file the units load. It was
+# documented in `rabbit.env.example`, which the installer never renders, so no
+# fresh install ever had it and nothing reported its absence.
+
+def test_env_template_enables_the_assistant():
+    """`env.template` is what becomes /etc/kirra/robot.env. If the flag is not
+    there — or is there but commented out — a fresh install ships the assistant
+    silently disabled, which reads as a code fault rather than a config gap."""
+    lines = (HERE / "env.template").read_text().splitlines()
+    active = [ln for ln in lines
+              if ln.strip().startswith("KIRRA_ASSIST_ENABLED=")]
+    check(active, "env.template must set KIRRA_ASSIST_ENABLED (uncommented)")
+    check(any(ln.split("=", 1)[1].strip() in ("1", "true", "yes", "on")
+              for ln in active),
+          f"KIRRA_ASSIST_ENABLED must be truthy in env.template, got {active}")
+
+
+def test_the_units_load_the_file_the_template_renders():
+    """The chain has to close: template -> robot.env -> EnvironmentFile. A unit
+    reading some OTHER env file would make the template edit useless."""
+    unit = (HERE / "systemd" / "kirra-rabbit-voice.service").read_text()
+    check("EnvironmentFile=/etc/kirra/robot.env" in unit,
+          "kirra-rabbit-voice must load /etc/kirra/robot.env")
+
+
+def test_enablement_is_deployment_not_code():
+    """`assistant.enabled()` must stay fail-closed. Turning the assistant on is
+    a deployment decision; a code default would make every environment — tests,
+    CI, a developer's laptop — silently authoritative."""
+    src = (HERE.parent / "assistant.py").read_text()
+    body = src.split("def enabled():", 1)[1].split("\n\n", 1)[0]
+    check("KIRRA_ASSIST_ENABLED" in body,
+          "enabled() must read the env var")
+    for default in ('or "1"', "or '1'", 'or "true"', "return True"):
+        check(default not in body,
+              f"enabled() must not default-enable ({default!r})")
+
+
+def test_verification_reports_a_disabled_assistant():
+    """An absent flag must be REPORTED, not silent — that is the whole reason
+    this went unnoticed. WARN, not FAIL: a robot without the voice layer is a
+    valid deployment."""
+    rep = vd.Report()
+    vd.check_voice_env(rep, {})
+    check(rep.rows, "an empty env must produce a row, not silence")
+    check(rep.rows[0]["status"] == vd.WARN,
+          f"absent flag should WARN, got {rep.rows[0]['status']}")
+    check(rep.rows[0]["fix"], "…and must tell the operator how to fix it")
+    check(rep.failed == 0, "a missing OPT-IN flag must not FAIL the deployment")
+
+    rep = vd.Report()
+    vd.check_voice_env(rep, {"KIRRA_ASSIST_ENABLED": "1"})
+    check(rep.rows[0]["status"] == vd.PASS, "an enabled assistant passes")
+
+    # The exact trap that makes this fail-closed: a value that LOOKS set but is
+    # not truthy leaves the feature off, so it must not report as enabled.
+    rep = vd.Report()
+    vd.check_voice_env(rep, {"KIRRA_ASSIST_ENABLED": "0"})
+    check(rep.rows[0]["status"] == vd.WARN,
+          "a non-truthy value must not report as enabled")
+
+
 # ── the migration report ─────────────────────────────────────────────────────
 
 def test_the_report_never_prints_a_secret():

--- a/robot/install/env.template
+++ b/robot/install/env.template
@@ -212,3 +212,40 @@ KIRRA_R2_V_PER_PWM_RIGHT=0.0194
 #KIRRA_R2_ODOM_TOPIC=/odom
 #KIRRA_R2_ODOM_FRAME=odom
 #KIRRA_R2_ODOM_CHILD_FRAME=base_link
+
+# ---------------------------------------------------------------------------
+# VOICE LAYER — Rabbit / the Engineering Assistant.
+#
+# WHY THIS SECTION EXISTS: every kirra-rabbit-* unit reads THIS file
+# (`EnvironmentFile=/etc/kirra/robot.env`), but until now the template only
+# described the consumer/drive stack. The voice-layer variables were documented
+# in `rabbit.env.example`, which the installer never renders anywhere — so a
+# fresh install produced a robot.env with no voice keys at all, and the
+# assistant was off on every machine that had never been hand-edited. The
+# symptom is silent and easy to misread as a code fault: `classify()` returns a
+# correct typed request and `handle()` then returns None, because `enabled()`
+# is fail-closed on an absent variable.
+
+# KIRRA ENGINEERING ASSISTANT: grounded repository questions and the two
+# approved git workflows, answered from TYPED, READ-ONLY tools (git plumbing,
+# git grep over tracked files, bounded file reads) — never from model memory.
+# Authority is capped at level 2; levels 3 (repo mutation) and 4 (system/robot
+# mutation) are defined and REFUSED, and no shell tool exists. Retrieved file
+# content can never alter a dispatch decision.
+#
+# Tool SELECTION here is deterministic (`assistant.classify`) — no model is in
+# the path — so this flag turns on a closed, reviewable command set rather than
+# anything the model can steer. Unset/blank/anything-but-a-truthy-value keeps it
+# OFF: `assistant.enabled()` is fail-closed and is deliberately NOT defaulted on
+# in code. Enabling is a DEPLOYMENT decision, made here.
+# See robot/assistant.py + docs/KIRRA_ENGINEERING_ASSISTANT.md.
+KIRRA_ASSIST_ENABLED=1
+# Optional JSONL audit trail for assistant tool calls (timestamp, role,
+# transcript, tool, arguments, request id, status, reason, mutated). No secrets.
+#KIRRA_ASSIST_AUDIT_PATH=/var/log/kirra/assistant.jsonl
+
+# WAKE WORD (opt-in, and separately gated): hands-free "hello rabbit".
+# kirra-rabbit-voice.service exits 0 and rests inactive without this, so
+# enabling the unit alone is a no-op. KIRRA_WAKE_STT_CMD is REQUIRED when on.
+#KIRRA_WAKE_ENABLED=1
+#KIRRA_WAKE_STT_CMD=

--- a/robot/install/install_robot_units.sh
+++ b/robot/install/install_robot_units.sh
@@ -75,3 +75,11 @@ echo "    sudo systemctl start kirra-ros-stack   && journalctl -u kirra-ros-stac
 echo "    sudo systemctl start kirra-rabbit-watch  && journalctl -u kirra-rabbit-watch -f"
 echo "    sudo systemctl start kirra-rabbit-voice  && journalctl -u kirra-rabbit-voice -f"
 echo "      (wake word is OPT-IN: also set KIRRA_WAKE_ENABLED=1 + KIRRA_WAKE_STT_CMD in robot.env)"
+echo
+echo "  the Engineering Assistant is enabled by env.template on a FRESH install."
+echo "  An EXISTING /etc/kirra/robot.env is never overwritten (it holds measured"
+echo "  calibration), so upgrading robots need the line appended once:"
+echo "    grep -q '^KIRRA_ASSIST_ENABLED=' /etc/kirra/robot.env \\"
+echo "      || echo 'KIRRA_ASSIST_ENABLED=1' | sudo tee -a /etc/kirra/robot.env"
+echo "    sudo systemctl restart kirra-rabbit-voice"
+echo "  Check it with: robot/install/verify_deployment.py"

--- a/robot/install/rabbit.env.example
+++ b/robot/install/rabbit.env.example
@@ -5,6 +5,13 @@
 # (rabbit_ask / rabbit_converse / rabbit_watch / rabbit_voice.sh) reads these; nothing
 # here is safety-critical — it is the operator UX layer (Channel A + the fenced
 # /intent door). See docs/hardware/RABBIT_BRINGUP_RUNBOOK.md.
+#
+# ⚠ THIS FILE IS A REFERENCE, NOT A DEPLOYMENT ARTIFACT. The installer never
+# renders it anywhere. `/etc/kirra/robot.env` — what the systemd units actually
+# load — is rendered from `env.template`, so a variable that lives ONLY here is
+# absent on every fresh install. That is exactly how the Engineering Assistant
+# shipped disabled on a machine whose code was correct. Anything that should be
+# set by default belongs in `env.template`; keep the two in agreement.
 
 # ── Speech engines (external OS processes — never crate deps) ────────────────
 # STT: receives the WAV path APPENDED as its last arg; prints the transcript.
@@ -57,7 +64,9 @@ KIRRA_TTS_CMD="./speak.sh"
 # mutation) are defined and REFUSED. No shell tool exists. Retrieved file content
 # can never alter policy. Default off -> the router is byte-identical.
 # See robot/assistant.py + docs/KIRRA_ENGINEERING_ASSISTANT.md.
-#KIRRA_ASSIST_ENABLED=1
+# ON by default in `env.template`, so a fresh install has it; shown active here
+# so the two files agree.
+KIRRA_ASSIST_ENABLED=1
 # Optional JSONL audit trail for assistant tool calls (timestamp, role,
 # transcript, tool, arguments, request id, status, reason, mutated). No secrets.
 #KIRRA_ASSIST_AUDIT_PATH=/var/log/kirra/assistant.jsonl

--- a/robot/install/verify_deployment.py
+++ b/robot/install/verify_deployment.py
@@ -215,6 +215,41 @@ def check_env(rep: Report, env: dict) -> None:
                 f"all {r['required_count']} required key(s) set for mode {r['mode']}")
 
 
+#: Voice-layer flags that are OPT-IN in code and enabled by DEPLOYMENT. Reported
+#: because their failure mode is silence: the assistant answers nothing, and
+#: `classify()` still returns a correct typed request, so the box looks like a
+#: code fault when it is a missing line in robot.env. WARN, never FAIL — a robot
+#: installed without the voice layer is a valid deployment, it just should not be
+#: mistaken for a broken one.
+VOICE_FLAGS = (
+    ("KIRRA_ASSIST_ENABLED", "Engineering Assistant",
+     "docs/KIRRA_ENGINEERING_ASSISTANT.md"),
+)
+
+
+def check_voice_env(rep: Report, env: dict) -> None:
+    """Is the voice layer actually switched on in the file the units load?"""
+    for key, label, doc in VOICE_FLAGS:
+        raw = (env.get(key) or "").strip()
+        if raw.lower() in ("1", "true", "yes", "on"):
+            rep.add(f"{label} enabled", PASS, f"{key}={raw}")
+        elif raw:
+            rep.add(f"{label} enabled", WARN,
+                    f"{key}={raw!r} is not a truthy value, so it stays OFF "
+                    "(fail-closed)",
+                    fix=f"set {key}=1 in {ROBOT_ENV}, then restart the unit")
+        else:
+            rep.add(f"{label} enabled", WARN,
+                    f"{key} is not set in {ROBOT_ENV} — the feature is OFF and "
+                    "will answer nothing (see " + doc + ")",
+                    # Phrased without the literal service-control command: a
+                    # sibling test forbids that string anywhere in this file, so
+                    # verification can never be edited into starting something
+                    # to prove a point. The operator still gets both steps.
+                    fix=f"append {key}=1 to {ROBOT_ENV}, then restart "
+                        "kirra-rabbit-voice (see install_robot_units.sh)")
+
+
 def run() -> Report:
     rep = Report()
     from preflight_consumer_env import parse_env_file
@@ -223,6 +258,7 @@ def run() -> Report:
         rep.add("robot.env readable", FAIL, f"{ROBOT_ENV} missing or empty")
     check_artifacts(rep)
     check_env(rep, env)
+    check_voice_env(rep, env)
     probe_ffi(rep, env)
     check_units(rep)
     check_services(rep)


### PR DESCRIPTION
## Summary

The Engineering Assistant was disabled on the Jetson while its code was correct. This is a **deployment-configuration fix only** — `assistant.enabled()` is untouched, stays fail-closed, and nothing is default-enabled in code.

Observed on the robot:

```python
assistant.classify("sync to main")
# ({'role': 'operator', 'tool': 'sync_to_main',
#   'arguments': {'transcript': 'sync to main'}}, 'matched')   ← correct

assistant.handle(...)   # None
assistant.enabled()     # False
```

Exporting `KIRRA_ASSIST_ENABLED=1` made it work immediately, which localizes the fault to configuration.

## Root cause: the variable had no rendered destination

```
kirra-rabbit-voice.service
  └─ EnvironmentFile=/etc/kirra/robot.env
       ├─ rendered by install_kirra.sh:146 from  env.template       ← no voice section at all
       └─ rabbit.env.example  ← documents the flag, rendered NOWHERE
```

All eight `kirra-*` units load `/etc/kirra/robot.env`. `install_kirra.sh` renders that file from `env.template`, and `env.template` described only the consumer/drive stack. The voice-layer variables lived in `rabbit.env.example`, which the installer copies nowhere — it is a reference document.

So **no fresh install has ever had the flag.** The only machines with a working assistant were ones somebody had hand-edited.

## Why it survived

The failure mode is silent and actively misleading: `classify()` returns a correct typed request, and `handle()` then returns `None`. That reads as a code fault, not a missing line in an env file. And nothing in `verify_deployment.py` looked at the flag, so no install ever reported it.

## Changes

| file | change |
|---|---|
| `env.template` | new **VOICE LAYER** section with `KIRRA_ASSIST_ENABLED=1` active — a fresh install now configures it automatically |
| `rabbit.env.example` | header states it is a **reference, not a deployment artifact**; anything wanted by default belongs in `env.template`. Assistant line uncommented so the two agree |
| `verify_deployment.py` | `check_voice_env()` — PASS when truthy, WARN when absent or non-truthy, each with a fix hint |
| `install_robot_units.sh` | prints the one-line append for **existing** robots |
| `deployment_verify_test.py` | 4 regression tests |

The load-bearing line:

```diff
+# ... `assistant.enabled()` is fail-closed and is deliberately NOT defaulted
+# on in code. Enabling is a DEPLOYMENT decision, made here.
+KIRRA_ASSIST_ENABLED=1
```

`KIRRA_WAKE_ENABLED` is included **commented**, since the wake word additionally needs an STT command to be useful — enabling it blindly would be a different kind of wrong.

## Reported, not silent — WARN not FAIL

A robot installed without the voice layer is a **valid deployment**; it just should not be mistaken for a broken one. So an absent flag warns with an actionable fix rather than failing the deployment.

The fix hint deliberately avoids the literal service-control string that a sibling test (`test_ffi_is_probed_explicitly_not_inferred_from_startup`) forbids anywhere in `verify_deployment.py`. That guard exists so verification can never be edited into *starting* something to prove a point; it is kept at full strength and the wording changed instead, so the operator still gets both steps.

## Existing robots need one line

`install_kirra.sh` **never overwrites** an existing `robot.env` — it holds ruler-measured R2 calibration, the governor key and the profile digest. So the template fix helps fresh installs only, and upgrades need:

```bash
grep -q '^KIRRA_ASSIST_ENABLED=' /etc/kirra/robot.env \
  || echo 'KIRRA_ASSIST_ENABLED=1' | sudo tee -a /etc/kirra/robot.env
sudo systemctl restart kirra-rabbit-voice
```

This is printed by `install_robot_units.sh` and surfaced as the `fix` hint on the new WARN.

## Tests

Four regressions, each pinning one link in the chain:

- `test_env_template_enables_the_assistant` — the flag is present, uncommented and truthy in the file that becomes `robot.env`;
- `test_the_units_load_the_file_the_template_renders` — the unit really loads `/etc/kirra/robot.env`, so the template edit reaches it;
- `test_enablement_is_deployment_not_code` — `enabled()` still reads the env var and does **not** default-enable;
- `test_verification_reports_a_disabled_assistant` — absent → WARN with a fix, `"1"` → PASS, `"0"` → WARN (a value that *looks* set but is not truthy must not report as enabled).

All `robot/*_test.py` and `robot/install/*_test.py` pass; `bash -n` and `shellcheck -S error` clean.

Verified end-to-end by reproducing the render (`cp env.template robot.env`), parsing it with the repo's own `parse_env_file`, and feeding the result to the real predicate: `KIRRA_ASSIST_ENABLED='1'` → `enabled() → True`.

## Scope

No service behaviour, unit ordering, or assistant logic changed. No other service touched. Independent of #1256 — disjoint file sets, based directly on `main`, mergeable on its own.

## One thing for the reporter to confirm

The unit was described as `rabbit-voice.service`, a **user** unit; the repo ships `kirra-rabbit-voice.service` as a **system** unit with `User=__KIRRA_ROBOT_USER__`. If the robot is genuinely running a user-level unit, it is not the repo's unit and may not read `/etc/kirra/robot.env` at all — worth checking `systemctl --user cat rabbit-voice` before assuming this fix reaches that process. This PR fixes the repo-maintained unit and its install path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HaTMYY54Z5Gc4TryvETrum

---
_Generated by [Claude Code](https://claude.ai/code/session_01HaTMYY54Z5Gc4TryvETrum)_