### PR TITLE
feat(mick): conversational sidecar — POST /chat, no motion authority

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1505,6 +1505,12 @@ jobs:
           # `$KIRRA_RECORD_CMD "$wav"` contract, and gates the linter's new
           # unquoted-multi-word check + --fix requoting.
           python3 robot/install/env_quoting_test.py
+          # mick_chat.py terminal client (host, stub HTTP server — no Ollama):
+          # success/malformed/timeout/4xx-5xx/EOF paths, the service error
+          # token surfaced, and the SEPARATION proofs — only /chat is ever
+          # contacted and the motion endpoint is unreferenced in the client
+          # source (no fallback to the motion door can exist).
+          python3 robot/mick_chat_test.py
           # Turn-state re-arm gate (Slice R, pure, no audio): the cross-process
           # "turn in progress" signal (fail-safe parse, active/done round-trip,
           # seq monotonicity) and the bounded rearm_decision that fixes the wake

--- a/crates/kirra-mick/src/lib.rs
+++ b/crates/kirra-mick/src/lib.rs
@@ -150,6 +150,125 @@ impl ModelClient for OllamaClient {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Conversational transport — deliberately SEPARATE from the motion path.
+// ---------------------------------------------------------------------------
+
+/// Default model id for the conversational endpoint (override with
+/// `KIRRA_MICK_CHAT_MODEL`). Deliberately its own variable: the chat model can
+/// be swapped without touching the motion model pin, and vice versa.
+pub const DEFAULT_CHAT_MODEL: &str = "gemma3:4b";
+
+/// One message in an Ollama `/api/chat` conversation.
+#[derive(Clone, Debug, Serialize)]
+pub struct ChatWireMessage {
+    /// `system` | `user` | `assistant`.
+    pub role: &'static str,
+    pub content: String,
+}
+
+/// Ollama `/api/chat` request (non-streaming).
+#[derive(Serialize)]
+struct ChatRequestWire<'a> {
+    model: &'a str,
+    stream: bool,
+    messages: &'a [ChatWireMessage],
+}
+
+#[derive(Deserialize)]
+struct ChatResponseWire {
+    message: ChatResponseMessage,
+}
+
+#[derive(Deserialize)]
+struct ChatResponseMessage {
+    content: String,
+}
+
+/// Plain conversational Ollama transport for the `mick_chat_service` sidecar.
+///
+/// **NOT a [`ModelClient`], on purpose.** The motion transport
+/// ([`OllamaClient`]) schema-constrains decoding to the typed-intent grammar —
+/// exactly what a conversational reply must NOT be constrained to. Rather than
+/// weaken or overload that abstraction, chat gets its own type and its own
+/// wire shape (`/api/chat`, a messages array, **no `format` field**): free
+/// text out, nothing downstream to parse it into an intent.
+///
+/// Same fail-closed posture as the motion transport: connection refused /
+/// timeout / non-200 / undecodable / empty all collapse to a stable error
+/// token, and the caller returns a chat error — never a fabricated reply.
+pub struct OllamaChatClient {
+    base_url: String,
+    model: String,
+    http: reqwest::blocking::Client,
+}
+
+impl OllamaChatClient {
+    /// Construct from the environment: `KIRRA_OLLAMA_URL` (default
+    /// [`DEFAULT_OLLAMA_URL`] — shared with the motion transport, one Ollama)
+    /// and `KIRRA_MICK_CHAT_MODEL` (default [`DEFAULT_CHAT_MODEL`]).
+    #[must_use]
+    pub fn new() -> Self {
+        let base_url =
+            std::env::var("KIRRA_OLLAMA_URL").unwrap_or_else(|_| DEFAULT_OLLAMA_URL.to_string());
+        let model = std::env::var("KIRRA_MICK_CHAT_MODEL")
+            .unwrap_or_else(|_| DEFAULT_CHAT_MODEL.to_string());
+        Self::with(base_url, model)
+    }
+
+    /// Construct with an explicit base URL + model id.
+    #[must_use]
+    pub fn with(base_url: impl Into<String>, model: impl Into<String>) -> Self {
+        let http = reqwest::blocking::Client::builder()
+            .timeout(REQUEST_TIMEOUT)
+            .build()
+            .unwrap_or_else(|_| reqwest::blocking::Client::new());
+        Self {
+            base_url: base_url.into(),
+            model: model.into(),
+            http,
+        }
+    }
+
+    /// The configured model id.
+    #[must_use]
+    pub fn model(&self) -> &str {
+        &self.model
+    }
+
+    /// One non-streaming conversational completion over the supplied message
+    /// list (system prompt + bounded history + the user turn — composed by the
+    /// caller; this transport adds nothing and constrains nothing).
+    pub fn chat_completion(&self, messages: &[ChatWireMessage]) -> Result<String, &'static str> {
+        let url = format!("{}/api/chat", self.base_url);
+        let body = ChatRequestWire {
+            model: &self.model,
+            stream: false,
+            messages,
+        };
+        let resp = self
+            .http
+            .post(&url)
+            .json(&body)
+            .send()
+            .map_err(|_| "MICK_CHAT_OLLAMA_REQUEST_FAILED")?;
+        if !resp.status().is_success() {
+            return Err("MICK_CHAT_OLLAMA_HTTP_STATUS");
+        }
+        let parsed: ChatResponseWire = resp.json().map_err(|_| "MICK_CHAT_OLLAMA_DECODE_FAILED")?;
+        if parsed.message.content.trim().is_empty() {
+            return Err("MICK_CHAT_OLLAMA_EMPTY_COMPLETION");
+        }
+        Ok(parsed.message.content)
+    }
+}
+
+impl Default for OllamaChatClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -215,6 +334,55 @@ mod tests {
             tags.iter().any(|t| t == "pull_over") && tags.iter().any(|t| t == "go_to"),
             "the constrained tag set is carried on the wire"
         );
+    }
+
+    // --- the conversational transport ---------------------------------------
+
+    /// CI-safe: an unreachable Ollama fails the chat transport closed with a
+    /// stable token — never a fabricated reply.
+    #[test]
+    fn unreachable_ollama_fails_chat_closed() {
+        let client = OllamaChatClient::with("http://127.0.0.1:1", DEFAULT_CHAT_MODEL);
+        let messages = [ChatWireMessage {
+            role: "user",
+            content: "hello".to_string(),
+        }];
+        assert_eq!(
+            client.chat_completion(&messages),
+            Err("MICK_CHAT_OLLAMA_REQUEST_FAILED")
+        );
+    }
+
+    /// The chat wire shape is `/api/chat` messages with NO `format` field —
+    /// the motion path's schema-constrained decoding must never leak into the
+    /// conversational path (a chat grammar-locked to intent JSON would be the
+    /// exact live failure this service exists to end). CI-safe: serializes the
+    /// body and inspects the wire, no network.
+    #[test]
+    fn chat_request_carries_messages_and_no_format_constraint() {
+        let messages = [
+            ChatWireMessage {
+                role: "system",
+                content: "you are conversational".to_string(),
+            },
+            ChatWireMessage {
+                role: "user",
+                content: "hi".to_string(),
+            },
+        ];
+        let body = ChatRequestWire {
+            model: "gemma3:4b",
+            stream: false,
+            messages: &messages,
+        };
+        let wire: serde_json::Value = serde_json::to_value(&body).expect("body serializes");
+        assert!(
+            wire.get("format").is_none(),
+            "chat must NOT schema-constrain decoding: {wire}"
+        );
+        assert_eq!(wire["stream"], false);
+        assert_eq!(wire["messages"][0]["role"], "system");
+        assert_eq!(wire["messages"][1]["role"], "user");
     }
 
     /// Live round-trip — requires `ollama pull gemma3:4b` and a running server. Ignored in

