### PR TITLE
Add consumer callback diagnostics and a gated release-path trace

### DIFF
--- a/robot/diagnostics/probe_publisher.py
+++ b/robot/diagnostics/probe_publisher.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Matching publisher for `ros_callback_matrix.py`.
+
+Publishes a 3-byte UInt8MultiArray on /kirra/probe at 10 Hz with the same QoS
+the production consumer subscribes with (reliable, volatile, depth 10).
+
+SAFETY
+    The payload is 3 bytes, deliberately NOT the 272-byte governed frame, and it
+    carries no release token. It cannot pass the verify core and therefore cannot
+    reach actuation — it exercises DDS delivery only.
+
+USAGE
+    source /opt/kirra/robot/ros_env.sh && kirra_source_ros
+    python3 robot/diagnostics/probe_publisher.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+PROBE_TOPIC = "/kirra/probe"
+PROBE_PAYLOAD = [9, 8, 7]  # 3 bytes — never 272
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--hz", type=float, default=10.0)
+    parser.add_argument("--topic", default=PROBE_TOPIC)
+    args = parser.parse_args(argv)
+
+    import rclpy
+    from rclpy.node import Node
+    from std_msgs.msg import UInt8MultiArray
+
+    rclpy.init()
+    node = Node("kirra_probe_publisher")
+    pub = node.create_publisher(UInt8MultiArray, args.topic, 10)
+    sent = 0
+
+    def tick() -> None:
+        nonlocal sent
+        msg = UInt8MultiArray()
+        msg.data = PROBE_PAYLOAD
+        pub.publish(msg)
+        sent += 1
+        if sent % int(max(1.0, args.hz)) == 0:
+            print(f"published {sent} probe frames ({len(PROBE_PAYLOAD)} bytes)", flush=True)
+
+    node.create_timer(1.0 / args.hz, tick)
+    print(f"publishing {len(PROBE_PAYLOAD)}-byte probes on {args.topic} @ {args.hz:.0f} Hz",
+          flush=True)
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        if rclpy.ok():
+            rclpy.shutdown()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/robot/diagnostics/ros_callback_matrix.py
+++ b/robot/diagnostics/ros_callback_matrix.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""Controlled test matrix: why does a node service timers but not subscriptions?
+
+Isolates the failure boundary for the fault where `kirra_motor_consumer.py`
+executes its liveness timer but never its `/kirra/release` subscription, even
+though DDS discovery shows a matched pair and a standalone subscriber in another
+process receives the same messages.
+
+Each mode changes exactly ONE variable relative to mode `a`, so the first mode
+that stops delivering subscription callbacks names the cause:
+
+    a  pure ROS                      — node + sub + timer, SingleThreadedExecutor
+    b  + import Rosmaster_Lib        — imported, NOT instantiated
+    c  + instantiate Rosmaster       — serial opened, receive thread NOT started
+    d  + create_receive_threading()  — the vendor blocking-read thread is live
+    e  separate callback groups      — sub and timer in distinct MutuallyExclusive groups
+    f  MultiThreadedExecutor         — one clean try/finally, num_threads=2
+    g  executor readiness probe      — logs what the wait set reports ready
+    h  alternate RMW                 — run under a different RMW_IMPLEMENTATION
+
+`a` through `d` are the important ones: they walk the vendor object in one step
+at a time. If `d` is the first failure, the vendor receive thread is the cause.
+If `a` already fails, the cause is environmental (RMW/domain), not the vendor.
+
+SAFETY
+    This script NEVER writes a motor. Modes c/d construct `Rosmaster` (which
+    opens the serial port) but issue no motion primitive and no stop primitive —
+    it commands nothing at all, so it cannot move the robot. Even so, run it
+    with the robot on blocks and with the consumer service stopped, because
+    opening the port while the consumer holds TIOCEXCL will fail by design.
+
+    The probe topic carries a 3-byte payload, deliberately NOT the 272-byte
+    governed frame, so no governed actuation path can be reached from here.
+
+USAGE
+    source /opt/kirra/robot/ros_env.sh && kirra_source_ros
+    python3 robot/diagnostics/ros_callback_matrix.py a
+    python3 robot/diagnostics/ros_callback_matrix.py d --seconds 15
+
+    # in a second shell, the matching publisher:
+    python3 robot/diagnostics/probe_publisher.py
+
+Exit status is 0 when subscription callbacks were observed, 1 when they were
+not — so the matrix can be swept non-interactively.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import threading
+import time
+
+PROBE_TOPIC = "/kirra/probe"
+PROBE_PAYLOAD_LEN = 3  # deliberately not 272 — cannot reach governed actuation
+
+MODES = ("a", "b", "c", "d", "e", "f", "g", "h")
+
+
+def _stderr(msg: str) -> None:
+    print(msg, file=sys.stderr, flush=True)
+
+
+def _report_environment() -> None:
+    """Record the DDS-relevant environment before anything else runs.
+
+    Hypothesis 6 (an RMW/DDS mismatch invisible to graph discovery) can only be
+    argued from the environment the process actually had, so it is captured in
+    every run rather than reconstructed afterwards.
+    """
+    keys = (
+        "RMW_IMPLEMENTATION",
+        "ROS_DOMAIN_ID",
+        "ROS_LOCALHOST_ONLY",
+        "ROS_AUTOMATIC_DISCOVERY_RANGE",
+        "ROS_STATIC_PEERS",
+        "FASTRTPS_DEFAULT_PROFILES_FILE",
+        "CYCLONEDDS_URI",
+        "RMW_FASTRTPS_USE_QOS_FROM_XML",
+    )
+    print("== environment ==", flush=True)
+    for k in keys:
+        print(f"   {k}={os.environ.get(k, '<unset>')}", flush=True)
+    try:
+        from rmw_implementation import get_rmw_implementation_identifier
+
+        print(f"   active rmw={get_rmw_implementation_identifier()}", flush=True)
+    except Exception as e:  # noqa: BLE001 — diagnostic only
+        print(f"   active rmw=<unavailable: {e}>", flush=True)
+    print(f"   pid={os.getpid()} threads={threading.active_count()}", flush=True)
+
+
+def _open_vendor(mode: str, port: str):
+    """Return (bot, note) for the vendor-object modes; (None, note) otherwise.
+
+    Mode b imports the library without constructing it, so an import-time side
+    effect is separated from a construction-time one. Mode c constructs it
+    (opening the serial port) without the receive thread. Mode d additionally
+    starts the vendor's blocking-read thread — the one variable under suspicion.
+    """
+    if mode == "a":
+        return None, "no vendor import"
+
+    from Rosmaster_Lib import Rosmaster  # noqa: F401 — mode b measures the import alone
+
+    if mode == "b":
+        return None, "Rosmaster_Lib imported, not instantiated"
+
+    if mode not in ("c", "d"):
+        return None, "no vendor object for this mode"
+
+    bot = Rosmaster(com=port)
+    if mode == "c":
+        return bot, f"Rosmaster({port}) constructed, receive thread NOT started"
+
+    bot.create_receive_threading()
+    # The vendor reads car type only to prove the thread is genuinely running:
+    # without the receive thread this returns -1, with it, 5.
+    time.sleep(0.5)
+    try:
+        car_type = bot.get_car_type_from_machine()
+    except Exception as e:  # noqa: BLE001 — diagnostic only
+        car_type = f"<raised {e}>"
+    return bot, (
+        f"Rosmaster({port}) constructed + create_receive_threading(); "
+        f"car_type={car_type} (expect 5 when the thread is live, -1 when not)"
+    )
+
+
+def run(mode: str, seconds: float, port: str) -> int:
+    import rclpy
+    from rclpy.node import Node
+    from std_msgs.msg import UInt8MultiArray
+
+    _report_environment()
+
+    bot, note = _open_vendor(mode, port)
+    print(f"== mode {mode}: {note} ==", flush=True)
+    print(f"   threads after vendor setup={threading.active_count()}", flush=True)
+
+    rclpy.init()
+    node = Node(f"kirra_callback_matrix_{mode}")
+
+    counts = {"sub": 0, "timer": 0}
+    first_sub_at: list[float] = []
+    started = time.monotonic()
+
+    def on_probe(msg: UInt8MultiArray) -> None:
+        counts["sub"] += 1
+        if not first_sub_at:
+            first_sub_at.append(time.monotonic() - started)
+            print(
+                f"SUB CALLBACK #1 after {first_sub_at[0]:.2f}s "
+                f"bytes={len(msg.data)} data={list(msg.data)[:8]}",
+                flush=True,
+            )
+
+    def on_timer() -> None:
+        counts["timer"] += 1
+
+    # Callback groups: only mode e separates them. Everywhere else both entities
+    # land in the node's default MutuallyExclusive group, which is what the
+    # production consumer uses.
+    if mode == "e":
+        from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
+
+        sub_group = MutuallyExclusiveCallbackGroup()
+        timer_group = MutuallyExclusiveCallbackGroup()
+        print("   sub and timer in SEPARATE MutuallyExclusive groups", flush=True)
+    else:
+        sub_group = None
+        timer_group = None
+
+    # The return values are retained deliberately. rclpy's Node already holds a
+    # reference, so this does not change lifetime — it only makes hypothesis 10
+    # (an entity being collected or invalidated) inspectable rather than assumed.
+    sub = node.create_subscription(
+        UInt8MultiArray, PROBE_TOPIC, on_probe, 10, callback_group=sub_group
+    )
+    timer = node.create_timer(0.1, on_timer, callback_group=timer_group)
+
+    print(
+        f"   subscription={sub.topic_name} timer_period={timer.timer_period_ns / 1e9:.3f}s",
+        flush=True,
+    )
+
+    executor = None
+    try:
+        if mode in ("f", "h"):
+            from rclpy.executors import MultiThreadedExecutor
+
+            executor = MultiThreadedExecutor(num_threads=2)
+        elif mode == "g":
+            executor = _readiness_probe_executor()
+        else:
+            from rclpy.executors import SingleThreadedExecutor
+
+            executor = SingleThreadedExecutor()
+
+        executor.add_node(node)
+        print(f"   executor={type(executor).__name__} spinning {seconds:.0f}s", flush=True)
+
+        deadline = time.monotonic() + seconds
+        while time.monotonic() < deadline and rclpy.ok():
+            executor.spin_once(timeout_sec=0.1)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        # Exactly one finally for the one try. Teardown order: detach the node
+        # from the executor, shut the executor down, then destroy the node.
+        if executor is not None:
+            try:
+                executor.remove_node(node)
+                executor.shutdown()
+            except Exception:  # noqa: BLE001 — teardown must not mask the result
+                pass
+        try:
+            node.destroy_node()
+        except Exception:  # noqa: BLE001
+            pass
+        if rclpy.ok():
+            rclpy.shutdown()
+        # The vendor object is released without commanding anything. No motion
+        # primitive and no stop primitive is issued, because none was issued
+        # during the run either — the port is simply closed.
+        if bot is not None:
+            try:
+                if hasattr(bot, "ser") and bot.ser is not None:
+                    bot.ser.close()
+            except Exception:  # noqa: BLE001
+                pass
+
+    elapsed = time.monotonic() - started
+    print(
+        f"== mode {mode} RESULT: sub_callbacks={counts['sub']} "
+        f"timer_callbacks={counts['timer']} over {elapsed:.1f}s ==",
+        flush=True,
+    )
+    if counts["timer"] == 0:
+        _stderr("   INCONCLUSIVE: the timer never fired either — the executor "
+                "never span. This mode says nothing about subscriptions.")
+        return 2
+    if counts["sub"] == 0:
+        _stderr("   FAILURE BOUNDARY: timer fired but subscription did not. "
+                "The variable introduced by this mode is implicated.")
+        return 1
+    print("   OK: both entity types dispatched.", flush=True)
+    return 0
+
+
+def _readiness_probe_executor():
+    """Mode g: a SingleThreadedExecutor that logs what the wait set reports ready.
+
+    Hypothesis 12 asks whether the subscriber is considered ready but never
+    dispatched. That distinction is only visible between `wait_for_ready_callbacks`
+    and the handler call, so this subclass reports the ready entity types — rate
+    limited to one line per second, because an unthrottled log here would itself
+    change the timing it is trying to measure.
+    """
+    from rclpy.executors import SingleThreadedExecutor
+
+    class ReadinessProbeExecutor(SingleThreadedExecutor):
+        def __init__(self) -> None:
+            super().__init__()
+            self._last_log = 0.0
+            self._seen: dict[str, int] = {}
+
+        def spin_once(self, timeout_sec=None):  # noqa: ANN001
+            try:
+                handler, entity, _node = self.wait_for_ready_callbacks(
+                    timeout_sec=timeout_sec
+                )
+            except StopIteration:
+                return
+            except TimeoutError:
+                return
+            kind = type(entity).__name__
+            self._seen[kind] = self._seen.get(kind, 0) + 1
+            now = time.monotonic()
+            if now - self._last_log >= 1.0:
+                self._last_log = now
+                print(f"   [ready] {dict(sorted(self._seen.items()))}", flush=True)
+            handler()
+
+    return ReadinessProbeExecutor()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("mode", choices=MODES, help="which matrix row to run")
+    parser.add_argument("--seconds", type=float, default=10.0,
+                        help="how long to spin (default 10)")
+    parser.add_argument("--port", default=os.environ.get("KIRRA_MOTOR_PORT", "/dev/myserial"),
+                        help="serial port for the vendor modes (c, d)")
+    args = parser.parse_args(argv)
+
+    if args.mode == "h" and not os.environ.get("RMW_IMPLEMENTATION"):
+        _stderr("mode h requires RMW_IMPLEMENTATION to be set explicitly, e.g.\n"
+                "  RMW_IMPLEMENTATION=rmw_cyclonedds_cpp python3 "
+                "robot/diagnostics/ros_callback_matrix.py h\n"
+                "Set it per-process only — do not change system configuration.")
+        return 2
+
+    return run(args.mode, args.seconds, args.port)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/robot/diagnostics/run_callback_matrix.sh
+++ b/robot/diagnostics/run_callback_matrix.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Sweep the callback-dispatch matrix and print the failure boundary.
+#
+# Runs each mode of ros_callback_matrix.py against a live probe publisher and
+# reports which mode is the FIRST to lose subscription callbacks. That mode's
+# distinguishing variable is the cause.
+#
+# SAFETY: no motor is ever commanded. Modes c/d open the serial port but issue
+# no motion primitive. Run with the robot on blocks and the consumer stopped.
+#
+# USAGE
+#   source /opt/kirra/robot/ros_env.sh && kirra_source_ros
+#   robot/diagnostics/run_callback_matrix.sh            # modes a b c d
+#   robot/diagnostics/run_callback_matrix.sh a b c d e f g
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SECONDS_PER_MODE="${SECONDS_PER_MODE:-10}"
+MODES=("$@")
+if [[ ${#MODES[@]} -eq 0 ]]; then
+  MODES=(a b c d)
+fi
+
+# ---- process hygiene --------------------------------------------------------
+# Enumerate then kill explicitly. A bare `pkill -f kirra_motor_consumer` also
+# matches this script's own command line when it is passed as an argument, so
+# the PIDs are listed, filtered against $$ and this script's PPID, and only then
+# signalled.
+kill_matching() {
+  local pattern="$1" pid
+  local -a victims=()
+  while read -r pid; do
+    [[ -z "$pid" ]] && continue
+    [[ "$pid" == "$$" || "$pid" == "$PPID" ]] && continue
+    victims+=("$pid")
+  done < <(pgrep -f "$pattern" || true)
+  if [[ ${#victims[@]} -gt 0 ]]; then
+    echo "   killing ${pattern}: ${victims[*]}"
+    sudo kill -KILL "${victims[@]}" 2>/dev/null || kill -KILL "${victims[@]}" 2>/dev/null || true
+  fi
+}
+
+echo "== process hygiene =="
+sudo systemctl stop kirra-consumer.service 2>/dev/null || true
+kill_matching '/opt/kirra/robot/kirra_motor_consumer'
+kill_matching 'kirra_release_publisher\.py'
+kill_matching 'ros_callback_matrix\.py'
+kill_matching 'probe_publisher\.py'
+sleep 2
+
+echo "== survivors (expect none) =="
+pgrep -af 'kirra_motor_consumer|kirra_release_publisher|ros_callback_matrix|probe_publisher' || echo "   none"
+echo "== serial ownership (expect none) =="
+sudo fuser -v /dev/myserial 2>&1 || echo "   unowned"
+
+# ---- sweep ------------------------------------------------------------------
+declare -a RESULTS=()
+for mode in "${MODES[@]}"; do
+  echo
+  echo "############ MODE ${mode} ############"
+
+  python3 -u "${HERE}/probe_publisher.py" >/tmp/kirra_probe_pub.log 2>&1 &
+  pub_pid=$!
+  sleep 2  # let discovery settle before the subscriber starts
+
+  set +e
+  python3 -u "${HERE}/ros_callback_matrix.py" "$mode" --seconds "$SECONDS_PER_MODE"
+  rc=$?
+  set -e
+
+  kill -TERM "$pub_pid" 2>/dev/null || true
+  wait "$pub_pid" 2>/dev/null || true
+  sleep 1
+
+  case "$rc" in
+    0) RESULTS+=("${mode}: PASS  (sub + timer dispatched)") ;;
+    1) RESULTS+=("${mode}: FAIL  (timer dispatched, subscription did NOT)") ;;
+    2) RESULTS+=("${mode}: INCONCLUSIVE (executor never span / mode skipped)") ;;
+    *) RESULTS+=("${mode}: ERROR (exit ${rc})") ;;
+  esac
+done
+
+echo
+echo "======== MATRIX SUMMARY ========"
+printf '%s\n' "${RESULTS[@]}"
+echo
+echo "The FIRST mode to report FAIL names the cause:"
+echo "  a → environmental (RMW/domain), not the vendor library"
+echo "  b → an import-time side effect of Rosmaster_Lib"
+echo "  c → constructing Rosmaster / opening the serial port"
+echo "  d → create_receive_threading(), the vendor blocking-read thread"
+echo "  e/f/g → a callback-group or executor-structure issue"
+echo "If NO mode fails, the fault is not reproduced by this matrix and the"
+echo "deployed file itself is the next suspect — diff it against the repo source."

--- a/robot/diagnostics/uid_asymmetry_test.sh
+++ b/robot/diagnostics/uid_asymmetry_test.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Minimal reproduction for the leading hypothesis: the subscriber never receives
+# because it runs as a DIFFERENT UID than the publisher.
+#
+# WHY THIS TEST EXISTS
+#   Every observation that WORKED was same-user (jetson → jetson):
+#     - ros2 topic echo /kirra/release --once          (jetson)
+#     - the minimal standalone Python subscriber       (jetson)
+#     - kirra_release_publisher.py                     (jetson)
+#   The one thing that FAILS is started with sudo, i.e. as root:
+#     sudo bash -c '... exec python3 /opt/kirra/robot/kirra_motor_consumer.py'
+#   kirra-consumer.service specifies User=<robot user>, so root is NOT the
+#   designed configuration — it is an artefact of the manual start line.
+#
+#   Fast DDS carries discovery over UDP multicast (which is why the graph shows a
+#   matched, reliable, volatile pair) but carries DATA over shared memory for
+#   same-host peers. The /dev/shm segments are created with the creating
+#   participant's ownership. A writer must WRITE into the reader's segment, so a
+#   jetson-owned publisher writing into a root-owned reader segment can be
+#   refused at the filesystem layer while discovery still succeeds — timers keep
+#   firing (they are local) and the subscription is simply never marked ready.
+#
+#   That is a hypothesis, not a conclusion. This script settles it.
+#
+# WHAT IT PROVES
+#   Runs the SAME pure-ROS subscriber (matrix mode a: no vendor library, no
+#   serial, no motors) twice against one jetson-owned publisher — once as the
+#   invoking user, once as root. If the user run passes and the root run fails,
+#   the UID boundary is the cause and no Python change is warranted. If both
+#   pass, the hypothesis is dead and the vendor matrix (modes b-d) is next.
+#
+# SAFETY
+#   Touches no serial port, constructs no Rosmaster, commands no motor. The
+#   payload is 3 bytes, never the 272-byte governed frame.
+#
+# USAGE
+#   source /opt/kirra/robot/ros_env.sh && kirra_source_ros
+#   robot/diagnostics/uid_asymmetry_test.sh
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SECS="${SECS:-8}"
+
+if [[ "$(id -u)" -eq 0 ]]; then
+  echo "❌ run this as the ROBOT USER, not root — the script elevates for the" >&2
+  echo "   second leg itself. Running the whole thing as root tests nothing." >&2
+  exit 2
+fi
+
+echo "== invoking user: $(id -un) (uid $(id -u)) =="
+echo "== RMW_IMPLEMENTATION=${RMW_IMPLEMENTATION:-<unset, Humble default rmw_fastrtps_cpp>} =="
+echo "== ROS_DOMAIN_ID=${ROS_DOMAIN_ID:-<unset>} =="
+
+echo
+echo "== /dev/shm before (DDS segment ownership) =="
+ls -la /dev/shm 2>/dev/null | head -30 || echo "   <unreadable>"
+
+# ---- publisher, as the invoking user ---------------------------------------
+python3 -u "${HERE}/probe_publisher.py" >/tmp/kirra_uid_pub.log 2>&1 &
+pub_pid=$!
+# shellcheck disable=SC2064  # expand pub_pid now, deliberately
+trap "kill -TERM ${pub_pid} 2>/dev/null || true" EXIT
+sleep 2
+echo
+echo "== publisher running as $(id -un), pid ${pub_pid} =="
+
+# ---- leg 1: subscriber as the invoking user --------------------------------
+echo
+echo "######## LEG 1: subscriber as $(id -un) ########"
+set +e
+python3 -u "${HERE}/ros_callback_matrix.py" a --seconds "${SECS}"
+rc_user=$?
+set -e
+
+# ---- leg 2: subscriber as root ---------------------------------------------
+# The ROS environment does not survive sudo, so it is re-established inside the
+# elevated shell exactly the way the failing consumer start line does.
+echo
+echo "######## LEG 2: subscriber as root ########"
+set +e
+sudo -E bash -c "
+  source /opt/kirra/robot/ros_env.sh
+  kirra_source_ros
+  export ROS_DOMAIN_ID='${ROS_DOMAIN_ID:-28}'
+  export PYTHONPATH='/opt/kirra/robot'
+  exec python3 -u '${HERE}/ros_callback_matrix.py' a --seconds '${SECS}'
+"
+rc_root=$?
+set -e
+
+echo
+echo "== /dev/shm after (note the owner column) =="
+ls -la /dev/shm 2>/dev/null | head -30 || echo "   <unreadable>"
+
+# ---- verdict ----------------------------------------------------------------
+describe() { case "$1" in 0) echo "PASS (subscription dispatched)";; 1) echo "FAIL (timer fired, subscription did NOT)";; 2) echo "INCONCLUSIVE (executor never span)";; *) echo "ERROR (exit $1)";; esac; }
+
+echo
+echo "======== VERDICT ========"
+echo "  subscriber as $(id -un): $(describe ${rc_user})"
+echo "  subscriber as root:      $(describe ${rc_root})"
+echo
+
+if [[ ${rc_user} -eq 0 && ${rc_root} -eq 1 ]]; then
+  echo "✔ HYPOTHESIS CONFIRMED: the UID boundary is the cause."
+  echo "  Same code, same topic, same domain, same publisher — only the"
+  echo "  subscriber's user differs, and only the root run fails to receive."
+  echo "  The fix is to run the consumer as the robot user, which is what"
+  echo "  kirra-consumer.service already specifies (User=<robot user>)."
+  echo "  No change to the consumer's Python is warranted by this result."
+  exit 0
+fi
+
+if [[ ${rc_user} -eq 0 && ${rc_root} -eq 0 ]]; then
+  echo "✘ HYPOTHESIS REJECTED: root receives too, so the UID boundary is not it."
+  echo "  Next: the vendor matrix, which this test deliberately excluded —"
+  echo "  robot/diagnostics/run_callback_matrix.sh a b c d"
+  exit 1
+fi
+
+echo "? INCONCLUSIVE: the user leg did not cleanly pass, so the comparison"
+echo "  proves nothing. Check /tmp/kirra_uid_pub.log — if the publisher never"
+echo "  started, neither leg was a real test."
+exit 1

