### PR TITLE
Refuse to run the consumer as uid 0, with a loud override

### DIFF
--- a/robot/bound_consumer_test.py
+++ b/robot/bound_consumer_test.py
@@ -34,6 +34,7 @@ from kirra_ffi import (  # noqa: E402
     split_bound_frame,
     split_frame,
 )
+import kirra_motor_consumer as kmc  # noqa: E402
 from kirra_motor_consumer import (  # noqa: E402
     decide_bound_frame,
     format_bound_health,
@@ -407,6 +408,52 @@ def test_format_bound_health_names_the_diagnostic_counters():
                      "key_mismatch_alarm=1"):
         assert expected in line, (expected, line)
     assert format_bound_health(_Health()) == "no refusals recorded"
+
+
+# ---------------------------------------------------------------------------
+# Root refusal (uid 0)
+# ---------------------------------------------------------------------------
+
+def test_a_non_root_consumer_is_admitted():
+    verdict, msg = kmc.root_startup_verdict(1000, acknowledged=False)
+    assert verdict == "ok", msg
+
+
+def test_root_is_refused_by_default():
+    """Root breaks DDS shared-memory delivery while every other signal still
+    looks healthy — discovery matches, timers fire, the serial sentinel passes
+    because root bypasses its owner check. Refusing at startup turns a silent
+    absence of motion into one line on stderr."""
+    verdict, msg = kmc.root_startup_verdict(0, acknowledged=False)
+    assert verdict == "refuse", verdict
+    assert "shm" in msg or "/dev/shm" in msg, msg
+    assert kmc.ROOT_ACK_ENV in msg, "the refusal must name its own override"
+    assert "User=" in msg, "…and point at the supported way to run"
+
+
+def test_root_with_the_acknowledgement_runs_but_says_what_it_costs():
+    """The override exists for recovery and manufacturing. It is the same shape
+    as KIRRA_ALLOW_SHARED_SERIAL, which disarmed a real guard for hours, so it
+    must never be quiet."""
+    verdict, msg = kmc.root_startup_verdict(0, acknowledged=True)
+    assert verdict == "acknowledged", verdict
+    assert "WILL FAIL" in msg, "the cost must be stated, not implied"
+    assert "sentinel" in msg, "…including the serial check it also bypasses"
+
+
+def test_the_root_check_runs_before_ros_and_the_serial_port():
+    """Ordering is the point: a root consumer must fail BEFORE it opens the
+    motor port or joins the graph, not three minutes later as missing motion."""
+    import ast
+    src = (Path(__file__).resolve().parent / "kirra_motor_consumer.py").read_text()
+    main_fn = next(n for n in ast.walk(ast.parse(src))
+                   if isinstance(n, ast.FunctionDef) and n.name == "main")
+    body = ast.unparse(main_fn)
+    root_at = body.index("root_startup_verdict")
+    for later in ("import rclpy", "serial_exclusivity", "Rosmaster("):
+        if later in body:
+            assert root_at < body.index(later), \
+                f"the root check must precede {later!r}"
 
 
 # ---------------------------------------------------------------------------

--- a/robot/install/env.template
+++ b/robot/install/env.template
@@ -70,6 +70,16 @@ KIRRA_DEMO_VZ_MAX=0.4
 # the validated unit; confirm with capture_from_robot.sh after any reflash).
 KIRRA_MOTOR_PORT=/dev/myserial
 
+# The consumer REFUSES to run as uid 0. Root breaks Fast DDS shared-memory
+# delivery SILENTLY — the reader's /dev/shm segment is created root-owned at
+# 0644, so a robot-user publisher cannot write into it and release frames never
+# arrive, while discovery still matches and the liveness timer still fires. Root
+# also bypasses the 0600 owner check below, so the #887 sentinel passes for the
+# wrong reason. Set to 1 ONLY for a recovery or manufacturing workflow that
+# genuinely needs root; the run is loudly labeled and carries no delivery
+# guarantee. Never leave set. (kirra-consumer.service runs as the robot user.)
+#KIRRA_ALLOW_ROOT=1
+
 # ADR-0033 Tier-3 (#887): the consumer REFUSES to start unless it exclusively
 # owns the motor port (owner=this user, mode 0600, no other holder — see
 # robot/serial_exclusivity.py; install_kirra.sh installs the tightened udev

--- a/robot/kirra_motor_consumer.py
+++ b/robot/kirra_motor_consumer.py
@@ -66,6 +66,13 @@ Config — ALL required, NO defaults (fail-closed; a missing var aborts):
 Optional:
     KIRRA_RELEASE_TOPIC        (default /kirra/release)
     KIRRA_CONSUMER_LIB         explicit path to libkirra_consumer_ffi.so