--- a/crates/kirra-sidecars/src/bin/mick_chat_service.rs
+++ b/crates/kirra-sidecars/src/bin/mick_chat_service.rs
@@ -1,0 +1,110 @@
+//! **Mick conversational sidecar** — talk to Mick WITHOUT touching the motion
+//! path. Plain text in (`POST /chat`), plain conversational text out. No
+//! intents, no latch, no seq, no planner, no downstream consumer.
+//!
+//! The separation this binary exists to make structural:
+//!
+//! ```text
+//!   POST /chat    (this service, :8103) — conversation only, NO motion authority
+//!   POST /intent  (mick_service, :8102) — motion-intent classification only,
+//!                                          governed downstream
+//! ```
+//!
+//! A live failure showed why the two must not share a door: a greeting posted
+//! to the motion-only `/intent` came back as a schema-valid cruise intent.
+//! The deterministic fence now blocks that class at `/intent`; this service
+//! is where conversation actually belongs. It has no route to intent state
+//! (`/intent/last` here is a 404), its model call is a plain `/api/chat`
+//! completion with NO schema constraint, and a motion-shaped model reply is
+//! replaced by a routing explanation, never passed through
+//! (`kirra_sidecars::chat` — the pure, tested core).
+//!
+//! Chat has NO live robot state: posture, sensors, and diagnostics are only
+//! known if the caller includes them in the request text. The prompt forbids
+//! inventing nominal status.
+//!
+//!   POST /chat    {"text":"How are your systems doing?", "session_id"?: "terminal"}
+//!     → 200 {"ok":true,"reply":"..."}
+//!     → 422 {"ok":false,"error":"MICK_CHAT_EMPTY_REQUEST" | "MICK_CHAT_TEXT_TOO_LONG"
+//!                              | "MICK_CHAT_BAD_TEXT" | "MICK_CHAT_BAD_SESSION"}
+//!     → 429 {"ok":false,"error":"MICK_CHAT_RATE_LIMITED"}
+//!     → 502 {"ok":false,"error":"MICK_CHAT_MODEL_ERROR"}   (Ollama down/failed — fail closed)
+//!   GET  /health  → {"status":"ok"}
+//!
+//! Config (boot-validated, fail-closed on malformed): `KIRRA_MICK_CHAT_ADDR`
+//! (default 127.0.0.1:8103, loopback-gated by `net::enforce_bind_policy`);
+//! `KIRRA_OLLAMA_URL` (shared — one local Ollama) + `KIRRA_MICK_CHAT_MODEL`
+//! (default gemma3:4b); `KIRRA_MICK_CHAT_HISTORY_TURNS` (default 6, 0 = off);
+//! `KIRRA_MICK_CHAT_MAX_CHARS` (default 1000);
+//! `KIRRA_SIDECAR_ALLOW_NONLOCAL=1` to permit a routable bind.
+//!
+//! History is in-memory only, bounded per session and across sessions, never
+//! persisted, never logged, and cleared on restart.
+
+use std::net::{TcpListener, TcpStream};
+
+use kirra_mick::{ChatWireMessage, OllamaChatClient};
+use kirra_sidecars::chat::{handle_request, ChatConfig, ChatMessage, ChatModelClient, ChatService};
+use kirra_sidecars::http::{read_request, respond, respond_error};
+use kirra_sidecars::net::{allow_nonlocal_from_env, enforce_bind_policy, now_ms};
+
+/// The Ollama chat transport, adapted to the service core's port. Role tags
+/// pass through verbatim; nothing is added, constrained, or rewritten.
+struct OllamaChat(OllamaChatClient);
+
+impl ChatModelClient for OllamaChat {
+    fn chat(&self, messages: &[ChatMessage]) -> Result<String, &'static str> {
+        let wire: Vec<ChatWireMessage> = messages
+            .iter()
+            .map(|m| ChatWireMessage {
+                role: m.role,
+                content: m.content.clone(),
+            })
+            .collect();
+        self.0.chat_completion(&wire)
+    }
+}
+
+fn serve(mut stream: TcpStream, svc: &mut ChatService<OllamaChat>) {
+    let req = match read_request(&mut stream) {
+        Ok(r) => r,
+        Err(status) => return respond_error(&mut stream, status),
+    };
+    let (status, body) = handle_request(svc, &req.method, &req.path, &req.body, now_ms());
+    respond(&mut stream, status, &body);
+}
+
+fn main() {
+    let addr =
+        std::env::var("KIRRA_MICK_CHAT_ADDR").unwrap_or_else(|_| "127.0.0.1:8103".to_string());
+    if let Err(e) = enforce_bind_policy(&addr, allow_nonlocal_from_env()) {
+        eprintln!("mick_chat_service: {e}");
+        std::process::exit(1);
+    }
+    let cfg = match ChatConfig::from_env() {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("mick_chat_service: {e}");
+            std::process::exit(1);
+        }
+    };
+    let client = OllamaChatClient::new();
+    let model = client.model().to_string();
+    let mut svc = ChatService::new(OllamaChat(client), cfg);
+    let listener = TcpListener::bind(&addr).unwrap_or_else(|e| {
+        eprintln!("mick_chat_service: bind {addr}: {e}");
+        std::process::exit(1);
+    });
+    println!(
+        "Mick chat service on http://{addr}  (POST /chat, GET /health) — model {model}, \
+         conversation only: NO motion authority, no intent state, history in-memory \
+         ({} turns × {} chars)",
+        cfg.history_turns, cfg.max_chars
+    );
+    for stream in listener.incoming() {
+        match stream {
+            Ok(s) => serve(s, &mut svc),
+            Err(e) => eprintln!("mick_chat_service: accept error: {e}"),
+        }
+    }
+}