--- a/robot/install/env.template
+++ b/robot/install/env.template
@@ -193,6 +193,11 @@ KIRRA_R2_V_PER_PWM_RIGHT=0.0194
 #KIRRA_R2_CLOSED_LOOP_DEBUG=1       # log-only: throttled per-cycle closed-loop line
                                     # (target, filtered L/R speed, PWMs) so the loop
                                     # is observable over SSH. No actuation change.
+#KIRRA_CONSUMER_RX_DEBUG=1          # log-only: release-path trace — RX (a frame
+                                    # arrived over DDS), ACTUATE (the core released
+                                    # it), R2 WRITE (what reached the motors). Use
+                                    # for bring-up instead of hand-patching the
+                                    # deployed file. No actuation change.
 
 # ---------------------------------------------------------------------------
 # R2 wheel-ODOMETRY (proposal follow-up) — OFF by default.

--- a/robot/kirra_motor_consumer.py
+++ b/robot/kirra_motor_consumer.py
@@ -359,15 +359,23 @@ def make_frame_handler(
     return handle
 
 
-def make_tick_handler(consumer, actuate, now_fn=now_ms):
+def make_tick_handler(consumer, actuate, now_fn=now_ms, trace=None):
     """Build the liveness-clock callback (SS-002 decel-to-zero ramp).
 
     A refusal does NOT feed liveness — the core's watermark only advances on a
     release — so a refusal flood starves into the same stop as silence.
+
+    `trace`, when given, is handed (now_ms, tick) after every call — the ONLY
+    place the core's raw liveness verdict is observable. It is diagnostic and
+    read-only: it cannot change whether `actuate` runs. Default `None` keeps the
+    handler byte-identical.
     """
 
     def on_tick() -> None:
-        tick = consumer.on_tick(now_fn())
+        now = now_fn()
+        tick = consumer.on_tick(now)
+        if trace is not None:
+            trace(now, tick)
         if tick.write == 1:
             actuate(tick.linear, tick.angular)
 
@@ -465,6 +473,17 @@ def main() -> int:
     r2_cl_debug = (
         r2_matcher is not None
         and (os.environ.get("KIRRA_R2_CLOSED_LOOP_DEBUG") or "").strip().lower() in ("1", "true", "yes", "on")
+    )
+
+    # Release-path tracing — OPT-IN, log-only, no actuation change. Answers the
+    # one question a field bring-up keeps asking: did the frame ARRIVE (DDS
+    # delivered it), was it RELEASED (the core said yes), and what reached the
+    # motors. Previously this was hand-patched into the deployed file each time,
+    # which is how /opt/kirra drifted from this source; gated here so the
+    # question can be answered without editing the file that drives the wheels.
+    # Off by default → byte-identical to the untraced path.
+    rx_debug = (os.environ.get("KIRRA_CONSUMER_RX_DEBUG") or "").strip().lower() in (
+        "1", "true", "yes", "on"
     )
 
     # R2 wheel-odometry — OPT-IN (default OFF → byte-identical, no /odom publish).
@@ -728,6 +747,12 @@ def main() -> int:
 
     def actuate(linear: float, angular: float) -> None:
         nonlocal cl_debug_ctr, last_delta_rad
+        if rx_debug:
+            # Reaching here means the core RELEASED — a refusal never calls
+            # actuate. This is the release boundary, not a decision point.
+            node.get_logger().info(
+                f"ACTUATE linear={linear:.3f} angular={angular:.3f}"
+            )
         if drive_mode == DRIVE_MODE_R2CP:
             # 🔴 TRANSPORT ONLY. `linear`/`angular` are what the verify core
             # already released; nothing here decides, clamps or authorizes.
@@ -766,6 +791,12 @@ def main() -> int:
             # this actuation applied (0.0 for a stop/MRC). Latched for the odom timer.
             last_delta_rad = act.delta_rad
             if r2_matcher is None:
+                if rx_debug:
+                    node.get_logger().info(
+                        f"R2 WRITE steer={act.steer_cmd} "
+                        f"motor=({act.pwm_left},0,0,{act.pwm_right}) "
+                        f"reason={act.reason} mrc={act.is_mrc}"
+                    )
                 apply_actuation(bot, act)  # open-loop equal-PWM (default)
                 return
             # §9 closed loop: translate() stays the safety front (non-finite /
@@ -773,6 +804,12 @@ def main() -> int:
             # zeros). Only when translate says "ok" do we KEEP its steer command
             # and REPLACE the two drive PWMs with the per-wheel speed-matched ones.
             if act.is_mrc or act.reason == "stopped":
+                if rx_debug:
+                    node.get_logger().info(
+                        f"R2 WRITE steer={act.steer_cmd} "
+                        f"motor=({act.pwm_left},0,0,{act.pwm_right}) "
+                        f"reason={act.reason} mrc={act.is_mrc}"
+                    )
                 apply_actuation(bot, act)  # zeros → stop; drop the loop's history
                 r2_matcher.reset()
                 return
@@ -826,6 +863,11 @@ def main() -> int:
     )
 
     def on_msg(msg: UInt8MultiArray) -> None:
+        if rx_debug:
+            # Arrival only — says nothing about whether the frame is admissible.
+            # Length is the useful field: a 272-byte frame is a candidate V2
+            # release, anything else never reaches the core.
+            node.get_logger().info(f"RX bytes={len(msg.data)}")
         frame_handler(bytes(msg.data))
 
     node.create_subscription(UInt8MultiArray, topic, on_msg, 10)
@@ -833,7 +875,33 @@ def main() -> int:
     # Liveness clock: on_tick every control period drives the SS-002 decel-to-zero
     # ramp when releases stop arriving (never hold-last). A refusal does NOT feed
     # liveness — a flood starves into the stop exactly as silence does.
-    node.create_timer(control_period_ms / 1000.0, make_tick_handler(consumer, actuate))
+    if rx_debug:
+        # The core's raw liveness verdict, ~1 Hz. The heartbeat already proved
+        # the timer fires; what it could not show is what on_tick RETURNS. A
+        # field robot kept its last PWM latched through ~100 ticks while the
+        # core's own tests ramp to zero under every sequence (single release,
+        # sustained train, train interleaved with ticks), so the disagreement
+        # is between the core's verdict and what reaches the wheels — and this
+        # is the only place that verdict is observable.
+        #
+        # Throttled to every 10th tick so the instrument cannot perturb the
+        # control rate it measures, and read-only: `trace` cannot change
+        # whether actuate runs.
+        _tick_n = {"n": 0}
+
+        def _trace_tick(now, tick) -> None:
+            _tick_n["n"] += 1
+            if _tick_n["n"] % 10 == 0:
+                node.get_logger().info(
+                    f"TICK n={_tick_n['n']} now={now} "
+                    f"write={tick.write} linear={tick.linear:.3f} "
+                    f"angular={tick.angular:.3f}"
+                )
+
+        _tick_handler = make_tick_handler(consumer, actuate, trace=_trace_tick)
+    else:
+        _tick_handler = make_tick_handler(consumer, actuate)
+    node.create_timer(control_period_ms / 1000.0, _tick_handler)
 
     # R2 wheel-odometry publisher (opt-in). Reads the rear-wheel encoders each
     # period and publishes an Ackermann dead-reckoning pose so the planner sees


