### PR TITLE
docs: record measured Orin voice-latency baselines in RABBIT_AUDIO_STACK

### DIFF
--- a/docs/hardware/RABBIT_AUDIO_STACK.md
+++ b/docs/hardware/RABBIT_AUDIO_STACK.md
@@ -48,7 +48,7 @@ and not a guarantee for other units. Measured with the merged instrumentation
 over a fixed 3 s WAV fixture for the staged voice path — record time excluded by
 construction, so add your record window / VAD time on top).
 
-Configuration: whisper.cpp **CUDA** build (`build/bin/whisper-cli`, `base.en`,
+Configuration: whisper.cpp **CUDA** build (`~/whisper.cpp/build/bin/whisper-cli`, `base.en`,
 `-t 6`), chat sidecar `mick_chat_service` on **`phi3:3.8b`** (48-token cap,
 temperature 0.2, model resident via keep-alive, warmed), piper
 `en_US-lessac-medium` via the raw-stream seam (`KIRRA_TTS_STREAM_CMD` +
@@ -56,7 +56,7 @@ temperature 0.2, model resident via keep-alive, warmed), piper
 
 | Stage | Measured | Notes |
 |---|---|---|
-| STT (whisper `base.en`, CUDA, `-t 6`) | **~515 ms** | same clip took 5 528 ms on the CPU build (3 913 ms with `-t 6`) — the CUDA build is ~7× |
+| STT (whisper `base.en`, CUDA, `-t 6`) | **~515 ms** | same clip took 5528 ms on the CPU build (3913 ms with `-t 6`) — the CUDA build is ~7.6× |
 | Chat TTFT (`phi3:3.8b`, via sidecar) | **~95 ms** | `gemma3:4b` measured ~910 ms on the same rig — its prefill is the outlier, not the sidecar (~30 ms overhead) |
 | Chat first sentence | **~990 ms** | transcript → first complete sentence handed to TTS |
 | Piper synth to first audio | **~785 ms** | first raw PCM bytes out for that sentence |
@@ -87,10 +87,13 @@ KIRRA_STT_CMD="whisper-cli -m models/ggml-base.en.bin -np -nt -f"
 House convention (all engines): the **WAV path is appended as the last argument**;
 STT prints the transcript to stdout. `-np -nt` = no-prints / no-timestamps so only
 the text comes back. Build with CUDA on the Orin if you can — it moves STT from the
-"seconds" column to the "sub-second" column (measured: 3 913 ms → 515 ms on the
+"seconds" column to the "sub-second" column (measured: 3913 ms → 515 ms on the
 same 3 s clip, `base.en` `-t 6`; see the baseline table above). The CUDA binary
-lands in `build/bin/whisper-cli` — point `KIRRA_STT_CMD` at that path in the env
-files, or the services keep running the old CPU binary from `$PATH`.
+lands in `build/bin/` inside the whisper.cpp checkout — point `KIRRA_STT_CMD` at
+it by **absolute path** (e.g. `/home/<user>/whisper.cpp/build/bin/whisper-cli`),
+or install/symlink it over the old binary; a bare `whisper-cli` keeps resolving
+to the old CPU build on `$PATH`, and a relative path fails under systemd (the
+robot scripts exec the command verbatim, from the service's own working dir).
 
 **Recording** is a *bounded* clip — never an open mic:
 ```bash

--- a/docs/hardware/RABBIT_AUDIO_STACK.md
+++ b/docs/hardware/RABBIT_AUDIO_STACK.md
@@ -40,6 +40,34 @@ recipe below). The two dominant terms are the **fixed record window** and the
 > straight to piper. That's why the safety-/reliability-relevant speech is
 > instant and the conversational speech is the only thing that waits.
 
+### Measured baseline — Jetson Orin NX, 2026-08-01
+
+One robot, one day — a **baseline for regression comparison**, not a WCET claim
+and not a guarantee for other units. Measured with the merged instrumentation
+(`robot/mick_chat_benchmark.py` for the text path, `robot/mick_voice_benchmark.py`
+over a fixed 3 s WAV fixture for the staged voice path — record time excluded by
+construction, so add your record window / VAD time on top).
+
+Configuration: whisper.cpp **CUDA** build (`build/bin/whisper-cli`, `base.en`,
+`-t 6`), chat sidecar `mick_chat_service` on **`phi3:3.8b`** (48-token cap,
+temperature 0.2, model resident via keep-alive, warmed), piper
+`en_US-lessac-medium` via the raw-stream seam (`KIRRA_TTS_STREAM_CMD` +
+`--output-raw`). Two consecutive runs agreed within 20 ms.
+
+| Stage | Measured | Notes |
+|---|---|---|
+| STT (whisper `base.en`, CUDA, `-t 6`) | **~515 ms** | same clip took 5 528 ms on the CPU build (3 913 ms with `-t 6`) — the CUDA build is ~7× |
+| Chat TTFT (`phi3:3.8b`, via sidecar) | **~95 ms** | `gemma3:4b` measured ~910 ms on the same rig — its prefill is the outlier, not the sidecar (~30 ms overhead) |
+| Chat first sentence | **~990 ms** | transcript → first complete sentence handed to TTS |
+| Piper synth to first audio | **~785 ms** | first raw PCM bytes out for that sentence |
+| **End of utterance → speech starts** | **~1.8 s** | `voice_to_first_audio_ms`; was ~7–8 s before the CUDA build + model swap |
+
+Notes from the same session: `voice_total_ms` is dominated by *playback duration*
+of the full reply (not latency — don't tune it); the deterministic fast routes
+(greetings, motion refusals) measure `ttft=0 ms` end-to-end as designed; and the
+model-comparison sweep (`mick_chat_benchmark.py --compare-models`) is the tool
+that located the gemma3 prefill outlier — re-run it before blaming the stack.
+
 ---
 
 ## 1. STT — whisper.cpp (`whisper-cli`)
@@ -59,7 +87,10 @@ KIRRA_STT_CMD="whisper-cli -m models/ggml-base.en.bin -np -nt -f"
 House convention (all engines): the **WAV path is appended as the last argument**;
 STT prints the transcript to stdout. `-np -nt` = no-prints / no-timestamps so only
 the text comes back. Build with CUDA on the Orin if you can — it moves STT from the
-"seconds" column to the "sub-second" column.
+"seconds" column to the "sub-second" column (measured: 3 913 ms → 515 ms on the
+same 3 s clip, `base.en` `-t 6`; see the baseline table above). The CUDA binary
+lands in `build/bin/whisper-cli` — point `KIRRA_STT_CMD` at that path in the env
+files, or the services keep running the old CPU binary from `$PATH`.
 
 **Recording** is a *bounded* clip — never an open mic:
 ```bash


### PR DESCRIPTION
## What

Documentation-only: records the first on-hardware voice-latency baselines in `docs/hardware/RABBIT_AUDIO_STACK.md`, measured on the Jetson Orin NX with the instrumentation merged in #1283/#1284 (`robot/mick_chat_benchmark.py`, `robot/mick_voice_benchmark.py`).

## Changes

- **New "Measured baseline — Jetson Orin NX, 2026-08-01" section** under the indicative latency-budget table, explicitly labeled a regression baseline (one robot, one day), not a WCET claim:
  - STT (whisper `base.en`, CUDA build, `-t 6`): **~515 ms** (was 5 528 ms CPU / 3 913 ms CPU `-t 6` on the same 3 s clip)
  - Chat TTFT via the sidecar (`phi3:3.8b`): **~95 ms** (gemma3:4b measured ~910 ms on the same rig — its prefill is the outlier; sidecar overhead ~30 ms)
  - Chat first sentence: **~990 ms**; piper first raw audio: **~785 ms**
  - **End of utterance → speech starts: ~1.8 s** (`voice_to_first_audio_ms`), two consecutive runs within 20 ms
  - Notes: `voice_total_ms` is playback duration (not latency); deterministic fast routes measure `ttft=0 ms`; the `--compare-models` sweep is the tool that located the gemma3 prefill outlier
- **Section 1 CUDA note firmed up** with the measured 3 913 → 515 ms delta and the operational pitfall: the CUDA binary lands in `build/bin/whisper-cli`, so `KIRRA_STT_CMD` must point at that path or services keep running the old CPU binary from `$PATH`.

## Why

The doc's latency table was indicative-only ("measure yours"); these are the first measured numbers, kept next to the recipe so future tuning has a comparison point and the CUDA-build claim carries evidence.

No code changes; no safety-relevant path touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_