--- a/crates/kirra-sidecars/src/chat.rs
+++ b/crates/kirra-sidecars/src/chat.rs
@@ -1,0 +1,726 @@
+//! The Mick CONVERSATIONAL service core — **typed text in, plain text out,
+//! never an intent.**
+//!
+//! Why this exists: casual conversation must not be sent to the motion-only
+//! `POST /intent` endpoint. That endpoint is deliberately schema-constrained
+//! to typed motion intents, and a live failure showed what happens when a
+//! greeting reaches it ("Hello Mr. Parker, how are you?" →
+//! `{"intent":"cruise","target_speed_mps":10}`). The deterministic non-motion
+//! fence now blocks that class *at* `/intent`; this module is the long-term
+//! half of the design — a SEPARATE place for conversation, so conversational
+//! text has somewhere to go that structurally cannot move the platform.
+//!
+//! **The separation, in one table:**
+//!
+//! | route | purpose | authority |
+//! |---|---|---|
+//! | `POST /chat`   | conversation only | none — plain text, no downstream consumer |
+//! | `POST /intent` | motion-intent classification | governed downstream (Occy grounds, KIRRA bounds, the consumer enforces) |
+//!
+//! **No path to motion, structurally.** This module never references the
+//! typed-intent machinery: no intent parse, no intent schema, no latch, no
+//! seq, no planner types. The model transport is a plain-text `/api/chat`
+//! completion with NO schema constraint. The crate-level actuation fence
+//! (`ci/check_mick_actuation_fence.py`) already proves kirra-sidecars has no
+//! dependency route to actuation; `tests/mick_chat_separation.rs` adds the
+//! finer source-level fence that the CHAT path does not even touch the
+//! intent machinery this crate legitimately uses elsewhere.
+//!
+//! **Output guard.** Chat must not *masquerade* as the motion API either: if
+//! the model emits a JSON object shaped like a motion intent, the reply is
+//! REPLACED by a fixed routing explanation ([`MOTION_SHAPE_REFUSAL`]) — the
+//! motion-looking JSON is never passed through as if it were actionable, and
+//! it is never parsed into anything. Pure and unit-tested
+//! ([`looks_like_motion_intent_json`]).
+//!
+//! **History.** Bounded, in-memory, per-session: capped turns, capped total
+//! characters, capped session count with oldest-session eviction. Nothing is
+//! persisted, nothing is logged (counters only), everything clears on process
+//! restart.
+
+use std::collections::HashMap;
+
+use crate::net::RateLimiter;
+use serde::Deserialize;
+
+/// LLM-call rate bound (burst / steady-state per second) — the same plumbing
+/// shape as the intent service: each request is a full model completion, so a
+/// runaway caller is shed cheaply before the LLM call.
+pub const CHAT_RATE_BURST: f64 = 3.0;
+pub const CHAT_RATE_PER_S: f64 = 1.0;
+
+/// Hard ceiling on live sessions; the oldest-touched session is evicted when
+/// a new one would exceed it (memory bound, not a feature).
+pub const CHAT_MAX_SESSIONS: usize = 32;
+
+/// The conversational system prompt. Deliberately explicit that this surface
+/// has NO motion authority — and deliberately free of any intent-JSON forms,
+/// so the prompt cannot teach the model the motion wire shape
+/// (`tests` pin both properties).
+pub const CHAT_SYSTEM_PROMPT: &str = "You are Mick, the robot's conversational assistant.\n\
+\n\
+You may answer questions, explain robot status information supplied in the \
+user's text, and engage in ordinary conversation.\n\
+\n\
+You are conversational only. You have no authority to move or control the \
+robot. Never claim that you started, stopped, steered, navigated, or \
+commanded the platform. Never emit motion-intent JSON. If asked to move the \
+robot, explain that motion requests must go through the dedicated governed \
+intent path.\n\
+\n\
+Do not claim access to live sensors, posture, diagnostics, or state unless \
+that information is explicitly included in the request context. Do not \
+invent nominal status.";
+
+/// The fixed reply substituted when the model emits motion-shaped JSON: the
+/// chat surface explains the governed path instead of passing through
+/// something that could be mistaken for an actionable result.
+pub const MOTION_SHAPE_REFUSAL: &str =
+    "I can't move or command the robot from chat. Motion requests go through \
+the dedicated governed intent path, where the planner grounds them and the \
+KIRRA governor bounds them. Happy to keep talking here.";
+
+/// One `POST /chat` request. `session_id` selects a bounded in-memory history
+/// (optional; absent → the shared `\"default\"` session).
+#[derive(Deserialize)]
+pub struct ChatRequest {
+    pub text: String,
+    #[serde(default)]
+    pub session_id: Option<String>,
+}
+
+/// Boot-validated configuration (the env_config convention: a malformed value
+/// aborts startup, never a silent default at use).
+#[derive(Clone, Copy, Debug)]
+pub struct ChatConfig {
+    /// Max characters of user text per request (`KIRRA_MICK_CHAT_MAX_CHARS`).
+    pub max_chars: usize,
+    /// Max retained PAIRS (user + reply) per session
+    /// (`KIRRA_MICK_CHAT_HISTORY_TURNS`); 0 disables history.
+    pub history_turns: usize,
+}
+
+impl Default for ChatConfig {
+    fn default() -> Self {
+        Self {
+            max_chars: 1000,
+            history_turns: 6,
+        }
+    }
+}
+
+impl ChatConfig {
+    /// Read from the environment, fail-closed: present-but-malformed values
+    /// are an `Err` for the binary to abort on.
+    pub fn from_env() -> Result<Self, String> {
+        let mut cfg = Self::default();
+        if let Ok(v) = std::env::var("KIRRA_MICK_CHAT_MAX_CHARS") {
+            cfg.max_chars = v
+                .trim()
+                .parse::<usize>()
+                .ok()
+                .filter(|n| *n > 0)
+                .ok_or_else(|| format!("KIRRA_MICK_CHAT_MAX_CHARS malformed: {v:?}"))?;
+        }
+        if let Ok(v) = std::env::var("KIRRA_MICK_CHAT_HISTORY_TURNS") {
+            cfg.history_turns = v
+                .trim()
+                .parse::<usize>()
+                .map_err(|_| format!("KIRRA_MICK_CHAT_HISTORY_TURNS malformed: {v:?}"))?;
+        }
+        Ok(cfg)
+    }
+}
+
+/// One message handed to the chat model transport.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ChatMessage {
+    /// `system` | `user` | `assistant`.
+    pub role: &'static str,
+    pub content: String,
+}
+
+/// Abstract "messages → completion text" port for the CONVERSATIONAL path.
+/// Deliberately not the motion `ModelClient`: that abstraction carries the
+/// schema-constrained intent decode, which chat must never inherit.
+pub trait ChatModelClient {
+    fn chat(&self, messages: &[ChatMessage]) -> Result<String, &'static str>;
+}
+
+/// Is `reply`, as a whole (after trimming and unwrapping one Markdown code
+/// fence), a JSON OBJECT carrying an `"intent"` key? That is the structural
+/// signature of the motion wire shape, and the chat surface must not emit it.
+///
+/// Deliberately structural, not semantic: the check uses only serde_json —
+/// the reply is NEVER parsed by the typed-intent parser, and an unknown
+/// `intent` tag is guarded all the same (a new intent added later must not
+/// leak through an out-of-date guard). Prose that merely *mentions* intent
+/// JSON is not guarded — it does not parse as a lone object — and that is
+/// fine: the guard exists to stop the reply LOOKING LIKE the motion API's
+/// output, not to censor discussion of it.
+#[must_use]
+pub fn looks_like_motion_intent_json(reply: &str) -> bool {
+    let mut candidate = reply.trim();
+    // Unwrap one ```...``` fence (Gemma habitually fences JSON).
+    if let Some(inner) = candidate.strip_prefix("```") {
+        if let Some(end) = inner.rfind("```") {
+            let inner = &inner[..end];
+            // Drop an optional language tag on the fence line.
+            candidate = inner
+                .split_once('\n')
+                .map_or(inner, |(_, rest)| rest)
+                .trim();
+        }
+    }
+    match serde_json::from_str::<serde_json::Value>(candidate) {
+        Ok(v) => v.is_object() && v.get("intent").is_some(),
+        Err(_) => false,
+    }
+}
+
+/// Why a request was refused (stable wire tokens).
+pub type ChatError = &'static str;
+
+struct Session {
+    /// (user, assistant) pairs, oldest first.
+    pairs: Vec<(String, String)>,
+    last_used_ms: u64,
+}
+
+/// The service core: transport + per-session bounded history + rate limit.
+/// Single-threaded, like the serve loop that drives it. Holds NO intent
+/// state — there is no latch, no seq, nothing for a consumer to poll.
+pub struct ChatService<M: ChatModelClient> {
+    model: M,
+    cfg: ChatConfig,
+    limiter: RateLimiter,
+    sessions: HashMap<String, Session>,
+    /// How many motion-shaped replies the output guard has replaced.
+    motion_shape_guarded: u64,
+}
+
+impl<M: ChatModelClient> ChatService<M> {
+    #[must_use]
+    pub fn new(model: M, cfg: ChatConfig) -> Self {
+        Self {
+            model,
+            cfg,
+            limiter: RateLimiter::new(CHAT_RATE_BURST, CHAT_RATE_PER_S),
+            sessions: HashMap::new(),
+            motion_shape_guarded: 0,
+        }
+    }
+
+    /// How many replies the motion-shape output guard has replaced.
+    #[must_use]
+    pub fn motion_shape_guarded(&self) -> u64 {
+        self.motion_shape_guarded
+    }
+
+    /// Handle one chat request at `now_ms`. Returns the reply text, or a
+    /// stable error token. Validation happens BEFORE the model call; the
+    /// output guard happens after it; history records only what was actually
+    /// returned to the caller (a guarded reply stores the refusal, never the
+    /// motion-shaped text).
+    pub fn handle_chat(&mut self, req: &ChatRequest, now_ms: u64) -> Result<String, ChatError> {
+        if !self.limiter.admit(now_ms) {
+            return Err("MICK_CHAT_RATE_LIMITED");
+        }
+        let text = req.text.trim();
+        if text.is_empty() {
+            return Err("MICK_CHAT_EMPTY_REQUEST");
+        }
+        if req.text.chars().count() > self.cfg.max_chars {
+            return Err("MICK_CHAT_TEXT_TOO_LONG");
+        }
+        // Control characters (beyond ordinary whitespace) are rejected, not
+        // stripped: terminal-escape smuggling into a reply a human will read
+        // in a terminal is exactly the abuse this bound exists for.
+        if text
+            .chars()
+            .any(|c| c.is_control() && c != '\n' && c != '\r' && c != '\t')
+        {
+            return Err("MICK_CHAT_BAD_TEXT");
+        }
+        let session_id = validate_session_id(req.session_id.as_deref())?;
+
+        // Compose: system prompt + this session's bounded history + the turn.
+        let mut messages = vec![ChatMessage {
+            role: "system",
+            content: CHAT_SYSTEM_PROMPT.to_string(),
+        }];
+        if let Some(s) = self.sessions.get(&session_id) {
+            for (user, assistant) in &s.pairs {
+                messages.push(ChatMessage {
+                    role: "user",
+                    content: user.clone(),
+                });
+                messages.push(ChatMessage {
+                    role: "assistant",
+                    content: assistant.clone(),
+                });
+            }
+        }
+        messages.push(ChatMessage {
+            role: "user",
+            content: text.to_string(),
+        });
+
+        let raw = self
+            .model
+            .chat(&messages)
+            .map_err(|_| "MICK_CHAT_MODEL_ERROR")?;
+        let reply = if looks_like_motion_intent_json(&raw) {
+            self.motion_shape_guarded += 1;
+            // Count + log the KIND only — never the transcript.
+            eprintln!(
+                "mick_chat: motion-shape output guard engaged (guarded={}) — \
+                 reply replaced with the routing explanation",
+                self.motion_shape_guarded
+            );
+            MOTION_SHAPE_REFUSAL.to_string()
+        } else {
+            raw
+        };
+
+        self.record_turn(&session_id, text, &reply, now_ms);
+        Ok(reply)
+    }
+
+    /// Append a (user, reply) pair to the session, enforcing every bound:
+    /// per-session turns, per-session characters, and the session-count cap
+    /// (oldest-touched evicted). In-memory only; cleared on restart.
+    fn record_turn(&mut self, session_id: &str, user: &str, reply: &str, now_ms: u64) {
+        if self.cfg.history_turns == 0 {
+            return;
+        }
+        if !self.sessions.contains_key(session_id) && self.sessions.len() >= CHAT_MAX_SESSIONS {
+            if let Some(oldest) = self
+                .sessions
+                .iter()
+                .min_by_key(|(_, s)| s.last_used_ms)
+                .map(|(k, _)| k.clone())
+            {
+                self.sessions.remove(&oldest);
+            }
+        }
+        let session = self
+            .sessions
+            .entry(session_id.to_string())
+            .or_insert(Session {
+                pairs: Vec::new(),
+                last_used_ms: now_ms,
+            });
+        session.last_used_ms = now_ms;
+        session.pairs.push((user.to_string(), reply.to_string()));
+        while session.pairs.len() > self.cfg.history_turns {
+            session.pairs.remove(0);
+        }
+        // Character bound over the whole session: trim oldest pairs until the
+        // total fits (2× max_chars per retained turn is the generous ceiling).
+        let char_cap = self.cfg.history_turns.saturating_mul(self.cfg.max_chars) * 2;
+        while session.pairs.len() > 1
+            && session
+                .pairs
+                .iter()
+                .map(|(u, a)| u.chars().count() + a.chars().count())
+                .sum::<usize>()
+                > char_cap
+        {
+            session.pairs.remove(0);
+        }
+    }
+
+    /// Retained history pairs for a session (tests/observability; content is
+    /// never logged by the service itself).
+    #[must_use]
+    pub fn history_len(&self, session_id: &str) -> usize {
+        self.sessions.get(session_id).map_or(0, |s| s.pairs.len())
+    }
+
+    #[must_use]
+    pub fn session_count(&self) -> usize {
+        self.sessions.len()
+    }
+}
+
+/// Session ids are short, filename-safe tokens; anything else is refused
+/// rather than truncated or normalized. Absent → the shared default session.
+fn validate_session_id(raw: Option<&str>) -> Result<String, ChatError> {
+    let id = raw.unwrap_or("default");
+    if id.is_empty()
+        || id.len() > 64
+        || !id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
+    {
+        return Err("MICK_CHAT_BAD_SESSION");
+    }
+    Ok(id.to_string())
+}
+
+/// Route one parsed HTTP request — the single handler path the binary's serve
+/// loop delegates to, extracted pure so the wire contract is testable without
+/// sockets. Returns `(status line, body)`.
+///
+/// Deliberately: there is NO `/intent` route here and NO `/intent/last` route
+/// — a chat caller cannot reach, read, or mutate Mick intent state through
+/// this service by construction (`tests/mick_chat_separation.rs` pins it).
+pub fn handle_request<M: ChatModelClient>(
+    svc: &mut ChatService<M>,
+    method: &str,
+    path: &str,
+    body: &[u8],
+    now_ms: u64,
+) -> (&'static str, String) {
+    match (method, path) {
+        ("GET", "/health") => ("200 OK", "{\"status\":\"ok\"}".to_string()),
+        ("POST", "/chat") => match serde_json::from_slice::<ChatRequest>(body) {
+            Ok(req) => match svc.handle_chat(&req, now_ms) {
+                Ok(reply) => (
+                    "200 OK",
+                    serde_json::json!({"ok": true, "reply": reply}).to_string(),
+                ),
+                Err("MICK_CHAT_RATE_LIMITED") => (
+                    "429 Too Many Requests",
+                    "{\"ok\":false,\"error\":\"MICK_CHAT_RATE_LIMITED\"}".to_string(),
+                ),
+                Err("MICK_CHAT_MODEL_ERROR") => (
+                    "502 Bad Gateway",
+                    "{\"ok\":false,\"error\":\"MICK_CHAT_MODEL_ERROR\"}".to_string(),
+                ),
+                Err(code) => (
+                    "422 Unprocessable Entity",
+                    serde_json::json!({"ok": false, "error": code}).to_string(),
+                ),
+            },
+            Err(e) => (
+                "400 Bad Request",
+                serde_json::json!({"ok": false, "error": format!("{e}")}).to_string(),
+            ),
+        },
+        _ => ("404 Not Found", "{\"error\":\"unknown route\"}".to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    struct StubModel {
+        reply: String,
+        calls: Rc<Cell<u32>>,
+    }
+
+    impl ChatModelClient for StubModel {
+        fn chat(&self, _messages: &[ChatMessage]) -> Result<String, &'static str> {
+            self.calls.set(self.calls.get() + 1);
+            Ok(self.reply.clone())
+        }
+    }
+
+    struct FailingModel;
+    impl ChatModelClient for FailingModel {
+        fn chat(&self, _messages: &[ChatMessage]) -> Result<String, &'static str> {
+            Err("MICK_CHAT_OLLAMA_REQUEST_FAILED")
+        }
+    }
+
+    fn service(reply: &str) -> (ChatService<StubModel>, Rc<Cell<u32>>) {
+        let calls = Rc::new(Cell::new(0));
+        let svc = ChatService::new(
+            StubModel {
+                reply: reply.to_string(),
+                calls: Rc::clone(&calls),
+            },
+            ChatConfig::default(),
+        );
+        (svc, calls)
+    }
+
+    fn req(text: &str) -> ChatRequest {
+        ChatRequest {
+            text: text.to_string(),
+            session_id: None,
+        }
+    }
+
+    // --- the system prompt contract -----------------------------------------
+
+    #[test]
+    fn system_prompt_declares_conversational_only_and_denies_motion_authority() {
+        assert!(CHAT_SYSTEM_PROMPT.contains("conversational only"));
+        assert!(CHAT_SYSTEM_PROMPT.contains("no authority to move or control the robot"));
+        assert!(CHAT_SYSTEM_PROMPT.contains("Never emit motion-intent JSON"));
+        assert!(CHAT_SYSTEM_PROMPT.contains("governed"));
+        assert!(CHAT_SYSTEM_PROMPT.contains("Do not invent nominal status"));
+    }
+
+    #[test]
+    fn system_prompt_does_not_teach_the_motion_wire_shape() {
+        // The prompt must not list the MickIntent JSON forms — the chat model
+        // must never learn the motion vocabulary from its own instructions.
+        for token in [
+            "cruise",
+            "go_to",
+            "lane_change",
+            "pull_over",
+            "route_to",
+            "target_speed_mps",
+            "\"intent\"",
+        ] {
+            assert!(
+                !CHAT_SYSTEM_PROMPT.contains(token),
+                "prompt leaks the motion wire shape: {token}"
+            );
+        }
+    }
+
+    // --- input validation ----------------------------------------------------
+
+    #[test]
+    fn empty_oversized_and_control_input_is_refused_before_the_model() {
+        let (mut svc, calls) = service("hello there");
+        assert_eq!(
+            svc.handle_chat(&req("   "), 10_000),
+            Err("MICK_CHAT_EMPTY_REQUEST")
+        );
+        let long = "x".repeat(1001);
+        assert_eq!(
+            svc.handle_chat(&req(&long), 12_000),
+            Err("MICK_CHAT_TEXT_TOO_LONG")
+        );
+        assert_eq!(
+            svc.handle_chat(&req("hi\u{1b}[2Jthere"), 14_000),
+            Err("MICK_CHAT_BAD_TEXT")
+        );
+        assert_eq!(calls.get(), 0, "invalid input reached the model");
+    }
+
+    #[test]
+    fn session_ids_are_validated_not_normalized() {
+        let (mut svc, _) = service("ok");
+        for (i, bad) in ["", "a b", "sess/../ion", "x".repeat(65).as_str()]
+            .into_iter()
+            .enumerate()
+        {
+            let r = ChatRequest {
+                text: "hello".to_string(),
+                session_id: Some(bad.to_string()),
+            };
+            // Spaced in time so the rate limiter never shadows the verdict.
+            assert_eq!(
+                svc.handle_chat(&r, 10_000 + i as u64 * 2_000),
+                Err("MICK_CHAT_BAD_SESSION"),
+                "{bad:?}"
+            );
+        }
+        assert_eq!(
+            validate_session_id(Some("terminal-1.a_b")).as_deref(),
+            Ok("terminal-1.a_b")
+        );
+        assert_eq!(validate_session_id(None).as_deref(), Ok("default"));
+    }
+
+    #[test]
+    fn rate_limit_sheds_before_the_model() {
+        let (mut svc, calls) = service("ok");
+        let mut shed = 0;
+        for _ in 0..10 {
+            if svc.handle_chat(&req("hello"), 10_000) == Err("MICK_CHAT_RATE_LIMITED") {
+                shed += 1;
+            }
+        }
+        assert!(
+            shed >= 6,
+            "burst bound must shed a same-instant flood: {shed}"
+        );
+        assert_eq!(calls.get() as usize, 10 - shed);
+    }
+
+    // --- the motion-shape output guard ---------------------------------------
+
+    #[test]
+    fn motion_shaped_json_is_detected_bare_and_fenced() {
+        for reply in [
+            r#"{"intent":"cruise","target_speed_mps":10}"#,
+            r#"  {"intent":"go_to","x_m":1.0,"y_m":0.0}  "#,
+            "```json\n{\"intent\":\"hold\"}\n```",
+            "```\n{\"intent\":\"future_unknown_tag\",\"weird\":1}\n```",
+        ] {
+            assert!(looks_like_motion_intent_json(reply), "{reply:?}");
+        }
+    }
+
+    #[test]
+    fn ordinary_text_and_non_intent_json_pass_the_guard() {
+        for reply in [
+            "All monitored systems are nominal.",
+            "The word intent appears in prose without JSON.",
+            r#"{"status":"ok"}"#,
+            r#"["intent"]"#,
+            "I would answer {\"intent\":...} if asked, but here is prose around it.",
+            "",
+        ] {
+            assert!(!looks_like_motion_intent_json(reply), "{reply:?}");
+        }
+    }
+
+    #[test]
+    fn a_motion_shaped_reply_is_replaced_never_passed_through() {
+        let (mut svc, _) = service(r#"{"intent":"cruise","target_speed_mps":10}"#);
+        let reply = svc
+            .handle_chat(&req("Drive forward one meter."), 10_000)
+            .unwrap();
+        assert_eq!(reply, MOTION_SHAPE_REFUSAL);
+        assert_eq!(svc.motion_shape_guarded(), 1);
+        // And the HISTORY stores the refusal, not the motion-shaped text —
+        // the guard must not smuggle the shape back in via the next prompt.
+        let (mut svc2, _) = service(r#"{"intent":"hold"}"#);
+        svc2.handle_chat(&req("go"), 10_000).unwrap();
+        assert_eq!(svc2.history_len("default"), 1);
+    }
+
+    // --- history bounds -------------------------------------------------------
+
+    #[test]
+    fn history_is_bounded_by_turns_and_isolated_by_session() {
+        let (mut svc, _) = service("reply");
+        for i in 0..10 {
+            let r = ChatRequest {
+                text: format!("turn {i}"),
+                session_id: Some("a".to_string()),
+            };
+            svc.handle_chat(&r, 10_000 + i * 2_000).unwrap();
+        }
+        assert_eq!(svc.history_len("a"), ChatConfig::default().history_turns);
+        assert_eq!(svc.history_len("b"), 0, "sessions must be isolated");
+    }
+
+    #[test]
+    fn session_count_is_capped_with_oldest_eviction() {
+        let (mut svc, _) = service("r");
+        for i in 0..(CHAT_MAX_SESSIONS + 5) {
+            let r = ChatRequest {
+                text: "hi".to_string(),
+                session_id: Some(format!("s{i}")),
+            };
+            svc.handle_chat(&r, 10_000 + i as u64 * 2_000).unwrap();
+        }
+        assert_eq!(svc.session_count(), CHAT_MAX_SESSIONS);
+        assert_eq!(svc.history_len("s0"), 0, "oldest session must be evicted");
+        let newest = format!("s{}", CHAT_MAX_SESSIONS + 4);
+        assert_eq!(svc.history_len(&newest), 1);
+    }
+
+    #[test]
+    fn zero_history_turns_disables_history_cleanly() {
+        let calls = Rc::new(Cell::new(0));
+        let mut svc = ChatService::new(
+            StubModel {
+                reply: "r".to_string(),
+                calls,
+            },
+            ChatConfig {
+                history_turns: 0,
+                ..ChatConfig::default()
+            },
+        );
+        svc.handle_chat(&req("hello"), 10_000).unwrap();
+        assert_eq!(svc.session_count(), 0);
+    }
+
+    // --- the model boundary ---------------------------------------------------
+
+    #[test]
+    fn a_model_failure_maps_to_the_stable_chat_error() {
+        let mut svc = ChatService::new(FailingModel, ChatConfig::default());
+        assert_eq!(
+            svc.handle_chat(&req("hello"), 10_000),
+            Err("MICK_CHAT_MODEL_ERROR")
+        );
+    }
+
+    #[test]
+    fn the_prompt_history_and_turn_are_composed_in_order() {
+        /// One captured model call: the (role, content) list it was handed.
+        type SeenCalls = Rc<std::cell::RefCell<Vec<Vec<(String, String)>>>>;
+        struct CapturingModel {
+            seen: SeenCalls,
+        }
+        impl ChatModelClient for CapturingModel {
+            fn chat(&self, messages: &[ChatMessage]) -> Result<String, &'static str> {
+                self.seen.borrow_mut().push(
+                    messages
+                        .iter()
+                        .map(|m| (m.role.to_string(), m.content.clone()))
+                        .collect(),
+                );
+                Ok("fine".to_string())
+            }
+        }
+        let seen = Rc::new(std::cell::RefCell::new(Vec::new()));
+        let mut svc = ChatService::new(
+            CapturingModel {
+                seen: Rc::clone(&seen),
+            },
+            ChatConfig::default(),
+        );
+        svc.handle_chat(&req("first"), 10_000).unwrap();
+        svc.handle_chat(&req("second"), 12_000).unwrap();
+        let calls = seen.borrow();
+        let second = &calls[1];
+        assert_eq!(second[0].0, "system");
+        assert_eq!(second[0].1, CHAT_SYSTEM_PROMPT);
+        assert_eq!(
+            &second[1..],
+            &[
+                ("user".to_string(), "first".to_string()),
+                ("assistant".to_string(), "fine".to_string()),
+                ("user".to_string(), "second".to_string()),
+            ]
+        );
+    }
+
+    // --- the wire (handler path, no sockets) ----------------------------------
+
+    #[test]
+    fn wire_contract_health_chat_and_no_intent_routes() {
+        let (mut svc, _) = service("All monitored systems are nominal.");
+        let (status, body) = handle_request(&mut svc, "GET", "/health", b"", 10_000);
+        assert_eq!((status, body.as_str()), ("200 OK", "{\"status\":\"ok\"}"));
+
+        let (status, body) = handle_request(
+            &mut svc,
+            "POST",
+            "/chat",
+            br#"{"text":"How are your systems doing?"}"#,
+            12_000,
+        );
+        assert_eq!(status, "200 OK");
+        let v: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(v["ok"], true);
+        assert_eq!(v["reply"], "All monitored systems are nominal.");
+
+        // The chat service exposes NO intent surface: it cannot read the
+        // latch, cannot mutate it, and cannot accept a motion request.
+        for path in ["/intent", "/intent/last"] {
+            for method in ["GET", "POST"] {
+                let (status, _) = handle_request(&mut svc, method, path, b"{}", 14_000);
+                assert_eq!(status, "404 Not Found", "{method} {path}");
+            }
+        }
+
+        let (status, _) = handle_request(&mut svc, "POST", "/chat", b"not json", 16_000);
+        assert_eq!(status, "400 Bad Request");
+    }
+
+    #[test]
+    fn config_defaults_are_the_documented_bounds() {
+        let cfg = ChatConfig::default();
+        assert_eq!(cfg.max_chars, 1000);
+        assert_eq!(cfg.history_turns, 6);
+    }
+}

--- a/crates/kirra-sidecars/src/chat.rs
+++ b/crates/kirra-sidecars/src/chat.rs
@@ -109,9 +109,15 @@ impl Default for ChatConfig {
     }
 }
 
