### PR TITLE
fix(robot): capture the Rabbit mic through the session sound server, fail-closed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1427,6 +1427,14 @@ jobs:
           # rabbit_wake control matcher incl. non-overlap with the OTA/diag/
           # drive matchers. See docs/hardware/RABBIT_AUDIO_STACK.md §3b.
           python3 robot/wake_word_test.py
+          # Mic capture-backend selection (host, no audio/PulseAudio): the
+          # fail-closed resolver (default = pulse_capture.sh over an EXPLICIT
+          # KIRRA_PULSE_SOURCE; bare no-device arecord REFUSED — unpinned mic +
+          # session-sound-server EBUSY; explicit backends verbatim), the
+          # wrapper's --check/--print-cmd contract under stub pactl/parec, and
+          # the deployment sources actually emitting the Pulse config. See
+          # docs/hardware/R2_VOICE_AUDIO_SETUP.md §4.
+          python3 robot/wake_capture_test.py
           # Shipped systemd units, structurally. ORDERING IS NOT A DEPENDENCY:
           # mick and the Rabbit voice listener are ordered AFTER ollama (and mick),
           # but must never Requires=/BindsTo= them — a hard dep would mean that

--- a/docs/hardware/R2_VOICE_AUDIO_SETUP.md
+++ b/docs/hardware/R2_VOICE_AUDIO_SETUP.md
@@ -86,34 +86,56 @@ sudo chmod +x /opt/kirra/robot/speak.sh
 > `KIRRA_TTS_CMD` at that path (§4).
 
 ## 4. Env — `/etc/kirra/robot.env` (the single source every Rabbit script sources)
+
+> **🎤 Mic capture goes through the SESSION SOUND SERVER, not direct ALSA
+> (2026-07 hardening finding).** With the desktop session's PulseAudio active,
+> the server owns the C-Media mic: `arecord -D plughw:CARD=Device,DEV=0 …`
+> fails **`Device or resource busy`** even while
+> `/proc/asound/card*/pcm0c/sub0/status` reads `closed` and no process holds
+> the PCM (D-Bus device reservation) — the recorder dies instantly and the
+> wake listener loops "capture stream ended". Capture with `parec` against an
+> **explicit** source via `robot/pulse_capture.sh` (fail-closed: missing
+> parec/source is a visible refusal, never a default-mic fallback). Derive the
+> source name once — it is stable across reboots, unlike ALSA card numbers:
+> ```bash
+> pactl list short sources        # → alsa_input.usb-…USB_PnP_Sound_Device-00.analog-mono
+> ```
+
 ```bash
 KIRRA_STT_CMD="whisper-cli -m /home/jetson/whisper.cpp/models/ggml-base.en.bin -np -nt -f"
 KIRRA_TTS_CMD="/opt/kirra/robot/speak.sh"                                   # git-safe path (§3)
-KIRRA_RECORD_CMD="arecord -D plughw:CARD=Device,DEV=0 -d 4 -f S16_LE -r 16000 -c 1"  # -D = the MIC (name, not number)
+# Mic — through the session sound server (see the note above). Explicit source:
+KIRRA_PULSE_SOURCE="alsa_input.usb-C-Media_Electronics_Inc._USB_PnP_Sound_Device-00.analog-mono"
+KIRRA_RECORD_CMD="python3 /opt/kirra/robot/vad_record.py"      # bounded turn recorder (VAD endpointed)
+KIRRA_VAD_CAPTURE_CMD="/opt/kirra/robot/pulse_capture.sh"      # its raw stream, via parec
+# (KIRRA_WAKE_RECORD_CMD stays UNSET — the wake listener defaults to
+#  pulse_capture.sh over KIRRA_PULSE_SOURCE; bare no-device arecord is refused.)
+# ALSA-direct alternative, ONLY for a headless/no-session install (RABBIT_AUDIO_STACK.md §4):
+# KIRRA_RECORD_CMD="arecord -D plughw:CARD=Device,DEV=0 -d 4 -f S16_LE -r 16000 -c 1"
 # (optional) let rabbit_converse ground perception ("what do you see?") — see §7:
 # KIRRA_ROS_SETUP="/opt/ros/humble/setup.bash"
 # (optional) verdict-narration voice — an AUDITOR-role token, never the admin token:
 # KIRRA_MICK_AUDITOR_TOKEN="<auditor principal token>"
 ```
-Only the two `-D plughw:CARD=…` values and the real paths differ from
-`robot/install/rabbit.env.example`. `-d 4` is the record window — but prefer
-**VAD endpointing**, which stops on trailing silence instead of always waiting
-the full window (~1.3 s for a short command vs a flat 4 s):
+Only the `KIRRA_PULSE_SOURCE` / speaker `-D plughw:CARD=…` values and the real
+paths differ from `robot/install/rabbit.env.example`.
+
+The turn recorder is **VAD-endpointed** (stops on trailing silence — ~1.3 s for
+a short command vs a flat 4 s window) and pulls its raw stream through the same
+Pulse backend, so no ALSA device var is needed. Tunables if the room needs them:
 
 ```bash
-KIRRA_RECORD_CMD="python3 /opt/kirra/robot/vad_record.py"
-KIRRA_VAD_DEVICE="plughw:CARD=Device,DEV=0"   # REQUIRED — there is NO default
 KIRRA_VAD_SILENCE_MS=650
 KIRRA_VAD_MIN_SPEECH_MS=250
 KIRRA_VAD_MAX_MS=6000
 KIRRA_VAD_START_TIMEOUT_MS=3000
 ```
 
-The device moves from the `arecord -D` flag to `KIRRA_VAD_DEVICE`, and it is
-**required**: unset, `vad_record.py` refuses before opening anything rather than
-falling back to ALSA's default (which is not the mic, and fails silently). Still
-a bounded mic — `KIRRA_VAD_MAX_MS` is a hard ceiling and a wedged device is
-bounded by a wall clock. Details + tuning: `RABBIT_AUDIO_STACK.md` §1a.
+Still a bounded mic — `KIRRA_VAD_MAX_MS` is a hard ceiling and a wedged device
+is bounded by a wall clock. (Only the headless ALSA-direct variant uses
+`KIRRA_VAD_DEVICE`, which is then **required**: unset, `vad_record.py` refuses
+before opening anything rather than falling back to ALSA's default — not the
+mic, and it fails silently.) Details + tuning: `RABBIT_AUDIO_STACK.md` §1a.
 
 ## 5. PTT button (GPIO) — the Orin gotchas
 ```bash
@@ -210,6 +232,9 @@ publish a `/goal_pose` directly instead of going through STT→LLM (see
 
 # 1. engines standalone:
 echo "rabbit online" | ~/kirra-runtime-sdk/speak.sh                 # hear the speaker
+# mic through the sound server (5 s of raw s16le/16k/mono ≈ 160,000 bytes):
+set -a; . /etc/kirra/robot.env; set +a
+timeout 5 /opt/kirra/robot/pulse_capture.sh >/tmp/kirra-mic.raw; ls -l /tmp/kirra-mic.raw
 whisper-cli -m ~/whisper.cpp/models/ggml-base.en.bin -np -nt -f /tmp/t.wav   # prints your words
 
 # 2. the governed door over TEXT (no mic/button needed — remote-friendly):
@@ -228,6 +253,7 @@ unset KIRRA_TTS_CMD                              # print-only when you can't hea
 ```
 
 ## Reconfigure checklist
-Changed a device / reflashed? Re-derive card numbers (§0), update the two
-`plughw:X,0` values in `speak.sh` (speaker) and `KIRRA_RECORD_CMD` (mic), and
-re-run the §Verify steps. Nothing else moves.
+Changed a device / reflashed? Re-derive the speaker card (§0) for `speak.sh`'s
+`plughw:CARD=…` and the mic's PulseAudio source name
+(`pactl list short sources`) for `KIRRA_PULSE_SOURCE` (§4), then re-run the
+§Verify steps. Nothing else moves.

