### PR TITLE
fix(install): stage every local module the robot scripts import

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1488,6 +1488,13 @@ jobs:
           # is not mistaken for running it), and that the migration report never
           # prints the governor verifying key.
           python3 robot/install/deployment_verify_test.py
+          # Installer staging completeness (host, AST only): the transitive
+          # closure of local robot/*.py imports over every staged script must
+          # itself be staged — a module missing from the installer list is a
+          # ModuleNotFoundError crash-loop AT THE SERVICE (found on the R2:
+          # wake_word imported rabbit_latency, never staged; the old
+          # repo-checkout unit masked it). Also: every listed payload exists.
+          python3 robot/install/staging_completeness_test.py
           # Turn-state re-arm gate (Slice R, pure, no audio): the cross-process
           # "turn in progress" signal (fail-safe parse, active/done round-trip,
           # seq monotonicity) and the bounded rearm_decision that fixes the wake

--- a/robot/install/install_robot_units.sh
+++ b/robot/install/install_robot_units.sh
@@ -33,11 +33,22 @@ echo "== robot-side unit install — user: ${ROBOT_USER} =="
 # ship the whole Rabbit/voice set so the interactive tools are staged too.
 echo "== 1. Rabbit scripts -> ${OPT}/robot =="
 sudo install -d -m 0755 "${OPT}/robot"
+# 🔴 STAGING COMPLETENESS: every LOCAL module a staged script imports
+# (transitively) must itself be in this list — the deployed scripts run from
+# /opt/kirra/robot with no repo checkout on sys.path, so a missing module is a
+# ModuleNotFoundError crash-loop AT THE SERVICE, not at install time (found the
+# hard way on the R2: wake_word.py imported rabbit_latency, which was never
+# staged; the old repo-checkout unit had masked it). Enforced by
+# robot/install/staging_completeness_test.py — extend THIS list when a robot
+# script grows a new local import.
 for f in rabbit_persona.py rabbit_watch.py rabbit_ask.py rabbit_converse.py rabbit_boot.py \
          rabbit_voice.sh ptt_button.py run_voice_ptt.sh inspect_corridor.py rabbit_ota.py \
          ros_env.sh kirra_voice_doctor.sh kirra_doctor.py rabbit_diag.py \
          wake_word.py rabbit_wake.py turn_state.py vad_record.py pulse_capture.sh \
-         barge_in.py skill_registry.py world_model.py mission.py; do
+         barge_in.py skill_registry.py world_model.py mission.py \
+         rabbit_latency.py rabbit_stream.py rabbit_tone.py repo_command.py \
+         rabbit_model_smoketest.py assistant.py assistant_admission.py \
+         assistant_contract.py assistant_report.py assistant_tools.py; do
   [[ -f "${REPO}/robot/${f}" ]] || { echo "  ⚠ missing ${REPO}/robot/${f} — skipped"; continue; }
   sudo install -m 0755 "${REPO}/robot/${f}" "${OPT}/robot/${f}"
   echo "  installed ${OPT}/robot/${f}"

