### PR TITLE
feat(mick-chat): low-latency streaming conversation — TTFT is the metric

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1511,6 +1511,14 @@ jobs:
           # contacted and the motion endpoint is unreferenced in the client
           # source (no fallback to the motion door can exist).
           python3 robot/mick_chat_test.py
+          # mick_voice_chat.py streaming voice client (host, stub SSE server +
+          # timestamping fake TTS — no Ollama, no audio): PROVES the first
+          # sentence reaches TTS before the stream completes (the low-latency
+          # claim), one TTS process per reply, soft failure on timeout/
+          # malformed streams, only /chat/stream ever contacted, and timing
+          # logs free of transcript text. Benchmarks are compile-gated.
+          python3 robot/mick_voice_chat_test.py
+          python3 -m py_compile robot/mick_chat_benchmark.py robot/mick_voice_benchmark.py
           # Turn-state re-arm gate (Slice R, pure, no audio): the cross-process
           # "turn in progress" signal (fail-safe parse, active/done round-trip,
           # seq monotonicity) and the bounded rearm_decision that fixes the wake

--- a/crates/kirra-mick/src/lib.rs
+++ b/crates/kirra-mick/src/lib.rs
@@ -167,17 +167,44 @@ pub struct ChatWireMessage {
     pub content: String,
 }
 
-/// Ollama `/api/chat` request (non-streaming).
+/// Latency-bearing generation knobs, carried on every chat request.
+///
+/// - `keep_alive` holds the model RESIDENT between requests (Ollama's default
+///   is ~5 minutes → the next turn pays a multi-second cold reload; the same
+///   lever as the Rabbit path's `KIRRA_RABBIT_KEEP_ALIVE`).
+/// - `num_predict` caps output tokens — a spoken reply should be one or two
+///   short sentences, and every un-generated token is latency not spent.
+/// - `temperature` low for consistent, terse conversational replies.
+#[derive(Clone, Debug)]
+pub struct ChatGenOptions {
+    pub keep_alive: String,
+    pub num_predict: u32,
+    pub temperature: f64,
+}
+
+/// Ollama `/api/chat` request.
 #[derive(Serialize)]
 struct ChatRequestWire<'a> {
     model: &'a str,
     stream: bool,
+    keep_alive: &'a str,
+    options: ChatOptionsWire,
     messages: &'a [ChatWireMessage],
 }
 
+#[derive(Serialize)]
+struct ChatOptionsWire {
+    num_predict: u32,
+    temperature: f64,
+}
+
+/// One NDJSON line of a streaming `/api/chat` response.
 #[derive(Deserialize)]
-struct ChatResponseWire {
-    message: ChatResponseMessage,
+struct ChatStreamLine {
+    #[serde(default)]
+    message: Option<ChatResponseMessage>,
+    #[serde(default)]
+    done: bool,
 }
 
 #[derive(Deserialize)]
@@ -236,14 +263,31 @@ impl OllamaChatClient {
         &self.model
     }
 
-    /// One non-streaming conversational completion over the supplied message
-    /// list (system prompt + bounded history + the user turn — composed by the
-    /// caller; this transport adds nothing and constrains nothing).
-    pub fn chat_completion(&self, messages: &[ChatWireMessage]) -> Result<String, &'static str> {
+    /// One STREAMING conversational completion. `on_delta` receives each
+    /// incremental content fragment as it arrives off the wire (NDJSON lines);
+    /// returning `false` CANCELS the generation — the response body is
+    /// dropped, the connection closes, and Ollama aborts the remaining
+    /// decode. Time-to-first-token is whenever the caller's first delta
+    /// lands; this transport adds no buffering of its own.
+    ///
+    /// A completion that streams NOTHING before `done` is an error (an empty
+    /// reply is never fabricated into a turn).
+    pub fn stream_chat(
+        &self,
+        messages: &[ChatWireMessage],
+        gen: &ChatGenOptions,
+        on_delta: &mut dyn FnMut(&str) -> bool,
+    ) -> Result<(), &'static str> {
+        use std::io::{BufRead, BufReader};
         let url = format!("{}/api/chat", self.base_url);
         let body = ChatRequestWire {
             model: &self.model,
-            stream: false,
+            stream: true,
+            keep_alive: &gen.keep_alive,
+            options: ChatOptionsWire {
+                num_predict: gen.num_predict,
+                temperature: gen.temperature,
+            },
             messages,
         };
         let resp = self
@@ -255,11 +299,38 @@ impl OllamaChatClient {
         if !resp.status().is_success() {
             return Err("MICK_CHAT_OLLAMA_HTTP_STATUS");
         }
-        let parsed: ChatResponseWire = resp.json().map_err(|_| "MICK_CHAT_OLLAMA_DECODE_FAILED")?;
-        if parsed.message.content.trim().is_empty() {
-            return Err("MICK_CHAT_OLLAMA_EMPTY_COMPLETION");
+        let mut lines = BufReader::new(resp);
+        let mut line = String::new();
+        let mut streamed_any = false;
+        loop {
+            line.clear();
+            match lines.read_line(&mut line) {
+                Ok(0) => break, // EOF
+                Ok(_) => {}
+                Err(_) => return Err("MICK_CHAT_OLLAMA_STREAM_FAILED"),
+            }
+            if line.trim().is_empty() {
+                continue;
+            }
+            let parsed: ChatStreamLine =
+                serde_json::from_str(line.trim()).map_err(|_| "MICK_CHAT_OLLAMA_DECODE_FAILED")?;
+            if let Some(m) = &parsed.message {
+                if !m.content.is_empty() {
+                    streamed_any = true;
+                    if !on_delta(&m.content) {
+                        return Ok(()); // caller cancelled; drop aborts Ollama
+                    }
+                }
+            }
+            if parsed.done {
+                if !streamed_any {
+                    return Err("MICK_CHAT_OLLAMA_EMPTY_COMPLETION");
+                }
+                return Ok(());
+            }
         }
-        Ok(parsed.message.content)
+        // EOF before a `done` line: the stream was cut mid-generation.
+        Err("MICK_CHAT_OLLAMA_STREAM_TRUNCATED")
     }
 }
 
@@ -338,6 +409,14 @@ mod tests {
 
     // --- the conversational transport ---------------------------------------
 
+    fn gen_opts() -> ChatGenOptions {
+        ChatGenOptions {
+            keep_alive: "30m".to_string(),
+            num_predict: 48,
+            temperature: 0.2,
+        }
+    }
+
     /// CI-safe: an unreachable Ollama fails the chat transport closed with a
     /// stable token — never a fabricated reply.
     #[test]
@@ -347,19 +426,20 @@ mod tests {
             role: "user",
             content: "hello".to_string(),
         }];
+        let mut sink = |_: &str| true;
         assert_eq!(
-            client.chat_completion(&messages),
+            client.stream_chat(&messages, &gen_opts(), &mut sink),
             Err("MICK_CHAT_OLLAMA_REQUEST_FAILED")
         );
     }
 
-    /// The chat wire shape is `/api/chat` messages with NO `format` field —
-    /// the motion path's schema-constrained decoding must never leak into the
-    /// conversational path (a chat grammar-locked to intent JSON would be the
-    /// exact live failure this service exists to end). CI-safe: serializes the
-    /// body and inspects the wire, no network.
+    /// The chat wire shape: `/api/chat` messages, STREAMING, with the latency
+    /// levers (keep_alive residency, num_predict output cap, temperature) and
+    /// NO `format` field — the motion path's schema-constrained decoding must
+    /// never leak into the conversational path. CI-safe: serializes the body
+    /// and inspects the wire, no network.
     #[test]