+    KIRRA_ALLOW_ROOT           "1" acknowledges running as uid 0. Default:
+                               REFUSED. Root breaks DDS shared-memory delivery
+                               silently (the reader's /dev/shm segment is
+                               root-owned; a robot-user publisher cannot write
+                               into it) while discovery and timers still look
+                               healthy, and it bypasses the #887 serial owner
+                               check. Recovery/manufacturing only.
     KIRRA_ALLOW_SHARED_SERIAL  "1" acknowledges a bring-up run on a port that
                                FAILS the ADR-0033 Tier-3 exclusivity sentinel
                                (wrong owner / loose mode / another holder).
@@ -382,7 +389,71 @@ def make_tick_handler(consumer, actuate, now_fn=now_ms, trace=None):
     return on_tick
 
 
+ROOT_ACK_ENV = "KIRRA_ALLOW_ROOT"
+
+
+def root_startup_verdict(euid: int, acknowledged: bool) -> tuple[str, str]:
+    """Refuse to run the consumer as uid 0 unless deliberately acknowledged.
+
+    Running as root breaks DDS delivery SILENTLY. Fast DDS carries discovery
+    over UDP multicast but same-host data over /dev/shm segments owned by their
+    creating participant at 0644, and a writer must write into the reader's
+    segment. A root-owned reader therefore cannot be fed by a robot-user
+    publisher — while `ros2 topic info --verbose` still shows a matched
+    reliable/volatile pair and local timers keep firing. On 2026-07-31 that
+    combination produced a node that serviced its liveness clock, never its
+    release subscription, and looked correct from every graph-level query.
+
+    Root ALSO bypasses the 0600 owner check on the motor port, so the #887
+    exclusivity sentinel passes for the wrong reason and reports nothing.
+
+    Pure decision over (euid, acknowledged) so it is host-testable without
+    being root. Mirrors serial_exclusivity.startup_verdict deliberately: same
+    three outcomes, same shape, one idiom to learn.
+
+    🔴 The override exists because recovery and manufacturing workflows may
+    genuinely need it, but it is the same shape as KIRRA_ALLOW_SHARED_SERIAL —
+    which silently disarmed a real guard for hours. It is therefore reported
+    LOUDLY every run and names what it is giving up.
+    """
+    if euid != 0:
+        return "ok", f"running as uid {euid} (not root) — DDS shared memory is exchangeable"
+    if acknowledged:
+        return "acknowledged", (
+            f"RUNNING AS ROOT (acknowledged via {ROOT_ACK_ENV}=1). DDS "
+            f"shared-memory delivery from a non-root publisher WILL FAIL "
+            f"silently: discovery still matches and timers still fire, so the "
+            f"node looks healthy while no release is ever received. The #887 "
+            f"serial sentinel is also bypassed — root ignores the 0600 owner "
+            f"check, so its OK carries no authority claim this run."
+        )
+    return "refuse", (
+        f"REFUSING to run as root (uid 0). Fast DDS creates this reader's "
+        f"/dev/shm segment root-owned at 0644, so a robot-user publisher "
+        f"cannot write into it and release frames are never delivered — while "
+        f"discovery still matches and the liveness timer still fires, which "
+        f"looks like a working node. Run as the robot user instead: "
+        f"kirra-consumer.service already sets User=<robot user>, and "
+        f"install_kirra.sh renders it from SUDO_USER. If a recovery or "
+        f"manufacturing workflow genuinely requires root, set {ROOT_ACK_ENV}=1 "
+        f"to acknowledge that releases may never arrive."
+    )
+
+
 def main() -> int:
+    # FIRST, before ROS, the vendor library or the serial port: a root consumer
+    # cannot receive releases over shared memory, and every downstream signal
+    # would still look healthy. Fail here, loudly, rather than three minutes
+    # later as a silent absence of motion.
+    _root_verdict, _root_msg = root_startup_verdict(
+        os.geteuid(), (os.environ.get(ROOT_ACK_ENV) or "").strip() in ("1", "true", "yes", "on")
+    )
+    if _root_verdict == "refuse":
+        print(f"FATAL: {_root_msg}", file=sys.stderr)
+        return 2
+    if _root_verdict == "acknowledged":
+        print(f"WARNING: {_root_msg}", file=sys.stderr)
+
     # ROS + vendor lib imported inside main so the file parses/syntax-checks on a
     # host without them (CI py_compile); they are required on the robot.
     import rclpy