--- a/robot/install/staging_completeness_test.py
+++ b/robot/install/staging_completeness_test.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Staging-completeness gate for robot/install/install_robot_units.sh.
+
+THE BUG CLASS THIS PINS (found on the R2, 2026-08): the installer stages an
+explicit list of robot scripts to /opt/kirra/robot, and the deployed units run
+them FROM THERE — no repo checkout on sys.path. A robot script that grows a new
+local import (`import rabbit_latency`) works in the repo, passes every host
+test, installs cleanly — and then crash-loops AT THE SERVICE with
+ModuleNotFoundError, because the imported module was never added to the
+installer's list. The old repo-checkout unit masked exactly this for four
+modules' worth of features.
+
+The gate: parse the installer's `for f in …` list, compute the TRANSITIVE
+closure of local `robot/*.py` imports (AST, top-level absolute imports) over
+every staged .py, and require closure ⊆ staged list. Also: every listed file
+must exist in robot/ (a stale entry is skipped-with-a-warning at install time —
+silent payload loss), and the doctor package dir is handled separately by the
+installer so `doctor.*` imports are exempt.
+
+Runs standalone (`python3 robot/install/staging_completeness_test.py`, exit 1
+on any failure); also importable under pytest.
+"""
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent          # robot/install
+ROBOT = HERE.parent                              # robot/
+INSTALLER = HERE / "install_robot_units.sh"
+
+# Local packages the installer stages as DIRECTORIES (not via the file list).
+DIR_STAGED = {"doctor"}
+
+
+def staged_list() -> set[str]:
+    """The installer's explicit `for f in …; do` payload list."""
+    m = re.search(r"for f in (.*?); do", INSTALLER.read_text(), re.S)
+    assert m, "installer file list not found (for f in …; do)"
+    return set(re.findall(r"[\w.]+\.(?:py|sh)", m.group(1)))
+
+
+def local_imports(path: Path, local: dict[str, Path]) -> set[str]:
+    """Top-level-resolvable local robot/ modules `path` imports. Conditional
+    imports count too — a module that is sometimes needed must be staged."""
+    try:
+        tree = ast.parse(path.read_text())
+    except SyntaxError as e:  # a staged script must at least parse
+        raise AssertionError(f"{path.name} does not parse: {e}") from e
+    out: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            out |= {a.name.split(".")[0] for a in node.names}
+        elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+            out.add(node.module.split(".")[0])
+    return {m for m in out if m in local}
+
+
+def import_closure(staged: set[str]) -> set[str]:
+    """Transitive closure of local imports over the staged .py scripts."""
+    local = {p.stem: p for p in ROBOT.glob("*.py")}
+    seen: set[str] = set()
+    todo = [ROBOT / f for f in staged if f.endswith(".py") and (ROBOT / f).exists()]
+    while todo:
+        p = todo.pop()
+        if p.stem in seen:
+            continue
+        seen.add(p.stem)
+        todo.extend(local[m] for m in local_imports(p, local)
+                    if m not in seen and m not in DIR_STAGED)
+    return seen
+
+
+def test_every_listed_payload_exists() -> None:
+    """A listed-but-absent file is silently skipped at install time (the
+    installer warns and continues) — that is payload loss, so it fails here."""
+    missing = sorted(f for f in staged_list() if not (ROBOT / f).is_file())
+    assert not missing, f"installer lists files absent from robot/: {missing}"
+
+
+def test_staged_scripts_import_closure_is_fully_staged() -> None:
+    staged = staged_list()
+    needed = {f"{mod}.py" for mod in import_closure(staged)}
+    missing = sorted(needed - staged)
+    assert not missing, (
+        "staged robot scripts import local modules the installer does NOT "
+        f"stage (ModuleNotFoundError crash-loop at the service): {missing} — "
+        "add them to install_robot_units.sh's file list")
+
+
+def test_closure_is_nonvacuous() -> None:
+    """Anchor the gate on the exact regression that motivated it: wake_word →
+    rabbit_latency, and the conversational front-end's deeper chains. If these
+    ever leave the closure the parser broke, not the dependency."""
+    closure = import_closure(staged_list())
+    for anchor in ("wake_word", "rabbit_latency", "rabbit_converse",
+                   "rabbit_persona", "turn_state"):
+        assert anchor in closure, f"closure lost its anchor {anchor!r} — parser broken?"
+
+
+# --- standalone runner (house pattern) ----------------------------------------
+
+def _run_all() -> int:
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"  ok  {name}")
+            except AssertionError as e:
+                failures += 1
+                print(f"FAIL  {name}: {e}")
+    print("staging_completeness_test:",
+          "ALL OK" if failures == 0 else f"{failures} FAILURE(S)")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())

--- a/robot/install/staging_completeness_test.py
+++ b/robot/install/staging_completeness_test.py
@@ -11,11 +11,14 @@ installer's list. The old repo-checkout unit masked exactly this for four
 modules' worth of features.
 
 The gate: parse the installer's `for f in …` list, compute the TRANSITIVE