-    fn chat_request_carries_messages_and_no_format_constraint() {
+    fn chat_request_carries_latency_levers_and_no_format_constraint() {
         let messages = [
             ChatWireMessage {
                 role: "system",
@@ -370,9 +450,15 @@ mod tests {
                 content: "hi".to_string(),
             },
         ];
+        let opts = gen_opts();
         let body = ChatRequestWire {
             model: "gemma3:4b",
-            stream: false,
+            stream: true,
+            keep_alive: &opts.keep_alive,
+            options: ChatOptionsWire {
+                num_predict: opts.num_predict,
+                temperature: opts.temperature,
+            },
             messages: &messages,
         };
         let wire: serde_json::Value = serde_json::to_value(&body).expect("body serializes");
@@ -380,9 +466,74 @@ mod tests {
             wire.get("format").is_none(),
             "chat must NOT schema-constrain decoding: {wire}"
         );
-        assert_eq!(wire["stream"], false);
+        assert_eq!(wire["stream"], true);
+        assert_eq!(wire["keep_alive"], "30m", "model residency lever missing");
+        assert_eq!(wire["options"]["num_predict"], 48, "output cap missing");
+        assert_eq!(wire["options"]["temperature"], 0.2);
         assert_eq!(wire["messages"][0]["role"], "system");
         assert_eq!(wire["messages"][1]["role"], "user");
+    }
+
+    /// Streaming parse over a canned NDJSON body, via a loopback TCP stub —
+    /// deltas arrive incrementally, `done` ends cleanly, and cancellation
+    /// (on_delta → false) stops consumption early. No Ollama needed.
+    #[test]
+    fn stream_chat_parses_ndjson_deltas_and_honours_cancellation() {
+        use std::io::Write;
+        use std::net::TcpListener;
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let body = concat!(
+            "{\"message\":{\"role\":\"assistant\",\"content\":\"Hel\"},\"done\":false}\n",
+            "{\"message\":{\"role\":\"assistant\",\"content\":\"lo. \"},\"done\":false}\n",
+            "{\"message\":{\"role\":\"assistant\",\"content\":\"More.\"},\"done\":false}\n",
+            "{\"done\":true}\n"
+        );
+        let handle = std::thread::spawn(move || {
+            for _ in 0..2 {
+                let (mut s, _) = listener.accept().unwrap();
+                // Drain the request head + body enough to reply.
+                let _ = {
+                    use std::io::Read;
+                    let mut buf = [0u8; 4096];
+                    s.read(&mut buf)
+                };
+                let resp = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                let _ = s.write_all(resp.as_bytes());
+            }
+        });
+        let client = OllamaChatClient::with(format!("http://{addr}"), "m");
+        let messages = [ChatWireMessage {
+            role: "user",
+            content: "hi".to_string(),
+        }];
+
+        // Full consumption: all three deltas, clean end.
+        let mut got = Vec::new();
+        let mut sink = |d: &str| {
+            got.push(d.to_string());
+            true
+        };
+        client
+            .stream_chat(&messages, &gen_opts(), &mut sink)
+            .unwrap();
+        assert_eq!(got, vec!["Hel", "lo. ", "More."]);
+
+        // Cancellation after the first delta: consumption stops early, Ok.
+        let mut seen = 0u32;
+        let mut cancel_after_one = |_: &str| {
+            seen += 1;
+            false
+        };
+        client
+            .stream_chat(&messages, &gen_opts(), &mut cancel_after_one)
+            .unwrap();
+        assert_eq!(seen, 1, "cancellation must stop consumption immediately");
+        handle.join().unwrap();
     }
 
     /// Live round-trip — requires `ollama pull gemma3:4b` and a running server. Ignored in

--- a/crates/kirra-sidecars/src/bin/mick_chat_service.rs
+++ b/crates/kirra-sidecars/src/bin/mick_chat_service.rs
@@ -1,59 +1,61 @@
 //! **Mick conversational sidecar** — talk to Mick WITHOUT touching the motion
-//! path. Plain text in (`POST /chat`), plain conversational text out. No
-//! intents, no latch, no seq, no planner, no downstream consumer.
-//!
-//! The separation this binary exists to make structural:
+//! path, tuned for LOW PERCEIVED LATENCY (time to first audible response).
 //!
 //! ```text
-//!   POST /chat    (this service, :8103) — conversation only, NO motion authority
-//!   POST /intent  (mick_service, :8102) — motion-intent classification only,
-//!                                          governed downstream
+//!   POST /chat         (:8103) one-shot reply + timings
+//!   POST /chat/stream  (:8103) SSE: start / delta / sentence / done — TTS can
+//!                              begin on the first sentence
+//!   GET  /health               warming | ready | degraded (honest readiness)
+//!   POST /intent       (:8102, mick_service) — the governed motion door; NOT here
 //! ```
 //!
-//! A live failure showed why the two must not share a door: a greeting posted
-//! to the motion-only `/intent` came back as a schema-valid cruise intent.
-//! The deterministic fence now blocks that class at `/intent`; this service
-//! is where conversation actually belongs. It has no route to intent state
-//! (`/intent/last` here is a 404), its model call is a plain `/api/chat`
-//! completion with NO schema constraint, and a motion-shaped model reply is
-//! replaced by a routing explanation, never passed through
-//! (`kirra_sidecars::chat` — the pure, tested core).
+//! Latency levers wired here: model residency (`keep_alive` on every request +
+//! a one-shot boot warm-up), a compact system prompt, capped output tokens,
+//! streaming deltas with sentence chunking, and deterministic fast routes —
+//! all in `kirra_sidecars::chat` (pure, tested). Timings are logged as stage
+//! durations only; transcript and reply text are never logged.
 //!
-//! Chat has NO live robot state: posture, sensors, and diagnostics are only
-//! known if the caller includes them in the request text. The prompt forbids
-//! inventing nominal status.
+//! Concurrency: the serve loop is single-threaded — exactly ONE in-flight
+//! model request (`CHAT_MAX_INFLIGHT`), further connections wait in the TCP
+//! backlog. A client that hangs up mid-stream cancels the generation (the
+//! sink write fails → the transport stops consuming → dropping the response
+//! aborts Ollama's decode). Process shutdown closes connections promptly.
 //!
-//!   POST /chat    {"text":"How are your systems doing?", "session_id"?: "terminal"}
-//!     → 200 {"ok":true,"reply":"..."}
-//!     → 422 {"ok":false,"error":"MICK_CHAT_EMPTY_REQUEST" | "MICK_CHAT_TEXT_TOO_LONG"
-//!                              | "MICK_CHAT_BAD_TEXT" | "MICK_CHAT_BAD_SESSION"}
-//!     → 429 {"ok":false,"error":"MICK_CHAT_RATE_LIMITED"}
-//!     → 502 {"ok":false,"error":"MICK_CHAT_MODEL_ERROR"}   (Ollama down/failed — fail closed)
-//!   GET  /health  → {"status":"ok"}
-//!
-//! Config (boot-validated, fail-closed on malformed): `KIRRA_MICK_CHAT_ADDR`
-//! (default 127.0.0.1:8103, loopback-gated by `net::enforce_bind_policy`);
-//! `KIRRA_OLLAMA_URL` (shared — one local Ollama) + `KIRRA_MICK_CHAT_MODEL`
-//! (default gemma3:4b); `KIRRA_MICK_CHAT_HISTORY_TURNS` (default 6, 0 = off);
-//! `KIRRA_MICK_CHAT_MAX_CHARS` (default 1000);
-//! `KIRRA_SIDECAR_ALLOW_NONLOCAL=1` to permit a routable bind.
-//!
-//! History is in-memory only, bounded per session and across sessions, never
-//! persisted, never logged, and cleared on restart.
+//! Config (boot-validated, fail-closed): `KIRRA_MICK_CHAT_ADDR`
+//! (default 127.0.0.1:8103, loopback-gated); `KIRRA_OLLAMA_URL` +
+//! `KIRRA_MICK_CHAT_MODEL` (default gemma3:4b);
+//! `KIRRA_MICK_CHAT_MAX_INPUT_CHARS` (500);
+//! `KIRRA_MICK_CHAT_MAX_OUTPUT_TOKENS` (48);
+//! `KIRRA_MICK_CHAT_TEMPERATURE` (0.2); `KIRRA_MICK_CHAT_KEEP_ALIVE` (30m);
+//! `KIRRA_MICK_CHAT_HISTORY_TURNS` (0 = stateless, hard cap 2);
+//! `KIRRA_MICK_CHAT_WARMUP` (default on; `0` = fail-soft, health reports the
+//! listener without a warm model); `KIRRA_SIDECAR_ALLOW_NONLOCAL=1` for a
+//! routable bind.
 
 use std::net::{TcpListener, TcpStream};
+use std::sync::atomic::{AtomicU64, AtomicU8, Ordering};
+use std::sync::Arc;
+use std::time::Instant;
 
-use kirra_mick::{ChatWireMessage, OllamaChatClient};
-use kirra_sidecars::chat::{handle_request, ChatConfig, ChatMessage, ChatModelClient, ChatService};
+use kirra_mick::{ChatGenOptions, ChatWireMessage, OllamaChatClient};
+use kirra_sidecars::chat::{
+    handle_request, stream_chat_into, ChatConfig, ChatGenParams, ChatMessage, ChatModelClient,
+    ChatService, WarmState,
+};
 use kirra_sidecars::http::{read_request, respond, respond_error};
-use kirra_sidecars::net::{allow_nonlocal_from_env, enforce_bind_policy, now_ms};
+use kirra_sidecars::net::{allow_nonlocal_from_env, enforce_bind_policy};
 
-/// The Ollama chat transport, adapted to the service core's port. Role tags
-/// pass through verbatim; nothing is added, constrained, or rewritten.
+/// The Ollama chat transport, adapted to the core's streaming port. Role tags
+/// and deltas pass through verbatim; nothing is added or constrained.
 struct OllamaChat(OllamaChatClient);
 
 impl ChatModelClient for OllamaChat {
-    fn chat(&self, messages: &[ChatMessage]) -> Result<String, &'static str> {
+    fn stream_chat(
+        &self,
+        messages: &[ChatMessage],
+        gen: &ChatGenParams,
+        on_delta: &mut dyn FnMut(&str) -> bool,
+    ) -> Result<(), &'static str> {
         let wire: Vec<ChatWireMessage> = messages
             .iter()
             .map(|m| ChatWireMessage {
@@ -61,17 +63,102 @@ impl ChatModelClient for OllamaChat {
                 content: m.content.clone(),
             })
             .collect();
-        self.0.chat_completion(&wire)
+        let opts = ChatGenOptions {
+            keep_alive: gen.keep_alive.clone(),
+            num_predict: gen.num_predict,
+            temperature: gen.temperature,
+        };
+        self.0.stream_chat(&wire, &opts, on_delta)
     }
 }
 
-fn serve(mut stream: TcpStream, svc: &mut ChatService<OllamaChat>) {
+/// Shared warm-up state: 0 warming, 1 ready, 2 degraded; warm-up duration ms.
+struct Shared {
+    state: AtomicU8,
+    warmup_ms: AtomicU64,
+}
+
+fn warm_state(shared: &Shared) -> (WarmState, Option<u64>) {
+    match shared.state.load(Ordering::Relaxed) {
+        1 => (
+            WarmState::Ready,
+            Some(shared.warmup_ms.load(Ordering::Relaxed)),
+        ),
+        2 => (WarmState::Degraded, None),
+        _ => (WarmState::Warming, None),
+    }
+}
+
+/// One-shot warm-up: a tiny capped completion whose output is discarded. On
+/// success the model is resident (keep_alive) and /health flips to ready;
+/// on failure → degraded (requests still fail closed individually).
+fn warm_up(cfg: &ChatConfig, shared: &Shared) {
+    let t0 = Instant::now();
+    let client = OllamaChatClient::new();
+    let messages = [ChatWireMessage {
+        role: "user",
+        content: "Say the single word: ready".to_string(),
+    }];
+    let opts = ChatGenOptions {
+        keep_alive: cfg.keep_alive.clone(),
+        num_predict: 8,
+        temperature: 0.0,
+    };
+    let mut discard = |_: &str| true;
+    match client.stream_chat(&messages, &opts, &mut discard) {
+        Ok(()) => {
+            let ms = t0.elapsed().as_millis() as u64;
+            shared.warmup_ms.store(ms, Ordering::Relaxed);
+            shared.state.store(1, Ordering::Relaxed);
+            eprintln!("mick_chat_service: warm-up complete (warmup_ms={ms})");
+        }
+        Err(e) => {
+            shared.state.store(2, Ordering::Relaxed);
+            eprintln!("mick_chat_service: warm-up failed ({e}) — health degraded; requests fail closed until Ollama is reachable");
+        }
+    }
+}
+
+fn serve(
+    mut stream: TcpStream,
+    svc: &mut ChatService<OllamaChat>,
+    shared: &Shared,
+    model: &str,
+    epoch: Instant,
+) {
     let req = match read_request(&mut stream) {
         Ok(r) => r,
         Err(status) => return respond_error(&mut stream, status),
     };
-    let (status, body) = handle_request(svc, &req.method, &req.path, &req.body, now_ms());
-    respond(&mut stream, status, &body);
+    // Process-monotonic millisecond clock (shared across requests so the rate
+    // limiter refills correctly; per-request stages are differences on it).
+    let mut clock = move || epoch.elapsed().as_millis() as u64;
+    match (req.method.as_str(), req.path.as_str()) {
+        ("POST", "/chat/stream") => {
+            if let Err(code) = stream_chat_into(svc, &req.body, &mut clock, &mut stream) {
+                // Nothing streamed yet on admission errors — plain JSON error.
+                let status = match code {
+                    "MICK_CHAT_RATE_LIMITED" => "429 Too Many Requests",
+                    "MICK_CHAT_MODEL_ERROR" => "502 Bad Gateway",
+                    "MICK_CHAT_CANCELLED" => return, // client already gone
+                    "MICK_CHAT_BAD_REQUEST" => "400 Bad Request",
+                    _ => "422 Unprocessable Entity",
+                };
+                respond(
+                    &mut stream,
+                    status,
+                    &format!("{{\"ok\":false,\"error\":\"{code}\"}}"),
+                );
+            }
+        }
+        (method, path) => {
+            let (status, body) = handle_request(svc, method, path, &req.body, &mut clock, {
+                let (s, w) = warm_state(shared);
+                (s, model, w)
+            });
+            respond(&mut stream, status, &body);
+        }
+    }
 }
 
 fn main() {
@@ -90,20 +177,40 @@ fn main() {
     };
     let client = OllamaChatClient::new();
     let model = client.model().to_string();
-    let mut svc = ChatService::new(OllamaChat(client), cfg);
+    let mut svc = ChatService::new(OllamaChat(client), cfg.clone());
     let listener = TcpListener::bind(&addr).unwrap_or_else(|e| {
         eprintln!("mick_chat_service: bind {addr}: {e}");
         std::process::exit(1);
     });
+    let shared = Arc::new(Shared {
+        state: AtomicU8::new(0),
+        warmup_ms: AtomicU64::new(0),
+    });
+    let warmup_enabled = std::env::var("KIRRA_MICK_CHAT_WARMUP")
+        .map(|v| v != "0")
+        .unwrap_or(true);
+    if warmup_enabled {
+        let cfg2 = cfg.clone();
+        let shared2 = Arc::clone(&shared);
+        std::thread::spawn(move || warm_up(&cfg2, &shared2));
+    } else {
+        // Explicit fail-soft: the operator opted out of readiness gating.
+        shared.state.store(1, Ordering::Relaxed);
+        eprintln!("mick_chat_service: warm-up disabled (KIRRA_MICK_CHAT_WARMUP=0) — health reports ready without a warm model");
+    }
     println!(
-        "Mick chat service on http://{addr}  (POST /chat, GET /health) — model {model}, \
-         conversation only: NO motion authority, no intent state, history in-memory \
-         ({} turns × {} chars)",
-        cfg.history_turns, cfg.max_chars
+        "Mick chat service on http://{addr}  (POST /chat, POST /chat/stream, GET /health) — \
+         model {model}, conversation only: NO motion authority. \
+         stateless={} keep_alive={} num_predict={} max_input={} inflight=1",
+        cfg.history_turns == 0,
+        cfg.keep_alive,
+        cfg.max_output_tokens,
+        cfg.max_input_chars
     );
+    let epoch = Instant::now();
     for stream in listener.incoming() {
         match stream {
-            Ok(s) => serve(s, &mut svc),
+            Ok(s) => serve(s, &mut svc, &shared, &model, epoch),
             Err(e) => eprintln!("mick_chat_service: accept error: {e}"),
         }
     }

--- a/crates/kirra-sidecars/src/chat.rs
+++ b/crates/kirra-sidecars/src/chat.rs
@@ -1,132 +1,166 @@
 //! The Mick CONVERSATIONAL service core — **typed text in, plain text out,
-//! never an intent.**
+//! never an intent** — tuned for LOW PERCEIVED LATENCY.
 //!
-//! Why this exists: casual conversation must not be sent to the motion-only
-//! `POST /intent` endpoint. That endpoint is deliberately schema-constrained
-//! to typed motion intents, and a live failure showed what happens when a
-//! greeting reaches it ("Hello Mr. Parker, how are you?" →
-//! `{"intent":"cruise","target_speed_mps":10}`). The deterministic non-motion
-//! fence now blocks that class *at* `/intent`; this module is the long-term
-//! half of the design — a SEPARATE place for conversation, so conversational
-//! text has somewhere to go that structurally cannot move the platform.
-//!
-//! **The separation, in one table:**
+//! Two doors, never merged:
 //!
 //! | route | purpose | authority |
 //! |---|---|---|
-//! | `POST /chat`   | conversation only | none — plain text, no downstream consumer |
-//! | `POST /intent` | motion-intent classification | governed downstream (Occy grounds, KIRRA bounds, the consumer enforces) |
+//! | `POST /chat`, `POST /chat/stream` | conversation only | none — plain text, no downstream consumer |
+//! | `POST /intent` (other binary)     | motion-intent classification | governed downstream |
 //!
-//! **No path to motion, structurally.** This module never references the
-//! typed-intent machinery: no intent parse, no intent schema, no latch, no
-//! seq, no planner types. The model transport is a plain-text `/api/chat`
-//! completion with NO schema constraint. The crate-level actuation fence
-//! (`ci/check_mick_actuation_fence.py`) already proves kirra-sidecars has no
-//! dependency route to actuation; `tests/mick_chat_separation.rs` adds the
-//! finer source-level fence that the CHAT path does not even touch the
-//! intent machinery this crate legitimately uses elsewhere.
+//! **Latency design** (time to first audible response is the metric):
 //!
-//! **Output guard.** Chat must not *masquerade* as the motion API either: if
-//! the model emits a JSON object shaped like a motion intent, the reply is
-//! REPLACED by a fixed routing explanation ([`MOTION_SHAPE_REFUSAL`]) — the
-//! motion-looking JSON is never passed through as if it were actionable, and
-//! it is never parsed into anything. Pure and unit-tested
-//! ([`looks_like_motion_intent_json`]).
+//!  1. STATELESS by default — history off (`KIRRA_MICK_CHAT_HISTORY_TURNS=0`);
+//!     every remembered turn is prompt-eval time. Optional history is bounded
+//!     to ≤ 2 pairs and in-memory only.
+//!  2. COMPACT system prompt (length-pinned by test) — prompt tokens are TTFT.
+//!  3. Output capped (`num_predict`, default 48 tokens) + low temperature —
+//!     a spoken reply is one or two short sentences.
+//!  4. Model kept RESIDENT (`keep_alive`, default 30m) + a one-shot warm-up on
+//!     boot; `/health` reports warming/ready/degraded honestly.
+//!  5. STREAMING deltas + sentence-boundary chunking, so TTS can start on the
+//!     first sentence while the model generates the rest.
+//!  6. Deterministic FAST ROUTES for trivial utterances (hello/thanks/goodbye)
+//!     and a conservative leading-verb MOTION REFUSAL — zero model calls.
 //!
-//! **History.** Bounded, in-memory, per-session: capped turns, capped total
-//! characters, capped session count with oldest-session eviction. Nothing is
-//! persisted, nothing is logged (counters only), everything clears on process
-//! restart.
+//! **No path to motion, structurally**: no intent types, no latch, no seq, no
+//! planner; `tests/mick_chat_separation.rs` fences the sources and the wire.
+//! A motion-shaped model reply is held back and REPLACED
+//! ([`MOTION_SHAPE_REFUSAL`]) — never surfaced as if actionable, never parsed.
+//!
+//! **Privacy**: history is memory-only and restart-cleared; logs carry stage
+//! names, durations, and counters — never transcript or reply text.
 
 use std::collections::HashMap;
+use std::io::Write;
 
 use crate::net::RateLimiter;
 use serde::Deserialize;
 
-/// LLM-call rate bound (burst / steady-state per second) — the same plumbing
-/// shape as the intent service: each request is a full model completion, so a
-/// runaway caller is shed cheaply before the LLM call.
+/// LLM-call rate bound (burst / steady-state per second).
 pub const CHAT_RATE_BURST: f64 = 3.0;
 pub const CHAT_RATE_PER_S: f64 = 1.0;
 
-/// Hard ceiling on live sessions; the oldest-touched session is evicted when
-/// a new one would exceed it (memory bound, not a feature).
+/// Hard ceiling on live sessions (only relevant when history is enabled).
 pub const CHAT_MAX_SESSIONS: usize = 32;
 
-/// The conversational system prompt. Deliberately explicit that this surface
-/// has NO motion authority — and deliberately free of any intent-JSON forms,
-/// so the prompt cannot teach the model the motion wire shape
-/// (`tests` pin both properties).
-pub const CHAT_SYSTEM_PROMPT: &str = "You are Mick, the robot's conversational assistant.\n\
-\n\
-You may answer questions, explain robot status information supplied in the \
-user's text, and engage in ordinary conversation.\n\
-\n\
-You are conversational only. You have no authority to move or control the \
-robot. Never claim that you started, stopped, steered, navigated, or \
-commanded the platform. Never emit motion-intent JSON. If asked to move the \
-robot, explain that motion requests must go through the dedicated governed \
-intent path.\n\
-\n\
-Do not claim access to live sensors, posture, diagnostics, or state unless \
-that information is explicitly included in the request context. Do not \
-invent nominal status.";
+/// History is bounded to at most this many prior (user, assistant) pairs —
+/// a hard design cap, not a default: every remembered pair is prompt-eval
+/// latency on EVERY subsequent turn.
+pub const CHAT_MAX_HISTORY_TURNS: usize = 2;
 
-/// The fixed reply substituted when the model emits motion-shaped JSON: the
-/// chat surface explains the governed path instead of passing through
-/// something that could be mistaken for an actionable result.
+/// In-flight model requests. The serve loop is single-threaded, so this is
+/// structural (a second connection waits in the TCP backlog); documented as
+/// config for the day the loop grows threads.
+pub const CHAT_MAX_INFLIGHT: usize = 1;
+
+/// The compact conversational system prompt. Short ON PURPOSE — prompt tokens
+/// are paid on every turn as time-to-first-token; the length is pinned by a
+/// regression test. Says what it must (no motion authority, no invented
+/// state) and nothing else.
+pub const CHAT_SYSTEM_PROMPT: &str = "You are Mick, a concise conversational robot assistant. \
+Answer naturally in one or two short sentences. \
+You cannot move or control the robot. \
+Never claim access to live state unless it is provided in the request. \
+For motion requests, say they must use the governed motion path.";
+
+/// Ceiling the prompt-length regression test enforces.
+pub const CHAT_SYSTEM_PROMPT_MAX_CHARS: usize = 400;
+
+/// Reply substituted when the model emits motion-shaped JSON.
 pub const MOTION_SHAPE_REFUSAL: &str =
-    "I can't move or command the robot from chat. Motion requests go through \
-the dedicated governed intent path, where the planner grounds them and the \
-KIRRA governor bounds them. Happy to keep talking here.";
+    "Motion requests must use the governed motion path. Happy to keep talking here.";
 
-/// One `POST /chat` request. `session_id` selects a bounded in-memory history
-/// (optional; absent → the shared `\"default\"` session).
+/// Reply for a deterministically detected explicit motion request — no model
+/// call at all.
+pub const MOTION_ROUTE_REPLY: &str = "That needs the governed motion path.";
+
+/// One `POST /chat` / `POST /chat/stream` request. An optional per-request
+/// `max_output_tokens` may only REDUCE the configured cap, never raise it.
 #[derive(Deserialize)]
 pub struct ChatRequest {
     pub text: String,
     #[serde(default)]
     pub session_id: Option<String>,
+    #[serde(default)]
+    pub max_output_tokens: Option<u32>,
 }
 
-/// Boot-validated configuration (the env_config convention: a malformed value
-/// aborts startup, never a silent default at use).
-#[derive(Clone, Copy, Debug)]
+/// Boot-validated configuration (fail-closed: malformed values abort startup).
+#[derive(Clone, Debug)]
 pub struct ChatConfig {
-    /// Max characters of user text per request (`KIRRA_MICK_CHAT_MAX_CHARS`).
-    pub max_chars: usize,
-    /// Max retained PAIRS (user + reply) per session
-    /// (`KIRRA_MICK_CHAT_HISTORY_TURNS`); 0 disables history.
+    /// `KIRRA_MICK_CHAT_MAX_INPUT_CHARS` (default 500).
+    pub max_input_chars: usize,
+    /// `KIRRA_MICK_CHAT_HISTORY_TURNS` (default 0 = stateless; hard cap
+    /// [`CHAT_MAX_HISTORY_TURNS`], larger values are a boot error).
     pub history_turns: usize,
+    /// `KIRRA_MICK_CHAT_MAX_OUTPUT_TOKENS` (default 48) — the num_predict cap.
+    pub max_output_tokens: u32,
+    /// `KIRRA_MICK_CHAT_TEMPERATURE` (default 0.2).
+    pub temperature: f64,
+    /// `KIRRA_MICK_CHAT_KEEP_ALIVE` (default "30m") — model residency.
+    pub keep_alive: String,
 }
 
 impl Default for ChatConfig {
     fn default() -> Self {
         Self {
-            max_chars: 1000,
-            history_turns: 6,
+            max_input_chars: 500,
+            history_turns: 0,
+            max_output_tokens: 48,
+            temperature: 0.2,
+            keep_alive: "30m".to_string(),
         }
     }
 }
 
 impl ChatConfig {
-    /// Read from the environment, fail-closed: present-but-malformed values
-    /// are an `Err` for the binary to abort on.
+    /// Read from the environment, fail-closed on malformed values.
     pub fn from_env() -> Result<Self, String> {
         let mut cfg = Self::default();
-        if let Ok(v) = std::env::var("KIRRA_MICK_CHAT_MAX_CHARS") {
-            cfg.max_chars = v
+        if let Ok(v) = std::env::var("KIRRA_MICK_CHAT_MAX_INPUT_CHARS") {
+            cfg.max_input_chars = v
                 .trim()
                 .parse::<usize>()
                 .ok()
                 .filter(|n| *n > 0)
-                .ok_or_else(|| format!("KIRRA_MICK_CHAT_MAX_CHARS malformed: {v:?}"))?;
+                .ok_or_else(|| format!("KIRRA_MICK_CHAT_MAX_INPUT_CHARS malformed: {v:?}"))?;
         }
         if let Ok(v) = std::env::var("KIRRA_MICK_CHAT_HISTORY_TURNS") {
-            cfg.history_turns = v
+            let n = v
                 .trim()
                 .parse::<usize>()
                 .map_err(|_| format!("KIRRA_MICK_CHAT_HISTORY_TURNS malformed: {v:?}"))?;
+            if n > CHAT_MAX_HISTORY_TURNS {
+                return Err(format!(
+                    "KIRRA_MICK_CHAT_HISTORY_TURNS={n} exceeds the hard cap \
+                     {CHAT_MAX_HISTORY_TURNS} (history is prompt-eval latency on every turn)"
+                ));
+            }
+            cfg.history_turns = n;
+        }
+        if let Ok(v) = std::env::var("KIRRA_MICK_CHAT_MAX_OUTPUT_TOKENS") {
+            cfg.max_output_tokens = v
+                .trim()
+                .parse::<u32>()
+                .ok()
+                .filter(|n| *n > 0)
+                .ok_or_else(|| format!("KIRRA_MICK_CHAT_MAX_OUTPUT_TOKENS malformed: {v:?}"))?;
+        }
+        if let Ok(v) = std::env::var("KIRRA_MICK_CHAT_TEMPERATURE") {
+            cfg.temperature = v
+                .trim()
+                .parse::<f64>()
+                .ok()
+                .filter(|t| t.is_finite() && *t >= 0.0)
+                .ok_or_else(|| format!("KIRRA_MICK_CHAT_TEMPERATURE malformed: {v:?}"))?;
+        }
+        if let Ok(v) = std::env::var("KIRRA_MICK_CHAT_KEEP_ALIVE") {
+            let t = v.trim();
+            if t.is_empty() {
+                return Err("KIRRA_MICK_CHAT_KEEP_ALIVE is empty".to_string());
+            }
+            cfg.keep_alive = t.to_string();
         }
         Ok(cfg)
     }
@@ -140,32 +174,195 @@ pub struct ChatMessage {
     pub content: String,
 }
 
-/// Abstract "messages → completion text" port for the CONVERSATIONAL path.
-/// Deliberately not the motion `ModelClient`: that abstraction carries the
-/// schema-constrained intent decode, which chat must never inherit.
-pub trait ChatModelClient {
-    fn chat(&self, messages: &[ChatMessage]) -> Result<String, &'static str>;
+/// Generation knobs carried per request (mirrors the transport's options;
+/// defined here so the core stays transport-free).
+#[derive(Clone, Debug, PartialEq)]
+pub struct ChatGenParams {
+    pub keep_alive: String,
+    pub num_predict: u32,
+    pub temperature: f64,
 }
 
-/// Is `reply`, as a whole (after trimming and unwrapping one Markdown code
-/// fence), a JSON OBJECT carrying an `"intent"` key? That is the structural
-/// signature of the motion wire shape, and the chat surface must not emit it.
+/// Abstract STREAMING "messages → delta text" port for the conversational
+/// path. Deliberately not the motion `ModelClient` (whose decode is
+/// intent-schema-constrained). `on_delta` returning `false` cancels the
+/// generation.
+pub trait ChatModelClient {
+    fn stream_chat(
+        &self,
+        messages: &[ChatMessage],
+        gen: &ChatGenParams,
+        on_delta: &mut dyn FnMut(&str) -> bool,
+    ) -> Result<(), &'static str>;
+}
+
+// ---------------------------------------------------------------------------
+// Deterministic fast paths (no model call)
+// ---------------------------------------------------------------------------
+
+/// Light local normalization for the fast routes: lowercase, punctuation to
+/// spaces, collapsed. (Local on purpose — the chat path shares no code with
+/// the intent-side fence.)
+fn light_normalize(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut pending = false;
+    for ch in text.chars() {
+        if ch.is_alphanumeric() || ch == '\'' {
+            if pending && !out.is_empty() {
+                out.push(' ');
+            }
+            pending = false;
+            out.extend(ch.to_lowercase());
+        } else {
+            pending = true;
+        }
+    }
+    out
+}
+
+/// Tiny, explicit fixed-reply table — the whole utterance must be one of
+/// these. Deliberately NOT a rule-based chatbot: three social niceties whose
+/// answers cannot be wrong, nothing that claims state.
+#[must_use]
+pub fn fast_route(text: &str) -> Option<&'static str> {
+    match light_normalize(text).as_str() {
+        "hello" | "hi" | "hey" => Some("Hello."),
+        "thank you" | "thanks" => Some("You're welcome."),
+        "goodbye" | "bye" => Some("Goodbye."),
+        _ => None,
+    }
+}
+
+/// Leading motion verbs/phrases → the utterance is an explicit motion request
+/// and chat refuses deterministically (no model call, no forwarding — chat
+/// NEVER invokes the motion door). Conservative: only a LEADING match counts
+/// ("how do I stop it" is conversation); false negatives fall through to the
+/// model whose motion-shaped output is guarded anyway.
+const MOTION_LEADS: &[&str] = &[
+    "drive",
+    "turn",
+    "stop",
+    "go",
+    "reverse",
+    "cruise",
+    "pull over",
+    "proceed",
+    "move",
+    "back up",
+    "follow",
+    "take me",
+    "head",
+    "steer",
+    "accelerate",
+    "slow down",
+];
+
+#[must_use]
+pub fn is_explicit_motion_request(text: &str) -> bool {
+    let n = light_normalize(text);
+    MOTION_LEADS
+        .iter()
+        .any(|lead| n == *lead || n.starts_with(&format!("{lead} ")))
+}
+
+// ---------------------------------------------------------------------------
+// Sentence chunking (for streaming TTS)
+// ---------------------------------------------------------------------------
+
+/// Sentence-boundary chunker: feed streamed deltas, get speakable chunks.
 ///
-/// Deliberately structural, not semantic: the check uses only serde_json —
-/// the reply is NEVER parsed by the typed-intent parser, and an unknown
-/// `intent` tag is guarded all the same (a new intent added later must not
-/// leak through an out-of-date guard). Prose that merely *mentions* intent
-/// JSON is not guarded — it does not parse as a lone object — and that is
-/// fine: the guard exists to stop the reply LOOKING LIKE the motion API's
-/// output, not to censor discussion of it.
+/// A chunk ends at `. ? ! ; :` when followed by whitespace/end AND the buffer
+/// has at least `min_chars` — with a decimal guard (`3.5` never splits: a
+/// period BETWEEN digits is not a boundary). A punctuation-free run longer
+/// than `max_chars` falls back to the last WORD boundary, so speech still
+/// starts. Word boundaries are always preserved.
+pub struct SentenceChunker {
+    buf: String,
+    pub min_chars: usize,
+    pub max_chars: usize,
+}
+
+impl SentenceChunker {
+    #[must_use]
+    pub fn new(min_chars: usize, max_chars: usize) -> Self {
+        Self {
+            buf: String::new(),
+            min_chars,
+            max_chars: max_chars.max(min_chars + 1),
+        }
+    }
+
+    /// Feed one delta; returns zero or more completed chunks.
+    pub fn push(&mut self, delta: &str) -> Vec<String> {
+        self.buf.push_str(delta);
+        let mut out = Vec::new();
+        while let Some(end) = self.next_boundary() {
+            let chunk: String = self.buf.drain(..end).collect();
+            let trimmed = chunk.trim().to_string();
+            if !trimmed.is_empty() {
+                out.push(trimmed);
+            }
+        }
+        out
+    }
+
+    /// Flush whatever remains (end of stream).
+    pub fn finish(&mut self) -> Option<String> {
+        let rest = std::mem::take(&mut self.buf);
+        let trimmed = rest.trim().to_string();
+        (!trimmed.is_empty()).then_some(trimmed)
+    }
+
+    /// Byte index one past the next chunk boundary, if any.
+    fn next_boundary(&self) -> Option<usize> {
+        let chars: Vec<char> = self.buf.chars().collect();
+        let mut count = 0usize;
+        let mut byte = 0usize;
+        let mut last_space_byte = None;
+        for (i, ch) in chars.iter().enumerate() {
+            count += 1;
+            byte += ch.len_utf8();
+            if ch.is_whitespace() {
+                last_space_byte = Some(byte);
+            }
+            let next = chars.get(i + 1);
+            let prev = if i > 0 { chars.get(i - 1) } else { None };
+            let is_punct = matches!(ch, '.' | '?' | '!' | ';' | ':');
+            // Decimal / dotted-token guard: punctuation flanked by digits or
+            // immediately followed by a non-space is not a sentence end
+            // ("3.5", "v2.0", "e.g." mid-token).
+            let followed_ok = next.is_none_or(|c| c.is_whitespace());
+            let decimal = *ch == '.'
+                && prev.is_some_and(|c| c.is_ascii_digit())
+                && next.is_some_and(|c| c.is_ascii_digit());
+            if is_punct && followed_ok && !decimal && count >= self.min_chars {
+                return Some(byte);
+            }
+            // Punctuation-free fallback: past the max, cut at the last word
+            // boundary so long unpunctuated output still starts speaking.
+            if count >= self.max_chars {
+                if let Some(sp) = last_space_byte {
+                    return Some(sp);
+                }
+            }
+        }
+        None
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Motion-shape output guard (streaming-aware)
+// ---------------------------------------------------------------------------
+
+/// Whole-reply structural check: is this (bare or once-code-fenced) a JSON
+/// object carrying an `"intent"` key? serde_json only — never the typed
+/// parser; unknown future tags guard identically.
 #[must_use]
 pub fn looks_like_motion_intent_json(reply: &str) -> bool {
     let mut candidate = reply.trim();
-    // Unwrap one ```...``` fence (Gemma habitually fences JSON).
     if let Some(inner) = candidate.strip_prefix("```") {
         if let Some(end) = inner.rfind("```") {
             let inner = &inner[..end];
-            // Drop an optional language tag on the fence line.
             candidate = inner
                 .split_once('\n')
                 .map_or(inner, |(_, rest)| rest)
@@ -178,25 +375,75 @@ pub fn looks_like_motion_intent_json(reply: &str) -> bool {
     }
 }
 
+/// Streaming guard policy: a reply whose first non-whitespace character opens
+/// a JSON object or code fence is HELD BACK in full (no deltas emitted) and
+/// guarded when complete; ordinary prose streams immediately. Deterministic:
+/// the decision is made once, on the first delta.
+#[must_use]
+pub fn must_hold_back(first_delta: &str) -> bool {
+    matches!(
+        first_delta.trim_start().chars().next(),
+        Some('{') | Some('`')
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Timing + stream events
+// ---------------------------------------------------------------------------
+
+/// Stage timings for one request, all relative to request receipt, measured
+/// on the caller-supplied monotonic clock. Never carries content.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct ChatTiming {
+    /// First model token observed (0 for deterministic fast routes).
+    pub ttft_ms: u64,
+    /// First speakable sentence ready.
+    pub first_sentence_ms: u64,
+    /// Reply complete.
+    pub total_ms: u64,
+    /// True when the reply came from a deterministic route (no model call).
+    pub deterministic: bool,
+}
+
+/// One streamed event, in emission order.
+#[derive(Clone, Debug, PartialEq)]
+pub enum StreamEvent {
+    /// Stream opened; `request_id` is a per-process counter.
+    Start { request_id: u64 },
+    /// One raw model delta (prose replies only; held-back replies emit none).
+    Delta { text: String },
+    /// One speakable sentence chunk.
+    Sentence { text: String },
+    /// Terminal: full reply + timings. Always the last event.
+    Done { reply: String, timing: ChatTiming },
+}
+
+/// Chunker bounds for the streamed `sentence` events
+/// (`KIRRA_CHAT_TTS_CHUNK_{MIN,MAX}_CHARS` are client-side knobs; the service
+/// uses these fixed, spoken-interaction bounds).
+pub const SENTENCE_MIN_CHARS: usize = 20;
+pub const SENTENCE_MAX_CHARS: usize = 120;
+
 /// Why a request was refused (stable wire tokens).
 pub type ChatError = &'static str;
 
 struct Session {
-    /// (user, assistant) pairs, oldest first.
     pairs: Vec<(String, String)>,
     last_used_ms: u64,
 }
 
-/// The service core: transport + per-session bounded history + rate limit.
-/// Single-threaded, like the serve loop that drives it. Holds NO intent
-/// state — there is no latch, no seq, nothing for a consumer to poll.
+/// The service core: transport + optional bounded history + rate limit +
+/// request counter. Single-threaded (CHAT_MAX_INFLIGHT = 1 structurally).
+/// Holds NO intent state.
 pub struct ChatService<M: ChatModelClient> {
     model: M,
     cfg: ChatConfig,
     limiter: RateLimiter,
     sessions: HashMap<String, Session>,
-    /// How many motion-shaped replies the output guard has replaced.
+    next_request_id: u64,
     motion_shape_guarded: u64,
+    fast_routed: u64,
+    motion_refused: u64,
 }
 
 impl<M: ChatModelClient> ChatService<M> {
@@ -207,35 +454,59 @@ impl<M: ChatModelClient> ChatService<M> {
             cfg,
             limiter: RateLimiter::new(CHAT_RATE_BURST, CHAT_RATE_PER_S),
             sessions: HashMap::new(),
+            next_request_id: 0,
             motion_shape_guarded: 0,
+            fast_routed: 0,
+            motion_refused: 0,
         }
     }
 
-    /// How many replies the motion-shape output guard has replaced.
     #[must_use]
     pub fn motion_shape_guarded(&self) -> u64 {
         self.motion_shape_guarded
     }
 
-    /// Handle one chat request at `now_ms`. Returns the reply text, or a
-    /// stable error token. Validation happens BEFORE the model call; the
-    /// output guard happens after it; history records only what was actually
-    /// returned to the caller (a guarded reply stores the refusal, never the
-    /// motion-shaped text).
-    pub fn handle_chat(&mut self, req: &ChatRequest, now_ms: u64) -> Result<String, ChatError> {
-        if !self.limiter.admit(now_ms) {
+    #[must_use]
+    pub fn fast_routed(&self) -> u64 {
+        self.fast_routed
+    }
+
+    #[must_use]
+    pub fn motion_refused(&self) -> u64 {
+        self.motion_refused
+    }
+
+    #[must_use]
+    pub fn session_count(&self) -> usize {
+        self.sessions.len()
+    }
+
+    #[must_use]
+    pub fn history_len(&self, session_id: &str) -> usize {
+        self.sessions.get(session_id).map_or(0, |s| s.pairs.len())
+    }
+
+    /// Handle one request, streaming events into `emit` (which returns
+    /// `false` to cancel — e.g. the client hung up). `clock` is a monotonic
+    /// milliseconds source. Returns the terminal timing, or a stable error
+    /// token; on error nothing was emitted beyond `Start`.
+    pub fn handle_chat_streamed(
+        &mut self,
+        req: &ChatRequest,
+        clock: &mut dyn FnMut() -> u64,
+        emit: &mut dyn FnMut(&StreamEvent) -> bool,
+    ) -> Result<ChatTiming, ChatError> {
+        let t0 = clock();
+        if !self.limiter.admit(t0) {
             return Err("MICK_CHAT_RATE_LIMITED");
         }
         let text = req.text.trim();
         if text.is_empty() {
             return Err("MICK_CHAT_EMPTY_REQUEST");
         }
-        if req.text.chars().count() > self.cfg.max_chars {
+        if req.text.chars().count() > self.cfg.max_input_chars {
             return Err("MICK_CHAT_TEXT_TOO_LONG");
         }
-        // Control characters (beyond ordinary whitespace) are rejected, not
-        // stripped: terminal-escape smuggling into a reply a human will read
-        // in a terminal is exactly the abuse this bound exists for.
         if text
             .chars()
             .any(|c| c.is_control() && c != '\n' && c != '\r' && c != '\t')
@@ -244,21 +515,63 @@ impl<M: ChatModelClient> ChatService<M> {
         }
         let session_id = validate_session_id(req.session_id.as_deref())?;
 
-        // Compose: system prompt + this session's bounded history + the turn.
+        self.next_request_id += 1;
+        let request_id = self.next_request_id;
+        if !emit(&StreamEvent::Start { request_id }) {
+            return Err("MICK_CHAT_CANCELLED");
+        }
+
+        // Deterministic fast paths: zero model calls, ~zero latency.
+        let deterministic_reply = if let Some(fixed) = fast_route(text) {
+            self.fast_routed += 1;
+            Some(fixed)
+        } else if is_explicit_motion_request(text) {
+            self.motion_refused += 1;
+            eprintln!(
+                "mick_chat: explicit motion request refused deterministically \
+                 (refused={}) — chat never forwards to the motion door",
+                self.motion_refused
+            );
+            Some(MOTION_ROUTE_REPLY)
+        } else {
+            None
+        };
+        if let Some(reply) = deterministic_reply {
+            let now = clock().saturating_sub(t0);
+            let timing = ChatTiming {
+                ttft_ms: 0,
+                first_sentence_ms: now,
+                total_ms: now,
+                deterministic: true,
+            };
+            emit(&StreamEvent::Sentence {
+                text: reply.to_string(),
+            });
+            emit(&StreamEvent::Done {
+                reply: reply.to_string(),
+                timing,
+            });
+            self.record_turn(&session_id, text, reply, t0);
+            return Ok(timing);
+        }
+
+        // Model path: compose compact prompt (+ optional bounded history).
         let mut messages = vec![ChatMessage {
             role: "system",
             content: CHAT_SYSTEM_PROMPT.to_string(),
         }];
-        if let Some(s) = self.sessions.get(&session_id) {
-            for (user, assistant) in &s.pairs {
-                messages.push(ChatMessage {
-                    role: "user",
-                    content: user.clone(),
-                });
-                messages.push(ChatMessage {
-                    role: "assistant",
-                    content: assistant.clone(),
-                });
+        if self.cfg.history_turns > 0 {
+            if let Some(s) = self.sessions.get(&session_id) {
+                for (user, assistant) in &s.pairs {
+                    messages.push(ChatMessage {
+                        role: "user",
+                        content: user.clone(),
+                    });
+                    messages.push(ChatMessage {
+                        role: "assistant",
+                        content: assistant.clone(),
+                    });
+                }
             }
         }
         messages.push(ChatMessage {
@@ -266,30 +579,132 @@ impl<M: ChatModelClient> ChatService<M> {
             content: text.to_string(),
         });
 
-        let raw = self
-            .model
-            .chat(&messages)
-            .map_err(|_| "MICK_CHAT_MODEL_ERROR")?;
-        let reply = if looks_like_motion_intent_json(&raw) {
-            self.motion_shape_guarded += 1;
-            // Count + log the KIND only — never the transcript.
-            eprintln!(
-                "mick_chat: motion-shape output guard engaged (guarded={}) — \
-                 reply replaced with the routing explanation",
-                self.motion_shape_guarded
-            );
-            MOTION_SHAPE_REFUSAL.to_string()
-        } else {
-            raw
+        // Per-request token cap may only REDUCE the configured maximum.
+        let num_predict = match req.max_output_tokens {
+            Some(n) if n > 0 => n.min(self.cfg.max_output_tokens),
+            _ => self.cfg.max_output_tokens,
+        };
+        let gen = ChatGenParams {
+            keep_alive: self.cfg.keep_alive.clone(),
+            num_predict,
+            temperature: self.cfg.temperature,
         };
 
-        self.record_turn(&session_id, text, &reply, now_ms);
-        Ok(reply)
+        let mut full = String::new();
+        let mut ttft_ms: Option<u64> = None;
+        let mut first_sentence_ms: Option<u64> = None;
+        let mut hold_back: Option<bool> = None;
+        let mut chunker = SentenceChunker::new(SENTENCE_MIN_CHARS, SENTENCE_MAX_CHARS);
+        let mut cancelled = false;
+
+        {
+            let emit_ref: &mut dyn FnMut(&StreamEvent) -> bool = emit;
+            let clock_ref: &mut dyn FnMut() -> u64 = clock;
+            let mut on_delta = |delta: &str| -> bool {
+                // First token: stamped exactly once.
+                if ttft_ms.is_none() {
+                    ttft_ms = Some(clock_ref().saturating_sub(t0));
+                    hold_back = Some(must_hold_back(delta));
+                }
+                full.push_str(delta);
+                if hold_back == Some(true) {
+                    return true; // buffer silently; guard decides at the end
+                }
+                if !emit_ref(&StreamEvent::Delta {
+                    text: delta.to_string(),
+                }) {
+                    cancelled = true;
+                    return false;
+                }
+                for chunk in chunker.push(delta) {
+                    if first_sentence_ms.is_none() {
+                        first_sentence_ms = Some(clock_ref().saturating_sub(t0));
+                    }
+                    if !emit_ref(&StreamEvent::Sentence { text: chunk }) {
+                        cancelled = true;
+                        return false;
+                    }
+                }
+                true
+            };
+            self.model
+                .stream_chat(&messages, &gen, &mut on_delta)
+                .map_err(|_| "MICK_CHAT_MODEL_ERROR")?;
+        }
+        if cancelled {
+            return Err("MICK_CHAT_CANCELLED");
+        }
+
+        // Assemble the final reply, applying the guard to held-back output.
+        let reply = if hold_back == Some(true) || looks_like_motion_intent_json(&full) {
+            if looks_like_motion_intent_json(&full) {
+                self.motion_shape_guarded += 1;
+                eprintln!(
+                    "mick_chat: motion-shape output guard engaged (guarded={}) — \
+                     reply replaced with the routing explanation",
+                    self.motion_shape_guarded
+                );
+                MOTION_SHAPE_REFUSAL.to_string()
+            } else {
+                // Held back but harmless (e.g. fenced non-intent JSON): emit
+                // it now as one late sentence rather than dribbling stale
+                // deltas.
+                full.clone()
+            }
+        } else {
+            full.clone()
+        };
+        // A guarded/held-back reply surfaces as a single sentence event here.
+        if hold_back == Some(true) || looks_like_motion_intent_json(&full) {
+            if first_sentence_ms.is_none() {
+                first_sentence_ms = Some(clock().saturating_sub(t0));
+            }
+            if !emit(&StreamEvent::Sentence {
+                text: reply.clone(),
+            }) {
+                return Err("MICK_CHAT_CANCELLED");
+            }
+        } else if let Some(tail) = chunker.finish() {
+            if first_sentence_ms.is_none() {
+                first_sentence_ms = Some(clock().saturating_sub(t0));
+            }
+            if !emit(&StreamEvent::Sentence { text: tail }) {
+                return Err("MICK_CHAT_CANCELLED");
+            }
+        }
+
+        let total_ms = clock().saturating_sub(t0);
+        let timing = ChatTiming {
+            ttft_ms: ttft_ms.unwrap_or(total_ms),
+            first_sentence_ms: first_sentence_ms.unwrap_or(total_ms),
+            total_ms,
+            deterministic: false,
+        };
+        emit(&StreamEvent::Done {
+            reply: reply.clone(),
+            timing,
+        });
+        self.record_turn(&session_id, text, &reply, t0);
+        Ok(timing)
     }
 
-    /// Append a (user, reply) pair to the session, enforcing every bound:
-    /// per-session turns, per-session characters, and the session-count cap
-    /// (oldest-touched evicted). In-memory only; cleared on restart.
+    /// Non-streaming convenience: collect the stream, return (reply, timing).
+    pub fn handle_chat(
+        &mut self,
+        req: &ChatRequest,
+        clock: &mut dyn FnMut() -> u64,
+    ) -> Result<(String, ChatTiming), ChatError> {
+        let mut reply = String::new();
+        let mut emit = |ev: &StreamEvent| {
+            if let StreamEvent::Done { reply: r, .. } = ev {
+                reply = r.clone();
+            }
+            true
+        };
+        let timing = self.handle_chat_streamed(req, clock, &mut emit)?;
+        Ok((reply, timing))
+    }
+
     fn record_turn(&mut self, session_id: &str, user: &str, reply: &str, now_ms: u64) {
         if self.cfg.history_turns == 0 {
             return;
@@ -316,36 +731,9 @@ impl<M: ChatModelClient> ChatService<M> {
         while session.pairs.len() > self.cfg.history_turns {
             session.pairs.remove(0);
         }
-        // Character bound over the whole session: trim oldest pairs until the
-        // total fits (2× max_chars per retained turn is the generous ceiling).
-        let char_cap = self.cfg.history_turns.saturating_mul(self.cfg.max_chars) * 2;
-        while session.pairs.len() > 1
-            && session
-                .pairs
-                .iter()
-                .map(|(u, a)| u.chars().count() + a.chars().count())
-                .sum::<usize>()
-                > char_cap
-        {
-            session.pairs.remove(0);
-        }
-    }
-
-    /// Retained history pairs for a session (tests/observability; content is
-    /// never logged by the service itself).
-    #[must_use]
-    pub fn history_len(&self, session_id: &str) -> usize {
-        self.sessions.get(session_id).map_or(0, |s| s.pairs.len())
-    }
-
-    #[must_use]
-    pub fn session_count(&self) -> usize {
-        self.sessions.len()
     }
 }
 
-/// Session ids are short, filename-safe tokens; anything else is refused
-/// rather than truncated or normalized. Absent → the shared default session.
 fn validate_session_id(raw: Option<&str>) -> Result<String, ChatError> {
     let id = raw.unwrap_or("default");
     if id.is_empty()
@@ -359,27 +747,117 @@ fn validate_session_id(raw: Option<&str>) -> Result<String, ChatError> {
     Ok(id.to_string())
 }
 
-/// Route one parsed HTTP request — the single handler path the binary's serve
-/// loop delegates to, extracted pure so the wire contract is testable without
-/// sockets. Returns `(status line, body)`.
-///
-/// Deliberately: there is NO `/intent` route here and NO `/intent/last` route
-/// — a chat caller cannot reach, read, or mutate Mick intent state through
-/// this service by construction (`tests/mick_chat_separation.rs` pins it).
+// ---------------------------------------------------------------------------
+// Health / warm-up
+// ---------------------------------------------------------------------------
+
+/// Service readiness. The HTTP listener being up is NOT health: the model may
+/// still be cold (warming) or Ollama unreachable (degraded).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WarmState {
+    Warming,
+    Ready,
+    Degraded,
+}
+
+/// The `/health` body for a state. Configured model is included; nothing
+/// secret exists to leak.
+#[must_use]
+pub fn health_body(state: WarmState, model: &str, warmup_ms: Option<u64>) -> String {
+    match state {
+        WarmState::Warming => format!(r#"{{"status":"warming","model":"{model}"}}"#),
+        WarmState::Ready => match warmup_ms {
+            Some(ms) => {
+                format!(r#"{{"status":"ready","model":"{model}","warmup_ms":{ms}}}"#)
+            }
+            None => format!(r#"{{"status":"ready","model":"{model}"}}"#),
+        },
+        WarmState::Degraded => {
+            format!(r#"{{"status":"degraded","reason":"OLLAMA_UNAVAILABLE","model":"{model}"}}"#)
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Wire (single handler path; streaming writes SSE into any `Write`)
+// ---------------------------------------------------------------------------
+
+/// Render one event as SSE. Content fields are JSON-encoded; timings carry no
+/// content.
+#[must_use]
+pub fn sse_event(ev: &StreamEvent) -> String {
+    match ev {
+        StreamEvent::Start { request_id } => {
+            format!("event: start\ndata: {{\"request_id\":\"{request_id}\"}}\n\n")
+        }
+        StreamEvent::Delta { text } => format!(
+            "event: delta\ndata: {}\n\n",
+            serde_json::json!({ "text": text })
+        ),
+        StreamEvent::Sentence { text } => format!(
+            "event: sentence\ndata: {}\n\n",
+            serde_json::json!({ "text": text })
+        ),
+        StreamEvent::Done { timing, .. } => format!(
+            "event: done\ndata: {}\n\n",
+            serde_json::json!({
+                "ttft_ms": timing.ttft_ms,
+                "first_sentence_ms": timing.first_sentence_ms,
+                "total_ms": timing.total_ms,
+                "deterministic": timing.deterministic,
+            })
+        ),
+    }
+}
+
+/// Handle `POST /chat/stream`: write the SSE response head + events into
+/// `sink` as they happen. A sink write failure cancels the generation (the
+/// client hung up — barge-in). Pure over (service, body, clock, sink).
+pub fn stream_chat_into<M: ChatModelClient>(
+    svc: &mut ChatService<M>,
+    body: &[u8],
+    clock: &mut dyn FnMut() -> u64,
+    sink: &mut dyn Write,
+) -> Result<(), ChatError> {
+    let req: ChatRequest = serde_json::from_slice(body).map_err(|_| "MICK_CHAT_BAD_REQUEST")?;
+    let head = "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n";
+    if sink.write_all(head.as_bytes()).is_err() {
+        return Err("MICK_CHAT_CANCELLED");
+    }
+    let mut emit = |ev: &StreamEvent| -> bool {
+        sink.write_all(sse_event(ev).as_bytes()).is_ok() && sink.flush().is_ok()
+    };
+    svc.handle_chat_streamed(&req, clock, &mut emit).map(|_| ())
+}
+
+/// Route one parsed NON-streaming request. `/chat/stream` is handled by
+/// [`stream_chat_into`] (it owns the socket); everything else lands here.
+/// There is deliberately NO intent surface on this service.
 pub fn handle_request<M: ChatModelClient>(
     svc: &mut ChatService<M>,
     method: &str,
     path: &str,
     body: &[u8],
-    now_ms: u64,
+    clock: &mut dyn FnMut() -> u64,
+    health: (WarmState, &str, Option<u64>),
 ) -> (&'static str, String) {
     match (method, path) {
-        ("GET", "/health") => ("200 OK", "{\"status\":\"ok\"}".to_string()),
+        ("GET", "/health") => ("200 OK", health_body(health.0, health.1, health.2)),
         ("POST", "/chat") => match serde_json::from_slice::<ChatRequest>(body) {
-            Ok(req) => match svc.handle_chat(&req, now_ms) {
-                Ok(reply) => (
+            Ok(req) => match svc.handle_chat(&req, clock) {
+                Ok((reply, timing)) => (
                     "200 OK",
-                    serde_json::json!({"ok": true, "reply": reply}).to_string(),
+                    serde_json::json!({
+                        "ok": true,
+                        "reply": reply,
+                        "timing": {
+                            "ttft_ms": timing.ttft_ms,
+                            "first_sentence_ms": timing.first_sentence_ms,
+                            "total_ms": timing.total_ms,
+                            "deterministic": timing.deterministic,
+                        }
+                    })
+                    .to_string(),
                 ),
                 Err("MICK_CHAT_RATE_LIMITED") => (
                     "429 Too Many Requests",
@@ -409,318 +887,631 @@ mod tests {
     use std::cell::Cell;
     use std::rc::Rc;
 
+    /// Stub model: replies with fixed deltas, counts calls, advances a shared
+    /// fake clock by `delta_cost_ms` per delta so TTFT/total are deterministic.
     struct StubModel {
-        reply: String,
+        deltas: Vec<String>,
         calls: Rc<Cell<u32>>,
+        clock: Rc<Cell<u64>>,
+        delta_cost_ms: u64,
     }
 
     impl ChatModelClient for StubModel {
-        fn chat(&self, _messages: &[ChatMessage]) -> Result<String, &'static str> {
+        fn stream_chat(
+            &self,
+            _messages: &[ChatMessage],
+            _gen: &ChatGenParams,
+            on_delta: &mut dyn FnMut(&str) -> bool,
+        ) -> Result<(), &'static str> {
             self.calls.set(self.calls.get() + 1);
-            Ok(self.reply.clone())
+            for d in &self.deltas {
+                self.clock.set(self.clock.get() + self.delta_cost_ms);
+                if !on_delta(d) {
+                    return Ok(());
+                }
+            }
+            Ok(())
         }
     }
 
-    struct FailingModel;
-    impl ChatModelClient for FailingModel {
-        fn chat(&self, _messages: &[ChatMessage]) -> Result<String, &'static str> {
-            Err("MICK_CHAT_OLLAMA_REQUEST_FAILED")
-        }
+    struct Harness {
+        svc: ChatService<StubModel>,
+        calls: Rc<Cell<u32>>,
+        clock: Rc<Cell<u64>>,
     }
 
-    fn service(reply: &str) -> (ChatService<StubModel>, Rc<Cell<u32>>) {
+    fn harness_with(deltas: &[&str], cfg: ChatConfig) -> Harness {
         let calls = Rc::new(Cell::new(0));
+        let clock = Rc::new(Cell::new(10_000));
         let svc = ChatService::new(
             StubModel {
-                reply: reply.to_string(),
+                deltas: deltas.iter().map(|s| (*s).to_string()).collect(),
                 calls: Rc::clone(&calls),
+                clock: Rc::clone(&clock),
+                delta_cost_ms: 50,
             },
-            ChatConfig::default(),
+            cfg,
         );
-        (svc, calls)
+        Harness { svc, calls, clock }
+    }
+
+    fn harness(deltas: &[&str]) -> Harness {
+        harness_with(deltas, ChatConfig::default())
     }
 
     fn req(text: &str) -> ChatRequest {
         ChatRequest {
             text: text.to_string(),
             session_id: None,
+            max_output_tokens: None,
         }
     }
 
-    // --- the system prompt contract -----------------------------------------
+    fn run(h: &mut Harness, text: &str) -> (Vec<StreamEvent>, Result<ChatTiming, ChatError>) {
+        let clock = Rc::clone(&h.clock);
+        // Advance a little per clock read so distinct stages get distinct stamps.
+        let mut clk = move || {
+            clock.set(clock.get() + 1);
+            clock.get()
+        };
+        let mut events = Vec::new();
+        let mut emit = |ev: &StreamEvent| {
+            events.push(ev.clone());
+            true
+        };
+        let r = h.svc.handle_chat_streamed(&req(text), &mut clk, &mut emit);
+        (events, r)
+    }
+
+    // --- prompt contract ------------------------------------------------------
 
     #[test]
-    fn system_prompt_declares_conversational_only_and_denies_motion_authority() {
-        assert!(CHAT_SYSTEM_PROMPT.contains("conversational only"));
-        assert!(CHAT_SYSTEM_PROMPT.contains("no authority to move or control the robot"));
-        assert!(CHAT_SYSTEM_PROMPT.contains("Never emit motion-intent JSON"));
-        assert!(CHAT_SYSTEM_PROMPT.contains("governed"));
-        assert!(CHAT_SYSTEM_PROMPT.contains("Do not invent nominal status"));
+    fn system_prompt_is_compact_and_denies_motion_authority() {
+        assert!(
+            CHAT_SYSTEM_PROMPT.chars().count() <= CHAT_SYSTEM_PROMPT_MAX_CHARS,
+            "prompt grew past {CHAT_SYSTEM_PROMPT_MAX_CHARS} chars — prompt tokens are TTFT"
+        );
+        assert!(CHAT_SYSTEM_PROMPT.contains("cannot move or control the robot"));
+        assert!(CHAT_SYSTEM_PROMPT.contains("governed motion path"));
+        assert!(CHAT_SYSTEM_PROMPT.contains("Never claim access to live state"));
     }
 
     #[test]
-    fn system_prompt_does_not_teach_the_motion_wire_shape() {
-        // The prompt must not list the MickIntent JSON forms — the chat model
-        // must never learn the motion vocabulary from its own instructions.
+    fn system_prompt_teaches_no_motion_wire_forms() {
         for token in [
             "cruise",
             "go_to",
             "lane_change",
-            "pull_over",
-            "route_to",
             "target_speed_mps",
             "\"intent\"",
         ] {
-            assert!(
-                !CHAT_SYSTEM_PROMPT.contains(token),
-                "prompt leaks the motion wire shape: {token}"
-            );
+            assert!(!CHAT_SYSTEM_PROMPT.contains(token), "{token}");
         }
     }
 
-    // --- input validation ----------------------------------------------------
+    // --- deterministic fast paths --------------------------------------------
+
+    #[test]
+    fn trivial_greetings_fast_route_with_zero_model_calls_and_zero_ttft() {
+        for (text, reply) in [
+            ("Hello!", "Hello."),
+            ("hi", "Hello."),
+            ("Thank you.", "You're welcome."),
+            ("thanks", "You're welcome."),
+            ("Goodbye", "Goodbye."),
+        ] {
+            let mut h = harness(&["never"]);
+            let (events, r) = run(&mut h, text);
+            let timing = r.unwrap();
+            assert!(timing.deterministic, "{text:?}");
+            assert_eq!(timing.ttft_ms, 0, "{text:?}");
+            assert_eq!(h.calls.get(), 0, "{text:?} reached the model");
+            assert!(matches!(&events[1], StreamEvent::Sentence { text: t } if t == reply));
+        }
+    }
+
+    #[test]
+    fn fast_routes_stay_tiny_and_do_not_swallow_real_questions() {
+        for text in [
+            "hello there how are you",
+            "thanks for the update on the dock",
+            "what is your status",
+            "tell me a joke",
+        ] {
+            assert_eq!(fast_route(text), None, "{text:?}");
+        }
+    }
+
+    #[test]
+    fn explicit_motion_requests_are_refused_without_a_model_call() {
+        let mut h = harness(&["never"]);
+        let (events, r) = run(&mut h, "Drive forward one meter.");
+        let timing = r.unwrap();
+        assert!(timing.deterministic);
+        assert_eq!(h.calls.get(), 0, "motion text reached the model");
+        assert_eq!(h.svc.motion_refused(), 1);
+        assert!(matches!(&events[1], StreamEvent::Sentence { text } if text == MOTION_ROUTE_REPLY));
+        for text in [
+            "turn left",
+            "stop",
+            "go to the dock",
+            "pull over now",
+            "back up",
+        ] {
+            assert!(is_explicit_motion_request(text), "{text:?}");
+        }
+    }
+
+    #[test]
+    fn motion_detector_is_conservative_leading_verb_only() {
+        for text in [
+            "how do I stop the recording",
+            "what does drive mode mean",
+            "the go button is red",
+            "can you explain pull over rules",
+        ] {
+            assert!(!is_explicit_motion_request(text), "{text:?}");
+        }
+    }
+
+    // --- streaming, ttft, sentences ------------------------------------------
+
+    #[test]
+    fn deltas_stream_before_completion_and_ttft_is_stamped_exactly_once() {
+        let mut h = harness(&["Hello", ". ", "How can I help", "?"]);
+        let (events, r) = run(&mut h, "introduce yourself briefly");
+        let timing = r.unwrap();
+        assert!(!timing.deterministic);
+        assert!(timing.ttft_ms > 0 && timing.ttft_ms < timing.total_ms);
+        // Delta events precede Done, and the first Delta precedes the last.
+        let delta_count = events
+            .iter()
+            .filter(|e| matches!(e, StreamEvent::Delta { .. }))
+            .count();
+        assert_eq!(delta_count, 4);
+        assert!(matches!(events.first(), Some(StreamEvent::Start { .. })));
+        assert!(matches!(events.last(), Some(StreamEvent::Done { .. })));
+        // Sentences arrived (chunked on punctuation).
+        let sentences: Vec<_> = events
+            .iter()
+            .filter_map(|e| match e {
+                StreamEvent::Sentence { text } => Some(text.clone()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(sentences, vec!["Hello. How can I help?"]);
+        assert!(timing.first_sentence_ms >= timing.ttft_ms);
+    }
+
+    #[test]
+    fn first_sentence_is_emitted_before_the_stream_completes() {
+        // Two sentences: the first must be emitted as a Sentence event BEFORE
+        // the final delta arrives (ordering proof via event positions).
+        let mut h = harness(&[
+            "All systems look fine to me. ",
+            "Ask me anything else you need",
+            ".",
+        ]);
+        let (events, _) = run(&mut h, "how are things going today");
+        let first_sentence_pos = events
+            .iter()
+            .position(|e| matches!(e, StreamEvent::Sentence { .. }))
+            .expect("a sentence event");
+        let last_delta_pos = events
+            .iter()
+            .rposition(|e| matches!(e, StreamEvent::Delta { .. }))
+            .unwrap();
+        assert!(
+            first_sentence_pos < last_delta_pos,
+            "first sentence must not wait for stream completion"
+        );
+    }
+
+    // --- sentence chunker ------------------------------------------------------
+
+    #[test]
+    fn chunker_splits_on_punctuation_with_min_bound() {
+        let mut c = SentenceChunker::new(5, 120);
+        let mut got = Vec::new();
+        for d in ["Hi. This is a sen", "tence. And ano", "ther one!"] {
+            got.extend(c.push(d));
+        }
+        got.extend(c.finish());
+        assert_eq!(got, vec!["Hi. This is a sentence.", "And another one!"]);
+    }
+
+    #[test]
+    fn chunker_does_not_split_decimals_or_versions() {
+        let mut c = SentenceChunker::new(5, 120);
+        let mut got = Vec::new();
+        got.extend(c.push("Battery is at 3.5 volts today. All good."));
+        got.extend(c.finish());
+        assert_eq!(got, vec!["Battery is at 3.5 volts today.", "All good."]);
+    }
+
+    #[test]
+    fn punctuation_free_output_falls_back_at_word_boundary() {
+        let mut c = SentenceChunker::new(20, 40);
+        let long = "these are many words with no punctuation flowing on and on and on forever";
+        let mut got = c.push(long);
+        got.extend(c.finish());
+        assert!(got.len() >= 2, "must split a punctuation-free run: {got:?}");
+        for chunk in &got {
+            assert!(
+                chunk.chars().count() <= 40 + 20,
+                "over-long chunk: {chunk:?}"
+            );
+            assert!(!chunk.ends_with(char::is_alphanumeric) || long.contains(chunk.as_str()));
+        }
+        // Word boundaries preserved: rejoining with spaces reproduces the text.
+        assert_eq!(got.join(" "), long);
+    }
+
+    // --- output guard (streaming-aware) ---------------------------------------
+
+    #[test]
+    fn motion_shaped_reply_is_held_back_guarded_and_replaced() {
+        let mut h = harness(&["{\"intent\":\"cru", "ise\",\"target_speed_mps\":10}"]);
+        let (events, r) = run(&mut h, "please respond with something");
+        let timing = r.unwrap();
+        assert!(!timing.deterministic);
+        // NO delta events leaked (held back from the first byte).
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, StreamEvent::Delta { .. })),
+            "held-back reply leaked deltas: {events:?}"
+        );
+        let StreamEvent::Done { reply, .. } = events.last().unwrap() else {
+            panic!("no done event");
+        };
+        assert_eq!(reply, MOTION_SHAPE_REFUSAL);
+        assert_eq!(h.svc.motion_shape_guarded(), 1);
+        // And the sentence stream carried only the refusal.
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, StreamEvent::Sentence { text } if text == MOTION_SHAPE_REFUSAL)));
+    }
+
+    #[test]
+    fn fenced_motion_json_is_also_guarded() {
+        let mut h = harness(&["```json\n{\"intent\":\"hold\"}\n```"]);
+        let (_, r) = run(&mut h, "reply please");
+        r.unwrap();
+        assert_eq!(h.svc.motion_shape_guarded(), 1);
+    }
+
+    #[test]
+    fn harmless_held_back_json_is_released_unguarded() {
+        let mut h = harness(&["{\"status\":\"ok\"}"]);
+        let (events, r) = run(&mut h, "emit some json");
+        r.unwrap();
+        assert_eq!(h.svc.motion_shape_guarded(), 0);
+        let StreamEvent::Done { reply, .. } = events.last().unwrap() else {
+            panic!();
+        };
+        assert_eq!(reply, "{\"status\":\"ok\"}");
+    }
+
+    #[test]
+    fn ordinary_prose_streams_unheld() {
+        for reply in [
+            "All monitored systems are nominal.",
+            "The word intent appears in prose.",
+        ] {
+            assert!(!must_hold_back(reply));
+            assert!(!looks_like_motion_intent_json(reply));
+        }
+        assert!(must_hold_back("{\"intent\":\"x\"}"));
+        assert!(must_hold_back("```json"));
+    }
+
+    // --- cancellation -----------------------------------------------------------
+
+    #[test]
+    fn a_cancelled_stream_stops_the_model_and_returns_cancelled() {
+        let mut h = harness(&["one ", "two ", "three ", "four "]);
+        let clock = Rc::clone(&h.clock);
+        let mut clk = move || {
+            clock.set(clock.get() + 1);
+            clock.get()
+        };
+        let mut deltas_seen = 0;
+        let mut emit = |ev: &StreamEvent| match ev {
+            StreamEvent::Delta { .. } => {
+                deltas_seen += 1;
+                deltas_seen < 2 // cancel on the second delta
+            }
+            _ => true,
+        };
+        let r = h
+            .svc
+            .handle_chat_streamed(&req("talk to me"), &mut clk, &mut emit);
+        assert_eq!(r, Err("MICK_CHAT_CANCELLED"));
+        assert_eq!(deltas_seen, 2, "consumption must stop at the cancel point");
+    }
+
+    // --- validation, limits, errors --------------------------------------------
 
     #[test]
     fn empty_oversized_and_control_input_is_refused_before_the_model() {
-        let (mut svc, calls) = service("hello there");
+        let mut h = harness(&["x"]);
+        let clock = Rc::clone(&h.clock);
+        let mut clk = move || {
+            clock.set(clock.get() + 1);
+            clock.get()
+        };
+        let mut emit = |_: &StreamEvent| true;
         assert_eq!(
-            svc.handle_chat(&req("   "), 10_000),
+            h.svc.handle_chat_streamed(&req("   "), &mut clk, &mut emit),
             Err("MICK_CHAT_EMPTY_REQUEST")
         );
-        let long = "x".repeat(1001);
+        let long = "x".repeat(501);
         assert_eq!(
-            svc.handle_chat(&req(&long), 12_000),
-            Err("MICK_CHAT_TEXT_TOO_LONG")
+            h.svc.handle_chat_streamed(&req(&long), &mut clk, &mut emit),
+            Err("MICK_CHAT_TEXT_TOO_LONG"),
+            "default input bound is 500 chars"
         );
         assert_eq!(
-            svc.handle_chat(&req("hi\u{1b}[2Jthere"), 14_000),
+            h.svc
+                .handle_chat_streamed(&req("hi\u{1b}[2Jthere"), &mut clk, &mut emit),
             Err("MICK_CHAT_BAD_TEXT")
         );
-        assert_eq!(calls.get(), 0, "invalid input reached the model");
+        assert_eq!(h.calls.get(), 0);
     }
 
     #[test]
-    fn session_ids_are_validated_not_normalized() {
-        let (mut svc, _) = service("ok");
-        for (i, bad) in ["", "a b", "sess/../ion", "x".repeat(65).as_str()]
-            .into_iter()
-            .enumerate()
-        {
-            let r = ChatRequest {
-                text: "hello".to_string(),
-                session_id: Some(bad.to_string()),
-            };
-            // Spaced in time so the rate limiter never shadows the verdict.
-            assert_eq!(
-                svc.handle_chat(&r, 10_000 + i as u64 * 2_000),
-                Err("MICK_CHAT_BAD_SESSION"),
-                "{bad:?}"
-            );
+    fn per_request_token_cap_only_reduces_never_raises() {
+        struct CapturingGen {
+            seen: Rc<Cell<u32>>,
         }
-        assert_eq!(
-            validate_session_id(Some("terminal-1.a_b")).as_deref(),
-            Ok("terminal-1.a_b")
-        );
-        assert_eq!(validate_session_id(None).as_deref(), Ok("default"));
-    }
-
-    #[test]
-    fn rate_limit_sheds_before_the_model() {
-        let (mut svc, calls) = service("ok");
-        let mut shed = 0;
-        for _ in 0..10 {
-            if svc.handle_chat(&req("hello"), 10_000) == Err("MICK_CHAT_RATE_LIMITED") {
-                shed += 1;
+        impl ChatModelClient for CapturingGen {
+            fn stream_chat(
+                &self,
+                _m: &[ChatMessage],
+                gen: &ChatGenParams,
+                on_delta: &mut dyn FnMut(&str) -> bool,
+            ) -> Result<(), &'static str> {
+                self.seen.set(gen.num_predict);
+                on_delta("ok");
+                Ok(())
             }
         }
-        assert!(
-            shed >= 6,
-            "burst bound must shed a same-instant flood: {shed}"
-        );
-        assert_eq!(calls.get() as usize, 10 - shed);
-    }
-
-    // --- the motion-shape output guard ---------------------------------------
-
-    #[test]
-    fn motion_shaped_json_is_detected_bare_and_fenced() {
-        for reply in [
-            r#"{"intent":"cruise","target_speed_mps":10}"#,
-            r#"  {"intent":"go_to","x_m":1.0,"y_m":0.0}  "#,
-            "```json\n{\"intent\":\"hold\"}\n```",
-            "```\n{\"intent\":\"future_unknown_tag\",\"weird\":1}\n```",
-        ] {
-            assert!(looks_like_motion_intent_json(reply), "{reply:?}");
-        }
-    }
-
-    #[test]
-    fn ordinary_text_and_non_intent_json_pass_the_guard() {
-        for reply in [
-            "All monitored systems are nominal.",
-            "The word intent appears in prose without JSON.",
-            r#"{"status":"ok"}"#,
-            r#"["intent"]"#,
-            "I would answer {\"intent\":...} if asked, but here is prose around it.",
-            "",
-        ] {
-            assert!(!looks_like_motion_intent_json(reply), "{reply:?}");
-        }
-    }
-
-    #[test]
-    fn a_motion_shaped_reply_is_replaced_never_passed_through() {
-        let (mut svc, _) = service(r#"{"intent":"cruise","target_speed_mps":10}"#);
-        let reply = svc
-            .handle_chat(&req("Drive forward one meter."), 10_000)
-            .unwrap();
-        assert_eq!(reply, MOTION_SHAPE_REFUSAL);
-        assert_eq!(svc.motion_shape_guarded(), 1);
-        // And the HISTORY stores the refusal, not the motion-shaped text —
-        // the guard must not smuggle the shape back in via the next prompt.
-        let (mut svc2, _) = service(r#"{"intent":"hold"}"#);
-        svc2.handle_chat(&req("go"), 10_000).unwrap();
-        assert_eq!(svc2.history_len("default"), 1);
-    }
-
-    // --- history bounds -------------------------------------------------------
-
-    #[test]
-    fn history_is_bounded_by_turns_and_isolated_by_session() {
-        let (mut svc, _) = service("reply");
-        for i in 0..10 {
-            let r = ChatRequest {
-                text: format!("turn {i}"),
-                session_id: Some("a".to_string()),
-            };
-            svc.handle_chat(&r, 10_000 + i * 2_000).unwrap();
-        }
-        assert_eq!(svc.history_len("a"), ChatConfig::default().history_turns);
-        assert_eq!(svc.history_len("b"), 0, "sessions must be isolated");
-    }
-
-    #[test]
-    fn session_count_is_capped_with_oldest_eviction() {
-        let (mut svc, _) = service("r");
-        for i in 0..(CHAT_MAX_SESSIONS + 5) {
-            let r = ChatRequest {
-                text: "hi".to_string(),
-                session_id: Some(format!("s{i}")),
-            };
-            svc.handle_chat(&r, 10_000 + i as u64 * 2_000).unwrap();
-        }
-        assert_eq!(svc.session_count(), CHAT_MAX_SESSIONS);
-        assert_eq!(svc.history_len("s0"), 0, "oldest session must be evicted");
-        let newest = format!("s{}", CHAT_MAX_SESSIONS + 4);
-        assert_eq!(svc.history_len(&newest), 1);
-    }
-
-    #[test]
-    fn zero_history_turns_disables_history_cleanly() {
-        let calls = Rc::new(Cell::new(0));
+        let seen = Rc::new(Cell::new(0));
         let mut svc = ChatService::new(
-            StubModel {
-                reply: "r".to_string(),
-                calls,
-            },
-            ChatConfig {
-                history_turns: 0,
-                ..ChatConfig::default()
-            },
-        );
-        svc.handle_chat(&req("hello"), 10_000).unwrap();
-        assert_eq!(svc.session_count(), 0);
-    }
-
-    // --- the model boundary ---------------------------------------------------
-
-    #[test]
-    fn a_model_failure_maps_to_the_stable_chat_error() {
-        let mut svc = ChatService::new(FailingModel, ChatConfig::default());
-        assert_eq!(
-            svc.handle_chat(&req("hello"), 10_000),
-            Err("MICK_CHAT_MODEL_ERROR")
-        );
-    }
-
-    #[test]
-    fn the_prompt_history_and_turn_are_composed_in_order() {
-        /// One captured model call: the (role, content) list it was handed.
-        type SeenCalls = Rc<std::cell::RefCell<Vec<Vec<(String, String)>>>>;
-        struct CapturingModel {
-            seen: SeenCalls,
-        }
-        impl ChatModelClient for CapturingModel {
-            fn chat(&self, messages: &[ChatMessage]) -> Result<String, &'static str> {
-                self.seen.borrow_mut().push(
-                    messages
-                        .iter()
-                        .map(|m| (m.role.to_string(), m.content.clone()))
-                        .collect(),
-                );
-                Ok("fine".to_string())
-            }
-        }
-        let seen = Rc::new(std::cell::RefCell::new(Vec::new()));
-        let mut svc = ChatService::new(
-            CapturingModel {
+            CapturingGen {
                 seen: Rc::clone(&seen),
             },
             ChatConfig::default(),
         );
-        svc.handle_chat(&req("first"), 10_000).unwrap();
-        svc.handle_chat(&req("second"), 12_000).unwrap();
-        let calls = seen.borrow();
-        let second = &calls[1];
-        assert_eq!(second[0].0, "system");
-        assert_eq!(second[0].1, CHAT_SYSTEM_PROMPT);
+        let mut clk = || 10_000;
+        let mut emit = |_: &StreamEvent| true;
+        // Reduction honoured.
+        let r = ChatRequest {
+            text: "hello world how are things".into(),
+            session_id: None,
+            max_output_tokens: Some(16),
+        };
+        svc.handle_chat_streamed(&r, &mut clk, &mut emit).unwrap();
+        assert_eq!(seen.get(), 16);
+        // Raising is clamped to the configured max (48).
+        let r = ChatRequest {
+            text: "hello world again my friend".into(),
+            session_id: None,
+            max_output_tokens: Some(4096),
+        };
+        svc.handle_chat_streamed(&r, &mut clk, &mut emit).unwrap();
+        assert_eq!(seen.get(), 48, "per-request cap must never exceed config");
+    }
+
+    #[test]
+    fn model_unavailable_maps_to_the_stable_error() {
+        struct Failing;
+        impl ChatModelClient for Failing {
+            fn stream_chat(
+                &self,
+                _m: &[ChatMessage],
+                _g: &ChatGenParams,
+                _d: &mut dyn FnMut(&str) -> bool,
+            ) -> Result<(), &'static str> {
+                Err("MICK_CHAT_OLLAMA_REQUEST_FAILED")
+            }
+        }
+        let mut svc = ChatService::new(Failing, ChatConfig::default());
+        let mut clk = || 10_000;
+        let mut emit = |_: &StreamEvent| true;
         assert_eq!(
-            &second[1..],
-            &[
-                ("user".to_string(), "first".to_string()),
-                ("assistant".to_string(), "fine".to_string()),
-                ("user".to_string(), "second".to_string()),
-            ]
+            svc.handle_chat_streamed(&req("say hello to everyone"), &mut clk, &mut emit),
+            Err("MICK_CHAT_MODEL_ERROR")
         );
     }
 
-    // --- the wire (handler path, no sockets) ----------------------------------
+    // --- history: stateless by default, bounded when enabled --------------------
 
     #[test]
-    fn wire_contract_health_chat_and_no_intent_routes() {
-        let (mut svc, _) = service("All monitored systems are nominal.");
-        let (status, body) = handle_request(&mut svc, "GET", "/health", b"", 10_000);
-        assert_eq!((status, body.as_str()), ("200 OK", "{\"status\":\"ok\"}"));
+    fn history_is_off_by_default_and_no_session_state_accrues() {
+        let mut h = harness(&["fine. "]);
+        for i in 0..3 {
+            let clock = Rc::clone(&h.clock);
+            let mut clk = move || {
+                clock.set(clock.get() + 1);
+                clock.get()
+            };
+            let mut emit = |_: &StreamEvent| true;
+            h.svc
+                .handle_chat_streamed(
+                    &req(&format!("turn number {i} says something")),
+                    &mut clk,
+                    &mut emit,
+                )
+                .unwrap();
+            h.clock.set(h.clock.get() + 2_000);
+        }
+        assert_eq!(
+            h.svc.session_count(),
+            0,
+            "stateless default must store nothing"
+        );
+    }
 
+    #[test]
+    fn enabled_history_is_bounded_to_the_hard_cap() {
+        let cfg = ChatConfig {
+            history_turns: 2,
+            ..ChatConfig::default()
+        };
+        let mut h = harness_with(&["fine. "], cfg);
+        for i in 0..6 {
+            let clock = Rc::clone(&h.clock);
+            let mut clk = move || {
+                clock.set(clock.get() + 1);
+                clock.get()
+            };
+            let mut emit = |_: &StreamEvent| true;
+            h.svc
+                .handle_chat_streamed(
+                    &req(&format!("history turn {i} content here")),
+                    &mut clk,
+                    &mut emit,
+                )
+                .unwrap();
+            h.clock.set(h.clock.get() + 2_000);
+        }
+        assert_eq!(h.svc.history_len("default"), 2);
+    }
+
+    #[test]
+    fn config_rejects_history_beyond_the_hard_cap() {
+        // from_env is env-driven; validate the invariant directly.
+        const { assert!(CHAT_MAX_HISTORY_TURNS == 2) };
+        let cfg = ChatConfig::default();
+        assert_eq!(cfg.history_turns, 0, "stateless by default");
+        assert_eq!(cfg.max_input_chars, 500);
+        assert_eq!(cfg.max_output_tokens, 48);
+        assert_eq!(cfg.temperature, 0.2);
+        assert_eq!(cfg.keep_alive, "30m");
+    }
+
+    // --- health -------------------------------------------------------------------
+
+    #[test]
+    fn health_reports_warming_ready_and_degraded_states() {
+        assert_eq!(
+            health_body(WarmState::Warming, "gemma3:4b", None),
+            r#"{"status":"warming","model":"gemma3:4b"}"#
+        );
+        assert_eq!(
+            health_body(WarmState::Ready, "gemma3:4b", Some(1234)),
+            r#"{"status":"ready","model":"gemma3:4b","warmup_ms":1234}"#
+        );
+        assert_eq!(
+            health_body(WarmState::Degraded, "gemma3:4b", None),
+            r#"{"status":"degraded","reason":"OLLAMA_UNAVAILABLE","model":"gemma3:4b"}"#
+        );
+    }
+
+    // --- wire ---------------------------------------------------------------------
+
+    #[test]
+    fn nonstreaming_chat_returns_reply_and_timing_and_no_intent_routes_exist() {
+        let mut h = harness(&["All monitored systems are nominal."]);
+        let clock = Rc::clone(&h.clock);
+        let mut clk = move || {
+            clock.set(clock.get() + 1);
+            clock.get()
+        };
         let (status, body) = handle_request(
-            &mut svc,
+            &mut h.svc,
             "POST",
             "/chat",
             br#"{"text":"How are your systems doing?"}"#,
-            12_000,
+            &mut clk,
+            (WarmState::Ready, "gemma3:4b", Some(10)),
         );
         assert_eq!(status, "200 OK");
         let v: serde_json::Value = serde_json::from_str(&body).unwrap();
         assert_eq!(v["ok"], true);
         assert_eq!(v["reply"], "All monitored systems are nominal.");
+        assert!(v["timing"]["ttft_ms"].is_u64());
+        assert!(v["timing"]["total_ms"].is_u64());
 
-        // The chat service exposes NO intent surface: it cannot read the
-        // latch, cannot mutate it, and cannot accept a motion request.
-        for path in ["/intent", "/intent/last"] {
+        for path in ["/intent", "/intent/last", "/narration/last"] {
             for method in ["GET", "POST"] {
-                let (status, _) = handle_request(&mut svc, method, path, b"{}", 14_000);
+                let (status, _) = handle_request(
+                    &mut h.svc,
+                    method,
+                    path,
+                    b"{}",
+                    &mut clk,
+                    (WarmState::Ready, "m", None),
+                );
                 assert_eq!(status, "404 Not Found", "{method} {path}");
             }
         }
-
-        let (status, _) = handle_request(&mut svc, "POST", "/chat", b"not json", 16_000);
-        assert_eq!(status, "400 Bad Request");
     }
 
     #[test]
-    fn config_defaults_are_the_documented_bounds() {
-        let cfg = ChatConfig::default();
-        assert_eq!(cfg.max_chars, 1000);
-        assert_eq!(cfg.history_turns, 6);
+    fn streaming_wire_emits_sse_events_into_the_sink() {
+        let mut h = harness(&["Hello. ", "How can I help?"]);
+        let clock = Rc::clone(&h.clock);
+        let mut clk = move || {
+            clock.set(clock.get() + 1);
+            clock.get()
+        };
+        let mut sink: Vec<u8> = Vec::new();
+        stream_chat_into(
+            &mut h.svc,
+            br#"{"text":"greet me please now"}"#,
+            &mut clk,
+            &mut sink,
+        )
+        .unwrap();
+        let text = String::from_utf8(sink).unwrap();
+        assert!(text.starts_with("HTTP/1.1 200 OK"));
+        assert!(text.contains("Content-Type: text/event-stream"));
+        assert!(text.contains("event: start"));
+        assert!(text.contains("event: delta"));
+        assert!(text.contains("event: sentence"));
+        assert!(text.contains("event: done"));
+        assert!(text.contains("ttft_ms"));
+        // No hidden prompt leakage: the system prompt never rides the wire.
+        assert!(!text.contains("governed motion path\" }"));
+        assert!(!text.contains(CHAT_SYSTEM_PROMPT));
+    }
+
+    #[test]
+    fn sse_done_event_carries_timings_and_no_content() {
+        let ev = StreamEvent::Done {
+            reply: "secret-ish content".to_string(),
+            timing: ChatTiming {
+                ttft_ms: 120,
+                first_sentence_ms: 300,
+                total_ms: 540,
+                deterministic: false,
+            },
+        };
+        let s = sse_event(&ev);
+        assert!(s.contains("\"ttft_ms\":120"));
+        assert!(
+            !s.contains("secret-ish"),
+            "done event must carry timings only, not the reply"
+        );
+    }
+
+    #[test]
+    fn rate_limit_sheds_before_the_model() {
+        let mut h = harness(&["x"]);
+        let mut shed = 0;
+        for _ in 0..10 {
+            let mut clk = || 10_000;
+            let mut emit = |_: &StreamEvent| true;
+            if h.svc
+                .handle_chat_streamed(&req("say something new"), &mut clk, &mut emit)
+                == Err("MICK_CHAT_RATE_LIMITED")
+            {
+                shed += 1;
+            }
+        }
+        assert!(shed >= 6, "burst bound must shed: {shed}");
     }
 }

--- a/crates/kirra-sidecars/tests/mick_chat_separation.rs
+++ b/crates/kirra-sidecars/tests/mick_chat_separation.rs
@@ -15,8 +15,9 @@ use std::cell::Cell;
 use std::rc::Rc;
 
 use kirra_sidecars::chat::{
-    handle_request, looks_like_motion_intent_json, ChatConfig, ChatMessage, ChatModelClient,
-    ChatRequest, ChatService, CHAT_SYSTEM_PROMPT, MOTION_SHAPE_REFUSAL,
+    handle_request, looks_like_motion_intent_json, ChatConfig, ChatGenParams, ChatMessage,
+    ChatModelClient, ChatRequest, ChatService, StreamEvent, WarmState, CHAT_SYSTEM_PROMPT,
+    MOTION_ROUTE_REPLY, MOTION_SHAPE_REFUSAL,
 };
 
 // --- 1. the source-level fence -----------------------------------------------
@@ -93,22 +94,32 @@ fn chat_binary_does_not_mention_the_intent_routes() {
 // --- 2 + 3. prompt and response behavior --------------------------------------
 
 struct StubModel {
-    reply: String,
+    deltas: Vec<String>,
     calls: Rc<Cell<u32>>,
 }
 
 impl ChatModelClient for StubModel {
-    fn chat(&self, _messages: &[ChatMessage]) -> Result<String, &'static str> {
+    fn stream_chat(
+        &self,
+        _messages: &[ChatMessage],
+        _gen: &ChatGenParams,
+        on_delta: &mut dyn FnMut(&str) -> bool,
+    ) -> Result<(), &'static str> {
         self.calls.set(self.calls.get() + 1);
-        Ok(self.reply.clone())
+        for d in &self.deltas {
+            if !on_delta(d) {
+                return Ok(());
+            }
+        }
+        Ok(())
     }
 }
 
-fn service(reply: &str) -> (ChatService<StubModel>, Rc<Cell<u32>>) {
+fn service(deltas: &[&str]) -> (ChatService<StubModel>, Rc<Cell<u32>>) {
     let calls = Rc::new(Cell::new(0));
     let svc = ChatService::new(
         StubModel {
-            reply: reply.to_string(),
+            deltas: deltas.iter().map(|s| (*s).to_string()).collect(),
             calls: Rc::clone(&calls),
         },
         ChatConfig::default(),
@@ -116,10 +127,18 @@ fn service(reply: &str) -> (ChatService<StubModel>, Rc<Cell<u32>>) {
     (svc, calls)
 }
 
+fn clock_from(base: u64) -> impl FnMut() -> u64 {
+    let t = Cell::new(base);
+    move || {
+        t.set(t.get() + 1);
+        t.get()
+    }
+}
+
 #[test]
 fn prompt_denies_motion_authority_and_lists_no_intent_forms() {
-    assert!(CHAT_SYSTEM_PROMPT.contains("conversational only"));
-    assert!(CHAT_SYSTEM_PROMPT.contains("no authority to move or control the robot"));
+    assert!(CHAT_SYSTEM_PROMPT.contains("cannot move or control the robot"));
+    assert!(CHAT_SYSTEM_PROMPT.contains("governed motion path"));
     for form in [
         "cruise",
         "go_to",
@@ -141,13 +160,15 @@ fn the_live_dangerous_reply_is_guarded_not_surfaced_as_a_result() {
     let live = r#"{"intent":"cruise","target_speed_mps":10}"#;
     assert!(looks_like_motion_intent_json(live));
 
-    let (mut svc, calls) = service(live);
+    let (mut svc, calls) = service(&[live]);
+    let mut clk = clock_from(10_000);
     let (status, body) = handle_request(
         &mut svc,
         "POST",
         "/chat",
-        br#"{"text":"Drive forward one meter."}"#,
-        10_000,
+        br#"{"text":"please answer with your favorite json"}"#,
+        &mut clk,
+        (WarmState::Ready, "gemma3:4b", Some(10)),
     );
     assert_eq!(status, "200 OK");
     let v: serde_json::Value = serde_json::from_str(&body).unwrap();
@@ -161,17 +182,48 @@ fn the_live_dangerous_reply_is_guarded_not_surfaced_as_a_result() {
     assert_eq!(svc.motion_shape_guarded(), 1);
 }
 
+#[test]
+fn an_explicit_motion_request_never_reaches_the_model_at_all() {
+    // Latency path AND separation path at once: "Drive forward one meter."
+    // resolves deterministically — zero model calls, the routing reply, and
+    // (self-evidently) no /intent forwarding, because none exists to call.
+    let (mut svc, calls) = service(&["never"]);
+    let mut clk = clock_from(10_000);
+    let (status, body) = handle_request(
+        &mut svc,
+        "POST",
+        "/chat",
+        br#"{"text":"Drive forward one meter."}"#,
+        &mut clk,
+        (WarmState::Ready, "gemma3:4b", None),
+    );
+    assert_eq!(status, "200 OK");
+    let v: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(v["reply"], MOTION_ROUTE_REPLY);
+    assert_eq!(v["timing"]["deterministic"], true);
+    assert_eq!(calls.get(), 0, "motion text must not reach the chat model");
+    assert_eq!(svc.motion_refused(), 1);
+}
+
 // --- 4. endpoint separation ----------------------------------------------------
 
 #[test]
 fn chat_serves_no_intent_surface_at_the_wire() {
-    let (mut svc, _) = service("hello");
+    let (mut svc, _) = service(&["hello"]);
     for (method, path) in [
         ("GET", "/intent/last"),
         ("POST", "/intent"),
         ("GET", "/narration/last"),
     ] {
-        let (status, _) = handle_request(&mut svc, method, path, b"{}", 10_000);
+        let mut clk = clock_from(10_000);
+        let (status, _) = handle_request(
+            &mut svc,
+            method,
+            path,
+            b"{}",
+            &mut clk,
+            (WarmState::Ready, "m", None),
+        );
         assert_eq!(
             status, "404 Not Found",
             "{method} {path} must not exist on chat"
@@ -182,17 +234,23 @@ fn chat_serves_no_intent_surface_at_the_wire() {
 #[test]
 fn chat_requests_touch_no_intent_state_because_none_exists() {
     // The type-level fact, asserted as behavior: ChatService owns sessions
-    // and a guard counter — nothing else. Drive many turns and observe the
-    // only state that exists is conversational.
-    let (mut svc, _) = service("fine");
+    // and counters — nothing else. Stateless by default, so even session
+    // state stays empty across turns.
+    let (mut svc, _) = service(&["fine. "]);
     for i in 0..5u64 {
         let req = ChatRequest {
-            text: format!("turn {i}"),
+            text: format!("turn {i} says something new"),
             session_id: None,
+            max_output_tokens: None,
         };
-        svc.handle_chat(&req, 10_000 + i * 2_000).unwrap();
+        let t = Cell::new(10_000 + i * 2_000);
+        let mut clk = move || {
+            t.set(t.get() + 1);
+            t.get()
+        };
+        let mut emit = |_: &StreamEvent| true;
+        svc.handle_chat_streamed(&req, &mut clk, &mut emit).unwrap();
     }
-    assert_eq!(svc.session_count(), 1);
-    assert_eq!(svc.history_len("default"), 5);
+    assert_eq!(svc.session_count(), 0, "stateless default stores nothing");
     assert_eq!(svc.motion_shape_guarded(), 0);
 }

--- a/deploy/systemd/kirra-mick-chat.service
+++ b/deploy/systemd/kirra-mick-chat.service
@@ -34,11 +34,20 @@ After=ollama.service
 [Service]
 Type=simple
 ExecStart=/opt/kirra/mick_chat_service
+# The LOW-LATENCY defaults, explicit for ops visibility (all overridable in
+# the shared env file below): stateless (history off — remembered turns are
+# prompt-eval latency), short capped replies for spoken interaction, low
+# temperature, and the model held RESIDENT between requests. On start the
+# service runs a one-shot warm-up; GET /health reports warming/ready/degraded
+# honestly (the listener being up is not readiness).
 Environment=KIRRA_MICK_CHAT_ADDR=127.0.0.1:8103
-# Ollama endpoint (default http://localhost:11434) plus the chat-specific
-# knobs (KIRRA_MICK_CHAT_MODEL default gemma3:4b, KIRRA_MICK_CHAT_HISTORY_TURNS
-# default 6, KIRRA_MICK_CHAT_MAX_CHARS default 1000) come from the shared env
-# file. '-' makes it non-fatal if absent.
+Environment=KIRRA_MICK_CHAT_MODEL=gemma3:4b
+Environment=KIRRA_MICK_CHAT_MAX_OUTPUT_TOKENS=48
+Environment=KIRRA_MICK_CHAT_KEEP_ALIVE=30m
+Environment=KIRRA_MICK_CHAT_HISTORY_TURNS=0
+Environment=KIRRA_MICK_CHAT_TEMPERATURE=0.2
+# Ollama endpoint (default http://localhost:11434) and any overrides come from
+# the shared env file. '-' makes it non-fatal if absent.
 EnvironmentFile=-/etc/kirra/kirra.env
 Restart=always
 RestartSec=3

--- a/robot/install/install_robot_units.sh
+++ b/robot/install/install_robot_units.sh
@@ -49,7 +49,8 @@ for f in rabbit_persona.py rabbit_watch.py rabbit_ask.py rabbit_converse.py rabb
          rabbit_latency.py rabbit_stream.py rabbit_tone.py repo_command.py \
          rabbit_model_smoketest.py assistant.py assistant_admission.py \
          assistant_contract.py assistant_report.py assistant_tools.py \
-         mick_chat.py; do
+         mick_chat.py mick_voice_chat.py mick_chat_benchmark.py \
+         mick_voice_benchmark.py; do
   [[ -f "${REPO}/robot/${f}" ]] || { echo "  ⚠ missing ${REPO}/robot/${f} — skipped"; continue; }
   sudo install -m 0755 "${REPO}/robot/${f}" "${OPT}/robot/${f}"
   echo "  installed ${OPT}/robot/${f}"

--- a/robot/mick_chat.py
+++ b/robot/mick_chat.py
@@ -33,6 +33,8 @@ import urllib.error
 import urllib.request
 
 DEFAULT_URL = "http://127.0.0.1:8103"
+# Last turn's server-reported timing (numbers only; module-level for display).
+LAST_TIMING: dict = {}
 # Bounded: a local 4B model can take a while on a busy Orin, but a hung
 # service must hand the terminal back.
 REQUEST_TIMEOUT_S = 90.0
@@ -71,6 +73,9 @@ def post_chat(base_url: str, text: str, timeout_s: float = REQUEST_TIMEOUT_S):
         return None, "malformed response from the chat service"
     if parsed.get("ok") is not True or not isinstance(parsed.get("reply"), str):
         return None, f"unexpected response shape: {sorted(parsed.keys())}"
+    LAST_TIMING.clear()
+    if isinstance(parsed.get("timing"), dict):
+        LAST_TIMING.update(parsed["timing"])
     return parsed["reply"], None
 
 
@@ -94,6 +99,14 @@ def main() -> int:
             print(f"mick_chat: {err}", file=sys.stderr)
             continue
         print(f"Mick: {reply}")
+        # Server-reported stage timings (numbers only, no content).
+        if isinstance(LAST_TIMING.get("ttft_ms"), int):
+            print(
+                "mick_chat: timing "
+                f"ttft={LAST_TIMING.get('ttft_ms')}ms "
+                f"total={LAST_TIMING.get('total_ms')}ms",
+                file=sys.stderr,
+            )
 
 
 if __name__ == "__main__":

--- a/robot/mick_chat_benchmark.py
+++ b/robot/mick_chat_benchmark.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""mick_chat_benchmark.py — measure the Mick chat path, don't guess it.
+
+Two modes:
+
+1. SERVICE benchmark (default): N warm requests against the running
+   mick_chat_service, reporting p50/p90 TTFT and total (both server-reported
+   and client-measured wall), mean reply length, and failures.
+
+       python3 robot/mick_chat_benchmark.py --url http://127.0.0.1:8103 --runs 10
+
+2. MODEL comparison (--compare-models): drive Ollama /api/chat DIRECTLY with
+   the same compact prompt across INSTALLED models (from /api/tags — nothing
+   is ever downloaded), reporting warm TTFT, warm total, and tokens/second
+   per model, optionally with a cold-start figure (--cold unloads the model
+   with keep_alive:0 first — intrusive, off by default).
+
+       python3 robot/mick_chat_benchmark.py --compare-models
+       python3 robot/mick_chat_benchmark.py --compare-models --cold
+
+No transcript persistence; the fixed prompt set is benign and hardcoded.
+Latency numbers belong in benchmark reports, never in CI assertions.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import sys
+import time
+import urllib.error
+import urllib.request
+
+PROMPTS = [
+    "Hello Mick. How are you?",
+    "What can you help me with?",
+    "Tell me something short about robots.",
+    "Thanks for the chat so far.",
+    "Say one sentence about the weather.",
+]
+
+COMPACT_SYSTEM = (
+    "You are Mick, a concise conversational robot assistant. "
+    "Answer naturally in one or two short sentences."
+)
+
+
+def pctl(values: list[float], p: float) -> float:
+    if not values:
+        return float("nan")
+    s = sorted(values)
+    idx = min(len(s) - 1, max(0, round(p / 100.0 * (len(s) - 1))))
+    return s[idx]
+
+
+def bench_service(url: str, runs: int) -> int:
+    ttfts, totals, walls, chars = [], [], [], []
+    failures = 0
+    for i in range(runs):
+        prompt = PROMPTS[i % len(PROMPTS)]
+        body = json.dumps({"text": prompt}).encode()
+        req = urllib.request.Request(url.rstrip("/") + "/chat", data=body,
+                                     headers={"Content-Type": "application/json"},
+                                     method="POST")
+        t0 = time.monotonic()
+        try:
+            with urllib.request.urlopen(req, timeout=120.0) as resp:
+                parsed = json.loads(resp.read())
+        except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as e:
+            failures += 1
+            print(f"  run {i + 1}: FAILED ({e})", file=sys.stderr)
+            continue
+        wall_ms = (time.monotonic() - t0) * 1000.0
+        if parsed.get("ok") is not True:
+            failures += 1
+            continue
+        timing = parsed.get("timing", {})
+        ttfts.append(float(timing.get("ttft_ms", wall_ms)))
+        totals.append(float(timing.get("total_ms", wall_ms)))
+        walls.append(wall_ms)
+        chars.append(len(parsed.get("reply", "")))
+        print(f"  run {i + 1}: ttft={timing.get('ttft_ms')}ms "
+              f"total={timing.get('total_ms')}ms wall={wall_ms:.0f}ms",
+              file=sys.stderr)
+    print(json.dumps({
+        "count": runs,
+        "failures": failures,
+        "p50_ttft_ms": round(pctl(ttfts, 50)),
+        "p90_ttft_ms": round(pctl(ttfts, 90)),
+        "p50_total_ms": round(pctl(totals, 50)),
+        "p90_total_ms": round(pctl(totals, 90)),
+        "p50_wall_ms": round(pctl(walls, 50)),
+        "mean_reply_chars": round(statistics.mean(chars)) if chars else 0,
+    }, indent=2))
+    return 1 if failures else 0
+
+
+def ollama_chat_stream(base: str, model: str, prompt: str,
+                       keep_alive) -> tuple[float, float, int] | None:
+    """One streaming /api/chat run → (ttft_ms, total_ms, tokens)."""
+    body = json.dumps({
+        "model": model, "stream": True, "keep_alive": keep_alive,
+        "options": {"num_predict": 48, "temperature": 0.2},
+        "messages": [{"role": "system", "content": COMPACT_SYSTEM},
+                     {"role": "user", "content": prompt}],
+    }).encode()
+    req = urllib.request.Request(base.rstrip("/") + "/api/chat", data=body,
+                                 headers={"Content-Type": "application/json"})
+    t0 = time.monotonic()
+    ttft = None
+    tokens = 0
+    try:
+        with urllib.request.urlopen(req, timeout=300.0) as resp:
+            for line in resp:
+                if not line.strip():
+                    continue
+                parsed = json.loads(line)
+                if parsed.get("message", {}).get("content"):
+                    tokens += 1
+                    if ttft is None:
+                        ttft = (time.monotonic() - t0) * 1000.0
+                if parsed.get("done"):
+                    break
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError):
+        return None
+    total = (time.monotonic() - t0) * 1000.0
+    return (ttft or total, total, tokens)
+
+
+def compare_models(base: str, cold: bool) -> int:
+    try:
+        with urllib.request.urlopen(base.rstrip("/") + "/api/tags", timeout=10.0) as r:
+            models = [m["name"] for m in json.loads(r.read()).get("models", [])]
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as e:
+        print(f"cannot list installed models: {e}", file=sys.stderr)
+        return 1
+    if not models:
+        print("no models installed", file=sys.stderr)
+        return 1
+    print(f"installed models: {models}", file=sys.stderr)
+    results = []
+    for model in models:
+        row = {"model": model}
+        if cold:
+            # Unload, then measure the first request (cold start). Intrusive.
+            ollama_chat_stream(base, model, "hi", 0)
+            time.sleep(1.0)
+            r = ollama_chat_stream(base, model, PROMPTS[0], "10m")
+            row["cold_total_ms"] = round(r[1]) if r else None
+        # One warm-up, then measured warm runs.
+        ollama_chat_stream(base, model, "hi", "10m")
+        ttfts, totals, tokrates = [], [], []
+        for prompt in PROMPTS[:3]:
+            r = ollama_chat_stream(base, model, prompt, "10m")
+            if r is None:
+                continue
+            ttft, total, tokens = r
+            ttfts.append(ttft)
+            totals.append(total)
+            if total > ttft and tokens > 1:
+                tokrates.append((tokens - 1) / ((total - ttft) / 1000.0))
+        if ttfts:
+            row.update({
+                "warm_ttft_ms": round(statistics.mean(ttfts)),
+                "warm_total_ms": round(statistics.mean(totals)),
+                "tokens_per_s": round(statistics.mean(tokrates), 1) if tokrates else None,
+            })
+        else:
+            row["error"] = "all runs failed"
+        results.append(row)
+        print(f"  {row}", file=sys.stderr)
+    print(json.dumps(results, indent=2))
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Mick chat latency benchmark")
+    ap.add_argument("--url", default=os.environ.get("KIRRA_MICK_CHAT_URL",
+                                                    "http://127.0.0.1:8103"))
+    ap.add_argument("--runs", type=int, default=10)
+    ap.add_argument("--compare-models", action="store_true")
+    ap.add_argument("--ollama-url", default=os.environ.get("KIRRA_OLLAMA_URL",
+                                                           "http://127.0.0.1:11434"))
+    ap.add_argument("--cold", action="store_true",
+                    help="also measure cold start (unloads models; intrusive)")
+    args = ap.parse_args()
+    if args.compare_models:
+        return compare_models(args.ollama_url, args.cold)
+    return bench_service(args.url, args.runs)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/robot/mick_voice_benchmark.py
+++ b/robot/mick_voice_benchmark.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""mick_voice_benchmark.py — repeatable voice-stage latency measurement from a
+pre-recorded WAV fixture (no speaking, no microphone, no motion).
+
+    python3 robot/mick_voice_benchmark.py --wav /tmp/kirra-test.wav \
+        --chat-url http://127.0.0.1:8103
+
+Stages measured (monotonic; names + durations only, never content):
+
+    stt_ms                KIRRA_STT_CMD over the fixture
+    chat_ttft_ms          transcript POSTed → first streamed text
+    first_sentence_ms     transcript POSTed → first speakable chunk
+    tts_start_ms          first sentence → TTS process spawned
+    first_audio_ms        first RAW AUDIO bytes out of the TTS engine —
+                          requires KIRRA_TTS_STREAM_CMD (a command that
+                          writes raw audio to stdout, e.g.
+                          "piper --model … --output-raw"); with only a
+                          play-through KIRRA_TTS_CMD this is reported null
+    voice_to_first_audio_ms   transcript-ready → first audio bytes
+    voice_total_ms        fixture in → reply complete (audio drained)
+
+Run it several times; the first run after idle shows the cold model, the rest
+show the warm path. No transcripts or replies are persisted or logged.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+
+
+def sse_events(resp):
+    event, data = None, None
+    for raw in resp:
+        line = raw.decode("utf-8", "replace").rstrip("\r\n")
+        if line.startswith("event: "):
+            event = line[7:]
+        elif line.startswith("data: "):
+            data = line[6:]
+        elif line == "" and event is not None:
+            try:
+                yield event, json.loads(data or "{}")
+            except json.JSONDecodeError:
+                return
+            event, data = None, None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="voice-stage latency benchmark (WAV fixture)")
+    ap.add_argument("--wav", required=True)
+    ap.add_argument("--chat-url", default=os.environ.get("KIRRA_MICK_CHAT_URL",
+                                                         "http://127.0.0.1:8103"))
+    ap.add_argument("--no-tts", action="store_true")
+    args = ap.parse_args()
+
+    report: dict[str, object] = {}
+    t_start = time.monotonic()
+
+    # --- STT over the fixture ------------------------------------------------
+    stt = os.environ.get("KIRRA_STT_CMD")
+    if not stt:
+        print("KIRRA_STT_CMD is required (wav path appended)", file=sys.stderr)
+        return 1
+    t0 = time.monotonic()
+    try:
+        p = subprocess.run(  # noqa: S603 — operator-configured argv
+            shlex.split(stt) + [args.wav], capture_output=True, text=True,
+            timeout=300.0)
+    except (subprocess.TimeoutExpired, OSError) as e:
+        print(f"STT failed: {e}", file=sys.stderr)
+        return 1
+    transcript = " ".join(p.stdout.split()).strip()
+    report["stt_ms"] = round((time.monotonic() - t0) * 1000.0)
+    if not transcript:
+        print("STT produced an empty transcript", file=sys.stderr)
+        return 1
+    t_transcript = time.monotonic()
+
+    # --- streamed chat + (optional) TTS -------------------------------------
+    tts_stream_cmd = None if args.no_tts else os.environ.get("KIRRA_TTS_STREAM_CMD")
+    tts_cmd = None if args.no_tts else os.environ.get("KIRRA_TTS_CMD")
+    body = json.dumps({"text": transcript}).encode()
+    req = urllib.request.Request(args.chat_url.rstrip("/") + "/chat/stream",
+                                 data=body,
+                                 headers={"Content-Type": "application/json"},
+                                 method="POST")
+    tts_proc = None
+    aplay = None
+    first_sentence_t = None
+    tts_start_t = None
+    first_audio_t = None
+    try:
+        with urllib.request.urlopen(req, timeout=300.0) as resp:
+            for event, data in sse_events(resp):
+                now = time.monotonic()
+                if event == "done":
+                    report["chat_ttft_ms"] = data.get("ttft_ms")
+                    report["chat_total_ms"] = data.get("total_ms")
+                elif event == "sentence" and data.get("text"):
+                    if first_sentence_t is None:
+                        first_sentence_t = now
+                        report["first_sentence_ms"] = round(
+                            (now - t_transcript) * 1000.0)
+                    if tts_proc is None and (tts_stream_cmd or tts_cmd):
+                        cmd = tts_stream_cmd or tts_cmd
+                        tts_proc = subprocess.Popen(  # noqa: S603
+                            shlex.split(cmd), stdin=subprocess.PIPE,
+                            stdout=subprocess.PIPE if tts_stream_cmd else subprocess.DEVNULL,
+                            stderr=subprocess.DEVNULL)
+                        tts_start_t = time.monotonic()
+                        report["tts_start_ms"] = round(
+                            (tts_start_t - first_sentence_t) * 1000.0)
+                    if tts_proc is not None and tts_proc.stdin is not None:
+                        try:
+                            tts_proc.stdin.write(
+                                (data["text"].strip() + "\n").encode())
+                            tts_proc.stdin.flush()
+                        except (BrokenPipeError, OSError):
+                            pass
+                        # Raw-audio seam: first bytes out = first audio.
+                        if (tts_stream_cmd and first_audio_t is None
+                                and tts_proc.stdout is not None):
+                            if aplay is None:
+                                aplay = subprocess.Popen(  # noqa: S603
+                                    ["aplay", "-q", "-r", "22050", "-f",
+                                     "S16_LE", "-t", "raw", "-"],
+                                    stdin=subprocess.PIPE,
+                                    stdout=subprocess.DEVNULL,
+                                    stderr=subprocess.DEVNULL)
+                            chunk = tts_proc.stdout.read(4096)
+                            if chunk:
+                                first_audio_t = time.monotonic()
+                                report["first_audio_ms"] = round(
+                                    (first_audio_t - tts_start_t) * 1000.0)
+                                report["voice_to_first_audio_ms"] = round(
+                                    (first_audio_t - t_transcript) * 1000.0)
+                                if aplay.stdin is not None:
+                                    aplay.stdin.write(chunk)
+    except (urllib.error.URLError, TimeoutError) as e:
+        print(f"chat stream failed: {e}", file=sys.stderr)
+        return 1
+    finally:
+        for proc in (tts_proc, aplay):
+            if proc is not None:
+                try:
+                    if proc.stdin is not None:
+                        proc.stdin.close()
+                    if proc is tts_proc and tts_stream_cmd and proc.stdout and aplay:
+                        # Drain remaining audio through the player.
+                        while True:
+                            chunk = proc.stdout.read(8192)
+                            if not chunk:
+                                break
+                            if aplay.stdin is not None:
+                                aplay.stdin.write(chunk)
+                        if aplay.stdin is not None:
+                            aplay.stdin.close()
+                    proc.wait(timeout=60.0)
+                except (subprocess.TimeoutExpired, OSError):
+                    proc.kill()
+
+    if "first_audio_ms" not in report:
+        report["first_audio_ms"] = None
+        report["voice_to_first_audio_ms"] = None
+    report["voice_total_ms"] = round((time.monotonic() - t_start) * 1000.0)
+    print(json.dumps(report, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/robot/mick_voice_chat.py
+++ b/robot/mick_voice_chat.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""mick_voice_chat.py — low-latency SPOKEN conversation with Mick.
+
+The fast path this client exists for:
+
+    transcript → POST /chat/stream (SSE) → sentence chunks → ONE TTS process
+                                                             per reply, fed
+                                                             incrementally
+
+The user hears the FIRST sentence while the model is still generating the
+rest, and the TTS engine (piper via KIRRA_TTS_CMD) is spawned once per reply
+— not once per sentence — so its model load is paid once per turn.
+
+Inputs (two modes, both repeatable without a microphone):
+  * default: one TRANSCRIPT per line on stdin (the rabbit_converse seam — any
+    trigger/recorder/STT front-end can pipe in);
+  * --wav FILE: transcribe FILE once via KIRRA_STT_CMD, run one turn, exit
+    (the voice-benchmark fixture mode).
+
+🔴 SEPARATION: talks ONLY to the conversational sidecar (default
+http://127.0.0.1:8103, override KIRRA_MICK_CHAT_URL). No fallback to the
+motion door — its path never appears in this file (host-tested). No shell
+strings, no transcript persistence.
+
+TIMING: every stage is measured on time.monotonic and logged to stderr as
+STAGE NAMES AND DURATIONS ONLY — transcript and reply text are never logged.
+Stages: stt_started/transcript_ready (wav mode), chat_request_started,
+first_text_received, first_sentence_ready, tts_started, first_audio_written,
+response_audio_complete → summary line with chat_ttft_ms, first_sentence_ms,
+tts_first_audio_ms, voice_to_first_audio_ms, voice_total_ms.
+
+Optional immediate acknowledgement: KIRRA_CHAT_ACK_TONE=1 plays a short
+locally generated tone (via aplay) the moment a turn starts — a nonverbal
+"heard you" while the model thinks. Off by default; it must never mask the
+mic (it plays once, ~120 ms, on the speaker).
+
+Env:
+  KIRRA_MICK_CHAT_URL           default http://127.0.0.1:8103
+  KIRRA_TTS_CMD                 text lines on stdin → audio out (speak.sh)
+  KIRRA_STT_CMD                 --wav mode only; wav path appended
+  KIRRA_CHAT_ACK_TONE           1 → play the ack tone (default off)
+  KIRRA_CHAT_TTS_CHUNK_MIN_CHARS / _MAX_CHARS   client-side re-chunk bounds
+                                (defaults 20 / 120; server sentences are
+                                usually already right-sized)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import shlex
+import struct
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+
+DEFAULT_URL = "http://127.0.0.1:8103"
+REQUEST_TIMEOUT_S = 90.0
+
+
+def log_stage(name: str, ms: float) -> None:
+    """Stage telemetry: name + duration only. NEVER content."""
+    print(f"mick_voice_chat: stage {name} {ms:.0f}ms", file=sys.stderr, flush=True)
+
+
+def chat_url() -> str:
+    return (os.environ.get("KIRRA_MICK_CHAT_URL") or DEFAULT_URL).rstrip("/")
+
+
+def ack_tone() -> None:
+    """~120 ms locally generated sine via aplay. Best-effort, nonverbal, and
+    never blocks the turn — a broken speaker must not add latency."""
+    if (os.environ.get("KIRRA_CHAT_ACK_TONE") or "") not in ("1", "true"):
+        return
+    rate, dur_s, freq = 22050, 0.12, 880.0
+    n = int(rate * dur_s)
+    pcm = b"".join(
+        struct.pack("<h", int(12000 * math.sin(2 * math.pi * freq * i / rate) *
+                              min(1.0, (n - i) / (0.25 * n))))
+        for i in range(n)
+    )
+    try:
+        subprocess.Popen(  # noqa: S603 — fixed argv, no shell
+            ["aplay", "-q", "-r", str(rate), "-f", "S16_LE", "-t", "raw", "-"],
+            stdin=subprocess.PIPE, stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        ).communicate(pcm, timeout=2.0)
+    except Exception:  # noqa: BLE001 — the tone is UX, never load-bearing
+        pass
+
+
+def sse_events(resp):
+    """Parse an SSE byte stream into (event, data-dict) pairs, incrementally.
+    Malformed data lines end the stream (the caller falls back gracefully)."""
+    event, data = None, None
+    for raw in resp:
+        line = raw.decode("utf-8", "replace").rstrip("\n").rstrip("\r")
+        if line.startswith("event: "):
+            event = line[7:]
+        elif line.startswith("data: "):
+            data = line[6:]
+        elif line == "" and event is not None:
+            try:
+                yield event, json.loads(data or "{}")
+            except json.JSONDecodeError:
+                return  # malformed stream → stop consuming, fail soft
+            event, data = None, None
+
+
+class TtsPipe:
+    """ONE TTS process per reply. Sentences are written as lines the moment
+    they arrive; piper synthesizes line by line, so audio starts on the first
+    sentence. Teardown is bounded; a dead TTS never wedges the turn."""
+
+    def __init__(self, cmd: str):
+        self.first_write_ms: float | None = None
+        self.proc = subprocess.Popen(  # noqa: S603 — operator-configured argv
+            shlex.split(cmd), stdin=subprocess.PIPE,
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+    def say(self, sentence: str) -> None:
+        if self.proc.stdin is None:
+            return
+        try:
+            self.proc.stdin.write((sentence.strip() + "\n").encode("utf-8"))
+            self.proc.stdin.flush()
+            if self.first_write_ms is None:
+                self.first_write_ms = time.monotonic() * 1000.0
+        except (BrokenPipeError, OSError):
+            pass  # TTS died — keep the turn alive, text still printed
+
+    def close(self, timeout_s: float = 30.0) -> None:
+        try:
+            if self.proc.stdin is not None:
+                self.proc.stdin.close()
+            self.proc.wait(timeout=timeout_s)
+        except subprocess.TimeoutExpired:
+            self.proc.kill()
+        except OSError:
+            pass
+
+
+def run_turn(base_url: str, text: str, tts_cmd: str | None) -> bool:
+    """One spoken turn. Returns False on transport failure (caller decides)."""
+    t0 = time.monotonic() * 1000.0
+    ack_tone()
+    body = json.dumps({"text": text}).encode("utf-8")
+    req = urllib.request.Request(
+        base_url + "/chat/stream", data=body,
+        headers={"Content-Type": "application/json"}, method="POST")
+    log_stage("chat_request_started", 0.0)
+    tts: TtsPipe | None = None
+    first_text_ms = first_sentence_ms = None
+    ok = False
+    try:
+        with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT_S) as resp:
+            for event, data in sse_events(resp):
+                now = time.monotonic() * 1000.0
+                if event == "delta" and first_text_ms is None:
+                    first_text_ms = now - t0
+                    log_stage("first_text_received", first_text_ms)
+                elif event == "sentence":
+                    sent = data.get("text", "")
+                    if not sent:
+                        continue
+                    if first_sentence_ms is None:
+                        first_sentence_ms = now - t0
+                        log_stage("first_sentence_ready", first_sentence_ms)
+                    print(f"Mick: {sent}")
+                    if tts_cmd and tts is None:
+                        tts = TtsPipe(tts_cmd)
+                        log_stage("tts_started", time.monotonic() * 1000.0 - t0)
+                    if tts is not None:
+                        tts.say(sent)
+                        if tts.first_write_ms is not None:
+                            log_stage("first_audio_written",
+                                      tts.first_write_ms - t0)
+                elif event == "done":
+                    ok = True
+                    log_stage("chat_ttft_ms", float(data.get("ttft_ms", 0)))
+                    log_stage("chat_total_ms", float(data.get("total_ms", 0)))
+    except urllib.error.HTTPError as e:
+        print(f"mick_voice_chat: HTTP {e.code}", file=sys.stderr)
+    except (urllib.error.URLError, TimeoutError) as e:
+        print(f"mick_voice_chat: cannot reach {base_url} ({e})", file=sys.stderr)
+    finally:
+        if tts is not None:
+            tts.close()
+            log_stage("response_audio_complete", time.monotonic() * 1000.0 - t0)
+    total = time.monotonic() * 1000.0 - t0
+    if ok:
+        first_audio = (tts.first_write_ms - t0) if tts and tts.first_write_ms else None
+        summary = (
+            f"voice_total_ms={total:.0f}"
+            + (f" first_sentence_ms={first_sentence_ms:.0f}" if first_sentence_ms else "")
+            + (f" voice_to_first_audio_ms={first_audio:.0f}" if first_audio else "")
+        )
+        print(f"mick_voice_chat: summary {summary}", file=sys.stderr, flush=True)
+    return ok
+
+
+def transcribe_wav(wav_path: str) -> str | None:
+    """--wav mode: run KIRRA_STT_CMD (wav path appended) and time it."""
+    stt = os.environ.get("KIRRA_STT_CMD")
+    if not stt:
+        print("mick_voice_chat: KIRRA_STT_CMD required for --wav", file=sys.stderr)
+        return None
+    t0 = time.monotonic() * 1000.0
+    log_stage("stt_started", 0.0)
+    try:
+        p = subprocess.run(  # noqa: S603 — operator-configured argv
+            shlex.split(stt) + [wav_path], capture_output=True, text=True,
+            timeout=120.0)
+    except (subprocess.TimeoutExpired, OSError) as e:
+        print(f"mick_voice_chat: STT failed ({e})", file=sys.stderr)
+        return None
+    log_stage("transcript_ready", time.monotonic() * 1000.0 - t0)
+    text = " ".join(p.stdout.split()).strip()
+    return text or None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="spoken conversation with Mick (chat only, no motion)")
+    ap.add_argument("--wav", help="transcribe this WAV once, run one turn, exit")
+    ap.add_argument("--no-tts", action="store_true", help="print only, no speech")
+    args = ap.parse_args()
+    base = chat_url()
+    tts_cmd = None if args.no_tts else os.environ.get("KIRRA_TTS_CMD")
+    if tts_cmd is None and not args.no_tts:
+        print("mick_voice_chat: KIRRA_TTS_CMD unset — printing only",
+              file=sys.stderr)
+    if args.wav:
+        text = transcribe_wav(args.wav)
+        if text is None:
+            return 1
+        return 0 if run_turn(base, text, tts_cmd) else 1
+    print("mick_voice_chat: transcript lines on stdin → spoken replies "
+          "(conversation only; motion uses the governed door). Ctrl-D quits.",
+          file=sys.stderr)
+    for line in sys.stdin:
+        text = line.strip()
+        if text:
+            run_turn(base, text, tts_cmd)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/robot/mick_voice_chat_test.py
+++ b/robot/mick_voice_chat_test.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Host tests for robot/mick_voice_chat.py — the low-latency spoken chat
+client. A stub SSE server stands in for mick_chat_service and a fake TTS
+command records WHEN each sentence reached it, so the latency-bearing claims
+are proven, not asserted:
+
+  * the first sentence reaches TTS BEFORE the stream completes (no
+    wait-for-full-reply);
+  * exactly one TTS process per reply;
+  * timeouts and malformed streams fail soft;
+  * only /chat/stream is ever contacted (never the motion endpoint — which is
+    also unreferenced in the client source);
+  * no transcript text appears in the timing logs, and nothing is written to
+    disk by the client.
+
+Runs standalone (`python3 robot/mick_voice_chat_test.py`, exit 1 on any
+failure); also importable under pytest.
+"""
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+import tempfile
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import mick_voice_chat  # noqa: E402
+
+SEEN_PATHS: list[str] = []
+STREAM_DONE_AT: list[float] = []
+
+
+def sse(event: str, data: dict) -> bytes:
+    return f"event: {event}\ndata: {json.dumps(data)}\n\n".encode()
+
+
+class StubHandler(BaseHTTPRequestHandler):
+    """Streams two sentences with a real delay between them, recording when
+    the stream finished — the ordering proof's reference point."""
+
+    mode = "ok"
+
+    def do_POST(self):  # noqa: N802
+        SEEN_PATHS.append(self.path)
+        length = int(self.headers.get("Content-Length", 0))
+        body = json.loads(self.rfile.read(length))
+        assert "text" in body
+        if self.mode == "malformed":
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.end_headers()
+            self.wfile.write(b"event: sentence\ndata: not json\n\n")
+            return
+        if self.mode == "slow":
+            time.sleep(2.0)
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.end_headers()
+        try:
+            self.wfile.write(sse("start", {"request_id": "1"}))
+            self.wfile.write(sse("delta", {"text": "First sentence here. "}))
+            self.wfile.write(sse("sentence", {"text": "First sentence here."}))
+            self.wfile.flush()
+            time.sleep(0.4)  # the model is "still generating"
+            self.wfile.write(sse("delta", {"text": "Second one arrives later."}))
+            self.wfile.write(sse("sentence", {"text": "Second one arrives later."}))
+            self.wfile.write(sse("done", {"ttft_ms": 10, "total_ms": 450}))
+            self.wfile.flush()
+            STREAM_DONE_AT.append(time.monotonic())
+        except BrokenPipeError:
+            pass
+
+    def log_message(self, *_args):
+        pass
+
+
+def _serve() -> tuple[HTTPServer, str]:
+    srv = HTTPServer(("127.0.0.1", 0), StubHandler)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    return srv, f"http://127.0.0.1:{srv.server_port}"
+
+
+def _fake_tts(tmp: Path) -> tuple[str, Path]:
+    """A TTS stand-in that timestamps each received line."""
+    log = tmp / "tts.log"
+    script = tmp / "fake_tts.py"
+    script.write_text(
+        "import sys, time\n"
+        "with open(sys.argv[1], 'a') as f:\n"
+        "    for line in sys.stdin:\n"
+        "        f.write(f'{time.monotonic()} {len(line.strip())}\\n')\n"
+        "        f.flush()\n"
+    )
+    return f"{sys.executable} {script} {log}", log
+
+
+def test_first_sentence_reaches_tts_before_stream_completes() -> None:
+    srv, url = _serve()
+    with tempfile.TemporaryDirectory() as d:
+        tts_cmd, log = _fake_tts(Path(d))
+        try:
+            StubHandler.mode = "ok"
+            STREAM_DONE_AT.clear()
+            real_out = sys.stdout
+            sys.stdout = io.StringIO()
+            try:
+                ok = mick_voice_chat.run_turn(url, "how are you doing", tts_cmd)
+            finally:
+                printed = sys.stdout.getvalue()
+                sys.stdout = real_out
+            assert ok, "the turn must succeed"
+            lines = log.read_text().splitlines()
+            assert len(lines) == 2, f"two sentences must reach TTS: {lines}"
+            first_tts_at = float(lines[0].split()[0])
+            assert STREAM_DONE_AT, "stub never finished?"
+            assert first_tts_at < STREAM_DONE_AT[0], (
+                "the first sentence must reach TTS BEFORE the stream completes "
+                f"(tts@{first_tts_at} vs done@{STREAM_DONE_AT[0]})"
+            )
+            assert "Mick: First sentence here." in printed
+        finally:
+            srv.shutdown()
+
+
+def test_timeout_fails_soft() -> None:
+    srv, url = _serve()
+    try:
+        StubHandler.mode = "slow"
+        old = mick_voice_chat.REQUEST_TIMEOUT_S
+        mick_voice_chat.REQUEST_TIMEOUT_S = 0.3
+        try:
+            ok = mick_voice_chat.run_turn(url, "hello there", None)
+        finally:
+            mick_voice_chat.REQUEST_TIMEOUT_S = old
+        assert not ok, "a timeout must not report success"
+    finally:
+        srv.shutdown()
+
+
+def test_malformed_stream_fails_soft_without_crash() -> None:
+    srv, url = _serve()
+    try:
+        StubHandler.mode = "malformed"
+        ok = mick_voice_chat.run_turn(url, "hello again", None)
+        assert not ok
+    finally:
+        srv.shutdown()
+
+
+def test_unreachable_service_fails_soft() -> None:
+    assert not mick_voice_chat.run_turn("http://127.0.0.1:1", "hello", None)
+
+
+def test_only_chat_stream_is_ever_contacted() -> None:
+    assert SEEN_PATHS, "suite wiring broken — stub saw nothing"
+    assert set(SEEN_PATHS) == {"/chat/stream"}, f"unexpected: {set(SEEN_PATHS)}"
+
+
+def test_timing_logs_never_carry_transcript_text() -> None:
+    srv, url = _serve()
+    try:
+        StubHandler.mode = "ok"
+        utterance = "zebra quantum waffle transcript"
+        real_err, real_out = sys.stderr, sys.stdout
+        sys.stderr = io.StringIO()
+        sys.stdout = io.StringIO()
+        try:
+            mick_voice_chat.run_turn(url, utterance, None)
+        finally:
+            err = sys.stderr.getvalue()
+            sys.stderr, sys.stdout = real_err, real_out
+        for word in utterance.split():
+            assert word not in err, f"transcript word {word!r} leaked into timing logs"
+        assert "stage" in err and "ms" in err, "stage timings must be logged"
+    finally:
+        srv.shutdown()
+
+
+def test_client_writes_no_files_and_references_no_motion_endpoint() -> None:
+    src = Path(mick_voice_chat.__file__).read_text()
+    code = "\n".join(line.split("#")[0] for line in src.splitlines())
+    needle = "/int" + "ent"
+    assert needle not in code, "client references the motion endpoint"
+    import re
+    assert not re.search(r"(?<![\w.])open\(", code), "client must not open files"
+    assert "os.system" not in code and "shell=True" not in code
+
+
+# --- standalone runner (house pattern) ----------------------------------------
+
+def _run_all() -> int:
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"  ok  {name}")
+            except AssertionError as e:
+                failures += 1
+                print(f"FAIL  {name}: {e}")
+    print("mick_voice_chat_test:", "ALL OK" if failures == 0 else f"{failures} FAILURE(S)")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_run_all())


### PR DESCRIPTION
## Stacked on #1283

This PR **stacks on #1283** (the conversational sidecar) — its base branch is `feat/mick-conversation-sidecar`, so the diff shows only the latency work. When #1283 merges, GitHub retargets this to `main`. Rebuilding from `main` would have produced a second, conflicting implementation of the same files.

## Objective

Optimize **time to first audible response** for spoken conversation with Mick, with the `/intent` separation untouched and re-fenced. Instrumentation and benchmarks land **before** tuning claims — no hardware numbers are asserted anywhere in this PR.

## What changed (each lever test-pinned)

**Latency levers**
- **Stateless by default** (`KIRRA_MICK_CHAT_HISTORY_TURNS=0`); optional history hard-capped at **2** pairs — a larger value is a **boot error**, because remembered turns are prompt-eval latency on every request.
- **Compact system prompt**, length-pinned ≤ 400 chars (prompt tokens are TTFT); still denies motion authority + invented state, still teaches no intent wire forms.
- **Output capped**: `num_predict` default 48, temperature 0.2; per-request `max_output_tokens` can only *reduce* the cap (test-pinned).
- **Model residency**: `keep_alive` (default 30m) on every request + one-shot boot **warm-up**; `GET /health` reports `warming` / `ready` (+`warmup_ms`) / `degraded (OLLAMA_UNAVAILABLE)` honestly — a listening socket is not readiness. `KIRRA_MICK_CHAT_WARMUP=0` is the explicit fail-soft opt-out.
- **Streaming end to end**: transport streams Ollama `/api/chat` NDJSON (still **no `format`** constraint — pinned) with **cancellation** (`on_delta → false` drops the response, aborting Ollama's decode; proven against a loopback stub). `POST /chat/stream` emits SSE `start`/`delta`/`sentence`/`done`; the `done` event carries `ttft_ms`/`first_sentence_ms`/`total_ms` and **never content** (pinned). `POST /chat` collects the same stream and returns `reply` + `timing`.
- **Sentence chunker** (pure): `.?!;:` boundaries, 20–120 char bounds, decimal-safe (`3.5` never splits), word-boundary fallback for punctuation-free runs.
- **Deterministic fast routes** (zero model calls, `ttft_ms: 0`): `hello/hi/hey`, `thanks/thank you`, `goodbye/bye` — a deliberately tiny table; plus a **conservative leading-verb motion detector** that refuses explicit motion requests with `"That needs the governed motion path."` — chat never forwards to the motion door (none is callable), and non-leading mentions ("how do I stop the recording") still reach the model.
- **Streaming-aware output guard**: a reply opening with `{` or a code fence is **held back** (no deltas leak), guarded whole; motion-shaped JSON → the routing refusal; harmless held-back JSON is released late. The live `{"intent":"cruise","target_speed_mps":10}` remains the end-to-end regression.
- **Concurrency**: single-threaded serve loop = structurally **one in-flight** model request (`CHAT_MAX_INFLIGHT=1`); a client hanging up mid-stream cancels generation via the failed sink write; shutdown closes connections promptly.

**Voice + measurement tooling**
- `robot/mick_voice_chat.py` — the spoken fast path: transcript in (stdin lines, or `--wav` via `KIRRA_STT_CMD`), `/chat/stream` SSE, sentences fed to **one TTS process per reply** as they arrive (piper synthesizes line-by-line: model load paid once per turn, audio starts on sentence one). Optional locally-generated ack tone (`KIRRA_CHAT_ACK_TONE`, default off, nonverbal, non-blocking). Stage logs are names+durations only — transcript-free, test-pinned. `rabbit_converse.py` and the whole Rabbit path are **untouched**.
- `robot/mick_chat_benchmark.py` — N warm runs → p50/p90 TTFT/total, mean reply chars, failures; `--compare-models` drives Ollama directly across **installed** models (never downloads) for warm TTFT/total/tokens-per-sec, optional `--cold`.
- `robot/mick_voice_benchmark.py` — WAV-fixture voice stages: `stt_ms`, chat TTFT, first sentence, TTS start, first audio (via a raw-audio `KIRRA_TTS_STREAM_CMD` seam; honestly `null` with a play-through TTS), `voice_to_first_audio_ms`, totals.
- Host test proof (stub SSE server + timestamping fake TTS): **the first sentence reaches TTS before the stream completes** — the low-latency claim as an assertion, not a hope.

## Investigation findings (code evidence; hardware measurement deferred to the Jetson)

1. **Model unloading**: yes — the Rust chat/motion transports sent no `keep_alive`, so Ollama's ~5-min default applied (the Rabbit Python path already pins 30m). Fixed for chat.
2. **Streaming reliability**: proven in-repo — `rabbit_stream.py` already streams `/api/chat` against gemma3:4b.
3. **Incremental TTS**: `rabbit_stream.py`'s pattern exists for Rabbit's JSON router; the chat path gets a simpler server-side chunker since replies are plain text.
4. **Piper reload**: `speak.sh` spawns piper per invocation → model load per call. This PR pays it once per *reply* (line-streamed stdin); a persistent cross-turn TTS daemon is a documented follow-up, not a fragile bolt-on here.
5. **Serialization**: the existing voice path is fully serial; the new client overlaps chat streaming with TTS.
6–8. **Smaller models / GPU offload / dominant stages**: unknowable from the repo — exactly what `--compare-models`, `ollama ps`, and the stage instrumentation exist to answer on hardware. No recommendation is made without measurements; the default stays `gemma3:4b`.

## Tests

`kirra-sidecars` **207/207** (chat core 27 incl. TTFT-stamped-once, chunker matrix, hold-back guard, cancellation, per-request cap clamp, warm/ready/degraded health, SSE wire; separation suite updated) · `kirra-mick` 6/6 + 1 ignored-live (NDJSON parse + cancellation against a TCP stub; latency levers on the wire; no `format`) · `kirra-planner mick` 75/75 · both governed-loop suites 3/3 · `ci/check_mick_actuation_fence.py` **INTACT** · `mick_chat_test.py` 8/8 · `mick_voice_chat_test.py` 7/7 (in CI) · `staging_completeness` green · fmt/clippy(`-D warnings`)/shellcheck/`git diff --check`/markers all clean.

## Acceptance targets

Recorded as optimization goals for the Jetson benchmark reports (TTFT ≤ 500 ms target / ≤ 1 s acceptable; first sentence ≤ 1.2 s; short-reply total ≤ 2.5 s; transcript→first-audio ≤ 1.8 s). **Deliberately not CI assertions** — hardware timing belongs in benchmark output, and no "fast" claim is made until measured.

## Jetson deployment + benchmarks (after merge; not run during repo work)

```bash
cd "$HOME/kirra-runtime-sdk" && git switch main && git pull --ff-only
cargo build --release -p kirra-sidecars --bin mick_chat_service
sudo install -m 0755 target/release/mick_chat_service /opt/kirra/mick_chat_service
sudo install -m 0644 deploy/systemd/kirra-mick-chat.service /etc/systemd/system/kirra-mick-chat.service
sudo systemctl daemon-reload && sudo systemctl enable --now kirra-mick-chat.service

curl -sS http://127.0.0.1:8103/health | python3 -m json.tool        # warming → ready + warmup_ms
python3 robot/mick_chat_benchmark.py --url http://127.0.0.1:8103 --runs 10
python3 robot/mick_chat_benchmark.py --compare-models               # installed models only
python3 robot/mick_chat.py                                          # harmless chat + timings
curl -sS -X POST http://127.0.0.1:8103/chat -H 'Content-Type: application/json' \
  -d '{"text":"Drive forward one meter."}' | python3 -m json.tool   # deterministic refusal, ttft 0
curl -sS http://127.0.0.1:8102/intent/last | python3 -m json.tool   # motion latch untouched
python3 robot/mick_voice_benchmark.py --wav /tmp/kirra-test.wav --chat-url http://127.0.0.1:8103
```

## Known bottlenecks left for measurement

Piper model load once per reply (follow-up: resident TTS daemon with teardown+tests if measurements show it dominates); STT duration (whisper model size trade); whether a 1B-class installed model beats gemma3:4b on TTFT without unacceptable quality loss (`--compare-models` answers this); GPU offload verification (`ollama ps` on the Jetson).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_