### PR TITLE
ci: split the Kani deep lane per harness and make timeouts red (#1260)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1350,6 +1350,18 @@ jobs:
         run: |
           python3 ci/check_reexport_shims.py --self-test
           python3 ci/check_reexport_shims.py
+      - name: Deep-harness matrix source (the weekly lane's coverage list)
+        # The weekly `kani-deep-weekly` lane derives its per-harness matrix from
+        # ci/deep_harnesses.py rather than a hardcoded list, so a newly-demoted
+        # harness joins the campaign with no workflow edit. That makes this
+        # script decide WHICH PROPERTIES GET PROVED: if it under-reports, the
+        # lane goes green having verified less than it claims. The tests pin the
+        # two hazards that were live during #1260 — both `deep-proofs` gate
+        # spellings are recognised (K7 uses `cfg(all(kani, feature = ...))`,
+        # which a grep for the plain spelling drops), and gated HELPERS that are
+        # not `#[kani::proof]` are excluded. Also asserts the script fails closed
+        # on an empty deep tier instead of emitting a vacuous empty matrix.
+        run: python3 ci/test_deep_harnesses.py
       - name: Mick actuation fence (no path from the intent layer to the motors)
         # The doer-checker thesis, structurally: kirra-mick and the sidecar
         # binaries must have NO dependency route to the release-token mint,

--- a/.github/workflows/kani-deep-weekly.yml
+++ b/.github/workflows/kani-deep-weekly.yml
@@ -37,13 +37,37 @@
 # an assertion that is RELATIONAL ARITHMETIC over two command fields does not
 # finish (K7, K8). Expect the second shape to land in this lane.
 #
-# This lane gives the solver the same scheduled multi-hour budget the EP-22
-# deep-fuzz campaign uses. Every deep property keeps a BLOCKING per-PR concrete
-# mirror in the kani crate's `cargo test` — for R2 the full speed-grid walk
-# swept along all four parameter axes, for K7 the 306,180-point exhaustive grid
-# over the executable return, for K8 the 2,880-point physical-dt grid — so
-# demotion here never leaves a property with zero per-PR coverage. Kept in its OWN workflow so the `schedule` trigger does
-# not fan the whole ci.yml job graph out weekly.
+# ⚠️ HISTORY, because the numbers above were written against a lane that did
+# not work (#1260). Between 12 July and 31 July 2026 this lane completed FOUR
+# runs' worth of wall-clock and produced ZERO verdicts. Every run was killed at
+# the GitHub-hosted SIX-HOUR per-job ceiling and reported `cancelled` — grey,
+# not red — so nothing surfaced it. Two distinct causes, both now fixed here:
+#
+#   * `timeout-minutes: 480` was INERT. A hosted job cannot exceed 360 minutes;
+#     declaring more does not buy more, it just means the PLATFORM decides the
+#     outcome, and the platform's word for "out of time" is `cancelled`.
+#   * ONE JOB, HARNESSES IN SERIES. The first non-terminating harness consumed
+#     everything behind it. On 2026-07-26 R2 spent 5 h 59 m inside a single
+#     kissat solve; on run 30629178939 K7 hung in CBMC's propositional
+#     reduction 17 s in and K3, K8 and R2 were never even started. Which
+#     property received any budget at all was decided by scheduling order.
+#
+# That run also split the two remaining unknowns apart, and the distinction is
+# load-bearing for what to do next. R2's orphan process was `kissat` — it is
+# solver-bound, a real budget question. K7's orphan was `cbmc` and no solver
+# was ever invoked — it is ENCODER non-termination, so "give it more hours" may
+# simply be the wrong diagnosis. K3 and K8 remain entirely unmeasured under a
+# multi-hour budget; the matrix below is what will finally measure them.
+#
+# Every deep property keeps a BLOCKING per-PR concrete mirror in the kani
+# crate's `cargo test` — for R2 the full speed-grid walk swept along all four
+# parameter axes, for K7 the 306,180-point exhaustive grid over the executable
+# return, for K8 the 2,880-point physical-dt grid. That rule is the only reason
+# four weeks of a dead lane was a coverage REDUCTION and not a coverage HOLE.
+# Treat it as load-bearing, not as belt-and-braces.
+#
+# Kept in its OWN workflow so the `schedule` trigger does not fan the whole
+# ci.yml job graph out weekly.
 name: Kani deep proofs (weekly)
 
 on:
@@ -61,12 +85,48 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  kani-deep:
-    name: Kani deep proofs (deep-proofs feature, multi-hour solver budget)
+  # The matrix is DERIVED from the source, never hand-maintained (#1260). The
+  # single `cargo kani --features deep-proofs` this lane used to run had one
+  # genuinely good property — a newly-demoted harness joined the campaign with
+  # no workflow edit — and a hardcoded list would have silently thrown it away.
+  # `ci/deep_harnesses.py` keeps it, and fails closed on an empty deep tier so
+  # the lane can never pass while proving nothing.
+  discover:
+    name: Enumerate deep harnesses
     runs-on: ubuntu-latest
-    # The whole point of this lane is budget: the R2 UNSAT solve is known to
-    # exceed 45 min and its true cost is unmeasured — give it the full window.
-    timeout-minutes: 480
+    timeout-minutes: 5
+    outputs:
+      harnesses: ${{ steps.list.outputs.harnesses }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - id: list
+        run: |
+          set -euo pipefail
+          harnesses="$(python3 ci/deep_harnesses.py)"
+          echo "deep harnesses: $harnesses"
+          echo "harnesses=$harnesses" >> "$GITHUB_OUTPUT"
+
+  kani-deep:
+    name: "Kani deep proof: ${{ matrix.harness }}"
+    needs: discover
+    runs-on: ubuntu-latest
+    strategy:
+      # One harness per job. Before #1260 every harness shared a single job, so
+      # the first non-terminating one consumed the whole lane and everything
+      # behind it got ZERO solver time — K7 starved K3/K8/R2 on run
+      # 30629178939, and R2 starved everything on 2026-07-26. Which property
+      # got any budget at all was decided by scheduling order.
+      fail-fast: false
+      matrix:
+        harness: ${{ fromJSON(needs.discover.outputs.harnesses) }}
+    # MUST stay below the GitHub-hosted 6 h (360 min) per-job ceiling, and that
+    # is the entire point of the number. The old `timeout-minutes: 480` was
+    # INERT: the platform killed the job at 360 min and reported `cancelled`,
+    # which renders grey rather than red, so four consecutive runs produced no
+    # verdict and nothing surfaced it. A timeout we own fires FIRST and fails
+    # the job. Do not raise this to or above 360 — that hands the decision back
+    # to the platform and restores the silent-grey failure.
+    timeout-minutes: 330
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
@@ -74,9 +134,11 @@ jobs:
         # No install-flake tolerance here (unlike the per-PR lane): this lane
         # exists ONLY to run the proofs, so a skipped run must read as red.
         run: cargo install kani-verifier --locked && cargo kani setup
-      - name: Run ALL Kani proofs with deep harnesses enabled (BLOCKING)
-        # `--features deep-proofs` compiles the deep harnesses IN ADDITION to
-        # the default set (re-running the fast set costs minutes against an
-        # 8 h budget and means a new deep harness joins this campaign with no
-        # workflow edit — the no-silent-caps rule).
-        run: cd verification/kani && cargo kani --features deep-proofs
+      - name: "Prove ${{ matrix.harness }} (BLOCKING)"
+        # Step timeout under the job timeout under the platform ceiling, so a
+        # non-terminating harness surfaces as a FAILED step naming itself,
+        # rather than a cancelled job naming nothing.
+        timeout-minutes: 300
+        run: |
+          cd verification/kani
+          cargo kani --features deep-proofs --harness '${{ matrix.harness }}'

--- a/ci/deep_harnesses.py
+++ b/ci/deep_harnesses.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Enumerate the Kani harnesses gated behind the `deep-proofs` feature.
+
+WHY THIS EXISTS. The weekly deep lane used to run every deep harness through a
+single `cargo kani --features deep-proofs`, which had one genuinely good
+property: a newly-demoted harness joined the campaign with no workflow edit.
+Splitting the lane into a per-harness matrix (#1260) would have thrown that
+away and replaced it with a hand-maintained list — a silent cap, which this
+repository's CI doctrine forbids. So the matrix is DERIVED from the source
+instead, and there is nothing to drift.
+
+That is not a hypothetical risk. The gate is spelled two different ways today:
+
+    #[cfg(feature = "deep-proofs")]                 # K3, K8, R2
+    #[cfg(all(kani, feature = "deep-proofs"))]      # K7
+
+A hand-written list built by grepping the first spelling silently omits K7 —
+the exact harness that consumed an entire six-hour run. Matching on the
+substring `deep-proofs` anywhere in a `#[cfg(...)]` attribute covers both, and
+any third spelling someone invents later.
+
+WHAT COUNTS. A harness is a function that carries BOTH a `#[cfg(...)]`
+attribute mentioning `deep-proofs` AND a `#[kani::proof]` attribute, in the
+same attribute block. The `#[kani::proof]` requirement is load-bearing:
+`proofs_rss.rs` also gates two `deep-proofs` HELPERS (`grid_speed`,
+`grid_param`) that are not harnesses, and feeding either to
+`cargo kani --harness` would fail the lane on a nonexistent harness.
+
+FAIL-CLOSED. Finding zero harnesses is an ERROR, not an empty matrix. An empty
+matrix produces a lane that passes while verifying nothing — the same vacuous
+-pass failure mode the mutation gate guards against with its own non-zero
+check. If every harness is legitimately promoted out of the deep tier, delete
+the lane deliberately rather than letting it pass empty.
+
+Emits a JSON array on stdout, sorted, for `fromJSON` in a matrix strategy.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+import sys
+
+# Repository-relative so it behaves the same locally and in CI.
+KANI_SRC = pathlib.Path(__file__).resolve().parent.parent / "verification" / "kani" / "src"
+
+_ATTR = re.compile(r"^\s*#\[")
+_CFG_DEEP = re.compile(r"^\s*#\[cfg\b.*deep-proofs")
+_KANI_PROOF = re.compile(r"^\s*#\[kani::proof\b")
+_FN = re.compile(r"^\s*(?:pub\s+)?(?:async\s+)?fn\s+([A-Za-z0-9_]+)")
+
+
+def harnesses_in(text: str) -> list[str]:
+    """Names of `deep-proofs`-gated `#[kani::proof]` functions in one file."""
+    found: list[str] = []
+    lines = text.splitlines()
+    i = 0
+    while i < len(lines):
+        if not _CFG_DEEP.match(lines[i]):
+            i += 1
+            continue
+        # Walk the contiguous attribute block: attributes may appear in any
+        # order, and `#[kani::stub(...)]` lines sit between them in practice.
+        saw_proof = False
+        j = i
+        while j < len(lines) and (_ATTR.match(lines[j]) or not lines[j].strip()):
+            if _KANI_PROOF.match(lines[j]):
+                saw_proof = True
+            j += 1
+        if saw_proof and j < len(lines):
+            m = _FN.match(lines[j])
+            if m:
+                found.append(m.group(1))
+        i = j if j > i else i + 1
+    return found
+
+
+def main() -> int:
+    if not KANI_SRC.is_dir():
+        print(f"error: {KANI_SRC} is not a directory", file=sys.stderr)
+        return 1
+
+    names: list[str] = []
+    for path in sorted(KANI_SRC.glob("*.rs")):
+        names.extend(harnesses_in(path.read_text(encoding="utf-8")))
+
+    names = sorted(set(names))
+    if not names:
+        print(
+            "error: no `deep-proofs`-gated #[kani::proof] harnesses found under "
+            f"{KANI_SRC}. Refusing to emit an empty matrix — a deep lane with no "
+            "harnesses passes while verifying nothing. If the deep tier is now "
+            "empty, remove the lane deliberately.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(json.dumps(names))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/test_deep_harnesses.py
+++ b/ci/test_deep_harnesses.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Tests for `ci/deep_harnesses.py` — the weekly deep lane's matrix source.
+
+This script decides WHICH PROPERTIES GET PROVED. If it silently returns too few
+names, the lane goes green having verified less than it claims — the failure
+mode #1260 is about. Two behaviours are therefore pinned here rather than left
+to inspection, because both were live hazards during that investigation:
+
+  1. BOTH gate spellings are recognised. K7 uses `cfg(all(kani, feature = ...))`
+     while its siblings use `cfg(feature = ...)`. A grep for the second spelling
+     alone drops K7 — the harness that ate an entire six-hour run.
+  2. `deep-proofs`-gated HELPERS are excluded. `proofs_rss.rs` gates
+     `grid_speed` and `grid_param` behind the same feature; neither is a
+     `#[kani::proof]`, and passing either to `cargo kani --harness` fails.
+
+Run: python3 ci/test_deep_harnesses.py
+"""
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+from deep_harnesses import harnesses_in  # noqa: E402
+
+CI = pathlib.Path(__file__).resolve().parent
+REPO = CI.parent
+
+_FAILURES: list[str] = []
+
+
+def check(cond: bool, label: str) -> None:
+    print(f"  {'ok  ' if cond else 'FAIL'} - {label}")
+    if not cond:
+        _FAILURES.append(label)
+
+
+print("== 1. both gate spellings are recognised ==")
+plain = """
+    #[cfg(feature = "deep-proofs")]
+    #[kani::proof]
+    fn k3_plain_gate() {}
+"""
+nested = """
+    #[cfg(all(kani, feature = "deep-proofs"))]
+    #[kani::proof]
+    #[kani::stub(f64::tan, stub_tan)]
+    fn k7_nested_gate() {}
+"""
+check(harnesses_in(plain) == ["k3_plain_gate"], "cfg(feature = ...) is found")
+check(harnesses_in(nested) == ["k7_nested_gate"],
+      "cfg(all(kani, feature = ...)) is found — the spelling a naive grep drops")
+
+print("== 2. stub attributes between the gate and the fn do not break parsing ==")
+interleaved = """
+    #[cfg(all(kani, feature = "deep-proofs"))]
+    #[kani::proof]
+    #[kani::stub(f64::powi, stub_powi)]
+    #[kani::stub(f64::tan, stub_tan)]
+    #[kani::stub(f64::atan, stub_atan)]
+    fn many_stubs() {}
+"""
+check(harnesses_in(interleaved) == ["many_stubs"], "attribute block is walked to the fn")
+
+print("== 3. deep-gated NON-proofs are excluded ==")
+helper = """
+    #[cfg(all(kani, feature = "deep-proofs"))]
+    fn grid_speed(i: u8) -> f64 { 0.0 }
+"""
+check(harnesses_in(helper) == [], "a deep-gated helper without #[kani::proof] is not a harness")
+
+print("== 4. non-deep proofs are excluded ==")
+shallow = """
+    #[cfg(kani)]
+    #[kani::proof]
+    fn k6_per_pr_harness() {}
+"""
+check(harnesses_in(shallow) == [], "a per-PR harness is not pulled into the deep matrix")
+
+print("== 5. against the REAL source tree ==")
+out = subprocess.run([sys.executable, str(CI / "deep_harnesses.py")],
+                     capture_output=True, text=True, cwd=REPO)
+check(out.returncode == 0, f"script exits 0 (got {out.returncode}: {out.stderr.strip()[:120]})")
+names = out.stdout.strip()
+for expected in ("k3_speed_ceiling_clamp_exact",
+                 "k7_executable_return_respects_the_rack_limit",
+                 "k8_executable_return_respects_the_rate_bound",
+                 "r2_longitudinal_monotone_in_closing_speed_on_grid"):
+    check(expected in names, f"{expected} is in the matrix")
+for helper_name in ("grid_speed", "grid_param"):
+    check(helper_name not in names, f"helper {helper_name} is NOT in the matrix")
+
+print("== 6. fail-closed on an empty deep tier ==")
+# A vacuous lane passes while proving nothing. Point the script at a tree with
+# no deep harnesses and require a non-zero exit rather than `[]`.
+import tempfile  # noqa: E402
+import textwrap  # noqa: E402
+
+with tempfile.TemporaryDirectory() as td:
+    fake = pathlib.Path(td) / "verification" / "kani" / "src"
+    fake.mkdir(parents=True)
+    (fake / "proofs.rs").write_text(textwrap.dedent("""
+        #[cfg(kani)]
+        #[kani::proof]
+        fn only_a_per_pr_harness() {}
+    """), encoding="utf-8")
+    shim = pathlib.Path(td) / "deep_harnesses.py"
+    shim.write_text((CI / "deep_harnesses.py").read_text(encoding="utf-8"), encoding="utf-8")
+    # The script resolves KANI_SRC relative to its own location's parent.
+    (pathlib.Path(td) / "ci").mkdir()
+    (pathlib.Path(td) / "ci" / "deep_harnesses.py").write_text(
+        (CI / "deep_harnesses.py").read_text(encoding="utf-8"), encoding="utf-8")
+    empty = subprocess.run(
+        [sys.executable, str(pathlib.Path(td) / "ci" / "deep_harnesses.py")],
+        capture_output=True, text=True)
+    check(empty.returncode != 0, "an empty deep tier is an ERROR, not an empty matrix")
+    check("Refusing to emit an empty matrix" in empty.stderr,
+          "the refusal explains itself")
+
+if _FAILURES:
+    print(f"\n== deep_harnesses: {len(_FAILURES)} FAILED ==")
+    for f in _FAILURES:
+        print(f"   - {f}")
+    raise SystemExit(1)
+print("\n== deep_harnesses: all checks passed ==")


### PR DESCRIPTION
Fixes the two unambiguous mechanical defects behind #1260. **Deliberately does not decide R2's fate** — that needs an explicit call, not a plumbing change.

No source changes, no proof changes. Two workflow files and two new `ci/` scripts.

## Defect 1 — the timeout was inert, so failures rendered grey

A GitHub-hosted job cannot exceed **360 minutes**. `timeout-minutes: 480` did not buy more time; it only meant the *platform* ended the job, and the platform's word for out-of-time is `cancelled` — which renders grey, not red. Four consecutive runs produced no verdict and nothing surfaced it.

```yaml
timeout-minutes: 330        # job, under the 360 ceiling
  timeout-minutes: 300      # proof step, under the job
```

A timeout we own now fires first and **fails**. The comment says not to raise it to 360, because that hands the outcome back to the platform and restores the silent grey.

## Defect 2 — one job, harnesses in series

The first non-terminating harness consumed everything behind it:

| Run | What hung | What starved |
|---|---|---|
| 2026-07-26 | R2, 5 h 59 m in one `kissat` solve | everything after it |
| [30629178939](https://github.com/kirra-systems/kirra-runtime-sdk/actions/runs/30629178939) | K7, hung 17 s in | **K3, K8 and R2 never started** |

Which property received any budget at all was decided by scheduling order. Each harness now gets its own job and its own full budget, with `fail-fast: false` so one hang cannot cancel its siblings.

## Why the matrix is derived rather than hardcoded

Splitting the lane would otherwise have destroyed a genuinely good property of the single `cargo kani --features deep-proofs` command — a newly-demoted harness joined the campaign with **no workflow edit** — and replaced it with a hand-maintained list, i.e. a silent cap. `ci/deep_harnesses.py` scans the source instead, so there is nothing to drift.

This is not a hypothetical risk. The gate is spelled two different ways today:

```rust
#[cfg(feature = "deep-proofs")]                 // K3, K8, R2
#[cfg(all(kani, feature = "deep-proofs"))]      // K7
```

A list built by grepping the first spelling silently omits **K7** — the harness that ate an entire six-hour run. I tripped over exactly that while enumerating them for this PR, which is why the behaviour is pinned by tests rather than trusted.

`ci/test_deep_harnesses.py` (wired into the guardrails job) covers:
- both gate spellings;
- exclusion of the two `deep-proofs`-gated **helpers** in `proofs_rss.rs` (`grid_speed`, `grid_param`) that are not `#[kani::proof]` — passing either to `--harness` would fail the lane;
- **fail-closed on an empty deep tier**, so the lane can never pass while proving nothing. Same doctrine as the mutation gate's non-zero check.

## The finding the last run isolated

Worth reading before deciding R2, because it splits the two unknowns apart:

- **R2's** orphan process was `kissat` — it is **solver-bound**, a genuine budget question.
- **K7's** orphan was `cbmc`, with *no solver ever invoked* — it hung in propositional reduction. That is **encoder non-termination**, and more hours may be the wrong remedy entirely. The "give it a bigger budget" framing that justified its demotion in #1242 may be the wrong diagnosis.
- **K3 and K8** remain completely unmeasured under a multi-hour budget. This matrix is what will measure them.

## Also recorded in the workflow header

The standing rule that every deep harness keeps a **blocking per-PR concrete mirror** is the only reason four weeks of a dead lane was a coverage *reduction* and not a coverage *hole*. That rule is load-bearing, not belt-and-braces, and the header now says so.

## Out of scope, on purpose

- **R2's disposition** — self-hosted runner, different solver strategy, or formal demotion out of the proof tier.
- **K7's diagnosis** — now that it is known to be an encoder rather than solver problem.
- **The record correction** — that is #1261, already open, and it stays valid until this lane is fixed *and* has completed a successful run.

## Verification

- both workflows parse; `step 300 < job 330 < platform 360` asserted by inspection of the parsed YAML
- `python3 ci/test_deep_harnesses.py` — all checks pass
- `python3 ci/deep_harnesses.py` → the four expected harnesses, helpers excluded
- `scripts/pin-actions.sh --check` — all action references SHA-pinned

The real proof is the next run of the lane, which is why #1261's correction does not lift on merge.

Refs #1260.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjDFKPcBVHURDZpXsvnYhC)_