### PR TITLE
Fix robot installer artifact modes

### DIFF
--- a/robot/install/install_kirra.sh
+++ b/robot/install/install_kirra.sh
@@ -126,7 +126,15 @@ echo "== 3. install -> ${OPT} =="
 sudo install -d -m 0755 "${OPT}/lib" "${OPT}/bin" "${OPT}/robot"
 sudo install -m 0644 "${SO}"   "${OPT}/lib/libkirra_consumer_ffi.so"
 sudo install -m 0755 "${MINT}" "${OPT}/bin/kirra_ros_release_mint"
-for f in kirra_motor_consumer.py kirra_ffi.py kirra_release_publisher.py r2_drive.py; do
+# The consumer is what kirra-consumer.service execs, so it must be EXECUTABLE —
+# installing it 0644 with the rest left the unit pointing at a non-executable
+# file and verify_deployment.py reporting it as such.
+sudo install -m 0755 "${REPO}/robot/kirra_motor_consumer.py" \
+                     "${OPT}/robot/kirra_motor_consumer.py"
+# Imported modules, never exec'd, so 0644 is correct for these.
+# motor_authority.py was missing entirely: robot/doctor/modules/devices.py
+# imports it at runtime, so a deployed robot needs it beside the consumer.
+for f in kirra_ffi.py kirra_release_publisher.py r2_drive.py motor_authority.py; do
   sudo install -m 0644 "${REPO}/robot/${f}" "${OPT}/robot/${f}"
 done
 for f in first_run_elevated.sh live_loop_elevated.sh steering_bench_elevated.sh; do


### PR DESCRIPTION
## Summary

- install `kirra_motor_consumer.py` with executable mode `0755`
- install `motor_authority.py` into `/opt/kirra/robot`
- eliminate the manual post-install `chmod` and artifact-copy repairs

## Problem

`install_kirra.sh` installed all Python robot artifacts with mode `0644` and omitted `motor_authority.py`.

As a result, deployment verification reported:

- `kirra_motor_consumer.py` was not executable
- `motor_authority.py` was missing

Both are exactly what `robot/install/verify_deployment.py` already asserts, so this change makes the installer match the contract the verifier has been checking all along rather than changing what a correct deployment looks like:

```python
EXPECTED_ARTIFACTS = [
    (f"{OPT}/robot/kirra_motor_consumer.py", True),    # must be executable
    ...
    (f"{OPT}/robot/motor_authority.py", False),        # module, not a script
]
```

The two modes are deliberately different:

- **`kirra_motor_consumer.py` → `0755`.** It is what `kirra-consumer.service` execs, and it is already `0755` in the repository — installing it `0644` left the unit pointing at a non-executable file.
- **`motor_authority.py` → `0644`.** It is an imported module, not a script: `robot/doctor/modules/devices.py` does `import motor_authority` at runtime, so a deployed robot needs it beside the consumer, but never executes it.

## Change

One file, one hunk:

```diff
-for f in kirra_motor_consumer.py kirra_ffi.py kirra_release_publisher.py r2_drive.py; do
+sudo install -m 0755 "${REPO}/robot/kirra_motor_consumer.py" \
+                     "${OPT}/robot/kirra_motor_consumer.py"
+for f in kirra_ffi.py kirra_release_publisher.py r2_drive.py motor_authority.py; do
   sudo install -m 0644 "${REPO}/robot/${f}" "${OPT}/robot/${f}"
 done
```

No other installer behaviour, unit, or robot state is touched.

## Validation

**Reported from the Jetson robot** (not run in this PR's environment):

```bash
sudo env "PATH=$HOME/.cargo/bin:$PATH" robot/install/install_kirra.sh
robot/install/verify_deployment.py
```

Final result: `✔ deployment verified`, confirming `kirra_motor_consumer.py` executable and present, `motor_authority.py` present, the consumer FFI loading, the consumer environment complete, the Engineering Assistant enabled, Taj healthy on contract v2 and Mick healthy on contract v1.

**Run against this branch:**

- `git diff --check` — clean
- `bash -n robot/install/install_kirra.sh` — syntax OK
- `shellcheck -S error robot/install/install_kirra.sh` — no errors
- `scripts/test-shellcheck-gate.sh` — 18/18, all 56 tracked scripts error-clean
- `robot/install/deployment_verify_test.py` — pass
- `robot/motor_authority_test.py` — pass
- every `robot/*_test.py` and `robot/install/*_test.py` — pass

No hardware was started: all of the above are host tests, and no motion, motor, lidar or other hardware-driving service was invoked.

The lidar discovery warning the installer prints is separate from this change — it is caused by the ROS workspace overlay not being visible to that installer invocation.

## Known gap, not addressed here

**No test asserts the installer's artifact modes.** `verify_deployment.py` checks the *deployed* result on a real robot, but nothing in CI checks that `install_kirra.sh` installs what `EXPECTED_ARTIFACTS` requires — which is why this drifted silently. A static test pairing the two lists would prevent a recurrence; it is left out of this PR to keep the diff to the single intended fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HaTMYY54Z5Gc4TryvETrum

---
_Generated by [Claude Code](https://claude.ai/code/session_01HaTMYY54Z5Gc4TryvETrum)_