-closure of local `robot/*.py` imports (AST, top-level absolute imports) over
-every staged .py, and require closure ⊆ staged list. Also: every listed file
-must exist in robot/ (a stale entry is skipped-with-a-warning at install time —
-silent payload loss), and the doctor package dir is handled separately by the
-installer so `doctor.*` imports are exempt.
+closure of local `robot/*.py` imports over every staged .py, and require
+closure ⊆ staged list. The AST scan covers imports ANYWHERE in a module —
+nested and conditional ones included, deliberately: a module that is only
+sometimes needed must still be staged. Also: every listed file must exist in
+robot/ (a stale entry is skipped-with-a-warning at install time — silent
+payload loss), and the package directories the installer stages separately
+(DIR_STAGED) must exist as real packages, since `doctor.*` imports are
+otherwise exempt from the closure.
 
 Runs standalone (`python3 robot/install/staging_completeness_test.py`, exit 1
 on any failure); also importable under pytest.
@@ -78,6 +81,22 @@ def test_every_listed_payload_exists() -> None:
     installer warns and continues) — that is payload loss, so it fails here."""
     missing = sorted(f for f in staged_list() if not (ROBOT / f).is_file())
     assert not missing, f"installer lists files absent from robot/: {missing}"
+
+
+def test_dir_staged_packages_exist() -> None:
+    """DIR_STAGED packages are staged by the installer OUTSIDE the file list
+    (cp -r of the directory), so the file-list existence check never sees them
+    — but a missing/renamed package dir breaks deployed imports just as hard
+    (kirra_doctor.py imports `doctor` at module import time). Require each to
+    exist as a real package."""
+    for pkg in sorted(DIR_STAGED):
+        d = ROBOT / pkg
+        assert d.is_dir(), f"DIR_STAGED package missing: robot/{pkg}/"
+        assert (d / "__init__.py").is_file(), (
+            f"robot/{pkg}/ is not a package (no __init__.py) — deployed "
+            f"`import {pkg}` would fail")
+        assert f"robot/{pkg}" in INSTALLER.read_text() or pkg in INSTALLER.read_text(), (
+            f"installer no longer references the {pkg}/ package dir")
 
 
 def test_staged_scripts_import_closure_is_fully_staged() -> None:


### PR DESCRIPTION
## Problem

The R2's freshly deployed `rabbit-voice` user unit crash-looped with `ModuleNotFoundError: No module named 'rabbit_latency'`. `wake_word.py`, running from `/opt/kirra/robot` (the installer's own convention, and the convention the #1277 user unit follows), imports `rabbit_latency` — which `install_robot_units.sh` never staged.

**Ten** modules were missing from the staged list — the local imports of the newer features (`rabbit_latency`, `rabbit_stream`, `rabbit_tone`, `repo_command`, `rabbit_model_smoketest`, and the five `assistant*` modules). This is a latent upstream gap, not a #1277 regression: the pre-merge list was identical (minus `pulse_capture.sh`). It stayed hidden because the hand-made unit on the robot ran from the repo checkout, where every module is always importable. The failure mode is the worst kind: works in the repo, passes every host test, installs cleanly — then crash-loops **at the service**.

## Fix

- **`robot/install/install_robot_units.sh`**: the ten missing modules added to the staged file list, with a staging-completeness banner pointing at the gate below.
- **`robot/install/staging_completeness_test.py`** (new, wired into the robot CI lane): parses the installer's `for f in …` list, computes the **transitive closure of local `robot/*.py` imports** (AST, conditional imports included — a sometimes-needed module must still be staged) over every staged script, and requires closure ⊆ staged. Also fails on listed-but-absent payloads (the installer skips those with only a warning — silent payload loss) and anchors non-vacuity on the exact regression (`wake_word → rabbit_latency`).
- Verified the gate **reds against the pre-fix installer** with precisely the ten missing modules.

No deployed-behavior change beyond staging the missing files; no service, env, or safety-path edits.

## Tests

- `python3 robot/install/staging_completeness_test.py` — 3/3 (and confirmed FAIL with the exact ten-module list when run against the unfixed installer)
- `python3 robot/service_units_test.py` — 14/14; `robot/install/deployment_verify_test.py` — 43/43
- `python3 robot/wake_capture_test.py` / `wake_word_test.py` — ALL OK
- `shellcheck -S error robot/install/install_robot_units.sh` clean; `bash -n` clean; `py_compile` clean

## Hardware note

The equivalent unblock was applied manually on the R2 (copying the ten modules to `/opt/kirra/robot`); a rerun of `robot/install/install_robot_units.sh` from this branch converges to the same state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_