### PR DESCRIPTION
## Summary

- `robot/diagnostics/` — a controlled ROS callback-dispatch matrix and a UID-boundary reproduction
- `KIRRA_CONSUMER_RX_DEBUG` — gates the release-path trace, a tick heartbeat, and the core's raw liveness verdict

Both exist to keep diagnosis **out of the file that drives the wheels**. 2 of 4 split PRs.

## Why

A robot serviced its liveness timer but never its `/kirra/release` subscription while DDS discovery showed a matched pair. Every round of diagnosis was done by hand-patching `/opt/kirra/robot/kirra_motor_consumer.py` — which is how the deployed file drifted from its source, and the drift then cost real time because the file that ran was no longer the file under review.

## The matrix

Each mode changes exactly **one** variable against mode `a`, so the first mode that stops dispatching *names* the cause rather than suggesting one:

| Mode | Variable |
|---|---|
| `a` | pure ROS: node + subscription + timer, `SingleThreadedExecutor` |
| `b` | `Rosmaster_Lib` imported, not instantiated (import-time side effect) |
| `c` | instantiated — serial opened, receive thread **not** started |
| `d` | `create_receive_threading()` — the vendor blocking-read thread |
| `e` | subscription and timer in separate callback groups |
| `f` | `MultiThreadedExecutor`, exactly one `try`/`finally` |
| `g` | executor readiness probe — ready-but-not-dispatched is visible here |
| `h` | alternate RMW, per-process only |

