### PR TITLE
Make the deployment's identity explicit at install time

### DIFF
--- a/robot/install/deployment_verify_test.py
+++ b/robot/install/deployment_verify_test.py
@@ -7,6 +7,7 @@ checkout and everything LOOKED fine: units active, /health ok, consumer started.
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 import sys
 import tempfile
@@ -260,6 +261,139 @@ def test_the_report_never_writes():
               "the env file was MODIFIED by a read-only report")
     finally:
         Path(p).unlink()
+
+
+def test_the_installer_derives_one_robot_user_everywhere():
+    """The unit's User= and the udev rule's OWNER must name the SAME account.
+
+    install_kirra.sh is documented to run under sudo. `id -un` therefore returns
+    root, while `${SUDO_USER:-${USER}}` returns the real robot user — so mixing
+    the two idioms rendered `User=root` into kirra-consumer.service while the
+    udev rule kept OWNER=<robot user>. Root bypasses the 0600 owner check on
+    /dev/myserial, so serial kept working and the split stayed invisible; Fast
+    DDS shared memory does not bypass, so release frames stopped being delivered
+    to a root-owned reader and the consumer serviced its timer but never its
+    subscription.
+
+    Asserting the two derivations agree is what makes that split impossible to
+    reintroduce silently.
+    """
+    src = (HERE / "install_kirra.sh").read_text()
+    assignments = re.findall(
+        r"^(?:KIRRA_USER|ROBOT_USER)=(.+)$", src, flags=re.MULTILINE
+    )
+    check(len(assignments) >= 2,
+          f"expected both KIRRA_USER and ROBOT_USER assignments, found {assignments}")
+    for rhs in assignments:
+        check("id -un" not in rhs,
+              f"robot-user derivation uses `id -un`, which is root under sudo: {rhs.strip()}")
+        check("SUDO_USER" in rhs,
+              f"robot-user derivation must honour SUDO_USER: {rhs.strip()}")
+    check(len(set(a.strip() for a in assignments)) == 1,
+          f"the robot user is derived inconsistently across the installer: {assignments}")
+
+
+def test_the_consumer_unit_never_ships_a_hardcoded_root_user():
+    """A rendered `User=root` is the failure this whole class produces."""
+    unit = (HERE / "systemd" / "kirra-consumer.service").read_text()
+    check("User=__KIRRA_ROBOT_USER__" in unit,
+          "the consumer unit template must keep the __KIRRA_ROBOT_USER__ placeholder")
+    check("User=root" not in unit,
+          "the consumer unit must never hardcode User=root — root-owned DDS "
+          "shared-memory segments are unwritable by the robot-user publisher")
+
+
+def test_the_installer_writes_the_consumer_lib_where_the_verifier_expects_it():
+    """The .so path in EXPECTED_ARTIFACTS must be a path install_kirra.sh writes.
+
+    A live robot ran an OLD verify core for hours: robot.env pinned
+    KIRRA_CONSUMER_LIB to the pre-lib/ layout, so every rebuild landed in
+    /opt/kirra/lib/ while the consumer dlopen'd a stale file one directory up.
+    Both files existed and both loaded, so nothing failed — the SS-002 stop ramp
+    simply never ran and the wheels kept turning after releases stopped.
+
+    The artifact-contract test above only pairs robot/-relative files, which is
+    exactly why this one slipped through it.
+    """
+    installer = (HERE / "install_kirra.sh").read_text()
+    # The destinations the installer writes the cdylib to, ${OPT} expanded.
+    installed = [
+        ln.split()[-1].strip('"').replace("${OPT}", "/opt/kirra")
+        for ln in installer.splitlines()
+        if "libkirra_consumer_ffi.so" in ln and ln.strip().startswith("sudo install")
+    ]
+    check(installed, "install_kirra.sh must install the consumer cdylib")
+    check(any(d == vd.INSTALLED_CONSUMER_LIB for d in installed),
+          f"the installer writes {installed}, the verifier expects "
+          f"{vd.INSTALLED_CONSUMER_LIB}")
+    expected = [p for p, _ in vd.EXPECTED_ARTIFACTS if p.endswith("libkirra_consumer_ffi.so")]
+    check(expected, "EXPECTED_ARTIFACTS must name the consumer cdylib")
+    for p in expected:
+        check(p == vd.INSTALLED_CONSUMER_LIB,
+              f"the verifier expects {p}, the installer writes "
+              f"{vd.INSTALLED_CONSUMER_LIB} — a robot pinned to the other one "
+              f"runs a core no rebuild can replace")
+
+
+def test_the_env_template_points_at_the_installed_consumer_lib():
+    """robot.env is rendered from env.template; if it names the other path the
+    consumer loads a library the installer never updates."""
+    tmpl = (HERE / "env.template").read_text()
+    vals = [ln.split("=", 1)[1].strip() for ln in tmpl.splitlines()
+            if ln.strip().startswith("KIRRA_CONSUMER_LIB=")]
+    check(vals, "env.template must set KIRRA_CONSUMER_LIB")
+    for v in vals:
+        check(v == vd.INSTALLED_CONSUMER_LIB,
+              f"env.template points KIRRA_CONSUMER_LIB at {v}, installer writes "
+              f"{vd.INSTALLED_CONSUMER_LIB}")
+
+
+def test_deployment_identity_flags_a_user_mismatch():
+    """The 2026-07-31 fault-1 shape: unit runs as root, port owned by the robot
+    user. Every component healthy, no message ever delivered."""
+    rep = vd.Report()
+    vd.check_deployment_identity(rep, {"KIRRA_CONSUMER_LIB": vd.INSTALLED_CONSUMER_LIB},
+                                 unit_user="root", port_owner="jetson",
+                                 configured_user="jetson")
+    bad = [r for r in rep.rows if r["status"] == vd.FAIL]
+    check(bad, "a root unit against a robot-user port must FAIL, not pass quietly")
+    check(any("unit user" in r["check"] for r in bad),
+          f"the unit-user row must be the failing one, got {[r['check'] for r in bad]}")
+    check(all(r["fix"] for r in bad), "a failure must tell the operator what to do")
+
+
+def test_deployment_identity_flags_a_library_pointing_elsewhere():
+    """Fault-2 shape: the consumer loads a library the installer never writes,
+    so it dlopen's fine and no rebuild ever reaches it."""
+    rep = vd.Report()
+    vd.check_deployment_identity(rep, {"KIRRA_CONSUMER_LIB": "/opt/kirra/libkirra_consumer_ffi.so"},
+                                 unit_user="jetson", port_owner="jetson",
+                                 configured_user="jetson")
+    bad = [r for r in rep.rows if r["status"] == vd.FAIL]
+    check(any("consumer library" in r["check"] for r in bad),
+          f"a library outside the installer's destination must FAIL, got "
+          f"{[(r['check'], r['status']) for r in rep.rows]}")
+
+
+def test_deployment_identity_accepts_a_consistent_deployment():
+    """…and must not cry wolf on a correct one, including an unplugged board."""
+    rep = vd.Report()
+    vd.check_deployment_identity(rep, {"KIRRA_CONSUMER_LIB": vd.INSTALLED_CONSUMER_LIB},
+                                 unit_user="jetson", port_owner="<absent>",
+                                 configured_user="jetson")
+    lib_rows = [r for r in rep.rows if "consumer library" in r["check"]]
+    check(not [r for r in rep.rows if r["status"] == vd.FAIL and "library" not in r["check"]],
+          "a consistent deployment with the board unplugged must not FAIL on user/owner")
+    check(lib_rows, "the library row must always be reported")
+
+
+def test_the_installer_prints_the_deployment_identity():
+    """The four lines must actually be emitted at install time — that is the
+    whole point: making the state explicit rather than inferable."""
+    src = (HERE / "install_kirra.sh").read_text()
+    for needle in ("configured robot user", "systemd User=",
+                   "/dev/myserial owner", "KIRRA_CONSUMER_LIB"):
+        check(needle in src, f"install_kirra.sh must print {needle!r}")
 
 
 def _run_all() -> int:

--- a/robot/install/install_kirra.sh
+++ b/robot/install/install_kirra.sh
@@ -193,7 +193,16 @@ echo "  capture_from_robot.sh + README.md 'Config capture'."
 echo "== 6. systemd unit (optional; staged, not enabled) =="
 # Render the unit's User= to the invoking user (review #906: never hard-code
 # an image-specific username). Serial access needs dialout membership.
-ROBOT_USER="$(id -un)"
+# Must match KIRRA_USER above (the udev rule's OWNER). `id -un` is WRONG here:
+# this installer is documented to run under sudo, so it returns root, and the
+# unit was rendered User=root. Root then bypasses the 0600 owner check on
+# /dev/myserial, so serial kept working and nothing surfaced — but Fast DDS
+# shared memory does NOT bypass: the reader's /dev/shm port segment is created
+# root:root 0644, the robot-user publisher cannot write into it, and release
+# frames are never delivered. Discovery still matches (UDP multicast) and timers
+# still fire (local), which is exactly the "timer runs, subscription never does"
+# fault. Derive it the same way as line 97 or the two drift apart again.
+ROBOT_USER="${SUDO_USER:-${USER}}"
 if id -nG "${ROBOT_USER}" | tr ' ' '\n' | grep -qx dialout; then
   ok "user '${ROBOT_USER}' is in dialout (serial access)"
 else
