### PR TITLE
Wire the deployment guards into the report, and prove they are wired

### DIFF
--- a/robot/install/deployment_verify_test.py
+++ b/robot/install/deployment_verify_test.py
@@ -461,6 +461,39 @@ def test_the_installer_records_a_manifest():
     check("sha256sum" in src, "…by hashing the artifacts it installed")
 
 
+def test_every_check_is_actually_wired_into_the_report():
+    """A guard that is defined, tested, and never CALLED is not a guard.
+
+    check_deployment_identity and check_installed_artifacts_unchanged shipped
+    exactly that way: both had passing unit tests that invoked them directly,
+    and neither appeared in run(). On the robot the verifier printed
+    "deployment verified" without ever evaluating them — the same shape as the
+    incident they exist to catch, where every component reported healthy and
+    nothing compared them.
+
+    Parsed from run()'s AST rather than grepped, so a mention in a comment or a
+    docstring cannot satisfy it.
+    """
+    import ast
+    src = (HERE / "verify_deployment.py").read_text()
+    tree = ast.parse(src)
+
+    defined = {n.name for n in ast.walk(tree)
+               if isinstance(n, ast.FunctionDef) and n.name.startswith("check_")}
+    run_fn = next((n for n in ast.walk(tree)
+                   if isinstance(n, ast.FunctionDef) and n.name == "run"), None)
+    check(run_fn is not None, "verify_deployment must define run()")
+    if run_fn is None:
+        return
+    called = {ast.unparse(n.func) for n in ast.walk(run_fn) if isinstance(n, ast.Call)}
+
+    unwired = sorted(defined - called)
+    check(not unwired,
+          f"check_* functions defined but never called from run(): {unwired} — "
+          f"a guard that does not run is worse than no guard, because the "
+          f"report still says 'verified'")
+
+
 def _run_all() -> int:
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
     print("deployment_verify_test:")

--- a/robot/install/verify_deployment.py
+++ b/robot/install/verify_deployment.py
@@ -387,9 +387,61 @@ def run() -> Report:
     check_env(rep, env)
     check_voice_env(rep, env)
     probe_ffi(rep, env)
+    check_deployment_identity(
+        rep, env,
+        unit_user=read_unit_user(),
+        port_owner=read_port_owner(env.get("KIRRA_MOTOR_PORT") or "/dev/myserial"),
+        configured_user=configured_robot_user(),
+    )
+    check_installed_artifacts_unchanged(
+        rep, *read_installed_manifest())
     check_units(rep)
     check_services(rep)
     return rep
+
+
+def configured_robot_user() -> str:
+    """The account the deployment is meant to run as.
+
+    The unit is the authority: install_kirra.sh renders User= from the invoking
+    (sudo) user, so the unit records the decision that was actually made. Falling
+    back to the calling user would make this check compare a value against
+    itself whenever an operator ran the verifier from a different account.
+    """
+    return read_unit_user() or ""
+
+
+def read_unit_user() -> str:
+    try:
+        d = subprocess.run(
+            ["systemctl", "show", "kirra-consumer.service", "-p", "User", "--value"],
+            capture_output=True, text=True, timeout=10)
+        return d.stdout.strip()
+    except Exception:  # noqa: BLE001 — an absent systemd is not a mismatch
+        return ""
+
+
+def read_port_owner(port: str) -> str:
+    """Owner of the REAL device, following the symlink.
+
+    /dev/myserial is a symlink and symlinks are always lrwxrwxrwx, so stat'ing
+    it without -L reports nothing useful — a distinction that cost real time
+    during the 2026-07-31 diagnosis.
+    """
+    try:
+        import pwd
+        return pwd.getpwuid(os.stat(port).st_uid).pw_name
+    except Exception:  # noqa: BLE001 — unplugged board, not a mismatch
+        return "<absent>"
+
+
+def read_installed_manifest():
+    """(recorded, current) digest maps for the manifest comparison."""
+    try:
+        recorded = parse_manifest(open(INSTALLED_MANIFEST).read())
+    except OSError:
+        return {}, {}
+    return recorded, {p: sha256_file(p) for p in recorded}
 
 
 def main(argv) -> int:


### PR DESCRIPTION
## Summary

- call `check_deployment_identity` and `check_installed_artifacts_unchanged` from `run()` — **they never were**
- add a meta-test that parses `run()`'s AST and requires every `check_*` function to be called there

## The defect

Both guards shipped in #1263 and #1267 defined, unit-tested, and **never invoked**. Their tests call them directly, so they passed. Nothing checked they were wired in.

Caught on the robot, where the verifier printed a clean bill of health without evaluating either:

```
== deployment verification ==
  ✔ artifact kirra_motor_consumer.py: …
  ✔ consumer FFI loads: dlopen(/opt/kirra/lib/libkirra_consumer_ffi.so) OK
  …
✔ deployment verified          ← no identity rows, no manifest row
```

This is the 2026-07-31 incident's own failure shape reproduced inside the tool built to catch it: every component reporting healthy, nothing comparing them, and a green summary over an invariant that was never evaluated. Worse than having no guard, because the report asserts a verification that did not happen.

## The fix

Both now run in `run()`, with reading split from deciding so the pure decision stays host-testable:

| Helper | Reads |
|---|---|
| `read_unit_user` | `systemctl show -p User --value` |
| `read_port_owner` | `stat` **following the symlink** |
| `read_installed_manifest` | recorded digests + current ones |
| `configured_robot_user` | the unit, which is the authority |

Two details worth noting:

**The symlink.** `/dev/myserial` is a symlink, and symlinks are always `lrwxrwxrwx` — stat'ing it directly reports nothing useful about the real device. That distinction cost real time during the original diagnosis, so the helper follows it.

**Why the unit is the authority for the expected user.** `install_kirra.sh` renders `User=` from the invoking (sudo) user, so the unit records the decision that was actually made. Defaulting to the *calling* user would make the check compare a value against itself whenever an operator ran the verifier from a different account — passing for the wrong reason.

## The meta-test

`test_every_check_is_actually_wired_into_the_report` parses `run()`'s AST and requires every `check_*` function to appear as a call there. **Parsed, not grepped** — a mention in a comment or docstring cannot satisfy it.

Tripwire verified: removing either call reds it with both names listed.

```
FAIL: check_* functions defined but never called from run():
      ['check_deployment_identity', 'check_installed_artifacts_unchanged'] —
      a guard that does not run is worse than no guard, because the report
      still says 'verified'
```

## Validation

`robot/install/deployment_verify_test.py` — **32/32** (31 before this).

Confirmed against the live robot: the pre-fix verifier printed `✔ deployment verified` with neither guard's rows present, despite the deployment being correct — so the omission was invisible in exactly the way that matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HaTMYY54Z5Gc4TryvETrum

---
_Generated by [Claude Code](https://claude.ai/code/session_01HaTMYY54Z5Gc4TryvETrum)_