### PR TITLE
Stop the lidar check from gating the deployment steps

### DIFF
--- a/robot/install/deployment_verify_test.py
+++ b/robot/install/deployment_verify_test.py
@@ -494,6 +494,59 @@ def test_every_check_is_actually_wired_into_the_report():
           f"report still says 'verified'")
 
 
+def test_the_lidar_check_does_not_gate_the_deployment_steps():
+    """An unrelated hardware-driver check must not abort before the steps that
+    record and verify the deployment.
+
+    install_kirra.sh used to `fail` (exit 1) on a missing ydlidar driver at
+    step 5, ahead of the systemd unit render, the installed-artifact manifest
+    and the deployment-identity block. A robot whose unit carried the wrong
+    User= therefore could not have it corrected by re-running the installer:
+    every attempt died at the lidar first. A robot that cannot render its unit
+    is a worse failure than one that cannot find its lidar.
+
+    The exit-code contract is unchanged — a missing driver still fails the
+    install — only the position of the verdict moved.
+    """
+    src = (HERE / "install_kirra.sh").read_text()
+    lines = src.splitlines()
+
+    def first_line_containing(needle):
+        return next((i for i, ln in enumerate(lines) if needle in ln), -1)
+
+    lidar_probe = first_line_containing("ros2 pkg prefix ydlidar_ros2_driver")
+    unit_render = first_line_containing("systemd unit (optional; staged, not enabled)")
+    manifest = first_line_containing("installed.sha256")
+    identity = first_line_containing("deployment identity (these four must agree)")
+
+    check(lidar_probe >= 0, "the lidar probe must still exist")
+    for name, idx in (("unit render", unit_render), ("manifest", manifest),
+                      ("identity block", identity)):
+        check(idx >= 0, f"the {name} step must exist")
+
+    # The probe may precede them; an ABORT must not. Matched as a CALL at the
+    # start of a statement, not as text: the warning string legitimately
+    # contains the words "then fail at the end", and a substring search on it
+    # would red this test for saying what it does.
+    aborts = [
+        (i + 1, ln.strip())
+        for i, ln in enumerate(lines[lidar_probe:max(unit_render, manifest, identity)],
+                               start=lidar_probe)
+        if ln.strip().startswith("fail ") or ln.strip() == "exit 1"
+    ]
+    check(not aborts,
+          f"no abort between the lidar probe and the deployment steps, found "
+          f"{aborts} — that ordering made the installer unable to repair its "
+          f"own unit")
+
+    # …and the failure must still happen, just later.
+    check("LIDAR_MISSING" in src,
+          "a missing lidar must still fail the install, deferred to the end")
+    deferred = first_line_containing('if [[ "${LIDAR_MISSING}" -eq 1 ]]; then')
+    check(deferred > max(unit_render, manifest, identity),
+          "the deferred lidar verdict must come AFTER the deployment steps")
+
+
 def _run_all() -> int:
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
     print("deployment_verify_test:")

--- a/robot/install/install_kirra.sh
+++ b/robot/install/install_kirra.sh
@@ -10,6 +10,19 @@
 # set_car_type — the steering/R2 platform layer is BLOCKED on the vendor R2
 # base image and is documented (not implemented) in PLATFORM_R2_PENDING.md.
 #
+# OVERLAY: run this with the workspace that provides ydlidar_ros2_driver already
+# sourced. sudo does not inherit it, and the vendor driver lives OUTSIDE this
+# repo (the validated unit had it under ~/yahboomcar_ros2_ws), so a plain
+# `sudo install_kirra.sh` reports the driver missing even when it is installed:
+#
+#   sudo env "PATH=$HOME/.cargo/bin:$PATH" bash -c '
+#     source /opt/ros/humble/setup.bash
+#     source "$HOME/yahboomcar_ros2_ws/software/library_ws/install/setup.bash"
+#     exec robot/install/install_kirra.sh'
+#
+# The lidar check is non-fatal in place and reported at the end, so a missing
+# driver no longer prevents the unit, manifest and identity steps from running.
+#
 # What it does (idempotent; loud on missing prereqs):
 #   1. preflight checks (ROS 2 Humble, Rosmaster_Lib, cargo, device symlinks)
 #   2. builds the verify-core cdylib + the dev mint binary (--skip-build to reuse)
@@ -179,10 +192,21 @@ set +u
 # shellcheck disable=SC1091
 source "${ROS_SETUP}"
 set -u
+# DEFERRED failure. A missing lidar driver still fails the install, but the
+# verdict is reported at the END rather than aborting here — see the exit at the
+# bottom. Aborting at this point skipped the systemd unit render, the installed-
+# artifact manifest and the deployment-identity block, all of which come later
+# and none of which have anything to do with the lidar. On 2026-07-31 that
+# ordering meant a robot whose unit carried the wrong User= could not have it
+# corrected by re-running the installer: every attempt died here first. A robot
+# that cannot render its unit is a worse failure than one that cannot find its
+# lidar, so the deployment work now completes either way.
+LIDAR_MISSING=0
 if ros2 pkg prefix ydlidar_ros2_driver >/dev/null 2>&1; then
   ok "ydlidar_ros2_driver present ($(ros2 pkg prefix ydlidar_ros2_driver))"
 else