`uid_asymmetry_test.sh` reproduces what turned out to be the real fault: the same pure-ROS subscriber against one publisher, once as the invoking user and once as root.

## Safety

Nothing commands a motor. Modes `c`/`d` open the serial port but issue no motion primitive and no stop primitive. The probe payload is **3 bytes, never the 272-byte governed frame**, so it cannot reach the verify core or actuation.

Process hygiene enumerates PIDs and filters `$$`/`$PPID` before signalling — a bare `pkill -f` also matches the sweep script's own command line.

## The gated trace

`KIRRA_CONSUMER_RX_DEBUG` surfaces the three facts bring-up keeps needing — `RX` (a frame arrived over DDS), `ACTUATE` (the core released it), `R2 WRITE` (what reached the motors) — plus a throttled tick heartbeat and the core's raw liveness verdict.

Off by default the path is **byte-identical**, so the WCET-critical actuation path is untouched. The trace is read-only: `make_tick_handler`'s optional `trace` cannot change whether `actuate` runs, and omitting it leaves the handler exactly as the 32 host tests already cover it.

Both instruments earned their place during the incident. The heartbeat separated *"the timer never fires"* from *"the core returns write=0"*; the verdict trace showed the deployed core disagreeing with source. Neither was observable before.

## Validation

- `py_compile` on the consumer and all diagnostics — clean
- `robot/bound_consumer_test.py` — 32/32 (the decision path is unchanged)
- `bash -n` + `shellcheck -S error` on both shell scripts — clean

**Caveat:** the diagnostics are compile-checked only. They were authored in an environment without `rclpy`, so the ROS paths have not been executed against a live graph — though `uid_asymmetry_test.sh`'s hypothesis was confirmed on hardware by other means.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HaTMYY54Z5Gc4TryvETrum

---
_Generated by [Claude Code](https://claude.ai/code/session_01HaTMYY54Z5Gc4TryvETrum)_