@@ -207,6 +216,47 @@ sudo install -m 0644 "${TMP_UNIT}" /etc/systemd/system/kirra-consumer.service
 rm -f "${TMP_UNIT}"
 sudo systemctl daemon-reload
 warn "kirra-consumer.service staged but NOT enabled: the consumer-as-a-service path has NOT been hardware-validated (the validated mode is a terminal run). Enable deliberately after an elevated re-test: sudo systemctl enable --now kirra-consumer"
+
+# ---- 6b. deployment identity ------------------------------------------------
+# Print the four facts that must agree, and FAIL LOUDLY when they do not.
+#
+# Both faults in the 2026-07-31 incident were invisible mismatches between these
+# lines. The unit ran as root while the udev rule owned the port to the robot
+# user, so Fast DDS shared-memory segments were unwritable by the publisher and
+# release frames were never delivered. Separately, KIRRA_CONSUMER_LIB pointed at
+# a path the installer does not write, so the consumer loaded an old verify core
+# and every rebuild changed nothing. Every individual component reported healthy
+# throughout; nothing printed them side by side.
+echo
+echo "== deployment identity (these four must agree) =="
+_id_unit="$(sed -n 's/^User=//p' /etc/systemd/system/kirra-consumer.service 2>/dev/null || true)"
+_id_port="$(stat -c '%U' -L /dev/myserial 2>/dev/null || echo '<absent>')"
+_id_lib="$(sed -n 's/^KIRRA_CONSUMER_LIB=//p' /etc/kirra/robot.env 2>/dev/null || true)"
+_id_lib_installed="${OPT}/lib/libkirra_consumer_ffi.so"
+[[ -n "${_id_lib}" ]] || _id_lib="<unset — defaults to ${_id_lib_installed}>"
+
+printf '  configured robot user : %s\n' "${ROBOT_USER}"
+printf '  systemd User=         : %s\n' "${_id_unit:-<unset>}"
+printf '  /dev/myserial owner   : %s\n' "${_id_port}"
+printf '  KIRRA_CONSUMER_LIB    : %s\n' "${_id_lib}"
+printf '  library exists        : %s\n' \
+  "$([[ -f "${_id_lib_installed}" ]] && echo yes || echo NO)"
+
+_id_bad=0
+[[ "${_id_unit}" == "${ROBOT_USER}" ]] || {
+  warn "systemd User='${_id_unit:-<unset>}' != robot user '${ROBOT_USER}' — a consumer running as another user cannot exchange DDS shared-memory data with same-host publishers, while discovery still matches and timers still fire"
+  _id_bad=1
+}
+# The port is absent until the board is plugged in; that is not a mismatch.
+if [[ "${_id_port}" != "<absent>" && "${_id_port}" != "${ROBOT_USER}" ]]; then
+  warn "/dev/myserial is owned by '${_id_port}', not '${ROBOT_USER}' — replug the board or re-trigger udev; the consumer's boot sentinel will refuse to start"
+  _id_bad=1
+fi
+if [[ "${_id_lib}" != "<unset"* && "${_id_lib}" != "${_id_lib_installed}" ]]; then
+  warn "KIRRA_CONSUMER_LIB='${_id_lib}' is not where this installer writes the cdylib (${_id_lib_installed}) — the consumer would load a library no rebuild replaces"
+  _id_bad=1
+fi
+[[ "${_id_bad}" -eq 0 ]] && ok "deployment identity consistent"
 
 # ---- 7. verification checklist ----------------------------------------------
 echo

--- a/robot/install/verify_deployment.py
+++ b/robot/install/verify_deployment.py
@@ -37,6 +37,10 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import consumer_config_contract as contract  # noqa: E402
 
 OPT = os.environ.get("KIRRA_OPT_DIR", "/opt/kirra")
+# The path install_kirra.sh actually writes the cdylib to. KIRRA_CONSUMER_LIB
+# must resolve here; a robot.env left on the pre-lib/ layout silently pins an
+# older core that every subsequent rebuild fails to replace.
+INSTALLED_CONSUMER_LIB = f"{OPT}/lib/libkirra_consumer_ffi.so"
 ROBOT_ENV = os.environ.get("KIRRA_ROBOT_ENV", "/etc/kirra/robot.env")
 
 # (path, must_be_executable) — the artifacts a governed robot actually runs.
