### PR TITLE
Deploy the verifier with the modules it imports

### DIFF
--- a/robot/install/deployment_verify_test.py
+++ b/robot/install/deployment_verify_test.py
@@ -841,6 +841,40 @@ def test_the_verifier_fails_when_a_governed_artifact_is_absent():
               f"a missing serial_exclusivity.py must FAIL; failing rows: {failed}")
 
 
+def test_the_verifier_ships_with_the_modules_it_imports():
+    """A verifier that only runs from a checkout reports what that CHECKOUT
+    believes, not what the robot is.
+
+    On 2026-07-31 the first post-fix run came from a stale checkout and reported
+    a FAIL against a correctly-deployed robot — the expectation was old, the
+    machine was fine, and the verdict described neither. Installing the tool
+    beside its imports means it can be run on a robot with no repo at all, and
+    the manifest digests it like every other artifact so its own version is
+    pinned.
+    """
+    src = (HERE / "install_kirra.sh").read_text()
+    for needed in ("verify_deployment.py", "consumer_config_contract.py",
+                   "preflight_consumer_env.py"):
+        check(f'"${{OPT}}/robot/{needed}"' in src,
+              f"install_kirra.sh must install {needed} to ${{OPT}}/robot — the "
+              f"verifier cannot run on the robot without it")
+    check(any(p.endswith("/robot/verify_deployment.py")
+              for p, _ in vd.EXPECTED_ARTIFACTS),
+          "the verifier must verify its own deployment")
+
+
+def test_the_verifier_runs_from_either_layout():
+    """Repo layout puts it in robot/install/ with its imports one level up;
+    the installed layout puts it flat in /opt/kirra/robot/ beside them. Both
+    directories must be on sys.path or the installed copy cannot import."""
+    src = (HERE / "verify_deployment.py").read_text()
+    head = src.split("import consumer_config_contract", 1)[0]
+    check("sys.path.insert(0, _HERE)" in head,
+          "its own directory must be on sys.path (installed, flat layout)")
+    check("sys.path.insert(0, os.path.dirname(_HERE))" in head,
+          "its parent must be on sys.path (repo layout)")
+
+
 def _run_all() -> int:
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
     print("deployment_verify_test:")

--- a/robot/install/install_kirra.sh
+++ b/robot/install/install_kirra.sh
@@ -167,6 +167,20 @@ for f in kirra_ffi.py kirra_release_publisher.py r2_drive.py motor_authority.py 
          serial_exclusivity.py clock_step_guard.py kirra_r2cp.py; do
   sudo install -m 0644 "${REPO}/robot/${f}" "${OPT}/robot/${f}"
 done
+
+# The VERIFIER itself, plus the two modules it imports. Without this it runs
+# only from a checkout, so its verdict describes whatever that checkout
+# believes rather than the robot: on 2026-07-31 a stale checkout reported a
+# stale expectation against a correctly-deployed machine, and the FAIL was an
+# artefact of where the tool was read from. Installed here it lands beside its
+# imports, is digested by the manifest below like every other artifact, and can
+# be run on a robot with no repo at all.
+sudo install -m 0755 "${REPO}/robot/install/verify_deployment.py" \
+                     "${OPT}/robot/verify_deployment.py"
+sudo install -m 0644 "${REPO}/robot/consumer_config_contract.py" \
+                     "${OPT}/robot/consumer_config_contract.py"
+sudo install -m 0644 "${REPO}/robot/install/preflight_consumer_env.py" \
+                     "${OPT}/robot/preflight_consumer_env.py"
 for f in first_run_elevated.sh live_loop_elevated.sh steering_bench_elevated.sh; do
   sudo install -m 0755 "${REPO}/robot/${f}" "${OPT}/robot/${f}"
 done