--- a/robot/teardown_smoke_test.py
+++ b/robot/teardown_smoke_test.py
@@ -328,6 +328,13 @@ def main() -> int:
         # run would. The sentinel's own logic is host-tested in
         # serial_exclusivity_test.py; THIS harness tests teardown paths.
         "KIRRA_ALLOW_SHARED_SERIAL": "1",
+        # Likewise the uid-0 refusal: a CI runner or dev container may well BE
+        # root, and this harness exercises TEARDOWN against a stub serial with
+        # no DDS participant at all — the delivery failure the refusal exists to
+        # prevent cannot occur here. The refusal's own logic is host-tested in
+        # bound_consumer_test.py; acknowledging it keeps this harness testing
+        # what it is for. On a robot the default (refuse) still applies.
+        "KIRRA_ALLOW_ROOT": "1",
     })
     ctx.spin_downs_context = True  # our handler already shut it down...
     ctx.spin_raises = ExternalShutdownException()  # ...and spin surfaces it


### PR DESCRIPTION
## Summary

- the consumer **refuses to start as root**, before ROS, the vendor library, or the serial port
- `KIRRA_ALLOW_ROOT=1` acknowledges the run, reported loudly and naming what it costs

The deferred follow-up from the 2026-07-31 incident. This is a **behaviour change** — a consumer started as root now exits 2 instead of running.

## Why

Running as root breaks DDS delivery **silently**, which is what made the original fault cost a day.

Fast DDS carries discovery over UDP multicast but same-host data over `/dev/shm` segments owned by their creating participant at 0644, and a writer must write into the reader's segment. A root-owned reader cannot be fed by a robot-user publisher — while `ros2 topic info --verbose` still shows a matched reliable/volatile pair and local timers keep firing. The node services its liveness clock, never its release subscription, and looks correct from **every** graph-level query.

Root **also** bypasses the 0600 owner check on the motor port, so the #887 exclusivity sentinel passes for the wrong reason and reports nothing. Both guards were blind at once, in the same direction.

## Design

Placed **first** in `main()` — before `import rclpy`, before `serial_exclusivity`, before `Rosmaster(...)`. A root consumer must fail before it joins the graph or claims the board, not three minutes later as an unexplained absence of motion.

`root_startup_verdict(euid, acknowledged)` is a pure decision, so it's host-testable without being root, and it **mirrors `serial_exclusivity.startup_verdict` deliberately** — same three outcomes (`ok` / `acknowledged` / `refuse`), same shape, one idiom to learn. Exit code 2 matches the sentinel's, which `RestartPreventExitStatus=2` already treats as "don't restart-loop".

## The override

`KIRRA_ALLOW_ROOT=1`, as you specified. It exists because recovery and manufacturing workflows may genuinely need root.

But it is the same shape as `KIRRA_ALLOW_SHARED_SERIAL`, **which silently disarmed a real guard for hours during the incident** — the sentinel detected the uid mismatch at every single boot and was told to downgrade it to a warning. So this one is reported loudly every run and names exactly what it gives up:

```
WARNING: RUNNING AS ROOT (acknowledged via KIRRA_ALLOW_ROOT=1). DDS
shared-memory delivery from a non-root publisher WILL FAIL silently:
discovery still matches and timers still fire, so the node looks healthy
while no release is ever received. The #887 serial sentinel is also
bypassed — root ignores the 0600 owner check, so its OK carries no
authority claim this run.
```

## Blast radius, found immediately

The guard failed `teardown_smoke_test` on its first run — **a CI runner or dev container may well be root**, and that harness spawns the consumer. Worth flagging as the practical cost of this change: anything that runs the consumer as root now needs the acknowledgement.

The harness acknowledges it, with the reason recorded: it exercises teardown against a stub serial with **no DDS participant at all**, so the delivery failure the refusal prevents cannot occur there. The refusal's own logic is tested separately. On a robot the default still refuses.

## Validation

- `robot/bound_consumer_test.py` — 36/36 (32 before)
- full robot host sweep — **40 suites, all pass**

Four new tests: each of the three verdicts, plus an AST check that the call precedes `import rclpy`, `serial_exclusivity` and `Rosmaster(`. Tripwire verified — moving it after the ROS import reds the ordering test with the offending name.

## Not hardware-tested

The refusal path can't be exercised on the robot without deliberately running as root. Worth one `sudo python3 /opt/kirra/robot/kirra_motor_consumer.py` after this lands, to confirm the message reads well and exits 2 — it should refuse instantly, before touching the port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HaTMYY54Z5Gc4TryvETrum

---
_Generated by [Claude Code](https://claude.ai/code/session_01HaTMYY54Z5Gc4TryvETrum)_