@@ -44,7 +48,7 @@ EXPECTED_ARTIFACTS = [
     (f"{OPT}/robot/kirra_motor_consumer.py", True),
     (f"{OPT}/robot/serial_exclusivity.py", False),
     (f"{OPT}/robot/motor_authority.py", False),
-    (f"{OPT}/libkirra_consumer_ffi.so", False),
+    (INSTALLED_CONSUMER_LIB, False),
     (f"{OPT}/taj_service", True),
     (f"{OPT}/mick_service", True),
 ]
@@ -132,6 +136,55 @@ def check_artifacts(rep: Report) -> dict:
     return digests
 
 
+def check_deployment_identity(rep: Report, env: dict, unit_user: str,
+                             port_owner: str, configured_user: str) -> None:
+    """The four facts that must name the same account / the same library.
+
+    Both 2026-07-31 faults were invisible disagreements between these values,
+    and every component reported healthy in isolation. A consumer running as a
+    different user than the publisher cannot exchange Fast DDS shared-memory
+    data — discovery still matches over UDP and local timers still fire, so the
+    node looks alive while no message is ever delivered. A KIRRA_CONSUMER_LIB
+    pointing anywhere but the installer's destination loads a core that no
+    rebuild replaces, and it dlopen's perfectly.
+
+    Pure decision over already-collected values so it is host-testable: the
+    caller does the reading, this decides.
+    """
+    lib = (env.get("KIRRA_CONSUMER_LIB") or "").strip() or INSTALLED_CONSUMER_LIB
+
+    if unit_user and configured_user and unit_user != configured_user:
+        rep.add("deployment identity: unit user", FAIL,
+                f"systemd User={unit_user}, robot user is {configured_user}",
+                fix=f"set User={configured_user} in kirra-consumer.service; a "
+                    f"mismatched user breaks DDS shared-memory delivery while "
+                    f"discovery and timers still look healthy")
+    else:
+        rep.add("deployment identity: unit user", PASS,
+                f"systemd User={unit_user or '<unset>'}")
+
+    # An absent port just means the board is unplugged — not a mismatch.
+    if port_owner and port_owner != "<absent>" and port_owner != configured_user:
+        rep.add("deployment identity: serial owner", FAIL,
+                f"/dev/myserial owned by {port_owner}, robot user is {configured_user}",
+                fix="re-trigger udev or replug the board; the consumer's boot "
+                    "sentinel refuses to start on an owner mismatch")
+    else:
+        rep.add("deployment identity: serial owner", PASS,
+                f"/dev/myserial owner={port_owner or '<absent>'}")
+
+    if os.path.realpath(lib) != os.path.realpath(INSTALLED_CONSUMER_LIB):
+        rep.add("deployment identity: consumer library", FAIL,
+                f"KIRRA_CONSUMER_LIB={lib}, installer writes {INSTALLED_CONSUMER_LIB}",
+                fix=f"point KIRRA_CONSUMER_LIB at {INSTALLED_CONSUMER_LIB} and "
+                    f"remove the stale copy — otherwise rebuilds never take effect")
+    elif not os.path.exists(lib):
+        rep.add("deployment identity: consumer library", FAIL,
+                f"{lib} does not exist", fix="build + install the cdylib")
+    else:
+        rep.add("deployment identity: consumer library", PASS, f"{lib} present")
+
+
 def probe_ffi(rep: Report, env: dict) -> None:
     """Load the consumer FFI EXPLICITLY.
 
@@ -140,11 +193,24 @@ def probe_ffi(rep: Report, env: dict) -> None:
     one restart, which is exactly how the live FFI failure hid inside a restart
     loop. A dlopen either works or names its own error.
     """
-    lib = (env.get("KIRRA_CONSUMER_LIB") or "").strip() or f"{OPT}/libkirra_consumer_ffi.so"
+    lib = (env.get("KIRRA_CONSUMER_LIB") or "").strip() or INSTALLED_CONSUMER_LIB
     if not os.path.exists(lib):
         rep.add("consumer FFI loads", FAIL, f"{lib} missing",
                 fix="build + install libkirra_consumer_ffi.so")
         return