--- a/robot/install/verify_deployment.py
+++ b/robot/install/verify_deployment.py
@@ -33,7 +33,17 @@ import os
 import subprocess
 import sys
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+# Both the repo layout and the installed one. In the repo this file sits at
+# robot/install/, so its GRANDparent (robot/) holds consumer_config_contract;
+# installed it sits flat in /opt/kirra/robot/ beside its imports, so its OWN
+# directory is the one that matters. Inserting both makes the same file run
+# unmodified from either location — which is the point of deploying it: a
+# verifier that only runs from a checkout reports whatever that checkout
+# believes, and on 2026-07-31 a stale one reported a stale verdict against a
+# correctly-deployed robot.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.dirname(_HERE))
+sys.path.insert(0, _HERE)
 import consumer_config_contract as contract  # noqa: E402
 
 OPT = os.environ.get("KIRRA_OPT_DIR", "/opt/kirra")
@@ -52,6 +62,11 @@ EXPECTED_ARTIFACTS = [
     (f"{OPT}/robot/kirra_motor_consumer.py", True),
     (f"{OPT}/robot/serial_exclusivity.py", False),
     (f"{OPT}/robot/motor_authority.py", False),
+    # The verifier verifies its own deployment. A robot carrying no copy of this
+    # tool can only be checked from a checkout, and a stale checkout reports a
+    # stale verdict — the failure mode that made the first post-fix run read as
+    # a deployment fault when the deployment was already correct.
+    (f"{OPT}/robot/verify_deployment.py", True),
     (INSTALLED_CONSUMER_LIB, False),
     (f"{OPT}/taj_service", True),
     (f"{OPT}/mick_service", True),


### PR DESCRIPTION
## Summary

- install `verify_deployment.py` to `${OPT}/robot` alongside its two imports
- make it run unmodified from either the repo or the installed layout
- it verifies its own deployment, and the manifest pins its version

Closes the last stale-source trust gap from the 2026-07-31 incident. No runtime motor policy is touched.

## The gap

A verifier that only runs from a checkout reports what that **checkout** believes, not what the robot is.

The first post-fix run today came from a stale checkout and returned a FAIL against a correctly-deployed robot:

```
❌ artifact libkirra_consumer_ffi.so: /opt/kirra/libkirra_consumer_ffi.so missing
✔  consumer FFI loads: dlopen(/opt/kirra/lib/libkirra_consumer_ffi.so) OK
```

Both lines from one run. The expectation was old, the machine was fine, and the verdict described neither. That is the same stale-source trust gap as the four deployment divergences the tool exists to catch — sitting in the tool itself.

## Both options, from one placement

You suggested either deploying it or recording a version/hash. They turn out not to be exclusive: installing it into `${OPT}/robot` puts it where the manifest glob (`${OPT}/robot/*.py`, added in #1267) **already digests everything**, so its own version is pinned and drift-checked by the same mechanism as every other artifact. No second versioning scheme.

Three files ship, because the tool has two imports and would `ImportError` without them:

| File | Mode | Why |
|---|---|---|
| `verify_deployment.py` | 0755 | the tool |
| `consumer_config_contract.py` | 0644 | imported at module scope |
| `preflight_consumer_env.py` | 0644 | imported inside `run()` |

## One source, two layouts

In the repo it sits at `robot/install/` with its imports one level up; installed it sits flat in `${OPT}/robot/` beside them. `sys.path` now carries **both** its own directory and its parent, so the same file runs unmodified from either. That matters — a deployed copy that had to be edited to work would reintroduce exactly the divergence this closes.

`EXPECTED_ARTIFACTS` gains the verifier, so it verifies its own deployment: a robot missing it now says so, instead of silently falling back to whatever checkout happens to be at hand.

## Validation

- `robot/install/deployment_verify_test.py` — **35/35** (33 before)
- `bash -n` + `shellcheck -S error` — clean
- the verifier still runs correctly from the repo layout (`--json` exercised)

Two new tests: the installer must place all three files, and both directories must be on `sys.path`. Tripwire verified — removing the install line reds the first with the exact filename.

The read-only guarantee is unchanged; the AST guard forbidding the tool to write, spawn `sudo`, or touch `systemctl` still passes.

## Not verified on hardware

The installed-layout import path has not been exercised on a robot. Worth one `install_kirra.sh` run followed by `python3 /opt/kirra/robot/verify_deployment.py` — with **no repo on `PYTHONPATH`** — to confirm the flat layout imports cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HaTMYY54Z5Gc4TryvETrum

---
_Generated by [Claude Code](https://claude.ai/code/session_01HaTMYY54Z5Gc4TryvETrum)_