+/// Hard ceilings on the configurable bounds, so a misconfiguration cannot
+/// defeat the "bounded" guarantees (out-of-range values ABORT startup, the
+/// same fail-closed posture as malformed ones).
+pub const CHAT_MAX_INPUT_CHARS_CEILING: usize = 8_192;
+pub const CHAT_HISTORY_TURNS_CEILING: usize = 32;
+
 impl ChatConfig {
-    /// Read from the environment, fail-closed: present-but-malformed values
-    /// are an `Err` for the binary to abort on.
+    /// Read from the environment, fail-closed: present-but-malformed OR
+    /// out-of-range values are an `Err` for the binary to abort on.
     pub fn from_env() -> Result<Self, String> {
         let mut cfg = Self::default();
         if let Ok(v) = std::env::var("KIRRA_MICK_CHAT_MAX_CHARS") {
@@ -119,14 +125,26 @@ impl ChatConfig {
                 .trim()
                 .parse::<usize>()
                 .ok()
-                .filter(|n| *n > 0)
-                .ok_or_else(|| format!("KIRRA_MICK_CHAT_MAX_CHARS malformed: {v:?}"))?;
+                .filter(|n| *n > 0 && *n <= CHAT_MAX_INPUT_CHARS_CEILING)
+                .ok_or_else(|| {
+                    format!(
+                        "KIRRA_MICK_CHAT_MAX_CHARS malformed or out of range \
+                         (1..={CHAT_MAX_INPUT_CHARS_CEILING}): {v:?}"
+                    )
+                })?;
         }
         if let Ok(v) = std::env::var("KIRRA_MICK_CHAT_HISTORY_TURNS") {
             cfg.history_turns = v
                 .trim()
                 .parse::<usize>()
-                .map_err(|_| format!("KIRRA_MICK_CHAT_HISTORY_TURNS malformed: {v:?}"))?;
+                .ok()
+                .filter(|n| *n <= CHAT_HISTORY_TURNS_CEILING)
+                .ok_or_else(|| {
+                    format!(
+                        "KIRRA_MICK_CHAT_HISTORY_TURNS malformed or out of range \
+                         (0..={CHAT_HISTORY_TURNS_CEILING}): {v:?}"
+                    )
+                })?;
         }
         Ok(cfg)
     }

--- a/crates/kirra-sidecars/src/lib.rs
+++ b/crates/kirra-sidecars/src/lib.rs
@@ -22,6 +22,7 @@
 #![forbid(unsafe_code)]
 
 pub mod capabilities;
+pub mod chat;
 pub mod http;
 pub mod mick;
 pub mod mick_fence;

--- a/crates/kirra-sidecars/tests/mick_chat_separation.rs
+++ b/crates/kirra-sidecars/tests/mick_chat_separation.rs
@@ -80,12 +80,18 @@ fn chat_sources_never_reference_intent_or_actuation_machinery() {
 fn chat_binary_does_not_mention_the_intent_routes() {
     // The chat binary must not even name the motion endpoints, so a future
     // "convenient" fallback from chat to /intent shows up as a fence break.
+    // Only PURE comment lines are skipped — splitting on "//" would also
+    // strip string literals like "http://…/intent" and let a fallback URL
+    // slip past the fence (review: Copilot on #1283).
     let bin = include_str!("../src/bin/mick_chat_service.rs");
     for line in bin.lines() {
-        let code = line.split("//").next().unwrap_or("");
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("//") {
+            continue; // doc/comment line — commentary may explain the fence
+        }
         assert!(
-            !code.contains("/intent"),
-            "chat binary carries an /intent route outside comments: {line:?}"
+            !line.contains("/intent"),
+            "chat binary carries an /intent reference in code: {line:?}"
         );
     }
 }

--- a/crates/kirra-sidecars/tests/mick_chat_separation.rs
+++ b/crates/kirra-sidecars/tests/mick_chat_separation.rs
@@ -1,0 +1,198 @@
+//! Structural + behavioral separation fence for the Mick CHAT path.
+//!
+//! The crate-level actuation fence (`ci/check_mick_actuation_fence.py`)
+//! already proves kirra-sidecars has no dependency route to actuation. This
+//! test adds the FINER invariant: the chat path (`src/chat.rs` +
+//! `src/bin/mick_chat_service.rs`) must not even touch the typed-intent
+//! machinery this crate legitimately uses elsewhere — no intent parse, no
+//! intent schema, no latch, no planner brain. Chat is conversation; the
+//! governed motion door is `/intent`, in a different binary.
+//!
+//! Source scanning is a ratchet against the convenient edge, not a proof —
+//! the behavioral halves below (guard + wire) are the semantics.
+
+use std::cell::Cell;
+use std::rc::Rc;
+
+use kirra_sidecars::chat::{
+    handle_request, looks_like_motion_intent_json, ChatConfig, ChatMessage, ChatModelClient,
+    ChatRequest, ChatService, CHAT_SYSTEM_PROMPT, MOTION_SHAPE_REFUSAL,
+};
+
+// --- 1. the source-level fence -----------------------------------------------
+
+/// Identifiers of the motion/intent machinery (and actuation seams) that must
+/// never appear in the chat sources. Every needle is built by CONCATENATION so
+/// neither this file's own text nor `ci/check_mick_actuation_fence.py`'s
+/// crate-wide symbol scan can match the list itself — the tokens only exist
+/// at runtime.
+fn forbidden_identifiers() -> Vec<String> {
+    let join = |a: &str, b: &str| format!("{a}{b}");
+    vec![
+        // the typed-intent machinery (legitimately used by mick.rs, forbidden here)
+        join("Mick", "Intent"),
+        join("from_llm", "_json"),
+        join("Intent", "Service"),
+        join("Intent", "Outcome"),
+        join("Llm", "Brain"),
+        join("intent_", "schema"),
+        join("kirra_", "planner"),
+        join("World", "Context"),
+        join("decide_", "request"),
+        // actuation seams (also caught crate-wide by the CI fence)
+        join("Release", "Token"),
+        join("issue_ros", "_release"),
+        join("write_", "twist"),
+        join("Motor", "Serial"),
+        join("cmd_", "vel"),
+        join("serial", "port"),
+    ]
+}
+
+#[test]
+fn chat_sources_never_reference_intent_or_actuation_machinery() {
+    for (name, src) in [
+        ("src/chat.rs", include_str!("../src/chat.rs")),
+        (
+            "src/bin/mick_chat_service.rs",
+            include_str!("../src/bin/mick_chat_service.rs"),
+        ),
+    ] {
+        // Scan CODE, not commentary — the docs may (and do) explain what the
+        // chat path is fenced FROM; only code touching it is a breach. Same
+        // comment-stripping convention as ci/check_mick_actuation_fence.py.
+        let code: String = src
+            .lines()
+            .map(|l| l.split("//").next().unwrap_or(""))
+            .collect::<Vec<_>>()
+            .join("\n");
+        for ident in forbidden_identifiers() {
+            assert!(
+                !code.contains(&ident),
+                "{name} references {ident:?} — the chat path must stay \
+                 structurally separate from the motion/intent machinery"
+            );
+        }
+    }
+}
+
+#[test]
+fn chat_binary_does_not_mention_the_intent_routes() {
+    // The chat binary must not even name the motion endpoints, so a future
+    // "convenient" fallback from chat to /intent shows up as a fence break.
+    let bin = include_str!("../src/bin/mick_chat_service.rs");
+    for line in bin.lines() {
+        let code = line.split("//").next().unwrap_or("");
+        assert!(
+            !code.contains("/intent"),
+            "chat binary carries an /intent route outside comments: {line:?}"
+        );
+    }
+}
+
+// --- 2 + 3. prompt and response behavior --------------------------------------
+
+struct StubModel {
+    reply: String,
+    calls: Rc<Cell<u32>>,
+}
+
+impl ChatModelClient for StubModel {
+    fn chat(&self, _messages: &[ChatMessage]) -> Result<String, &'static str> {
+        self.calls.set(self.calls.get() + 1);
+        Ok(self.reply.clone())
+    }
+}
+
+fn service(reply: &str) -> (ChatService<StubModel>, Rc<Cell<u32>>) {
+    let calls = Rc::new(Cell::new(0));
+    let svc = ChatService::new(
+        StubModel {
+            reply: reply.to_string(),
+            calls: Rc::clone(&calls),
+        },
+        ChatConfig::default(),
+    );
+    (svc, calls)
+}
+
+#[test]
+fn prompt_denies_motion_authority_and_lists_no_intent_forms() {
+    assert!(CHAT_SYSTEM_PROMPT.contains("conversational only"));
+    assert!(CHAT_SYSTEM_PROMPT.contains("no authority to move or control the robot"));
+    for form in [
+        "cruise",
+        "go_to",
+        "lane_change",
+        "target_speed_mps",
+        "{\"intent\"",
+    ] {
+        assert!(
+            !CHAT_SYSTEM_PROMPT.contains(form),
+            "prompt teaches a motion form: {form}"
+        );
+    }
+}
+
+#[test]
+fn the_live_dangerous_reply_is_guarded_not_surfaced_as_a_result() {
+    // The exact model output from the live /intent failure. On the CHAT
+    // surface it must never appear as if it were an actionable result.
+    let live = r#"{"intent":"cruise","target_speed_mps":10}"#;
+    assert!(looks_like_motion_intent_json(live));
+
+    let (mut svc, calls) = service(live);
+    let (status, body) = handle_request(
+        &mut svc,
+        "POST",
+        "/chat",
+        br#"{"text":"Drive forward one meter."}"#,
+        10_000,
+    );
+    assert_eq!(status, "200 OK");
+    let v: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(v["ok"], true);
+    assert_eq!(v["reply"], MOTION_SHAPE_REFUSAL);
+    assert!(
+        !body.contains("target_speed_mps"),
+        "motion-shaped JSON leaked to the chat wire: {body}"
+    );
+    assert_eq!(calls.get(), 1, "the model was consulted exactly once");
+    assert_eq!(svc.motion_shape_guarded(), 1);
+}
+
+// --- 4. endpoint separation ----------------------------------------------------
+
+#[test]
+fn chat_serves_no_intent_surface_at_the_wire() {
+    let (mut svc, _) = service("hello");
+    for (method, path) in [
+        ("GET", "/intent/last"),
+        ("POST", "/intent"),
+        ("GET", "/narration/last"),
+    ] {
+        let (status, _) = handle_request(&mut svc, method, path, b"{}", 10_000);
+        assert_eq!(
+            status, "404 Not Found",
+            "{method} {path} must not exist on chat"
+        );
+    }
+}
+
+#[test]
+fn chat_requests_touch_no_intent_state_because_none_exists() {
+    // The type-level fact, asserted as behavior: ChatService owns sessions
+    // and a guard counter — nothing else. Drive many turns and observe the
+    // only state that exists is conversational.
+    let (mut svc, _) = service("fine");
+    for i in 0..5u64 {
+        let req = ChatRequest {
+            text: format!("turn {i}"),
+            session_id: None,
+        };
+        svc.handle_chat(&req, 10_000 + i * 2_000).unwrap();
+    }
+    assert_eq!(svc.session_count(), 1);
+    assert_eq!(svc.history_len("default"), 5);
+    assert_eq!(svc.motion_shape_guarded(), 0);
+}

--- a/deploy/systemd/README.md
+++ b/deploy/systemd/README.md
@@ -11,11 +11,37 @@ typed-intent** sidecar (`:8102`).
 | `kirra-planner.service` | `planner_service` (Occy `POST /plan`) | 8100 | no |
 | `kirra-taj.service` | `taj_service` (Taj `POST /perception` — the cmd_vel cap) | 8101 | no |
 | `kirra-mick.service` | `mick_service` (Mick `POST /intent` — typed text → typed intent; never a command) | 8102 | optional (narrator auditor token) |
+| `kirra-mick-chat.service` | `mick_chat_service` (Mick `POST /chat` — conversation only, NO motion authority) | 8103 | no |
 | `kirra.target` | groups the stack for one-command lifecycle | — | — |
 
-The three sidecar binaries ship from the `kirra-sidecars` crate and are FENCED:
+The sidecar binaries ship from the `kirra-sidecars` crate and are FENCED:
 `ci/check_mick_actuation_fence.py` fails the build if any of them gains a
 dependency route to actuation (release-token mint, serial consumer, ROS/DDS).
+
+### `/chat` vs `/intent` — the two Mick doors
+
+```
+/chat   (:8103)  conversation only — plain text out, no motion authority,
+                 no intent state; a motion-shaped model reply is replaced
+                 with a routing explanation, never passed through
+/intent (:8102)  motion-intent classification only — typed, fail-closed,
+                 governed downstream (Occy grounds, KIRRA bounds, the
+                 verifying consumer enforces)
+```
+
+Casual conversation goes to `/chat`; it structurally cannot produce an
+intent (`crates/kirra-sidecars/tests/mick_chat_separation.rs` is the fence).
+Chat has **no live robot state** — posture/sensors/diagnostics are known only
+if the caller pastes them into the request text; the prompt forbids inventing
+nominal status. Terminal use:
+
+```bash
+python3 robot/mick_chat.py            # interactive: You: … / Mick: …
+# or one shot:
+curl -sS -X POST http://127.0.0.1:8103/chat \
+  -H 'Content-Type: application/json' \
+  -d '{"text":"How are you?"}' | python3 -m json.tool
+```
 
 ## Install
 

--- a/deploy/systemd/install.sh
+++ b/deploy/systemd/install.sh
@@ -43,6 +43,7 @@ declare -A SRC=(
   [planner_service]="$REL/planner_service"
   [taj_service]="$REL/taj_service"
   [mick_service]="$REL/mick_service"
+  [mick_chat_service]="$REL/mick_chat_service"
 )
 for name in "${!SRC[@]}"; do
   [[ -x "${SRC[$name]}" ]] || {
@@ -87,6 +88,7 @@ install -m 0644 "$UNITS/kirra-verifier.service" /etc/systemd/system/kirra-verifi
 install -m 0644 "$UNITS/kirra-planner.service"  /etc/systemd/system/kirra-planner.service
 install -m 0644 "$UNITS/kirra-taj.service"      /etc/systemd/system/kirra-taj.service
 install -m 0644 "$UNITS/kirra-mick.service"     /etc/systemd/system/kirra-mick.service
+install -m 0644 "$UNITS/kirra-mick-chat.service" /etc/systemd/system/kirra-mick-chat.service
 install -m 0644 "$UNITS/kirra.target"           /etc/systemd/system/kirra.target
 # Make kirra.target own the verifier too, without editing the committed unit.
 dropin=/etc/systemd/system/kirra-verifier.service.d
@@ -99,10 +101,10 @@ echo "  installed 5 units + PartOf drop-in"
 
 echo "== 5. enable + start =="
 systemctl daemon-reload
-systemctl enable kirra.target kirra-verifier.service kirra-planner.service kirra-taj.service kirra-mick.service >/dev/null
+systemctl enable kirra.target kirra-verifier.service kirra-planner.service kirra-taj.service kirra-mick.service kirra-mick-chat.service >/dev/null
 systemctl restart kirra.target
 echo
 echo "done — the Kirra stack is enabled on boot."
-echo "  status:  systemctl status kirra.target kirra-verifier kirra-planner kirra-taj kirra-mick"
+echo "  status:  systemctl status kirra.target kirra-verifier kirra-planner kirra-taj kirra-mick kirra-mick-chat"
 echo "  logs:    journalctl -u kirra-verifier -f"
-echo "  stack:   verifier :8090  ·  planner :8100  ·  taj :8101  ·  mick :8102"
+echo "  stack:   verifier :8090  ·  planner :8100  ·  taj :8101  ·  mick :8102  ·  chat :8103"

--- a/deploy/systemd/install.sh
+++ b/deploy/systemd/install.sh
@@ -97,7 +97,7 @@ cat > "$dropin/10-kirra-target.conf" <<'EOF'
 [Unit]
 PartOf=kirra.target
 EOF
-echo "  installed 5 units + PartOf drop-in"
+echo "  installed unit files + PartOf drop-in"
 
 echo "== 5. enable + start =="
 systemctl daemon-reload

--- a/deploy/systemd/kirra-mick-chat.service
+++ b/deploy/systemd/kirra-mick-chat.service
@@ -34,12 +34,17 @@ After=ollama.service
 [Service]
 Type=simple
 ExecStart=/opt/kirra/mick_chat_service
-Environment=KIRRA_MICK_CHAT_ADDR=127.0.0.1:8103
 # Ollama endpoint (default http://localhost:11434) plus the chat-specific
 # knobs (KIRRA_MICK_CHAT_MODEL default gemma3:4b, KIRRA_MICK_CHAT_HISTORY_TURNS
 # default 6, KIRRA_MICK_CHAT_MAX_CHARS default 1000) come from the shared env
 # file. '-' makes it non-fatal if absent.
 EnvironmentFile=-/etc/kirra/kirra.env
+# Bind address AFTER the env file so the unit's loopback default WINS — a
+# stray addr line in kirra.env cannot silently widen the bind (systemd takes
+# the last assignment). Changing it requires a deliberate drop-in, and the
+# binary's bind policy still refuses non-loopback without
+# KIRRA_SIDECAR_ALLOW_NONLOCAL=1.
+Environment=KIRRA_MICK_CHAT_ADDR=127.0.0.1:8103
 Restart=always
 RestartSec=3
 # Least privilege (the sidecar convention).

--- a/deploy/systemd/kirra-mick-chat.service
+++ b/deploy/systemd/kirra-mick-chat.service
@@ -1,0 +1,58 @@
+# deploy/systemd/kirra-mick-chat.service
+#
+# systemd unit for the Mick CONVERSATIONAL sidecar (the kirra-sidecars
+# `mick_chat_service` binary): plain text in (POST /chat), plain conversational
+# text out. NO motion authority — no intents, no latch, no downstream
+# consumer; a motion-shaped model reply is replaced with a routing explanation
+# server-side. The separation:
+#
+#   /chat    (this unit, :8103)      conversation only, no motion authority
+#   /intent  (kirra-mick.service, :8102)  motion-intent classification only,
+#                                          governed downstream
+#
+# FENCED with the other Mick binaries: no dependency route to actuation
+# (ci/check_mick_actuation_fence.py + the finer chat source fence in
+# crates/kirra-sidecars/tests/mick_chat_separation.rs). Chat has NO live robot
+# state — posture/sensors/diagnostics are only known if the caller includes
+# them in the request text. Requires a local Ollama; without one every request
+# fails closed (502 MICK_CHAT_MODEL_ERROR, never a fabricated reply).
+#
+# Companion to kirra-mick; install/enable via deploy/systemd/install.sh.
+
+[Unit]
+Description=Kirra Mick chat sidecar (POST /chat — conversation only, no motion authority)
+Documentation=https://github.com/kirra-systems/kirra-runtime-sdk
+After=network-online.target
+Wants=network-online.target
+PartOf=kirra.target
+# Same Wants+After (never Requires/BindsTo) rationale as kirra-mick.service:
+# ordering is not readiness, and a briefly-away Ollama must degrade to
+# fail-closed chat errors, not take the service down.
+Wants=ollama.service
+After=ollama.service
+
+[Service]
+Type=simple
+ExecStart=/opt/kirra/mick_chat_service
+Environment=KIRRA_MICK_CHAT_ADDR=127.0.0.1:8103
+# Ollama endpoint (default http://localhost:11434) plus the chat-specific
+# knobs (KIRRA_MICK_CHAT_MODEL default gemma3:4b, KIRRA_MICK_CHAT_HISTORY_TURNS
+# default 6, KIRRA_MICK_CHAT_MAX_CHARS default 1000) come from the shared env
+# file. '-' makes it non-fatal if absent.
+EnvironmentFile=-/etc/kirra/kirra.env
+Restart=always
+RestartSec=3
+# Least privilege (the sidecar convention).
+User=kirra
+Group=kirra
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectKernelTunables=true
+ProtectControlGroups=true
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/uninstall.sh
+++ b/deploy/systemd/uninstall.sh
@@ -10,10 +10,12 @@ set -euo pipefail
 PURGE=0
 [[ "${1:-}" == "--purge" ]] && PURGE=1
 
-systemctl disable --now kirra.target kirra-verifier.service kirra-planner.service kirra-taj.service 2>/dev/null || true
+systemctl disable --now kirra.target kirra-verifier.service kirra-planner.service kirra-taj.service kirra-mick.service kirra-mick-chat.service 2>/dev/null || true
 rm -f /etc/systemd/system/kirra-verifier.service \
       /etc/systemd/system/kirra-planner.service \
       /etc/systemd/system/kirra-taj.service \
+      /etc/systemd/system/kirra-mick.service \
+      /etc/systemd/system/kirra-mick-chat.service \
       /etc/systemd/system/kirra.target
 rm -rf /etc/systemd/system/kirra-verifier.service.d
 rm -rf /opt/kirra

--- a/robot/install/install_robot_units.sh
+++ b/robot/install/install_robot_units.sh
@@ -48,7 +48,8 @@ for f in rabbit_persona.py rabbit_watch.py rabbit_ask.py rabbit_converse.py rabb
          barge_in.py skill_registry.py world_model.py mission.py \
          rabbit_latency.py rabbit_stream.py rabbit_tone.py repo_command.py \
          rabbit_model_smoketest.py assistant.py assistant_admission.py \
-         assistant_contract.py assistant_report.py assistant_tools.py; do
+         assistant_contract.py assistant_report.py assistant_tools.py \
+         mick_chat.py; do
   [[ -f "${REPO}/robot/${f}" ]] || { echo "  ⚠ missing ${REPO}/robot/${f} — skipped"; continue; }
   sudo install -m 0755 "${REPO}/robot/${f}" "${OPT}/robot/${f}"
   echo "  installed ${OPT}/robot/${f}"

--- a/robot/mick_chat.py
+++ b/robot/mick_chat.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""mick_chat.py — terminal client for the Mick CONVERSATIONAL sidecar.
+
+Talk to Mick without going through rabbit_converse.py and WITHOUT touching the
+motion-only endpoint on port 8102:
+
+    python3 robot/mick_chat.py
+    You: hello
+    Mick: Hello. How can I help?
+
+One line per turn; Ctrl-D (or Ctrl-C) exits. Speaks ONLY to the loopback
+`POST /chat` endpoint of mick_chat_service (default http://127.0.0.1:8103,
+override with KIRRA_MICK_CHAT_URL).
+
+🔴 SEPARATION, deliberately structural in this client too:
+  * /chat is conversation only — the service has NO motion authority, no
+    latched state, and a motion-shaped model reply is replaced server-side
+    with a routing explanation.
+  * This client has NO fallback to the motion endpoint: its path never
+    appears anywhere in this file (host-tested), so a chat failure can
+    never be "retried" against the motion door.
+  * No shell execution, no transcript persistence — turns live and die in
+    the terminal scrollback.
+
+stdlib only (urllib): no requests dependency for a bring-up tool.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+DEFAULT_URL = "http://127.0.0.1:8103"
+# Bounded: a local 4B model can take a while on a busy Orin, but a hung
+# service must hand the terminal back.
+REQUEST_TIMEOUT_S = 90.0
+SESSION_ID = "terminal"
+
+
+def chat_url() -> str:
+    return (os.environ.get("KIRRA_MICK_CHAT_URL") or DEFAULT_URL).rstrip("/")
+
+
+def post_chat(base_url: str, text: str, timeout_s: float = REQUEST_TIMEOUT_S):
+    """POST one turn to /chat. Returns (reply, None) or (None, error-string).
+    Pure I/O seam — every failure is a readable one-liner, never a traceback."""
+    body = json.dumps({"text": text, "session_id": SESSION_ID}).encode("utf-8")
+    req = urllib.request.Request(
+        base_url + "/chat", data=body,
+        headers={"Content-Type": "application/json"}, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout_s) as resp:
+            payload = resp.read()
+    except urllib.error.HTTPError as e:
+        # The service's error tokens are the useful part — surface them.
+        try:
+            detail = json.loads(e.read().decode("utf-8", "replace")).get("error", "")
+        except Exception:  # noqa: BLE001 — a broken error body is still an HTTP error
+            detail = ""
+        return None, f"HTTP {e.code}{f' ({detail})' if detail else ''}"
+    except urllib.error.URLError as e:
+        return None, (f"cannot reach {base_url} ({e.reason}) — is "
+                      "mick_chat_service running? (GET /health to check)")
+    except TimeoutError:
+        return None, f"timed out after {timeout_s:.0f}s (model busy or hung)"
+    try:
+        parsed = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None, "malformed response from the chat service"
+    if parsed.get("ok") is not True or not isinstance(parsed.get("reply"), str):
+        return None, f"unexpected response shape: {sorted(parsed.keys())}"
+    return parsed["reply"], None
+
+
+def main() -> int:
+    base = chat_url()
+    print(f"mick_chat: conversation only (POST {base}/chat) — motion requests "
+          "go through the governed door on the motion sidecar, not here. "
+          "Ctrl-D quits.",
+          file=sys.stderr)
+    while True:
+        try:
+            line = input("You: ")
+        except (EOFError, KeyboardInterrupt):
+            print(file=sys.stderr)
+            return 0
+        text = line.strip()
+        if not text:
+            continue
+        reply, err = post_chat(base, text)
+        if err is not None:
+            print(f"mick_chat: {err}", file=sys.stderr)
+            continue
+        print(f"Mick: {reply}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/robot/mick_chat_test.py
+++ b/robot/mick_chat_test.py
@@ -147,10 +147,18 @@ def test_eof_exits_the_loop_cleanly() -> None:
 
 
 def test_only_the_chat_endpoint_is_ever_contacted() -> None:
-    # The separation proof, from the server's perspective: across everything
-    # this suite drove, the client hit /chat and NOTHING else.
-    assert SEEN_PATHS, "the stub saw no requests — suite wiring broken?"
-    assert set(SEEN_PATHS) == {"/chat"}, f"unexpected endpoints contacted: {set(SEEN_PATHS)}"
+    # The separation proof, from the server's perspective — SELF-CONTAINED
+    # (no reliance on test order): one known call, then assert the stub saw
+    # exactly /chat and nothing else.
+    srv, url = _serve()
+    try:
+        StubHandler.mode = "ok"
+        SEEN_PATHS.clear()
+        reply, err = mick_chat.post_chat(url, "separation probe")
+        assert err is None and reply == "echo: separation probe"
+        assert SEEN_PATHS == ["/chat"], f"unexpected endpoints contacted: {SEEN_PATHS}"
+    finally:
+        srv.shutdown()
 
 
 def test_client_source_has_no_motion_endpoint_fallback() -> None:

--- a/robot/mick_chat_test.py
+++ b/robot/mick_chat_test.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Host tests for robot/mick_chat.py — the terminal client for the Mick
+conversational sidecar. A stub HTTP server stands in for mick_chat_service:
+no Ollama, no robot, no network beyond loopback.
+
+Covers: a successful reply; a malformed response body; a timeout; 4xx/5xx
+with the service's error token surfaced; EOF exit of the interactive loop;
+and the separation proofs — the stub records every path so we can assert
+/chat is the ONLY endpoint ever contacted, and the client source never
+mentions the motion endpoint at all (no fallback to /intent can exist).
+
+Runs standalone (`python3 robot/mick_chat_test.py`, exit 1 on any failure);
+also importable under pytest.
+"""
+from __future__ import annotations
+
+import io
+import json
+import sys
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import mick_chat  # noqa: E402
+
+SEEN_PATHS: list[str] = []
+
+
+class StubHandler(BaseHTTPRequestHandler):
+    """Scriptable /chat endpoint. The class attribute `mode` selects the
+    behavior; every request's path is recorded for the separation proof."""
+
+    mode = "ok"
+
+    def do_POST(self):  # noqa: N802 — http.server API
+        SEEN_PATHS.append(self.path)
+        length = int(self.headers.get("Content-Length", 0))
+        body = json.loads(self.rfile.read(length))
+        assert "text" in body, "client must send the text field"
+        if self.mode == "ok":
+            reply = {"ok": True, "reply": f"echo: {body['text']}"}
+            payload = json.dumps(reply).encode()
+            self.send_response(200)
+        elif self.mode == "garbage":
+            payload = b"not json at all"
+            self.send_response(200)
+        elif self.mode == "error503":
+            payload = json.dumps({"ok": False, "error": "MICK_CHAT_MODEL_ERROR"}).encode()
+            self.send_response(503)
+        elif self.mode == "error422":
+            payload = json.dumps({"ok": False, "error": "MICK_CHAT_TEXT_TOO_LONG"}).encode()
+            self.send_response(422)
+        elif self.mode == "slow":
+            time.sleep(2.0)
+            payload = json.dumps({"ok": True, "reply": "late"}).encode()
+            self.send_response(200)
+        else:  # pragma: no cover - test misconfiguration
+            raise AssertionError(f"unknown mode {self.mode}")
+        try:
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+        except BrokenPipeError:
+            pass  # the timed-out client hung up — expected in the slow mode
+
+    def log_message(self, *_args):  # silence the stub
+        pass
+
+
+def _serve() -> tuple[HTTPServer, str]:
+    srv = HTTPServer(("127.0.0.1", 0), StubHandler)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    return srv, f"http://127.0.0.1:{srv.server_port}"
+
+
+def test_successful_reply_round_trips() -> None:
+    srv, url = _serve()
+    try:
+        StubHandler.mode = "ok"
+        reply, err = mick_chat.post_chat(url, "hello")
+        assert err is None and reply == "echo: hello"
+    finally:
+        srv.shutdown()
+
+
+def test_malformed_response_is_a_readable_error() -> None:
+    srv, url = _serve()
+    try:
+        StubHandler.mode = "garbage"
+        reply, err = mick_chat.post_chat(url, "hello")
+        assert reply is None and "malformed" in err
+    finally:
+        srv.shutdown()
+
+
+def test_http_errors_surface_the_service_token() -> None:
+    srv, url = _serve()
+    try:
+        StubHandler.mode = "error503"
+        reply, err = mick_chat.post_chat(url, "hello")
+        assert reply is None and "503" in err and "MICK_CHAT_MODEL_ERROR" in err
+        StubHandler.mode = "error422"
+        reply, err = mick_chat.post_chat(url, "x" * 5000)
+        assert reply is None and "422" in err and "MICK_CHAT_TEXT_TOO_LONG" in err
+    finally:
+        srv.shutdown()
+
+
+def test_timeout_is_bounded_and_readable() -> None:
+    srv, url = _serve()
+    try:
+        StubHandler.mode = "slow"
+        reply, err = mick_chat.post_chat(url, "hello", timeout_s=0.3)
+        assert reply is None and "timed out" in err
+    finally:
+        srv.shutdown()
+
+
+def test_unreachable_service_names_the_fix() -> None:
+    reply, err = mick_chat.post_chat("http://127.0.0.1:1", "hello")
+    assert reply is None and "mick_chat_service" in err
+
+
+def test_eof_exits_the_loop_cleanly() -> None:
+    srv, url = _serve()
+    try:
+        StubHandler.mode = "ok"
+        real_stdin, real_stdout, real_stderr = sys.stdin, sys.stdout, sys.stderr
+        sys.stdin = io.StringIO("hello\n")  # one turn, then EOF
+        sys.stdout = io.StringIO()
+        sys.stderr = io.StringIO()
+        import os
+        os.environ["KIRRA_MICK_CHAT_URL"] = url
+        try:
+            rc = mick_chat.main()
+            out = sys.stdout.getvalue()
+        finally:
+            sys.stdin, sys.stdout, sys.stderr = real_stdin, real_stdout, real_stderr
+            os.environ.pop("KIRRA_MICK_CHAT_URL", None)
+        assert "Mick: echo: hello" in out, f"reply not printed: {out!r}"
+        assert rc == 0, "EOF must exit 0"
+    finally:
+        srv.shutdown()
+
+
+def test_only_the_chat_endpoint_is_ever_contacted() -> None:
+    # The separation proof, from the server's perspective: across everything
+    # this suite drove, the client hit /chat and NOTHING else.
+    assert SEEN_PATHS, "the stub saw no requests — suite wiring broken?"
+    assert set(SEEN_PATHS) == {"/chat"}, f"unexpected endpoints contacted: {set(SEEN_PATHS)}"
+
+
+def test_client_source_has_no_motion_endpoint_fallback() -> None:
+    # And from the source's perspective: the motion endpoint is not merely
+    # un-contacted, it is UNREACHABLE — the client never names it.
+    src = Path(mick_chat.__file__).read_text()
+    code = "\n".join(line.split("#")[0] for line in src.splitlines())
+    needle = "/int" + "ent"  # built by concat so this test cannot match itself
+    assert needle not in code, "client code references the motion endpoint"
+    for forbidden in ("subprocess", "os.system"):
+        assert forbidden not in code, f"client must not use {forbidden}"
+    # No transcript persistence: a BARE open( is a file access (urlopen is
+    # the network call and is fine).
+    import re
+    assert not re.search(r"(?<![\w.])open\(", code), "client must not open files"
+
+
+# --- standalone runner (house pattern) ----------------------------------------
+
+def _run_all() -> int:
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"  ok  {name}")
+            except AssertionError as e:
+                failures += 1
+                print(f"FAIL  {name}: {e}")
+    print("mick_chat_test:", "ALL OK" if failures == 0 else f"{failures} FAILURE(S)")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## Why

Users could talk to Mick only through `rabbit_converse.py` — or by posting conversation at the **motion-only** `/intent` endpoint, whose live failure (a greeting answered with a schema-valid cruise intent) is now deterministically fenced (#1281). The long-term design is not a chattier motion API: conversation gets its own door.

## Architecture

```
mick_chat_service (:8103)   POST /chat, GET /health — conversation only, NO motion authority
mick_service      (:8102)   POST /intent, GET /intent/last — unchanged, governed downstream
```

Separate binary per repo convention (one sidecar = one binary/port/unit), sharing only the HTTP/net plumbing and the Ollama host.

## Separation, made structural

- **Own transport**: `OllamaChatClient` in `kirra-mick` — `/api/chat`, messages array, non-streaming, and **no `format` field** (test-pinned: the motion path's intent-schema-constrained decoding must never leak into chat). The motion `ModelClient` abstraction is untouched. Own model var `KIRRA_MICK_CHAT_MODEL` (default `gemma3:4b`); shared `KIRRA_OLLAMA_URL` (one local Ollama, existing convention).
- **Own port type**: `ChatModelClient` in `kirra_sidecars::chat` — the chat path never touches the intent machinery: no intent parse, no schema, no latch, no seq, no planner types.
- **Fence tests** (`tests/mick_chat_separation.rs`): comment-stripped source scan of `chat.rs` + the binary for intent/actuation identifiers (needles built by concatenation so `ci/check_mick_actuation_fence.py`'s crate-wide symbol scan cannot match the list itself); the chat wire 404s `/intent`, `/intent/last`, `/narration/last`; the binary names no intent route outside comments. The crate-level actuation fence stays INTACT and covers the new binary automatically.
- **Output guard** (pure, unit-tested): a model reply that is — bare or inside one code fence — a JSON object carrying an `"intent"` key is **replaced** with a fixed routing explanation. Never passed through as if actionable, never parsed into anything (structural serde_json check, so unknown future intent tags are guarded too), and history stores the refusal, not the shape. The exact live dangerous reply `{"intent":"cruise","target_speed_mps":10}` is a regression case end-to-end: 200 + explanation, one model call, zero intent state.
- **System prompt**: conversational only; no authority to move/control; never emit motion-intent JSON; motion requests go through the governed path; no claimed sensor/posture/diagnostic access unless supplied in the request; no invented nominal status. Tests pin both what it says and that it lists **no** intent wire forms.

## Bounds and validation

- History: in-memory only, per-session — 6 turns × 1000-char requests (config: `KIRRA_MICK_CHAT_HISTORY_TURNS`, `KIRRA_MICK_CHAT_MAX_CHARS`, boot-validated fail-closed), 32 sessions max with oldest-touched eviction, isolated by validated `session_id` (≤64 filename-safe chars, refused not normalized), never persisted, never logged, cleared on restart. `history_turns=0` disables history cleanly.
- Input: empty/whitespace → `MICK_CHAT_EMPTY_REQUEST`; over-bound → `MICK_CHAT_TEXT_TOO_LONG`; control characters → `MICK_CHAT_BAD_TEXT`; malformed JSON → 400. Rate limit (same token-bucket plumbing as `/intent`) **before** admission → 429. Transport failure → 502 `MICK_CHAT_MODEL_ERROR`, never a fabricated reply.

## Terminal client + deploy

- `robot/mick_chat.py` — stdlib-only (`urllib`), `You:`/`Mick:` loop, Ctrl-D exits, 90 s bounded timeout, readable errors surfacing the service token. Host-tested against a stub HTTP server: success / malformed body / timeout / 4xx / 5xx / EOF — plus the separation proofs (only `/chat` ever contacted; the motion endpoint is unreferenced in the client source; no subprocess/os.system/file-open). Staged to `/opt/kirra/robot` by the installer (stdlib-only, staging-completeness gate green).
- `deploy/systemd/kirra-mick-chat.service` — least-privilege (NoNewPrivileges/ProtectSystem=strict/ProtectHome/PrivateTmp/PrivateDevices/RestrictAddressFamilies), loopback bind, `Wants`+`After` ollama (never `Requires`). `install.sh` stages the binary + unit; `uninstall.sh` removes both (and gains the previously-missing `kirra-mick.service` removal — a two-line pre-existing gap in the same lines). `deploy/systemd/README.md` documents the two-door separation with the curl example.

## Tests

`kirra-sidecars` **194/194** (was 177; +17: chat core, wire handler, separation fence) · `kirra-mick` 5/5 + 1 ignored-live (incl. the no-`format` wire pin) · `kirra-planner mick` 75/75 · `spoken_governed_loop` 3/3 · `mick_governed_loop` 3/3 · `ci/check_mick_actuation_fence.py` **INTACT** · `robot/mick_chat_test.py` 8/8 (in the CI robot lane) · `staging_completeness_test` green · `cargo fmt --check` clean · `clippy -p kirra-mick -p kirra-sidecars --all-targets -- -D warnings` clean · `bash -n`/`shellcheck -S error` clean on touched scripts · `git diff --check` clean, no conflict markers.

## Limitations (deliberate)

- **No live robot state**: chat knows posture/sensors/diagnostics only if the caller pastes them into the request text; the prompt forbids inventing nominal status. Wiring a read-only status context (e.g. the world-model projection) is a possible follow-up, kept out of this slice.
- No streaming, no voice routing yet (the wire shape is ready for both).
- Prose *mentioning* intent JSON is not guarded — only a reply that **is** a lone (possibly fenced) intent-shaped object; the guard prevents masquerading as the motion API, not discussion of it.

## Jetson deployment + harmless verification (after merge; do not run during repo work)

```bash
cd "$HOME/kirra-runtime-sdk" && git switch main && git pull --ff-only
cargo build --release -p kirra-sidecars --bin mick_chat_service
sudo install -m 0755 target/release/mick_chat_service /opt/kirra/mick_chat_service
sudo install -m 0644 deploy/systemd/kirra-mick-chat.service /etc/systemd/system/kirra-mick-chat.service
sudo systemctl daemon-reload
sudo systemctl start kirra-mick-chat.service

curl -sS http://127.0.0.1:8103/health | python3 -m json.tool
curl -sS -X POST http://127.0.0.1:8103/chat -H 'Content-Type: application/json' \
  -d '{"text":"Hello Mick. How are you?"}' | python3 -m json.tool
#   expect conversational text, no intent JSON
curl -sS -X POST http://127.0.0.1:8103/chat -H 'Content-Type: application/json' \
  -d '{"text":"Drive forward one meter."}' | python3 -m json.tool
#   expect a refusal/routing explanation
curl -sS http://127.0.0.1:8102/intent/last | python3 -m json.tool
#   expect the motion latch untouched by everything above
```

No planner start and no real motion request as part of chat verification. This feature adds conversational Mick **without** motion authority — it makes no claim about the voice-to-drive path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_