+    # A live robot ran an OLD core for hours because robot.env still pointed at
+    # the pre-lib/ layout: every rebuild landed in INSTALLED_CONSUMER_LIB while
+    # the consumer dlopen'd a stale file one directory up. Both existed, both
+    # loaded, and nothing compared them — so the fix "worked" and changed
+    # nothing. Loading the wrong core is not a load failure, so this is its own
+    # row rather than part of the dlopen check.
+    if os.path.realpath(lib) != os.path.realpath(INSTALLED_CONSUMER_LIB):
+        rep.add(
+            "consumer FFI is the installed one", WARN,
+            f"loads {lib}, installer writes {INSTALLED_CONSUMER_LIB}",
+            fix=f"point KIRRA_CONSUMER_LIB at {INSTALLED_CONSUMER_LIB} in "
+                f"/etc/kirra/robot.env, then remove the stale copy",
+        )
     code = ("import ctypes,sys\n"
             "try:\n"
             "    ctypes.CDLL(sys.argv[1])\n"


### PR DESCRIPTION
## Summary

- derive the robot user **once** in `install_kirra.sh`, honouring `SUDO_USER`
- derive the consumer cdylib path **once**, from `INSTALLED_CONSUMER_LIB`
- print the four facts that must agree, immediately after installation
- tests for both field failure shapes

Fixes the two configuration defects behind the 2026-07-31 incident. 1 of 4 split PRs; the others are diagnostics, test coverage, and the incident report.

## Defect 1 — the robot user was derived two ways

| Line | Purpose | Derivation | Under `sudo` |
|---|---|---|---|
| 97 | udev rule `OWNER` | `"${SUDO_USER:-${USER}}"` | robot user |
| 196 | systemd `User=` | `$(id -un)` | **root** |

The installer is documented to run under `sudo`, so `kirra-consumer.service` shipped `User=root` while `/dev/myserial` stayed owned by the robot user.

Root bypasses the 0600 owner check, so serial worked and nothing surfaced. **Fast DDS shared memory does not bypass.** A reader creates its `/dev/shm` port segment owned by its own user at 0644, and a writer must write into that segment and lock its semaphore. With the consumer as root and the publisher as the robot user, the publisher held `r--` and could not deliver.

Discovery runs over UDP multicast, so `ros2 topic info --verbose` showed a healthy reliable/volatile pair. Timers are local, so the liveness clock kept ticking. The node serviced its timer, never its subscription, and looked correct from every graph-level query.

Observed on the robot — same port, ownership flipping with the fix:

```
14:10  -rw-r--r--  1 root   root    sem.fastrtps_port14427_mutex
14:17  -rw-r--r--  1 jetson jetson  sem.fastrtps_port14427_mutex
```

RX count went 0 → 55.

## Defect 2 — the cdylib path was named two ways

`verify_deployment.py` carried the pre-`lib/` path in two places (the `EXPECTED_ARTIFACTS` entry and the fallback used when `KIRRA_CONSUMER_LIB` is unset) while the installer writes `${OPT}/lib/`. A robot pinned to the other path loaded an old verify core that `dlopen`'d perfectly and that no rebuild could replace:

```
caef2bb5…  /opt/kirra/libkirra_consumer_ffi.so       ← loaded
29f30719…  /opt/kirra/lib/libkirra_consumer_ffi.so   ← installed
```

Both now derive from one `INSTALLED_CONSUMER_LIB`, and a loaded-vs-installed mismatch is reported as **its own row** — loading the wrong core is not a load failure, and the `dlopen` check passes either way, which is exactly why this was invisible.

## The four lines

Printed at the end of `install_kirra.sh`, warning on each mismatch:

```
== deployment identity (these four must agree) ==
  configured robot user : jetson
  systemd User=         : jetson
  /dev/myserial owner   : jetson
  KIRRA_CONSUMER_LIB    : /opt/kirra/lib/libkirra_consumer_ffi.so
  library exists        : yes
```

Every individual component reported healthy throughout the incident. Nothing printed them side by side.

`check_deployment_identity` makes the same decision re-runnably, as a pure function over already-read values so it is host-testable — the caller reads, this decides. An absent port is not a mismatch; the board is simply unplugged.

## Validation

- `robot/install/deployment_verify_test.py` — 25/25 (was 17)
- `bash -n` + `shellcheck -S error` on `install_kirra.sh` — clean
- `scripts/test-shellcheck-gate.sh` — 18/18, all tracked scripts error-clean

New tests cover both field shapes: a root unit against a robot-user port, and a library outside the installer's destination. Each must FAIL **with a fix hint**; a consistent deployment must not cry wolf; and the installer must actually emit the four lines. Reverting either constant reds them — verified by tripwire.

## Scope

No change to the checker, the verify core, actuation, or serial exclusivity. Configuration derivation and reporting only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HaTMYY54Z5Gc4TryvETrum

---
_Generated by [Claude Code](https://claude.ai/code/session_01HaTMYY54Z5Gc4TryvETrum)_