-  fail "ydlidar_ros2_driver NOT found. The validated unit had it vendor-preinstalled; a from-source build is documented (but NOT hardware-validated) in README.md. The lidar is required for the live loop."
+  LIDAR_MISSING=1
+  warn "ydlidar_ros2_driver NOT found — the install will CONTINUE and then fail at the end. The validated unit had it vendor-preinstalled; a from-source build is documented (but NOT hardware-validated) in README.md. The lidar is required for the live loop. If the driver lives in an overlay workspace (the validated unit had it under ~/yahboomcar_ros2_ws), source that overlay before running this installer — see the usage note at the top of this script."
 fi
 echo "  validated launch (installer/platform_map.toml:31-37 — TG30, 512000 baud):"
 echo "    ros2 launch ydlidar_ros2_driver ydlidar_launch.py"
@@ -294,3 +318,12 @@ cat <<'EOF'
        ros2 topic echo /scan --once   # finite room-plausible ranges
   3. First governed motion: robot/first_run_elevated.sh — 🔴 WHEELS ELEVATED.
 EOF
+
+# ---- 8. deferred verdict ----------------------------------------------------
+# Everything above ran. If the lidar driver was missing, the install is still a
+# FAILURE and exits non-zero — the exit-code contract is unchanged, only its
+# position moved, so the deployment steps that come after step 5 are no longer
+# hostage to an unrelated driver check.
+if [[ "${LIDAR_MISSING}" -eq 1 ]]; then
+  fail "ydlidar_ros2_driver NOT found (reported at step 5). The deployment steps above COMPLETED — unit, manifest and identity are installed — but the live loop cannot run without the lidar. Install the driver, or source the overlay that provides it, and re-run."
+fi


### PR DESCRIPTION
## Summary

- the lidar-driver check warns in place; its **failure verdict moves to the end**
- the header documents the overlay requirement, which nothing did
- a test pins the ordering

## The defect

`install_kirra.sh` aborted (`exit 1`) at step 5 when `ydlidar_ros2_driver` was absent — **ahead of** the systemd unit render, the installed-artifact manifest, and the deployment-identity block. None of those have anything to do with a lidar.

That ordering meant a robot whose unit carried the wrong `User=` **could not have it corrected by re-running the installer**: every attempt died at the lidar first.

Hit directly during the 2026-07-31 diagnosis:

```
== 3. install -> /opt/kirra ==
✔ installed cdylib, mint binary, consumer + scripts
== 4. environment -> /etc/kirra/robot.env ==
✔ /etc/kirra/robot.env exists — leaving it untouched
== 5. lidar driver check ==
❌ ydlidar_ros2_driver NOT found.
        ← exits here; unit, manifest and identity never ran
```

A robot that cannot render its unit is a worse failure than one that cannot find its lidar.

## The change

The check now `warn`s in place and sets `LIDAR_MISSING`; the verdict is issued at the end of the script.

**The exit-code contract is unchanged** — a missing driver still fails the install. Only the position of the verdict moved, so the deployment work completes either way and the failure message names what *did* succeed:

```
❌ ydlidar_ros2_driver NOT found (reported at step 5). The deployment steps
   above COMPLETED — unit, manifest and identity are installed — but the live
   loop cannot run without the lidar.
```

## The overlay, which nothing documented

`sudo` does not inherit the ROS overlay, and the vendor driver lives **outside this repo** — the validated unit had it under `~/yahboomcar_ros2_ws`. So the documented invocation reports the driver missing even when it is installed. That is exactly how this was first hit, and the same artifact was noted in passing during #1258 without being fixed.

The header now shows the working invocation.

## The test

`test_the_lidar_check_does_not_gate_the_deployment_steps` asserts no abort between the probe and the three deployment steps, and that the deferred verdict comes strictly after them.

Matched as a **call at the start of a statement**, not as text — the warning string legitimately contains the words *"then fail at the end"*, and a substring search reds the test for saying what it does. I hit that while writing it; it's the same grep-versus-parse trap the wiring meta-test in #1269 avoids.

Tripwire verified: restoring the in-place `fail` reds the test with the offending line and number.

## Validation

- `robot/install/deployment_verify_test.py` — 32/32
- `bash -n` + `shellcheck -S error` — clean
- `scripts/test-shellcheck-gate.sh` — 18/18, all tracked scripts error-clean

Not run against a real robot: the lidar-present path is unchanged, and the lidar-absent path now reaches steps it previously never got to. Worth one install on the Jetson with the overlay deliberately unsourced to confirm the deferred failure reads correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HaTMYY54Z5Gc4TryvETrum

---
_Generated by [Claude Code](https://claude.ai/code/session_01HaTMYY54Z5Gc4TryvETrum)_