--- a/docs/hardware/RABBIT_AUDIO_STACK.md
+++ b/docs/hardware/RABBIT_AUDIO_STACK.md
@@ -78,20 +78,26 @@ gets its time — up to a hard ceiling. It writes the appended WAV path (the sam
 
 ```bash
 KIRRA_RECORD_CMD="python3 /opt/kirra/robot/vad_record.py"
-KIRRA_VAD_DEVICE="plughw:CARD=<YOUR_CARD>,DEV=0"   # REQUIRED — `arecord -l`
+# desktop image (session sound server owns the mic — §4): capture through it
+KIRRA_VAD_CAPTURE_CMD="/opt/kirra/robot/pulse_capture.sh"   # + KIRRA_PULSE_SOURCE
+# headless/no-session ALSA-direct variant instead:
+#KIRRA_VAD_DEVICE="plughw:CARD=<YOUR_CARD>,DEV=0"   # REQUIRED then — `arecord -l`
 KIRRA_VAD_SILENCE_MS=650      # trailing silence that ends the utterance
 KIRRA_VAD_MIN_SPEECH_MS=250   # min ACTUAL speech before an endpoint is honored
 KIRRA_VAD_MAX_MS=6000         # HARD ceiling
 KIRRA_VAD_START_TIMEOUT_MS=3000
 ```
 
-**The device is required.** There is deliberately no default: ALSA's default is
+**The microphone is always explicit.** On the ALSA-direct variant
+`KIRRA_VAD_DEVICE` is required with deliberately no default: ALSA's default is
 whichever card the kernel enumerated first, which on the R2 is not the
 microphone, and the failure is *silent* — near-silence arrives, every turn
 endpoints as "no speech", and the robot simply appears not to hear you. Unset →
-`vad_record.py` refuses at startup, **before opening anything**. This is the same
-rule the wake listener already enforces on `KIRRA_WAKE_RECORD_CMD`, and for the
-same reason; the two remain separate variables and separate contracts.
+`vad_record.py` refuses at startup, **before opening anything**. On the Pulse
+backend the same rule holds via `KIRRA_PULSE_SOURCE` (no default-source
+fallback). This is the same rule the wake listener already enforces on
+`KIRRA_WAKE_RECORD_CMD`, and for the same reason; the wake and turn recorders
+remain separate variables and separate contracts.
 
 What the ~2.6 s saving looks like on a short command ("how are you?", ~690 ms of
 speech):
@@ -346,7 +352,22 @@ So:
 - `aplay -l` / `arecord -l` numbering (`hw:0`) is **not stable** and the USB
   audio device is frequently **not** card 0.
 
-**The fix (recommended): bypass PulseAudio — talk to ALSA directly.**
+**Pick the backend by TOPOLOGY (2026-07 hardening finding):**
+
+- **No user session** (headless image, system service): bypass PulseAudio —
+  talk to ALSA directly (the fix below). There is no server to capture through.
+- **An active user audio session** (desktop image — the R2's current config):
+  the session sound server **owns the mic**, and a direct
+  `arecord -D plughw:…` open fails **`Device or resource busy`** even while
+  `/proc/asound/…/status` reads `closed` and no process holds the PCM (D-Bus
+  device reservation). ALSA-direct is not fixable there — capture **through**
+  the server with `robot/pulse_capture.sh` (parec, **explicit**
+  `KIRRA_PULSE_SOURCE`, fail-closed — no default-mic fallback) and run the
+  voice listener as a **user unit**
+  (`robot/install/systemd/user/rabbit-voice.service`) so parec can reach the
+  per-user Pulse socket. See `docs/hardware/R2_VOICE_AUDIO_SETUP.md` §4.
+
+**The fix for the no-session case: bypass PulseAudio — talk to ALSA directly.**
 
 1. **Name the exact device.** `aplay -l` and `arecord -l` → find your USB codec's
    card/device, e.g. `card 1: Device …`. Use `hw:1,0` (or `plughw:1,0` if you need
@@ -419,6 +440,7 @@ Sum = PTT-release → spoken reply. If it's too slow: shorten `-d`, drop to
 | Symptom | Cause | Fix |
 |---|---|---|
 | Works by hand, silent as a service | no session / Pulse socket unreachable | §4: ALSA-direct `-D plughw:X,0`; user in `audio` |
+| `arecord: … Device or resource busy` (PCM shows `closed`, no holder) | the session sound server owns the card (device reservation) | §4: capture through the server — `pulse_capture.sh` + `KIRRA_PULSE_SOURCE`, run as a user unit |
 | `aplay: ... No such file or directory` | wrong `hw:` card number | `aplay -l`; the USB codec is often not card 0 |
 | Chipmunk / slow-mo voice | `aplay -r` ≠ voice sample rate | match `-r` to the piper voice (medium = 22050) |
 | Records silence/garbage from a service | wrong `arecord -D` / not in `audio` | name the capture device; `usermod -aG audio` |

--- a/robot/install/install_robot_units.sh
+++ b/robot/install/install_robot_units.sh
@@ -36,8 +36,8 @@ sudo install -d -m 0755 "${OPT}/robot"
 for f in rabbit_persona.py rabbit_watch.py rabbit_ask.py rabbit_converse.py rabbit_boot.py \
          rabbit_voice.sh ptt_button.py run_voice_ptt.sh inspect_corridor.py rabbit_ota.py \
          ros_env.sh kirra_voice_doctor.sh kirra_doctor.py rabbit_diag.py \
-         wake_word.py rabbit_wake.py turn_state.py vad_record.py barge_in.py \
-         skill_registry.py world_model.py mission.py; do
+         wake_word.py rabbit_wake.py turn_state.py vad_record.py pulse_capture.sh \
+         barge_in.py skill_registry.py world_model.py mission.py; do
   [[ -f "${REPO}/robot/${f}" ]] || { echo "  ⚠ missing ${REPO}/robot/${f} — skipped"; continue; }
   sudo install -m 0755 "${REPO}/robot/${f}" "${OPT}/robot/${f}"
   echo "  installed ${OPT}/robot/${f}"
@@ -64,6 +64,19 @@ for u in kirra-ros-stack.service kirra-lidar.service \
   echo "  installed /etc/systemd/system/${u} (User=${ROBOT_USER})"
 done
 
+# ---- 2b. the USER unit (Pulse-capable voice listener) ------------------------
+# On a unit with an active user audio session the sound server owns the mic
+# (direct ALSA capture fails EBUSY) — the voice listener must run INSIDE the
+# user's session so pulse_capture.sh can reach the per-user Pulse socket. See
+# robot/install/systemd/user/rabbit-voice.service for the full rationale.
+echo "== 2b. user unit -> ~${ROBOT_USER}/.config/systemd/user =="
+USER_HOME="$(getent passwd "${ROBOT_USER}" | cut -d: -f6)"
+USER_UNIT_DIR="${USER_HOME}/.config/systemd/user"
+sudo -u "${ROBOT_USER}" mkdir -p "${USER_UNIT_DIR}"
+sudo install -m 0644 "${UNITS}/user/rabbit-voice.service" "${USER_UNIT_DIR}/rabbit-voice.service"
+sudo chown "${ROBOT_USER}:" "${USER_UNIT_DIR}/rabbit-voice.service"
+echo "  installed ${USER_UNIT_DIR}/rabbit-voice.service (user unit — Pulse-capable)"
+
 # ---- 3. reload -------------------------------------------------------------
 sudo systemctl daemon-reload
 echo "== done — STAGED, not enabled =="
@@ -75,6 +88,10 @@ echo "    sudo systemctl start kirra-ros-stack   && journalctl -u kirra-ros-stac
 echo "    sudo systemctl start kirra-rabbit-watch  && journalctl -u kirra-rabbit-watch -f"
 echo "    sudo systemctl start kirra-rabbit-voice  && journalctl -u kirra-rabbit-voice -f"
 echo "      (wake word is OPT-IN: also set KIRRA_WAKE_ENABLED=1 + KIRRA_WAKE_STT_CMD in robot.env)"
+echo "  when the mic is owned by the user session's sound server (desktop image;"
+echo "  direct ALSA capture fails EBUSY), use the USER unit instead — as ${ROBOT_USER}:"
+echo "    systemctl --user daemon-reload && systemctl --user start rabbit-voice"
+echo "      (needs KIRRA_PULSE_SOURCE in robot.env; loginctl enable-linger ${ROBOT_USER} for boot)"
 echo
 echo "  the Engineering Assistant is enabled by env.template on a FRESH install."
 echo "  An EXISTING /etc/kirra/robot.env is never overwritten (it holds measured"

--- a/robot/install/rabbit.env.example
+++ b/robot/install/rabbit.env.example
@@ -85,41 +85,64 @@ KIRRA_ASSIST_ENABLED=1
 # continue); a barge-in (Slice 2) cancels. Takes precedence over KIRRA_SKILLS_
 # ENABLED. Default off → the single-turn router. See robot/mission.py.
 #KIRRA_MISSIONS_ENABLED=1
+# ── Microphone capture backend ───────────────────────────────────────────────
+# On a unit with an active user audio session the session sound server
+# (PulseAudio/PipeWire) OWNS the USB mic: a direct `arecord -D plughw:…` open
+# fails "Device or resource busy" even while /proc/asound shows the PCM closed
+# (device reservation), and the recorder dies instantly. Capture must go
+# THROUGH the server: robot/pulse_capture.sh (parec) with an EXPLICIT source.
+# Fail-closed: NO default-source fallback — a wrong microphone is worse than a
+# visible failure. Find the exact name on YOUR unit (`pactl list short
+# sources`); the value below is the validated unit's C-Media USB mic:
+KIRRA_PULSE_SOURCE="alsa_input.usb-C-Media_Electronics_Inc._USB_PnP_Sound_Device-00.analog-mono"
+# ALSA-direct is ONLY for a headless/no-session install where no sound server
+# owns the mic (RABBIT_AUDIO_STACK.md §4) — and then always with a pinned
+# device NAME, never a bare/unpinned arecord.
+
 # ── The TURN recorder (ONE bounded clip per trigger; WAV path APPENDED) ───────
-# Fixed-window fallback: every turn costs the full -d seconds, however short the
-# command. The -d bound is what makes it a bounded mic, not an open one.
-KIRRA_RECORD_CMD="arecord -d 4 -f S16_LE -r 16000 -c 1"
+# VAD endpointing over the PulseAudio backend (the default): vad_record.py
+# endpoints on trailing silence and pulls its raw stream through
+# pulse_capture.sh (KIRRA_PULSE_SOURCE above). Still a BOUNDED mic —
+# KIRRA_VAD_MAX_MS is a HARD ceiling (the bounded-mic guarantee holds).
+KIRRA_RECORD_CMD="python3 /opt/kirra/robot/vad_record.py"
+KIRRA_VAD_CAPTURE_CMD="/opt/kirra/robot/pulse_capture.sh"
+# Fixed-window ALSA-direct fallback (headless/no-session installs only): every
+# turn costs the full -d seconds, however short the command. The -d bound is
+# what makes it a bounded mic, not an open one. Pin the device NAME (§ above).
+#KIRRA_RECORD_CMD="arecord -D plughw:CARD=<YOUR_CARD>,DEV=0 -d 4 -f S16_LE -r 16000 -c 1"
 #
-# VAD ENDPOINTING (RECOMMENDED) — stop on trailing SILENCE instead of the fixed
-# -d window, so a short command ("how are you?") finishes in ~1.3 s instead of
-# always 4 s. Drop-in: same contract (writes the appended WAV path), and still a
-# BOUNDED mic — KIRRA_VAD_MAX_MS is a HARD ceiling, and a wedged capture device
-# is bounded by a wall clock rather than held open. It only produces a clip the
-# existing pipeline transcribes: no new authority, and an empty/garbled clip
-# still dead-ends at the fenced /intent door (no intent, no motion).
-#
-# 🔴 KIRRA_VAD_DEVICE is REQUIRED (there is deliberately NO default) — same rule
-# as KIRRA_WAKE_RECORD_CMD below, for the same reason: ALSA's default device is
-# whichever card the kernel enumerated first, which on the R2 is not the mic, and
-# the failure is SILENT (near-silence arrives and every turn reads as "no
-# speech"). Unset → vad_record.py refuses at startup, BEFORE opening anything.
-# Run `arecord -l` and use the by-NAME form; it survives USB re-enumeration.
-#KIRRA_RECORD_CMD="python3 /opt/kirra/robot/vad_record.py"
-#KIRRA_VAD_DEVICE="plughw:CARD=<YOUR_CARD>,DEV=0"   # REQUIRED — `arecord -l`
+# VAD ENDPOINTING (the active default above) — stops on trailing SILENCE
+# instead of a fixed -d window, so a short command ("how are you?") finishes in
+# ~1.3 s instead of always 4 s. Same contract (writes the appended WAV path),
+# and still a BOUNDED mic — KIRRA_VAD_MAX_MS is a HARD ceiling, and a wedged
+# capture device is bounded by a wall clock rather than held open. It only
+# produces a clip the existing pipeline transcribes: no new authority, and an
+# empty/garbled clip still dead-ends at the fenced /intent door (no intent, no
+# motion). Tunables (defaults shown):
 #KIRRA_VAD_BACKEND=energy         # 'energy' (RMS, zero deps); silero/webrtc = later slice
 #KIRRA_VAD_RMS_FLOOR=300          # speech energy threshold (16-bit FS = 32767)
 #KIRRA_VAD_SILENCE_MS=650         # trailing silence that ends the utterance
 #KIRRA_VAD_MIN_SPEECH_MS=250      # min actual speech before an endpoint is honored
 #KIRRA_VAD_MAX_MS=6000            # HARD ceiling (the bounded-mic guarantee; <= 30000)
 #KIRRA_VAD_START_TIMEOUT_MS=3000  # if speech never starts, give up (empty clip → no-op)
-# A non-arecord capture backend instead? Give the whole command; it is used
-# verbatim and gets NO ALSA-specific validation (it has its own convention).
+#
+# 🔴 Running VAD over ALSA-direct instead (headless/no-session installs)?
+# Unset KIRRA_VAD_CAPTURE_CMD and set KIRRA_VAD_DEVICE — it is REQUIRED then
+# (deliberately NO default): ALSA's default device is whichever card the kernel
+# enumerated first, which on the R2 is not the mic, and the failure is SILENT
+# (near-silence arrives and every turn reads as "no speech"). Unset →
+# vad_record.py refuses at startup, BEFORE opening anything. `arecord -l`, use
+# the by-NAME form; it survives USB re-enumeration.
+#KIRRA_VAD_DEVICE="plughw:CARD=<YOUR_CARD>,DEV=0"   # `arecord -l`
+# Any other raw-PCM-to-stdout backend is also accepted verbatim (its own
+# device convention; no ALSA-specific validation):
 #KIRRA_VAD_CAPTURE_CMD="my-capture --raw --rate 16000"
 #
 # ⚠ MIGRATION: an already-deployed robot keeps its existing /etc/kirra/robot.env
-# — the installer never rewrites it. To adopt VAD you must edit that file by hand
-# (uncomment the two KIRRA_RECORD_CMD/KIRRA_VAD_DEVICE lines above, fill in your
-# card) and restart the voice units. Until you do, the fixed 4 s window stands.
+# — the installer never rewrites it. To adopt the Pulse-backed VAD recorder,
+# edit that file by hand (the three active KIRRA_PULSE_SOURCE /
+# KIRRA_RECORD_CMD / KIRRA_VAD_CAPTURE_CMD lines above, with YOUR source name)
+# and restart the voice units. Until you do, the old capture line stands.
 #
 # Tuning: raise KIRRA_VAD_SILENCE_MS if it cuts you off mid-sentence; lower it
 # (to ~500) for snappier turns in a quiet room. Raise KIRRA_VAD_RMS_FLOOR if a
@@ -139,22 +162,23 @@ KIRRA_RECORD_CMD="arecord -d 4 -f S16_LE -r 16000 -c 1"
 # Comma-separated phrases. Matching is ordered-adjacent tokens with a 1-edit
 # tolerance on long tokens only ("hallo rabbits" wakes; a stray "yo" never does).
 #KIRRA_WAKE_PHRASES="hello rabbit,hey rabbit,yo rabbit"
-# REQUIRED when KIRRA_WAKE_ENABLED=1 — the listener REFUSES to start without it.
+# Wake capture backend: DEFAULT (unset) = robot/pulse_capture.sh over
+# KIRRA_PULSE_SOURCE (the mic-capture section above) — no extra config needed.
+# Set KIRRA_WAKE_RECORD_CMD only to override with an explicit backend emitting
+# raw s16le/16 kHz/mono on stdout.
 #
-# There is deliberately no default. A bare `arecord` uses ALSA's DEFAULT device,
-# which is whichever card the kernel enumerated first; on the R2 that is not the
-# microphone. The failure is SILENT — the stream opens, delivers near-silence,
-# the unit looks healthy and nobody is ever heard — so an explicit device is
-# mandatory rather than recommended.
-#
-# Find YOUR card name (do not assume CARD=Device — it varies by microphone):
-#   arecord -l        → e.g. "card 1: Device [USB Audio Device]" → CARD=Device
-# Prefer the by-NAME form: card NUMBERS drift across reboots, names do not.
+# The listener still REFUSES to start on a guessable microphone: with no
+# override, KIRRA_PULSE_SOURCE is required; an override using bare `arecord`
+# without -D/--device is refused — ALSA's DEFAULT device is whichever card the
+# kernel enumerated first, on the R2 not the microphone, and the failure is
+# SILENT (the stream opens, delivers near-silence, the unit looks healthy and
+# nobody is ever heard). ALSA-direct override only for headless/no-session
+# installs; find YOUR card name (`arecord -l`) and prefer the by-NAME form —
+# card NUMBERS drift across reboots, names do not.
 #
 # NOTE this is NOT the same contract as KIRRA_RECORD_CMD above. That one is a
-# BOUNDED recorder (-d N, writes a wav file) for a single turn; this is an
-# UNBOUNDED raw stream the listener reads continuously. Do not copy one into the
-# other.
+# BOUNDED recorder (writes a wav file) for a single turn; this is an UNBOUNDED
+# raw stream the listener reads continuously. Do not copy one into the other.
 #KIRRA_WAKE_RECORD_CMD="arecord -D plughw:CARD=<YOUR_CARD>,DEV=0 -f S16_LE -r 16000 -c 1 -t raw"
 #KIRRA_WAKE_RMS_FLOOR=300        # energy pre-gate: a silent room runs ZERO inference
 #KIRRA_WAKE_COOLDOWN_S=2         # refractory period between wakes

--- a/robot/install/systemd/kirra-rabbit-voice.service
+++ b/robot/install/systemd/kirra-rabbit-voice.service
@@ -23,6 +23,11 @@
 # ⚠ AUDIO-FROM-A-SYSTEM-SERVICE caveat (same as kirra-rabbit-watch): use
 # ALSA-DIRECT record/STT/TTS commands and put the rendered User in the
 # `audio` group; a Pulse/PipeWire-based command may have no session sink.
+# ⚠ THE INVERSE TRAP: when the unit HAS an active user audio session (desktop
+# image), the session sound server owns the mic and ALSA-DIRECT capture fails
+# "Device or resource busy" (even with the PCM closed — device reservation).
+# In that topology run the USER unit variant instead, which captures through
+# the server: robot/install/systemd/user/rabbit-voice.service.
 #
 # ⚠ NOT YET HARDWARE-VALIDATED as a service. Enable deliberately:
 # `sudo systemctl enable --now kirra-rabbit-voice`. See R2_AUTOSTART_CHECKLIST.md.

--- a/robot/install/systemd/user/rabbit-voice.service
+++ b/robot/install/systemd/user/rabbit-voice.service
@@ -1,0 +1,48 @@
+# rabbit-voice.service (USER unit) — the Rabbit voice listener inside the
+# operator's login session: the PulseAudio-capable variant of
+# kirra-rabbit-voice.service.
+#
+# WHY A USER UNIT: on a unit with an active user audio session the session
+# sound server (PulseAudio/PipeWire) OWNS the USB mic — a direct
+# `arecord -D plughw:…` open from ANY service fails "Device or resource busy"
+# even while /proc/asound shows the PCM closed (device reservation). Capture
+# must go THROUGH the server (robot/pulse_capture.sh → parec), and parec needs
+# the per-user socket under /run/user/<uid> — which only a unit running INSIDE
+# that user's systemd manager has. Hence: user unit. A headless / no-session
+# install keeps the SYSTEM unit + ALSA-direct capture (RABBIT_AUDIO_STACK.md §4).
+#
+# 🔴 SAFETY: identical to the system unit — the wake word is a MICROPHONE
+# trigger with zero actuation authority; a (false) wake records ONE bounded
+# clip whose transcript enters the loop only through the fenced mick /intent
+# door (no intent, no motion on a mishear). It is NOT the e-stop.
+#
+# OPT-IN: wake_word.py exits 0 immediately unless KIRRA_WAKE_ENABLED=1 in
+# /etc/kirra/robot.env. The default capture backend needs KIRRA_PULSE_SOURCE
+# set there (explicit source; a missing/renamed source is a startup FATAL in
+# the journal, never a silent wrong-mic capture).
+#
+# Install (install_robot_units.sh stages this into ~/.config/systemd/user/):
+#   systemctl --user daemon-reload
+#   systemctl --user enable --now rabbit-voice.service
+#   loginctl enable-linger <user>   # start the user manager at boot (headless)
+
+[Unit]
+Description=KIRRA Rabbit voice listener (user session; wake word -> bounded turn -> fenced intent door)
+Documentation=https://github.com/kirra-systems/kirra-runtime-sdk
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/kirra/robot.env
+WorkingDirectory=/opt/kirra/robot
+# pipefail so a dead listener fails the pipeline (and vice versa); exec'd bash
+# stays the main PID and SIGTERM tears both halves down (pulse_capture.sh execs
+# parec, so the recorder terminates cleanly with its parent).
+ExecStart=/bin/bash -o pipefail -c 'python3 /opt/kirra/robot/wake_word.py | /opt/kirra/robot/rabbit_voice.sh'
+# on-failure (NOT always): a disabled listener (KIRRA_WAKE_ENABLED unset) exits
+# 0 and the unit rests inactive; a capture-preflight FATAL exits 1 and retries
+# at RestartSec pace — visible in the journal, never a tight restart loop.
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target

--- a/robot/kirra_voice_doctor.sh
+++ b/robot/kirra_voice_doctor.sh
@@ -31,6 +31,7 @@ warn() { [ "$QUIET" = 1 ] || echo "  ⚠ $*"; WARN=$((WARN + 1)); }
 fix()  { [ "$QUIET" = 1 ] || echo "       ↳ fix: $*"; }
 
 RENV="${KIRRA_ROBOT_ENV:-/etc/kirra/robot.env}"
+HERE="$(cd "$(dirname "$0")" && pwd)"
 
 # first token of a command string (the binary/script it invokes)
 first_tok() { set -- $1; printf '%s' "${1:-}"; }
@@ -55,6 +56,18 @@ card_present() {
     num)  "$tool" -l 2>/dev/null | grep -qE "^card ${val}:" ;;
     name) "$tool" -l 2>/dev/null | grep -qE "^card [0-9]+: ${val} " ;;
   esac
+}
+# PulseAudio mic-backend probe: delegates to pulse_capture.sh --check (the ONE
+# validation implementation — parec present, KIRRA_PULSE_SOURCE set, source in
+# `pactl list short sources`; explicit source, no default-mic fallback).
+pulse_backend_check() {  # $1 = label
+  local out
+  if out="$("$HERE/pulse_capture.sh" --check 2>&1)"; then
+    ok "$1 (PulseAudio): source present — ${KIRRA_PULSE_SOURCE:-?}"
+  else
+    bad "$1 (PulseAudio) check failed: $(printf '%s\n' "$out" | head -1)"
+    fix "robot/pulse_capture.sh --check for the full reason — set KIRRA_PULSE_SOURCE from \`pactl list short sources\` (needs the user session)"
+  fi
 }
 
 [ "$QUIET" = 1 ] || echo "== R2 voice/audio doctor =="
@@ -126,6 +139,11 @@ case "$turn_prog" in
         else
           ok "VAD capture command pins its device: -D $vdev"
         fi
+      elif [ "$vcp" = "pulse_capture.sh" ] || [ "$vcp" = "parec" ]; then
+        # The session-sound-server backend (the desktop image, where PulseAudio
+        # OWNS the mic and direct plughw: opens fail EBUSY): validate the
+        # explicit source instead of applying any ALSA rule.
+        pulse_backend_check "VAD mic capture"
       else
         ok "VAD uses a custom capture backend ($vcp) — no ALSA rule applied"
       fi
@@ -292,7 +310,10 @@ sys.exit(0 if parse_phrases(os.environ.get('KIRRA_WAKE_PHRASES', DEFAULT_PHRASES
     # SILENT: the stream opens, delivers near-silence, and nobody is heard.
     # So this is a FAIL, not a warning.
     if [ -z "${KIRRA_WAKE_RECORD_CMD:-}" ]; then
-      bad "KIRRA_WAKE_ENABLED is on but KIRRA_WAKE_RECORD_CMD unset"; fix 'set it with an EXPLICIT device, e.g. "arecord -D plughw:CARD=Device,DEV=0 -f S16_LE -r 16000 -c 1 -t raw" (arecord -l for the card name) — §0'
+      # Unset = the DEFAULT backend: pulse_capture.sh through the session sound
+      # server, which needs an explicit KIRRA_PULSE_SOURCE (wake_word.py's
+      # resolver refuses to guess a microphone — mirror that here).
+      pulse_backend_check "wake mic"
     else
       wrb="$(first_tok "$KIRRA_WAKE_RECORD_CMD")"
       if [ -z "$wrb" ]; then
@@ -314,6 +335,10 @@ sys.exit(0 if parse_phrases(os.environ.get('KIRRA_WAKE_PHRASES', DEFAULT_PHRASES
                 bad "wake mic device NOT in arecord -l (card drifted?): -D $wmic"; fix "arecord -l → update KIRRA_WAKE_RECORD_CMD -D plughw:CARD=<name>,DEV=0 — §0"
               fi
             fi
+            ;;
+          pulse_capture.sh|parec)
+            # The session-sound-server backend: validate the explicit source.
+            pulse_backend_check "wake mic"
             ;;
           *)
             # A custom capture backend has its own device convention; imposing

--- a/robot/pulse_capture.sh
+++ b/robot/pulse_capture.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# pulse_capture.sh — PulseAudio raw-capture backend for the Rabbit microphone.
+#
+# Emits the EXACT raw-stream contract wake_word.py / vad_record.py expect on
+# stdout — signed 16-bit little-endian PCM, mono, 16 kHz, long-running until
+# terminated — but through the SESSION SOUND SERVER (parec) instead of a direct
+# ALSA open. Why this exists: on a unit with an active user audio session the
+# sound server (PulseAudio/PipeWire) OWNS the USB mic, and a direct
+# `arecord -D plughw:…` open fails "Device or resource busy" even while
+# /proc/asound shows the PCM closed (device reservation) — the recorder dies
+# instantly and the wake listener sits deaf in its retry loop. Capturing
+# through the server is the reliable path in that topology. (A headless /
+# no-session system service keeps ALSA-direct — RABBIT_AUDIO_STACK.md §4.)
+#
+# 🔴 FAIL-CLOSED, NO MIC GUESSING: the source must be named EXPLICITLY in
+# KIRRA_PULSE_SOURCE (`pactl list short sources` → the name column). There is
+# deliberately NO fallback to the Pulse default source — a wrong microphone is
+# worse than a visible failure. Missing parec / missing pactl / unset or
+# absent source each exit nonzero with an actionable stderr message; stdout
+# stays clean (it is the PCM pipe).
+#
+# This is a MICROPHONE backend only: it feeds the same transcribe-and-discard
+# wake listener / bounded turn recorder and carries zero actuation authority.
+#
+# Usage:
+#   pulse_capture.sh              # validate, then exec parec (raw PCM → stdout)
+#   pulse_capture.sh --check      # validate only, no capture (exit 0/1)
+#   pulse_capture.sh --print-cmd  # print the parec argv, one arg per line
+#                                 # (host tests / debugging; no server needed)
+#
+# Env:
+#   KIRRA_PULSE_SOURCE  REQUIRED — exact PulseAudio source name, e.g.
+#     alsa_input.usb-C-Media_Electronics_Inc._USB_PnP_Sound_Device-00.analog-mono
+#   KIRRA_PULSE_PAREC   override the parec binary (host tests / diagnostics)
+#   KIRRA_PULSE_PACTL   override the pactl binary (host tests / diagnostics)
+set -euo pipefail
+
+# The wake_word.py raw-stream contract (SAMPLE_RATE / BYTES_PER_SAMPLE there).
+RATE=16000
+CHANNELS=1
+FORMAT=s16le
+
+PAREC="${KIRRA_PULSE_PAREC:-parec}"
+PACTL="${KIRRA_PULSE_PACTL:-pactl}"
+SRC="${KIRRA_PULSE_SOURCE:-}"
+
+MODE=run
+case "${1:-}" in
+  --check) MODE=check ;;
+  --print-cmd) MODE=print ;;
+  "") ;;
+  *) echo "pulse_capture: unknown argument '${1}' (known: --check, --print-cmd)" >&2; exit 2 ;;
+esac
+
+die() { echo "pulse_capture: ERROR: $*" >&2; exit 1; }
+
+[ -n "$SRC" ] || die "KIRRA_PULSE_SOURCE is unset/empty — set it to the exact PulseAudio source name (\`pactl list short sources\`, name column). Refusing to guess a microphone: there is no default-source fallback (a wrong mic is worse than a visible failure)."
+
+CMD=("$PAREC" "--device=$SRC" "--format=$FORMAT" "--rate=$RATE" "--channels=$CHANNELS")
+
+if [ "$MODE" = print ]; then
+  printf '%s\n' "${CMD[@]}"
+  exit 0
+fi
+
+command -v "$PAREC" >/dev/null 2>&1 \
+  || die "parec not found ('$PAREC') — install it (sudo apt install pulseaudio-utils) or point KIRRA_PULSE_PAREC at it."
+
+# Validate the configured source EXISTS before capturing — parec's own failure
+# would be silent to the caller (the listener DEVNULLs recorder stderr), and a
+# renamed/unplugged mic must be a visible refusal, never a wrong-mic capture.
+command -v "$PACTL" >/dev/null 2>&1 \
+  || die "pactl not found ('$PACTL') — install pulseaudio-utils; the configured source cannot be validated without it (refusing to start an unvalidated capture)."
+
+if ! sources="$("$PACTL" list short sources 2>&1)"; then
+  die "pactl cannot reach the sound server: ${sources:-no output}. Is this running OUTSIDE the user session (no XDG_RUNTIME_DIR / per-user pulse socket)? The Pulse backend needs the user session — run the voice listener as a USER unit; a no-session system service must use ALSA-direct instead (RABBIT_AUDIO_STACK.md §4)."
+fi
+
+if ! printf '%s\n' "$sources" | awk '{print $2}' | grep -Fxq -- "$SRC"; then
+  {
+    echo "pulse_capture: ERROR: configured source not present: $SRC"
+    echo "pulse_capture: available sources (pactl list short sources):"
+    printf '%s\n' "$sources" | awk '{print "pulse_capture:   " $2}'
+    echo "pulse_capture: fix KIRRA_PULSE_SOURCE (mic unplugged / renamed?). NOT falling back to another microphone."
+  } >&2
+  exit 1
+fi
+
+if [ "$MODE" = check ]; then
+  echo "pulse_capture: ok — parec + source '$SRC' present (${FORMAT}/${RATE}Hz/${CHANNELS}ch)" >&2
+  exit 0
+fi
+
+# exec so the caller's SIGTERM lands on parec itself (clean teardown when the
+# parent service stops) and stdout carries parec's raw PCM alone.
+exec "${CMD[@]}"

--- a/robot/wake_capture_test.py
+++ b/robot/wake_capture_test.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Host tests for the microphone CAPTURE-BACKEND selection: the fail-closed
+`wake_word.resolve_record_cmd` resolver, the `robot/pulse_capture.sh` wrapper's
+contract (--check / --print-cmd under stub pactl/parec binaries via the
+KIRRA_PULSE_PACTL / KIRRA_PULSE_PAREC seams — no audio, no PulseAudio needed),
+and the deployment sources actually emitting the Pulse-based configuration
+(rabbit.env.example / installer / the user unit).
+
+WHY (2026-07 field failure): with the desktop session's sound server active,
+direct `arecord -D plughw:…` capture fails "Device or resource busy" even with
+the PCM closed (device reservation) — the recorder dies instantly and the wake
+listener loops "capture stream ended". Capture must go THROUGH the server with
+an EXPLICIT source; a wrong microphone is worse than a visible failure, so
+every misconfiguration here must be a refusal, never a fallback.
+
+Runs standalone (`python3 robot/wake_capture_test.py`, exit 1 on any failure);
+also importable under pytest.
+"""
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROBOT = Path(__file__).resolve().parent
+REPO = ROBOT.parent
+WRAPPER = ROBOT / "pulse_capture.sh"
+
+sys.path.insert(0, str(ROBOT))
+from wake_word import (  # noqa: E402
+    BYTES_PER_SAMPLE, PULSE_CAPTURE_BASENAME, SAMPLE_RATE, resolve_record_cmd,
+)
+
+C_MEDIA = "alsa_input.usb-C-Media_Electronics_Inc._USB_PnP_Sound_Device-00.analog-mono"
+
+
+def _run_wrapper(args, env_extra):
+    env = {k: v for k, v in os.environ.items()
+           if not k.startswith("KIRRA_PULSE")}
+    env.update(env_extra)
+    return subprocess.run([str(WRAPPER)] + args, capture_output=True,
+                          text=True, timeout=20.0, env=env)
+
+
+def _stub(dir_path: Path, name: str, body: str) -> str:
+    p = dir_path / name
+    p.write_text("#!/bin/sh\n" + body)
+    p.chmod(p.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return str(p)
+
+
+PACTL_TWO_SOURCES = (
+    'if [ "$1 $2 $3" != "list short sources" ]; then '
+    'echo "unexpected: $*" >&2; exit 2; fi\n'
+    "printf '0\\talsa_input.stub-one.analog-mono\\tmodule.c\\ts16le 1ch 16000Hz\\tSUSPENDED\\n'\n"
+    f"printf '1\\t{C_MEDIA}\\tmodule.c\\ts16le 1ch 16000Hz\\tSUSPENDED\\n'\n")
+
+
+# --- the resolver (wake_word.py) ---------------------------------------------
+
+def test_default_backend_is_the_pulse_wrapper() -> None:
+    argv, err = resolve_record_cmd(None, C_MEDIA, str(ROBOT))
+    assert err is None
+    assert argv == [str(WRAPPER)]
+    assert os.path.basename(argv[0]) == PULSE_CAPTURE_BASENAME
+
+
+def test_default_without_a_source_is_a_fatal_not_a_guess() -> None:
+    for src in (None, "", "   "):
+        argv, err = resolve_record_cmd(None, src, str(ROBOT))
+        assert argv is None
+        assert err and "KIRRA_PULSE_SOURCE" in err
+        assert "Refusing to guess" in err
+
+
+def test_pulse_backends_are_accepted_verbatim() -> None:
+    for cmd in (f"parec --device={C_MEDIA} --format=s16le --rate=16000 --channels=1",
+                "/opt/kirra/robot/pulse_capture.sh"):
+        argv, err = resolve_record_cmd(cmd, None, str(ROBOT))
+        assert err is None, f"{cmd!r} must be accepted: {err}"
+        assert argv[0] in ("parec", "/opt/kirra/robot/pulse_capture.sh")
+
+
+def test_bare_arecord_is_rejected_never_silently_replaced() -> None:
+    # No -D → refused, even when a Pulse source IS configured (an explicit but
+    # invalid command must ERROR, not be silently swapped for the default).
+    argv, err = resolve_record_cmd(
+        "arecord -f S16_LE -r 16000 -c 1 -t raw", C_MEDIA, str(ROBOT))
+    assert argv is None
+    assert err and "-D" in err and "arecord" in err
+
+
+def test_arecord_with_a_pinned_device_remains_accepted() -> None:
+    # Back-compat where it does NOT weaken safety: an explicitly pinned ALSA
+    # device stays valid (the headless/no-session topology).
+    cmd = "arecord -D plughw:CARD=Device,DEV=0 -f S16_LE -r 16000 -c 1 -t raw"
+    argv, err = resolve_record_cmd(cmd, None, str(ROBOT))
+    assert err is None
+    assert argv[0] == "arecord" and "-D" in argv
+
+
+# --- the wrapper (pulse_capture.sh) ------------------------------------------
+
+def test_wrapper_cmd_requests_the_wake_stream_contract() -> None:
+    p = _run_wrapper(["--print-cmd"], {"KIRRA_PULSE_SOURCE": C_MEDIA})
+    assert p.returncode == 0, p.stderr
+    args = p.stdout.splitlines()
+    assert os.path.basename(args[0]) == "parec"
+    assert f"--device={C_MEDIA}" in args, "the source must be EXPLICIT"
+    assert "--format=s16le" in args
+    assert f"--rate={SAMPLE_RATE}" in args      # 16000 — wake_word.py parity
+    assert "--channels=1" in args
+    assert SAMPLE_RATE == 16_000 and BYTES_PER_SAMPLE == 2
+
+
+def test_wrapper_requires_an_explicit_source() -> None:
+    p = _run_wrapper(["--print-cmd"], {})
+    assert p.returncode != 0
+    assert "KIRRA_PULSE_SOURCE" in p.stderr
+    assert "pactl list short sources" in p.stderr
+
+
+def test_wrapper_check_passes_when_source_is_present() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        env = {
+            "KIRRA_PULSE_SOURCE": C_MEDIA,
+            "KIRRA_PULSE_PACTL": _stub(Path(d), "pactl", PACTL_TWO_SOURCES),
+            "KIRRA_PULSE_PAREC": _stub(Path(d), "parec", "exit 0\n"),
+        }
+        p = _run_wrapper(["--check"], env)
+        assert p.returncode == 0, p.stderr
+        assert C_MEDIA in p.stderr  # the ok line names the validated source
+
+
+def test_wrapper_missing_source_fails_with_a_useful_message() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        env = {
+            "KIRRA_PULSE_SOURCE": "alsa_input.usb-Not_Plugged_In-00.analog-mono",
+            "KIRRA_PULSE_PACTL": _stub(Path(d), "pactl", PACTL_TWO_SOURCES),
+            "KIRRA_PULSE_PAREC": _stub(Path(d), "parec", "exit 0\n"),
+        }
+        p = _run_wrapper(["--check"], env)
+        assert p.returncode != 0
+        assert "Not_Plugged_In" in p.stderr, "must name the missing source"
+        assert "available sources" in p.stderr and C_MEDIA in p.stderr
+        assert "NOT falling back" in p.stderr
+
+
+def test_wrapper_missing_parec_is_actionable() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        env = {
+            "KIRRA_PULSE_SOURCE": C_MEDIA,
+            "KIRRA_PULSE_PACTL": _stub(Path(d), "pactl", PACTL_TWO_SOURCES),
+            "KIRRA_PULSE_PAREC": str(Path(d) / "no-such-parec"),
+        }
+        p = _run_wrapper(["--check"], env)
+        assert p.returncode != 0
+        assert "parec not found" in p.stderr
+        assert "pulseaudio-utils" in p.stderr
+
+
+def test_wrapper_unreachable_sound_server_names_the_session_problem() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        env = {
+            "KIRRA_PULSE_SOURCE": C_MEDIA,
+            "KIRRA_PULSE_PACTL": _stub(Path(d), "pactl",
+                                       'echo "Connection failure: Connection refused" >&2; exit 1\n'),
+            "KIRRA_PULSE_PAREC": _stub(Path(d), "parec", "exit 0\n"),
+        }
+        p = _run_wrapper(["--check"], env)
+        assert p.returncode != 0
+        assert "user session" in p.stderr  # points at the user-unit topology
+
+
+# --- deployment sources emit the corrected configuration ---------------------
+
+def _active_lines(path: Path) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for line in path.read_text().splitlines():
+        s = line.strip()
+        if s and not s.startswith("#") and "=" in s:
+            k, v = s.split("=", 1)
+            out[k.strip()] = v.strip().strip('"')
+    return out
+
+def test_env_example_emits_pulse_capture_not_direct_alsa() -> None:
+    env = _active_lines(REPO / "robot/install/rabbit.env.example")
+    src = env.get("KIRRA_PULSE_SOURCE", "")
+    assert src.startswith("alsa_input."), "explicit Pulse source must be ACTIVE"
+    assert "pulse_capture.sh" in env.get("KIRRA_VAD_CAPTURE_CMD", "")
+    rec = env.get("KIRRA_RECORD_CMD", "")
+    assert "arecord" not in rec and "plughw" not in rec, \
+        f"turn recorder must not be direct ALSA by default: {rec!r}"
+    wake = env.get("KIRRA_WAKE_RECORD_CMD", "")
+    assert wake == "", "wake capture override must default to unset (Pulse)"
+
+
+def test_installer_stages_the_wrapper_and_the_user_unit() -> None:
+    installer = (REPO / "robot/install/install_robot_units.sh").read_text()
+    assert "pulse_capture.sh" in installer
+    assert "user/rabbit-voice.service" in installer
+    unit = REPO / "robot/install/systemd/user/rabbit-voice.service"
+    assert unit.is_file(), "user unit missing"
+    text = unit.read_text()
+    assert "wake_word.py" in text and "rabbit_voice.sh" in text
+    assert "EnvironmentFile=/etc/kirra/robot.env" in text
+
+
+def test_wrapper_is_executable() -> None:
+    assert os.access(WRAPPER, os.X_OK), "pulse_capture.sh must be executable"
+
+
+# --- standalone runner (house pattern) ----------------------------------------
+
+def _run_all() -> int:
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"  ok  {name}")
+            except AssertionError as e:
+                failures += 1
+                print(f"FAIL  {name}: {e}")
+    print("wake_capture_test:", "ALL OK" if failures == 0 else f"{failures} FAILURE(S)")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())

--- a/robot/wake_word.py
+++ b/robot/wake_word.py
@@ -42,16 +42,22 @@ Env (robot/install/rabbit.env.example has the annotated set):
   KIRRA_WAKE_STT_CMD      REQUIRED when enabled — whisper-cli + a TINY model;
                           wav path appended as the last arg (house convention)
   KIRRA_WAKE_PHRASES      comma-separated, default "hello rabbit,hey rabbit,yo rabbit"
-  KIRRA_WAKE_RECORD_CMD   REQUIRED when enabled — raw-stream capture, and it must
-                          name an ALSA device explicitly, e.g.
-                          "arecord -D plughw:CARD=Device,DEV=0 -f S16_LE -r 16000 -c 1 -t raw".
-                          There is deliberately NO default: ALSA's default device
-                          is whichever card the kernel enumerated first, which on
-                          the R2 is not the microphone, and the listener would sit
-                          on the wrong input hearing nothing. NOT derived from
+  KIRRA_WAKE_RECORD_CMD   raw-stream capture OVERRIDE. If set, it is used
+                          verbatim — except `arecord`, which must name an ALSA
+                          device explicitly, e.g.
+                          "arecord -D plughw:CARD=Device,DEV=0 -f S16_LE -r 16000 -c 1 -t raw"
+                          (ALSA's default device is whichever card the kernel
+                          enumerated first — on the R2 not the microphone — and
+                          the listener would sit on the wrong input hearing
+                          nothing). Unset → robot/pulse_capture.sh: capture
+                          through the SESSION SOUND SERVER, which on the desktop
+                          image OWNS the mic (direct plughw: opens fail EBUSY);
+                          requires KIRRA_PULSE_SOURCE. NOT derived from
                           KIRRA_RECORD_CMD — that one is a BOUNDED WAV-file
                           recorder (-d N, writes a file); this is an UNBOUNDED raw
                           stream. Different contracts, separate variables.
+  KIRRA_PULSE_SOURCE      exact PulseAudio source name for the default backend
+                          (`pactl list short sources`); no default-mic fallback
   KIRRA_WAKE_RMS_FLOOR    energy gate (default 300; 16-bit full scale = 32767)
   KIRRA_WAKE_COOLDOWN_S   refractory period between wakes (default 2)
   KIRRA_WAKE_HOLDOFF_S    mic released this long after a trigger (default 10;
@@ -449,6 +455,41 @@ def wake_record_device(argv: list[str]) -> str:
     return ""
 
 
+PULSE_CAPTURE_BASENAME = "pulse_capture.sh"
+
+
+def resolve_record_cmd(record_cmd_env: str | None, pulse_source_env: str | None,
+                       script_dir: str) -> tuple[list[str] | None, str | None]:
+    """Resolve the wake capture backend → (argv, None) or (None, fatal reason).
+
+    Pure (host-tested in wake_capture_test.py). Layers the PulseAudio default on
+    top of `validate_record_cmd` (whose rules are unchanged):
+
+      * KIRRA_WAKE_RECORD_CMD set → `validate_record_cmd` verbatim — bare
+        `arecord` with no -D/--device stays REFUSED (wrong-mic silence, plus a
+        direct ALSA open under a session sound server fails "Device or resource
+        busy" and the listener sits deaf in its retry loop). An explicit-but-
+        invalid command is an ERROR, never silently swapped for the default.
+      * unset → robot/pulse_capture.sh beside this script — capture through the
+        session sound server, which on the desktop image OWNS the mic. It
+        REQUIRES an explicit KIRRA_PULSE_SOURCE, checked here so the
+        misconfiguration is a startup FATAL in THIS log, not a silent death in
+        a DEVNULL'd child. NEVER a guessed/default microphone: a wrong mic is
+        worse than a visible failure.
+    """
+    raw = (record_cmd_env or "").strip()
+    if raw:
+        argv, why = validate_record_cmd(raw)
+        return argv, (why or None)
+    if not (pulse_source_env or "").strip():
+        return None, (
+            "no capture backend configured: set KIRRA_PULSE_SOURCE to the exact "
+            "PulseAudio source name (pactl list short sources) for the default "
+            "backend (robot/pulse_capture.sh), or set KIRRA_WAKE_RECORD_CMD to "
+            "an explicit capture command. Refusing to guess a microphone.")
+    return [os.path.join(script_dir, PULSE_CAPTURE_BASENAME)], None
+
+
 def main() -> int:
     if not _truthy(os.environ.get("KIRRA_WAKE_ENABLED")):
         _log("KIRRA_WAKE_ENABLED not set — wake word off (exit 0; PTT/Enter still work)")
@@ -471,12 +512,36 @@ def main() -> int:
     # Fail closed on the microphone BEFORE anything is opened or spawned. An
     # enabled listener on the wrong input is worse than a disabled one: the unit
     # looks healthy, the logs look healthy, and nobody is heard.
-    record_cmd, why = validate_record_cmd(os.environ.get("KIRRA_WAKE_RECORD_CMD", ""))
+    record_cmd, why = resolve_record_cmd(
+        os.environ.get("KIRRA_WAKE_RECORD_CMD"),
+        os.environ.get("KIRRA_PULSE_SOURCE"),
+        os.path.dirname(os.path.abspath(__file__)))
     if record_cmd is None:
         _log(f"FATAL: KIRRA_WAKE_ENABLED is on but {why}")
         return 1
-    device = wake_record_device(record_cmd)
-    _log(f"wake microphone: {device or os.path.basename(record_cmd[0]) + ' (custom backend)'}")
+    if os.path.basename(record_cmd[0]) == PULSE_CAPTURE_BASENAME:
+        # One-shot fail-closed preflight: the runtime capture spawns with its
+        # stderr DEVNULL'd, so surface the wrapper's diagnostics (missing
+        # parec / missing or renamed source / no session) HERE, at startup,
+        # instead of dying silently into the 2 s retry loop. A backend that
+        # breaks LATER (mic unplugged) still lands in that bounded retry loop —
+        # an unavailable capture backend is never classified as healthy.
+        try:
+            chk = subprocess.run(record_cmd + ["--check"], capture_output=True,
+                                 text=True, timeout=15.0)
+        except Exception as e:  # noqa: BLE001
+            _log(f"FATAL: capture preflight could not run ({type(e).__name__}: {e})")
+            return 1
+        if chk.returncode != 0:
+            for line in (chk.stderr or "").strip().splitlines():
+                _log(line)
+            _log("FATAL: PulseAudio capture preflight failed (see above)")
+            return 1
+        _log("wake microphone: PulseAudio source "
+             f"{os.environ.get('KIRRA_PULSE_SOURCE', '')} (via pulse_capture.sh)")
+    else:
+        device = wake_record_device(record_cmd)
+        _log(f"wake microphone: {device or os.path.basename(record_cmd[0]) + ' (custom backend)'}")
     rms_floor = float(os.environ.get("KIRRA_WAKE_RMS_FLOOR", "300"))
     cooldown_s = float(os.environ.get("KIRRA_WAKE_COOLDOWN_S", "2"))
     holdoff_s = float(os.environ.get("KIRRA_WAKE_HOLDOFF_S", "10"))


### PR DESCRIPTION
## Problem

The rabbit-voice listener on the R2 dies in a `capture stream ended (recorder died?) — retrying in 2 s` loop. With the desktop session's PulseAudio active, the sound server owns the C-Media USB mic (D-Bus device reservation): a direct `arecord -D plughw:CARD=Device,DEV=0 …` open fails **`Device or resource busy`** even while `/proc/asound/card2/pcm0c/sub0/status` reads `closed` and no process holds the PCM. The recorder exits instantly. `parec` through the server captures fine — the hardware is healthy; the ALSA-direct backend is wrong for this topology. The bad env line traces to `R2_VOICE_AUDIO_SETUP.md` §4 (correct for the old no-session system-service topology, wrong for the current user-session service).

## Fix

- **`robot/pulse_capture.sh`** (new): PulseAudio raw-capture backend emitting the exact wake/VAD stream contract (s16le / 16 kHz / mono, raw stdout; `exec parec` so SIGTERM tears the recorder down with its parent). Fail-closed: the source must be named **explicitly** in `KIRRA_PULSE_SOURCE`; missing `parec`/`pactl`, an unset source, an absent/renamed source, or an unreachable sound server each exit nonzero with an actionable message — **never a default-mic fallback** (a wrong microphone is worse than a visible failure). `--check` / `--print-cmd` modes.
- **`robot/wake_word.py`**: `resolve_record_cmd` layers the Pulse default on top of the existing `validate_record_cmd` (unchanged, all its rules and tests intact): explicit `KIRRA_WAKE_RECORD_CMD` runs verbatim with bare no-device `arecord` still refused; **unset now resolves to `pulse_capture.sh`** and requires `KIRRA_PULSE_SOURCE`. A one-shot `--check` preflight surfaces the wrapper's diagnostics in the journal at startup (the runtime capture spawn DEVNULLs stderr); a backend dying later still lands in the existing bounded 2 s retry loop.
- **`robot/install/systemd/user/rabbit-voice.service`** (new) + installer step: the user-unit variant the Pulse backend requires (per-user socket). The system unit keeps its ALSA-direct caveat and points here for the session-owned-mic topology.
- **`rabbit.env.example` / `R2_VOICE_AUDIO_SETUP.md` §4 / `RABBIT_AUDIO_STACK.md`**: corrected source-of-truth config — `KIRRA_PULSE_SOURCE` + the VAD turn recorder over `KIRRA_VAD_CAPTURE_CMD=pulse_capture.sh` (the `KIRRA_VAD_MAX_MS` hard-ceiling bounded-mic guarantee is unchanged); ALSA-direct stays the documented headless/no-session alternative, backend chosen by topology.
- **`robot/kirra_voice_doctor.sh`**: the turn-mic and wake-mic checks recognize the Pulse backend and delegate to `pulse_capture.sh --check` (one validation implementation); an unset wake capture now probes the Pulse default instead of reading as unconfigured.
- **`robot/wake_capture_test.py`** (new, wired into the robot CI lane): resolver accept/refuse matrix, the wrapper's contract under stub `pactl`/`parec` (via the `KIRRA_PULSE_PACTL`/`KIRRA_PULSE_PAREC` seams — no audio needed), and the deployment sources actually emitting the Pulse config.

No safety-behavior change: the wake word remains a microphone trigger with zero actuation authority behind the fenced mick `/intent` door; every new failure mode is a visible refusal, never a silent wrong-mic capture. No motion path is touched.

## Tests

- `python3 robot/wake_capture_test.py` — 14/14
- `python3 robot/wake_word_test.py` — ALL OK (incl. the existing `validate_record_cmd` refusal matrix, unchanged)
- `python3 robot/vad_record_test.py` — 32/32; `service_units_test.py` 14/14; `turn_state_test.py`, `rabbit_voice_test.py`, `robot/install/*_test.py` all green
- `shellcheck -S error` clean on all touched scripts; `py_compile` clean
- Live smokes: no-backend / bare-arecord / broken-Pulse each exit 1 with an actionable FATAL; a healthy streaming stub keeps the listener up with clean SIGTERM teardown

## Hardware validation required before merge (one Jetson run)

```bash
systemctl --user stop rabbit-voice.service
pactl list short sources                      # confirm the configured source name
set -a; . /etc/kirra/robot.env; set +a
robot/pulse_capture.sh --check
timeout 5 robot/pulse_capture.sh >/tmp/kirra-mic.raw   # expect exit 124, ~160 kB
systemctl --user restart rabbit-voice.service
sleep 5
tail -n 100 /tmp/rabbit.log
```

Then one spoken wake phrase + one harmless conversational request: capture stays alive, the wake ack fires, the transcript reaches `rabbit_converse.py`. **No motion is tested in this PR's verification** — voice-to-drive validation continues one boundary at a time after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_