### PR TITLE
fix(install): user voice unit loses EnvironmentFile access to /etc/kirra — narrow ACL grant

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1505,6 +1505,15 @@ jobs:
           # `$KIRRA_RECORD_CMD "$wav"` contract, and gates the linter's new
           # unquoted-multi-word check + --fix requoting.
           python3 robot/install/env_quoting_test.py
+          # User voice unit EnvironmentFile access (host, tmpdir ACL fixtures):
+          # the USER unit's env file is opened by the operator's user manager,
+          # not PID 1, so the 0750 /etc/kirra that protects governor secrets
+          # kills it before ExecStart (Result=resources, no log — live R2
+          # failure). Proves the ACL helper grants traverse-only + read-only,
+          # is idempotent, restores after inode replacement, fails closed on
+          # unknown user / missing tools, that lint --fix preserves ACLs, and
+          # the verifier classifier never PASSes an unverified state.
+          python3 robot/install/voice_env_access_test.py
           # mick_chat.py terminal client (host, stub HTTP server — no Ollama):
           # success/malformed/timeout/4xx-5xx/EOF paths, the service error
           # token surfaced, and the SEPARATION proofs — only /chat is ever

--- a/robot/install/ensure_voice_env_access.sh
+++ b/robot/install/ensure_voice_env_access.sh
@@ -59,6 +59,22 @@ fail() { echo "❌ $*" >&2; exit 1; }
 id -u "$TARGET_USER" >/dev/null 2>&1 \
   || fail "service user '$TARGET_USER' does not exist — refusing to grant access to a phantom account"
 
+# Guardrails on the grant TARGET (this runs under sudo — a typo'd --file must
+# not quietly grant read on a secret like kirra.env): the file must be named
+# robot.env, and it must live directly inside --dir. Pure bash expansions
+# (no basename/dirname) so the missing-acl-tools error path stays reachable
+# even on a minimal PATH.
+_file_name="${FILE##*/}"
+_file_parent="${FILE%/*}"; [[ "$_file_parent" == "$FILE" ]] && _file_parent="."
+[[ "$_file_name" == "robot.env" ]] \
+  || fail "refusing --file '$FILE': this helper grants access to robot.env ONLY (never another file — kirra.env holds governor secrets)"
+if [[ -d "$DIR" && -d "$_file_parent" ]]; then
+  _dir_real="$(cd "$DIR" && pwd)"
+  _file_dir_real="$(cd "$_file_parent" && pwd)"
+  [[ "$_file_dir_real" == "$_dir_real" ]] \
+    || fail "refusing: --file '$FILE' is not directly inside --dir '$DIR' (traverse grant and read grant must target the same directory)"
+fi
+
 # Diagnosis helper: can TARGET_USER actually read FILE? Runs the check AS the
 # target user when we are root (the honest test); as ourselves when we ARE the
 # target; otherwise reports that it cannot prove it either way.

--- a/robot/install/ensure_voice_env_access.sh
+++ b/robot/install/ensure_voice_env_access.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# ensure_voice_env_access.sh — grant the USER-unit voice service exactly the
+# filesystem access its EnvironmentFile= needs, and nothing else.
+#
+# WHY: rabbit-voice.service is a USER unit — its EnvironmentFile= is opened by
+# the operator's own `systemd --user` manager, which (unlike PID 1 opening the
+# same path for the system units) is subject to ordinary permission checks.
+# /etc/kirra is legitimately tight: deploy/systemd/install.sh keeps it
+# 0750 kirra:kirra because kirra.env in the same directory holds the governor
+# admin secrets. Result on the live R2: the operator account could not
+# TRAVERSE /etc/kirra, the user manager could not open robot.env, and the unit
+# died before ExecStart with Result=resources / pid=0 and no service log.
+#
+# THE FIX is two narrow POSIX ACL entries — least privilege, not a mode change:
+#     setfacl -m u:<user>:--x /etc/kirra            # traverse ONLY (no listing)
+#     setfacl -m u:<user>:r-- /etc/kirra/robot.env  # read ONLY this file
+# The user still cannot list /etc/kirra and still cannot read kirra.env (0600).
+# Deliberately NOT chmod 0755 on the directory (would expose every future
+# file's name and weaken the governor-secret posture), NOT a kirra-group
+# membership (group read = listing + every future group-readable file), and
+# NOT a default ACL (would grant access to every future file in the dir).
+#
+# ACL durability: chmod/chown from either installer re-running does NOT remove
+# these entries (a chmod only rewrites the ACL mask, and the group bits both
+# installers apply keep traverse effective). What DOES drop the FILE entry is
+# inode replacement — lint_robot_env.sh --fix, sed -i, tee-to-temp-then-rename.
+# lint_robot_env.sh --fix now restores ACLs itself; for anything else, re-run
+# this script (idempotent — setfacl -m updates in place, never duplicates).
+#
+#   sudo robot/install/ensure_voice_env_access.sh                # apply + verify
+#   sudo robot/install/ensure_voice_env_access.sh --user jetson  # explicit user
+#   robot/install/ensure_voice_env_access.sh --check             # read-only diagnosis
+#   sudo robot/install/ensure_voice_env_access.sh --remove       # rollback
+#
+# The service user resolves, in order: --user, $KIRRA_ROBOT_USER, $SUDO_USER,
+# $USER — the same "invoking user" convention install_robot_units.sh renders
+# into the units. --dir/--file exist for the host tests (tmpdir fixtures).
+set -euo pipefail
+
+DIR=/etc/kirra
+FILE=/etc/kirra/robot.env
+TARGET_USER="${KIRRA_ROBOT_USER:-${SUDO_USER:-${USER:-}}}"
+MODE=apply
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --user) TARGET_USER="${2:?--user needs a value}"; shift 2 ;;
+    --dir)  DIR="${2:?--dir needs a value}"; shift 2 ;;
+    --file) FILE="${2:?--file needs a value}"; shift 2 ;;
+    --check)  MODE=check; shift ;;
+    --remove) MODE=remove; shift ;;
+    *) echo "usage: $0 [--user U] [--dir D] [--file F] [--check|--remove]"; exit 2 ;;
+  esac
+done
+
+fail() { echo "❌ $*" >&2; exit 1; }
+
+[[ -n "$TARGET_USER" ]] || fail "cannot resolve the service user (pass --user, or set KIRRA_ROBOT_USER)"
+id -u "$TARGET_USER" >/dev/null 2>&1 \
+  || fail "service user '$TARGET_USER' does not exist — refusing to grant access to a phantom account"
+
+# Diagnosis helper: can TARGET_USER actually read FILE? Runs the check AS the
+# target user when we are root (the honest test); as ourselves when we ARE the
+# target; otherwise reports that it cannot prove it either way.
+as_user() {  # as_user <test-flag> <path>
+  if [[ "$(id -u)" -eq 0 ]]; then
+    runuser -u "$TARGET_USER" -- test "$1" "$2"
+  elif [[ "$(id -un)" == "$TARGET_USER" ]]; then
+    test "$1" "$2"
+  else
+    return 3   # cannot verify from this account
+  fi
+}
+
+diagnose() {
+  # Precise, in causal order: parent traverse → file existence → file read.
+  local rc=0
+  if as_user -x "$DIR"; then
+    echo "  ✔ $TARGET_USER can traverse $DIR"
+  else
+    rc=$?
+    if [[ $rc -eq 3 ]]; then
+      echo "  ⚠ cannot verify as '$TARGET_USER' from this account (run as root or as the user)"
+      return 3
+    fi
+    echo "  ❌ $TARGET_USER cannot traverse $DIR (this is the live-incident failure)"
+    echo "       ↳ fix: sudo $0 --user $TARGET_USER"
+    return 1
+  fi
+  if as_user -e "$FILE"; then
+    if as_user -r "$FILE"; then
+      echo "  ✔ $TARGET_USER can read $FILE"
+      return 0
+    fi
+    echo "  ❌ $TARGET_USER cannot READ $FILE (traverse ok, file mode/ACL blocks it)"
+    echo "       ↳ fix: sudo $0 --user $TARGET_USER"
+    return 1
+  fi
+  echo "  ❌ $FILE does not exist (for $TARGET_USER)"
+  echo "       ↳ fix: run robot/install/install_kirra.sh (renders robot.env if absent), then sudo $0 --user $TARGET_USER"
+  return 1
+}
+
+if [[ "$MODE" == check ]]; then
+  echo "== voice env access check — user: $TARGET_USER, file: $FILE =="
+  diagnose
+  exit $?
+fi
+
+# apply / remove need the ACL tools and the real paths.
+command -v setfacl >/dev/null 2>&1 && command -v getfacl >/dev/null 2>&1 \
+  || fail "setfacl/getfacl not found — install the 'acl' package (sudo apt-get install acl)"
+[[ -d "$DIR" ]]  || fail "$DIR does not exist — run the installer that creates it first (install_kirra.sh or deploy/systemd/install.sh)"
+
+if [[ "$MODE" == remove ]]; then
+  echo "== removing voice env ACLs — user: $TARGET_USER =="
+  [[ -e "$FILE" ]] && setfacl -x "u:$TARGET_USER" "$FILE" 2>/dev/null || true
+  setfacl -x "u:$TARGET_USER" "$DIR" 2>/dev/null || true
+  echo "  ✔ removed u:$TARGET_USER entries from $DIR and $FILE (where present)"
+  exit 0
+fi
+
+[[ -f "$FILE" ]] || fail "$FILE does not exist — render it first (install_kirra.sh; never created by this script)"
+
+# Apply the two narrow entries. setfacl -m is idempotent: re-running updates
+# the one named entry in place — repeated installer runs cannot accumulate
+# duplicates or touch any other entry, file, or the base mode bits.
+setfacl -m "u:$TARGET_USER:--x" "$DIR"
+setfacl -m "u:$TARGET_USER:r--" "$FILE"
+echo "  ✔ granted u:$TARGET_USER traverse-only on $DIR, read-only on $FILE"
+
+# Prove it with the real account, not our own privileges.
+rc=0
+diagnose || rc=$?
+if [[ $rc -eq 0 ]]; then
+  exit 0
+elif [[ $rc -eq 3 ]]; then
+  echo "  ⚠ ACLs applied, but verification needs root (or the target account): sudo $0 --check --user $TARGET_USER"
+  exit 0
+fi
+fail "ACLs applied but '$TARGET_USER' still cannot read $FILE — inspect: getfacl $DIR $FILE ; namei -l $FILE"

--- a/robot/install/install_robot_units.sh
+++ b/robot/install/install_robot_units.sh
@@ -90,6 +90,21 @@ sudo install -m 0644 "${UNITS}/user/rabbit-voice.service" "${USER_UNIT_DIR}/rabb
 sudo chown "${ROBOT_USER}:" "${USER_UNIT_DIR}/rabbit-voice.service"
 echo "  installed ${USER_UNIT_DIR}/rabbit-voice.service (user unit — Pulse-capable)"
 
+# The user unit's EnvironmentFile= is opened by ${ROBOT_USER}'s own user
+# manager, NOT by PID 1 — so unlike every system unit above, it needs real
+# filesystem access to /etc/kirra/robot.env. /etc/kirra is deliberately tight
+# (0750 kirra:kirra protects the governor secrets in kirra.env, and
+# deploy/systemd/install.sh RE-applies that mode on every run), so grant the
+# narrow ACL here, every install (idempotent): traverse-only on the dir,
+# read-only on robot.env. Without this the unit dies before ExecStart with
+# Result=resources and NO log — found live on the R2.
+if [[ -f /etc/kirra/robot.env ]]; then
+  sudo "${HERE}/ensure_voice_env_access.sh" --user "${ROBOT_USER}"
+else
+  echo "  ⚠ /etc/kirra/robot.env not present yet — after install_kirra.sh renders it, run:"
+  echo "      sudo ${HERE}/ensure_voice_env_access.sh --user ${ROBOT_USER}"
+fi
+
 # ---- 3. reload -------------------------------------------------------------
 sudo systemctl daemon-reload
 echo "== done — STAGED, not enabled =="

--- a/robot/install/install_robot_units.sh
+++ b/robot/install/install_robot_units.sh
@@ -90,6 +90,12 @@ sudo install -m 0644 "${UNITS}/user/rabbit-voice.service" "${USER_UNIT_DIR}/rabb
 sudo chown "${ROBOT_USER}:" "${USER_UNIT_DIR}/rabbit-voice.service"
 echo "  installed ${USER_UNIT_DIR}/rabbit-voice.service (user unit — Pulse-capable)"
 
+# Stage the access helper next to the doctor so its repair hints work on a
+# robot WITHOUT a repo checkout (the doctor and verifier are run from
+# /opt/kirra/robot and point at this staged copy).
+sudo install -m 0755 "${HERE}/ensure_voice_env_access.sh" "${OPT}/robot/ensure_voice_env_access.sh"
+echo "  installed ${OPT}/robot/ensure_voice_env_access.sh"
+
 # The user unit's EnvironmentFile= is opened by ${ROBOT_USER}'s own user
 # manager, NOT by PID 1 — so unlike every system unit above, it needs real
 # filesystem access to /etc/kirra/robot.env. /etc/kirra is deliberately tight
@@ -97,12 +103,19 @@ echo "  installed ${USER_UNIT_DIR}/rabbit-voice.service (user unit — Pulse-cap
 # deploy/systemd/install.sh RE-applies that mode on every run), so grant the
 # narrow ACL here, every install (idempotent): traverse-only on the dir,
 # read-only on robot.env. Without this the unit dies before ExecStart with
-# Result=resources and NO log — found live on the R2.
+# Result=resources and NO log — found live on the R2. A helper failure
+# (missing acl package, unsupported fs) is a LOUD warning, not an abort:
+# the voice unit is optional, the rest of the staging must still land, and
+# verify_deployment.py FAILs until access is actually granted.
 if [[ -f /etc/kirra/robot.env ]]; then
-  sudo "${HERE}/ensure_voice_env_access.sh" --user "${ROBOT_USER}"
+  if ! sudo "${HERE}/ensure_voice_env_access.sh" --user "${ROBOT_USER}"; then
+    echo "  ⚠ voice-env access grant FAILED — the user voice unit cannot start until this is fixed:"
+    echo "      sudo ${OPT}/robot/ensure_voice_env_access.sh --user ${ROBOT_USER}"
+    echo "    (verify_deployment.py will keep failing this check until it succeeds)"
+  fi
 else
   echo "  ⚠ /etc/kirra/robot.env not present yet — after install_kirra.sh renders it, run:"
-  echo "      sudo ${HERE}/ensure_voice_env_access.sh --user ${ROBOT_USER}"
+  echo "      sudo ${OPT}/robot/ensure_voice_env_access.sh --user ${ROBOT_USER}"
 fi
 
 # ---- 3. reload -------------------------------------------------------------

--- a/robot/install/lint_robot_env.sh
+++ b/robot/install/lint_robot_env.sh
@@ -149,9 +149,20 @@ print("# Provenance for each var lives in robot/install/env.template.")
 for k in order:
     print(f"{k}={last[k]}")
 PY
-# Preserve mode/owner of the original, then swap in.
+# Preserve mode/owner AND ACLs of the original, then swap in. The mv replaces
+# the inode, which silently drops POSIX ACL entries — and the user voice unit
+# depends on a u:<user>:r-- entry on this file (ensure_voice_env_access.sh),
+# so a --fix that lost it would kill rabbit-voice.service on its next start
+# with Result=resources. getfacl|setfacl round-trips the full ACL (base bits
+# included); the chmod/chown fallback covers systems without the acl tools.
 chmod --reference="$FILE" "${FILE}.tmp" 2>/dev/null || true
 chown --reference="$FILE" "${FILE}.tmp" 2>/dev/null || true
+if command -v getfacl >/dev/null 2>&1 && command -v setfacl >/dev/null 2>&1; then
+  getfacl --absolute-names -p "$FILE" 2>/dev/null | setfacl --set-file=- "${FILE}.tmp" 2>/dev/null \
+    || echo "  ⚠ could not copy ACLs to the rewritten file — if the user voice unit loses access, re-run: sudo robot/install/ensure_voice_env_access.sh"
+else
+  echo "  ⚠ acl tools not installed — any voice-unit ACL on $FILE is NOT preserved by --fix (sudo apt-get install acl, then re-run robot/install/ensure_voice_env_access.sh)"
+fi
 mv "${FILE}.tmp" "$FILE"
 echo "  ✔ normalized $FILE ($(grep -cE '^[A-Za-z_]' "$FILE") keys). Original at $BACKUP."
 echo "  restart the consumer to pick it up: sudo systemctl restart kirra-consumer"

--- a/robot/install/verify_deployment.py
+++ b/robot/install/verify_deployment.py
@@ -411,7 +411,7 @@ def diagnose_env_access(probes: dict) -> tuple:
     Returns (status, detail, fix) for Report.add.
     """
     user = probes.get("unit_user") or ""
-    helper = "sudo robot/install/ensure_voice_env_access.sh"
+    helper = f"sudo {acl_helper_path()}"
     if not user:
         return (WARN, "cannot determine the deployment user (unit User= "
                 "unreadable) — user-unit env access not verified",
@@ -434,6 +434,23 @@ def diagnose_env_access(probes: dict) -> tuple:
                 f"{ROBOT_ENV} (file mode/ACL)", fix)
     return (PASS, f"'{user}' can read {ROBOT_ENV} (traverse + read verified "
             "as that user)", None)
+
+
+def acl_helper_path() -> str:
+    """The repair helper's path FROM WHERE THIS VERIFIER RUNS.
+
+    The verifier runs from the installed /opt/kirra/robot tree on a robot
+    with no checkout — a repo-relative hint would be a dead end there. The
+    helper is a sibling in the staged tree and lives in this same directory
+    in a checkout; fall back to the repo-relative form only when neither
+    copy is present (fresh clone before install).
+    """
+    here = os.path.dirname(os.path.abspath(__file__))
+    for cand in (os.path.join(here, "ensure_voice_env_access.sh"),
+                 "/opt/kirra/robot/ensure_voice_env_access.sh"):
+        if os.access(cand, os.X_OK):
+            return cand
+    return "robot/install/ensure_voice_env_access.sh"
 
 
 def probe_env_access(user: str) -> dict:

--- a/robot/install/verify_deployment.py
+++ b/robot/install/verify_deployment.py
@@ -392,6 +392,99 @@ def check_voice_env(rep: Report, env: dict) -> None:
                         "kirra-rabbit-voice (see install_robot_units.sh)")
 
 
+def diagnose_env_access(probes: dict) -> tuple:
+    """Pure classifier for the user-unit EnvironmentFile access states.
+
+    The user voice unit (rabbit-voice.service) is the one unit whose
+    EnvironmentFile= is opened by the OPERATOR's user manager, not PID 1 —
+    root opens the system units' copy and bypasses permissions entirely, so
+    every other check here can pass while the user unit dies before ExecStart
+    with Result=resources, pid=0 and no service log (live R2 incident:
+    /etc/kirra re-tightened to 0750 kirra:kirra by deploy/systemd/install.sh).
+
+    `probes` keys (all set by probe_env_access, injected in tests):
+      unit_user        str  — account the deployment runs as ('' if unknown)
+      verified_as_user bool — the checks below were run AS unit_user
+      dir_traversable  bool
+      file_exists      bool
+      file_readable    bool
+    Returns (status, detail, fix) for Report.add.
+    """
+    user = probes.get("unit_user") or ""
+    helper = "sudo robot/install/ensure_voice_env_access.sh"
+    if not user:
+        return (WARN, "cannot determine the deployment user (unit User= "
+                "unreadable) — user-unit env access not verified",
+                f"{helper} --check --user <robot-user>")
+    fix = f"{helper} --user {user}"
+    if not probes.get("verified_as_user"):
+        return (WARN, f"cannot verify as '{user}' from this account — run the "
+                "verifier as root or as the deployment user",
+                f"{helper} --check --user {user}")
+    if not probes.get("dir_traversable"):
+        return (FAIL, f"'{user}' cannot traverse {os.path.dirname(ROBOT_ENV)} "
+                "— the user voice unit fails before ExecStart "
+                "(Result=resources, no log)", fix)
+    if not probes.get("file_exists"):
+        return (FAIL, f"{ROBOT_ENV} does not exist for '{user}'",
+                "robot/install/install_kirra.sh renders robot.env if absent, "
+                f"then {fix}")
+    if not probes.get("file_readable"):
+        return (FAIL, f"'{user}' can traverse the directory but cannot READ "
+                f"{ROBOT_ENV} (file mode/ACL)", fix)
+    return (PASS, f"'{user}' can read {ROBOT_ENV} (traverse + read verified "
+            "as that user)", None)
+
+
+def probe_env_access(user: str) -> dict:
+    """Live probes for diagnose_env_access, dropping privileges honestly.
+
+    As root: run `test` AS the unit user (runuser) — the only proof that
+    counts. As the unit user: direct os.access. As anyone else: report
+    unverified rather than guessing (root's own os.access always says yes).
+    """
+    probes = {"unit_user": user, "verified_as_user": False,
+              "dir_traversable": False, "file_exists": False,
+              "file_readable": False}
+    if not user:
+        return probes
+    d = os.path.dirname(ROBOT_ENV)
+
+    def as_user(flag: str, path: str) -> bool:
+        r = subprocess.run(["runuser", "-u", user, "--", "test", flag, path],
+                           capture_output=True, timeout=10)
+        return r.returncode == 0
+
+    try:
+        if os.geteuid() == 0:
+            probes["verified_as_user"] = True
+            probes["dir_traversable"] = as_user("-x", d)
+            probes["file_exists"] = as_user("-e", ROBOT_ENV)
+            probes["file_readable"] = as_user("-r", ROBOT_ENV)
+        elif pwd_name_of_euid() == user:
+            probes["verified_as_user"] = True
+            probes["dir_traversable"] = os.access(d, os.X_OK)
+            probes["file_exists"] = os.path.exists(ROBOT_ENV)
+            probes["file_readable"] = os.access(ROBOT_ENV, os.R_OK)
+    except Exception:  # noqa: BLE001 — a broken probe is "unverified", not a crash
+        probes["verified_as_user"] = False
+    return probes
+
+
+def pwd_name_of_euid() -> str:
+    import pwd
+    try:
+        return pwd.getpwuid(os.geteuid()).pw_name
+    except KeyError:
+        return ""
+
+
+def check_user_env_access(rep: Report) -> None:
+    user = configured_robot_user()
+    status, detail, fix = diagnose_env_access(probe_env_access(user))
+    rep.add("user voice unit can read robot.env", status, detail, fix=fix)
+
+
 def run() -> Report:
     rep = Report()
     from preflight_consumer_env import parse_env_file
@@ -401,6 +494,7 @@ def run() -> Report:
     check_artifacts(rep)
     check_env(rep, env)
     check_voice_env(rep, env)
+    check_user_env_access(rep)
     probe_ffi(rep, env)
     check_deployment_identity(
         rep, env,

--- a/robot/install/voice_env_access_test.py
+++ b/robot/install/voice_env_access_test.py
@@ -200,11 +200,27 @@ def test_fail_closed_paths():
         check("zz_no_such_user_9" in r.stderr + r.stdout,
               "unknown-user error must name the account")
 
-        missing = d / "nope.env"
-        r = _run_helper(d, missing)
+        empty = Path(t) / "empty-kirra"
+        empty.mkdir()
+        r = _run_helper(empty, empty / "robot.env")
         check(r.returncode != 0, "missing env file must fail closed")
         check("install_kirra.sh" in r.stderr + r.stdout,
               "missing-file error must say what renders it")
+
+        # Guardrails (the helper runs under sudo — a typo must not grant
+        # access to a secret): only a file NAMED robot.env, directly under
+        # the granted directory, is ever a valid target.
+        r = _run_helper(d, d / "kirra.env")
+        check(r.returncode != 0, "a non-robot.env target must be refused")
+        check("robot.env ONLY" in r.stderr + r.stdout,
+              f"secret-target refusal must state the rule: {r.stderr}")
+        outside = Path(t) / "robot.env"
+        outside.write_text("X=1\n")
+        r = _run_helper(d, outside)
+        check(r.returncode != 0,
+              "a robot.env OUTSIDE the granted directory must be refused")
+        check("not directly inside" in r.stderr + r.stdout,
+              f"mismatched-parent refusal must say so: {r.stderr}")
 
         # setfacl absent: a stub PATH with the tools the script needs BEFORE
         # the acl check (id), but no setfacl/getfacl.
@@ -269,6 +285,12 @@ def test_installer_wires_the_helper():
     check("ensure_voice_env_access.sh" in src,
           "install_robot_units.sh must grant user-unit env access when staging "
           "the user unit")
+    check("/opt/kirra" in src.split("ensure_voice_env_access.sh")[1][:200]
+          or "${OPT}/robot/ensure_voice_env_access.sh" in src,
+          "the helper must be STAGED so repair hints work without a checkout")
+    check("if ! sudo" in src,
+          "a helper failure must be a loud warning, not abort the whole "
+          "staging (set -e)")
     check("chmod 755 /etc/kirra" not in src and "chmod -R" not in src,
           "the installer must not broaden /etc/kirra")
     helper_src = HELPER.read_text()

--- a/robot/install/voice_env_access_test.py
+++ b/robot/install/voice_env_access_test.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Host tests for the user voice unit's EnvironmentFile access chain.
+
+The live failure: rabbit-voice.service (USER unit) died before ExecStart with
+Result=resources / pid=0 / no log, because /etc/kirra had been re-tightened to
+0750 kirra:kirra (deploy/systemd/install.sh protects kirra.env's governor
+secrets on EVERY run) and the operator's user manager — unlike PID 1, which
+opens the system units' EnvironmentFile as root — could not traverse the
+directory. The fix is a narrow ACL (traverse-only on the dir, read-only on
+robot.env) applied by robot/install/ensure_voice_env_access.sh.
+
+Layers tested here:
+  1. the pure classifier in verify_deployment.diagnose_env_access (all states);
+  2. the helper's ACL behavior on tmpdir fixtures (grants are narrow, idempotent,
+     survive re-runs, restorable after inode replacement; unrelated files and
+     base modes untouched) — ACL entries name `root` as the subject so the test
+     needs NO test user and NO root to *apply* (owners may set ACLs on their own
+     files); actually-denied assertions are root-only and skip loudly;
+  3. lint_robot_env.sh --fix preserves ACLs across its inode-replacing rewrite;
+  4. fail-closed paths: unknown user, missing acl tools, missing file;
+  5. source-level wiring: the installer grants access after staging the user
+     unit and nothing in the chain broadens /etc/kirra.
+
+Runs standalone (`python3 robot/install/voice_env_access_test.py`, exit 1 on
+any failure); ACL-unsupported filesystems skip the ACL layer loudly.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+HELPER = HERE / "ensure_voice_env_access.sh"
+LINTER = HERE / "lint_robot_env.sh"
+INSTALLER = HERE / "install_robot_units.sh"
+
+_F: list[str] = []
+
+
+def check(cond, msg):
+    if not cond:
+        _F.append(msg)
+        print(f"  FAIL: {msg}", file=sys.stderr)
+
+
+def sh(args, **kw):
+    return subprocess.run(args, capture_output=True, text=True, timeout=60, **kw)
+
+
+def getfacl(path) -> str:
+    return sh(["getfacl", "--omit-header", "-p", str(path)]).stdout
+
+
+def acl_supported() -> bool:
+    if not shutil.which("setfacl"):
+        return False
+    with tempfile.NamedTemporaryFile() as f:
+        return sh(["setfacl", "-m", "u:root:r--", f.name]).returncode == 0
+
+
+# --- 1. pure classifier -------------------------------------------------------
+
+def test_classifier_states():
+    sys.path.insert(0, str(HERE))
+    import verify_deployment as vd
+
+    def probes(**kw):
+        base = {"unit_user": "jetson", "verified_as_user": True,
+                "dir_traversable": True, "file_exists": True,
+                "file_readable": True}
+        base.update(kw)
+        return base
+
+    st, detail, fix = vd.diagnose_env_access(probes())
+    check(st == vd.PASS, f"all-good must PASS, got {st}")
+    check(fix is None, "PASS carries no fix")
+
+    st, detail, fix = vd.diagnose_env_access(probes(dir_traversable=False))
+    check(st == vd.FAIL, "non-traversable parent must FAIL")
+    check("traverse" in detail and "Result=resources" in detail,
+          f"traverse failure must name the symptom: {detail}")
+    check("ensure_voice_env_access.sh" in (fix or ""),
+          "traverse failure must name the repair helper")
+
+    st, detail, fix = vd.diagnose_env_access(probes(file_exists=False))
+    check(st == vd.FAIL, "missing file must FAIL")
+    check("install_kirra.sh" in (fix or ""), "missing file fix renders the env first")
+
+    st, detail, fix = vd.diagnose_env_access(probes(file_readable=False))
+    check(st == vd.FAIL, "unreadable file must FAIL")
+    check("READ" in detail, f"unreadable is distinct from untraversable: {detail}")
+
+    st, detail, fix = vd.diagnose_env_access(probes(verified_as_user=False))
+    check(st == vd.WARN, "unverifiable must WARN, never PASS")
+    check("--check" in (fix or ""), "unverifiable points at the read-only check")
+
+    st, detail, fix = vd.diagnose_env_access(probes(unit_user=""))
+    check(st == vd.WARN, "unknown unit user must WARN, never PASS")
+
+    # 'deployment verified' must be unreachable on a FAIL row.
+    rep = vd.Report()
+    rep.add("user voice unit can read robot.env", vd.FAIL, "x", fix="y")
+    check(rep.failed == 1, "a FAIL row must count as failed")
+
+
+# --- 2. helper ACL behavior (no root, no test user needed) --------------------
+
+def _fixture(tmp: Path):
+    d = tmp / "etc-kirra"
+    d.mkdir(mode=0o750)
+    env = d / "robot.env"
+    env.write_text("KIRRA_WAKE_ENABLED=1\n")
+    env.chmod(0o644)
+    secret = d / "kirra.env"
+    secret.write_text("KIRRA_ADMIN_TOKEN=sekrit\n")
+    secret.chmod(0o600)
+    return d, env, secret
+
+
+def _run_helper(d, env, extra=()):
+    return sh(["/bin/bash", str(HELPER), "--user", "root",
+               "--dir", str(d), "--file", str(env), *extra])
+
+
+def test_helper_grants_are_narrow_and_idempotent():
+    if not acl_supported():
+        print("  SKIP: filesystem/tools do not support POSIX ACLs — helper ACL tests skipped")
+        return
+    with tempfile.TemporaryDirectory() as t:
+        d, env, secret = _fixture(Path(t))
+        mode_before = (d.stat().st_mode, env.stat().st_mode, secret.stat().st_mode)
+
+        r = _run_helper(d, env)
+        check(r.returncode == 0, f"helper apply failed: {r.stdout}{r.stderr}")
+        check("user:root:--x" in getfacl(d),
+              f"dir must get traverse-ONLY for the user: {getfacl(d)}")
+        check("user:root:r--" in getfacl(env),
+              f"env file must get read-ONLY for the user: {getfacl(env)}")
+        check("user:root" not in getfacl(secret),
+              "the helper must NEVER touch other files in the directory")
+        check((d.stat().st_mode, env.stat().st_mode, secret.stat().st_mode)
+              == mode_before, "base permission bits must be unchanged")
+
+        first = (getfacl(d), getfacl(env))
+        r2 = _run_helper(d, env)
+        check(r2.returncode == 0, "second run must succeed")
+        check((getfacl(d), getfacl(env)) == first,
+              "repeated runs must not accumulate or alter entries")
+
+
+def test_replacement_drops_acl_and_helper_restores():
+    if not acl_supported():
+        print("  SKIP: no ACL support — replacement test skipped")
+        return
+    with tempfile.TemporaryDirectory() as t:
+        d, env, _ = _fixture(Path(t))
+        _run_helper(d, env)
+        check("user:root:r--" in getfacl(env), "precondition: entry present")
+        # Simulate sed -i / install / tmp+rename: a NEW inode replaces the file.
+        tmp = d / "robot.env.tmp"
+        tmp.write_text(env.read_text())
+        tmp.chmod(0o644)
+        tmp.rename(env)
+        check("user:root:r--" not in getfacl(env),
+              "inode replacement is expected to drop the file ACL (the hazard)")
+        check("user:root:--x" in getfacl(d),
+              "the directory ACL must survive file replacement")
+        r = _run_helper(d, env)
+        check(r.returncode == 0 and "user:root:r--" in getfacl(env),
+              "re-running the helper must restore file access")
+
+
+def test_lint_fix_preserves_acl():
+    if not acl_supported():
+        print("  SKIP: no ACL support — lint --fix ACL test skipped")
+        return
+    with tempfile.TemporaryDirectory() as t:
+        d, env, _ = _fixture(Path(t))
+        env.write_text("KIRRA_R2_WHEELBASE_M=0.229   # inline comment trap\n")
+        _run_helper(d, env)
+        check("user:root:r--" in getfacl(env), "precondition: entry present")
+        r = sh(["/bin/bash", str(LINTER), str(env), "--fix"])
+        check(r.returncode == 0, f"lint --fix failed: {r.stdout}{r.stderr}")
+        check("# inline" not in env.read_text(), "--fix must still normalize")
+        check("user:root:r--" in getfacl(env),
+              f"lint --fix must preserve the voice-unit ACL: {getfacl(env)}")
+
+
+def test_fail_closed_paths():
+    with tempfile.TemporaryDirectory() as t:
+        d, env, _ = _fixture(Path(t))
+
+        r = sh(["/bin/bash", str(HELPER), "--user", "zz_no_such_user_9",
+                "--dir", str(d), "--file", str(env)])
+        check(r.returncode != 0, "unknown user must fail closed")
+        check("zz_no_such_user_9" in r.stderr + r.stdout,
+              "unknown-user error must name the account")
+
+        missing = d / "nope.env"
+        r = _run_helper(d, missing)
+        check(r.returncode != 0, "missing env file must fail closed")
+        check("install_kirra.sh" in r.stderr + r.stdout,
+              "missing-file error must say what renders it")
+
+        # setfacl absent: a stub PATH with the tools the script needs BEFORE
+        # the acl check (id), but no setfacl/getfacl.
+        stub = Path(t) / "stubbin"
+        stub.mkdir()
+        for tool in ("id",):
+            real = shutil.which(tool)
+            if real:
+                (stub / tool).symlink_to(real)
+        r = sh(["/bin/bash", str(HELPER), "--user", "root",
+                "--dir", str(d), "--file", str(env)],
+               env={"PATH": str(stub)})
+        check(r.returncode != 0, "missing setfacl must fail, not silently skip")
+        check("acl" in (r.stderr + r.stdout).lower(),
+              f"missing-tool error must name the acl package: {r.stderr}")
+
+
+# --- 3. root-only integration: actual denial + grant for a real other user ----
+
+def test_root_integration_denial_and_grant():
+    if os.geteuid() != 0:
+        print("  SKIP: not root — real-denial integration test skipped "
+              "(the ACL layer above still ran)")
+        return
+    if not acl_supported():
+        print("  SKIP: no ACL support — root integration skipped")
+        return
+    probe = sh(["id", "-u", "nobody"])
+    if probe.returncode != 0:
+        print("  SKIP: no 'nobody' account — root integration skipped")
+        return
+    with tempfile.TemporaryDirectory() as t:
+        os.chmod(t, 0o755)  # 'nobody' must reach the fixture parent
+        d, env, secret = _fixture(Path(t))
+
+        def nobody_can(flag, path):
+            return sh(["runuser", "-u", "nobody", "--",
+                       "test", flag, str(path)]).returncode == 0
+
+        check(not nobody_can("-r", env),
+              "precondition: 0750 parent blocks the service user")
+        r = sh(["/bin/bash", str(HELPER), "--user", "nobody",
+                "--dir", str(d), "--file", str(env)])
+        check(r.returncode == 0, f"grant for nobody failed: {r.stdout}{r.stderr}")
+        check(nobody_can("-x", d), "after grant: traverse works")
+        check(nobody_can("-r", env), "after grant: env file readable")
+        check(not sh(["runuser", "-u", "nobody", "--", "ls", str(d)]).returncode == 0,
+              "traverse-only: the user must NOT be able to LIST the directory")
+        check(not nobody_can("-r", secret),
+              "the user must NOT be able to read unrelated secrets")
+
+        r = sh(["/bin/bash", str(HELPER), "--user", "nobody",
+                "--dir", str(d), "--file", str(env), "--remove"])
+        check(r.returncode == 0 and not nobody_can("-r", env),
+              "--remove must roll the grant back")
+
+
+# --- 4. source-level wiring ---------------------------------------------------
+
+def test_installer_wires_the_helper():
+    src = INSTALLER.read_text()
+    check("ensure_voice_env_access.sh" in src,
+          "install_robot_units.sh must grant user-unit env access when staging "
+          "the user unit")
+    check("chmod 755 /etc/kirra" not in src and "chmod -R" not in src,
+          "the installer must not broaden /etc/kirra")
+    helper_src = HELPER.read_text()
+    check("--default" not in helper_src
+          and "setfacl -d" not in helper_src
+          and "setfacl -R" not in helper_src,
+          "the helper must not use default/recursive ACLs (future files must "
+          "not inherit access)")
+    helper_code = "\n".join(line for line in helper_src.splitlines()
+                            if not line.lstrip().startswith("#"))
+    check("chmod" not in helper_code,
+          "the helper must not change permission bits at all — ACL entries only")
+    # Both unit families must keep loading the SAME env file, or the ACL
+    # target and the units drift apart.
+    sys_unit = (HERE / "systemd" / "kirra-rabbit-voice.service").read_text()
+    user_unit = (HERE / "systemd" / "user" / "rabbit-voice.service").read_text()
+    for name, src_ in (("system", sys_unit), ("user", user_unit)):
+        check("EnvironmentFile=/etc/kirra/robot.env" in src_,
+              f"{name} unit must load /etc/kirra/robot.env")
+
+
+def test_shell_syntax():
+    for f in (HELPER, LINTER, INSTALLER):
+        r = sh(["bash", "-n", str(f)])
+        check(r.returncode == 0, f"bash -n {f.name}: {r.stderr}")
+
+
+# --- standalone runner (house pattern) ----------------------------------------
+
+def main() -> int:
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            print(f"-- {name}")
+            fn()
+    if _F:
+        print(f"voice_env_access_test: {len(_F)} FAILURE(S)")
+        return 1
+    print("voice_env_access_test: ALL OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/robot/kirra_voice_doctor.sh
+++ b/robot/kirra_voice_doctor.sh
@@ -84,15 +84,25 @@ if [ -r "$RENV" ]; then
   set -a; . "$RENV"; set +a
 else
   RDIR="$(dirname "$RENV")"
+  # The repair helper lives beside this doctor when STAGED (/opt/kirra/robot),
+  # under install/ in a repo checkout — name the copy that actually exists so
+  # the hint is runnable from either context.
+  if [ -x "$HERE/ensure_voice_env_access.sh" ]; then
+    ACL_HELPER="$HERE/ensure_voice_env_access.sh"
+  elif [ -x "$HERE/install/ensure_voice_env_access.sh" ]; then
+    ACL_HELPER="$HERE/install/ensure_voice_env_access.sh"
+  else
+    ACL_HELPER="robot/install/ensure_voice_env_access.sh (from a repo checkout)"
+  fi
   if [ ! -x "$RDIR" ]; then
     bad "$(id -un) cannot traverse $RDIR — the user voice unit fails before ExecStart (Result=resources)"
-    fix "sudo robot/install/ensure_voice_env_access.sh --user $(id -un)   # traverse-only ACL, no chmod"
+    fix "sudo $ACL_HELPER --user $(id -un)   # traverse-only ACL, no chmod"
   elif [ ! -e "$RENV" ]; then
     bad "robot.env missing ($RENV)"
     fix "robot/install/install_kirra.sh renders it if absent — R2_VOICE_AUDIO_SETUP.md §4"
   else
     bad "robot.env exists but $(id -un) cannot READ it ($RENV)"
-    fix "sudo robot/install/ensure_voice_env_access.sh --user $(id -un)   # read-only file ACL"
+    fix "sudo $ACL_HELPER --user $(id -un)   # read-only file ACL"
   fi
 fi
 

--- a/robot/kirra_voice_doctor.sh
+++ b/robot/kirra_voice_doctor.sh
@@ -72,13 +72,28 @@ pulse_backend_check() {  # $1 = label
 
 [ "$QUIET" = 1 ] || echo "== R2 voice/audio doctor =="
 
-# 1. env file present + loadable
+# 1. env file present + loadable. Distinguish the three failure shapes — they
+# have different fixes, and the parent-traverse one is exactly how the user
+# voice unit (rabbit-voice.service) dies with Result=resources and no log:
+# /etc/kirra is deliberately 0750 (governor secrets), so THIS account needs
+# the narrow ACL from ensure_voice_env_access.sh, not a chmod. Read-only:
+# this doctor never modifies permissions.
 if [ -r "$RENV" ]; then
-  ok "robot.env readable ($RENV)"
+  ok "robot.env readable ($RENV) — the user voice unit can load its EnvironmentFile"
   # shellcheck disable=SC1090
   set -a; . "$RENV"; set +a
 else
-  bad "robot.env not readable ($RENV)"; fix "create it / check perms — R2_VOICE_AUDIO_SETUP.md §4"
+  RDIR="$(dirname "$RENV")"
+  if [ ! -x "$RDIR" ]; then
+    bad "$(id -un) cannot traverse $RDIR — the user voice unit fails before ExecStart (Result=resources)"
+    fix "sudo robot/install/ensure_voice_env_access.sh --user $(id -un)   # traverse-only ACL, no chmod"
+  elif [ ! -e "$RENV" ]; then
+    bad "robot.env missing ($RENV)"
+    fix "robot/install/install_kirra.sh renders it if absent — R2_VOICE_AUDIO_SETUP.md §4"
+  else
+    bad "robot.env exists but $(id -un) cannot READ it ($RENV)"
+    fix "sudo robot/install/ensure_voice_env_access.sh --user $(id -un)   # read-only file ACL"
+  fi
 fi
 
 # 2. STT engine + model


### PR DESCRIPTION
## Confirmed live failure

`rabbit-voice.service` (the **user** unit) dies before `ExecStart` with `Result=resources`, `pid=0`, `NRestarts=910`, and no service log. `namei -l /etc/kirra/robot.env` stops at `/etc/kirra` (`0750 kirra:kirra`); `sudo -u jetson test -r /etc/kirra/robot.env` exits 1.

## Root cause

**Two installers fight over `/etc/kirra`'s mode.** `install_kirra.sh` creates it `install -d -m 0755`; `deploy/systemd/install.sh` **re-applies** `install -d -m 0750 -o kirra -g kirra` on *every* run (deliberately — `kirra.env` in that directory holds the governor admin secrets). Whichever installer ran last wins. After a governor-stack reinstall, the operator account could no longer traverse `/etc/kirra`.

**Why only the user unit broke:** a system unit's `EnvironmentFile=` is opened by PID 1 as root, which bypasses permission checks. The user unit's is opened by the operator's own `systemd --user` manager, which is subject to ordinary DAC. The user manager fails to open the file before fork/exec — hence `Result=resources` with no PID and no service log. (No `EnvironmentFile` caching is involved; systemd reopens the file on every start. Prior successful starts simply predate the directory being re-tightened.)

## Fix — least privilege, not a mode change

Two narrow POSIX ACL entries (Option A):

```
setfacl -m u:<user>:--x /etc/kirra            # traverse ONLY — no listing
setfacl -m u:<user>:r-- /etc/kirra/robot.env  # read ONLY this file
```

The user still cannot list `/etc/kirra` and still cannot read `kirra.env` (0600). Rejected alternatives: `chmod 0755` on the dir exposes every future filename and weakens the governor-secret posture; adding the operator to the `kirra` group grants directory listing plus every future group-readable file; a separate voice-safe env file would fork ~40 calibration keys consumed by both unit families (`robot.env` holds no secrets today — the only token key in `rabbit.env.example` is optional and commented out).

**ACL durability:** either installer re-running `chmod`/`chown` only rewrites the ACL *mask* (their group bits keep traverse effective), so repeated installs cannot regress the grant. Inode replacement is the one hazard: `lint_robot_env.sh --fix` (tmp + `mv`) previously dropped the file entry silently and now round-trips ACLs; a manual `sed -i` is caught by verification with the exact repair command.

## Changes

- **`robot/install/ensure_voice_env_access.sh`** (new): applies the two entries; idempotent (`setfacl -m` updates in place — no accumulation); fails loudly on unknown user / missing `acl` tools (names the package) / missing env file (names what renders it); verifies **as the target user** (`runuser`) when root; `--check` read-only diagnosis distinguishing parent-untraversable / file-missing / file-unreadable; `--remove` rollback. No default ACLs, no recursion, no `chmod`. Service user resolves `--user` > `KIRRA_ROBOT_USER` > `SUDO_USER` > `USER` — the installer's existing invoking-user convention, not hardcoded `jetson`.
- **`install_robot_units.sh`**: applies the grant immediately after staging the user unit; when `robot.env` isn't rendered yet, prints the exact follow-up command.
- **`lint_robot_env.sh --fix`**: preserves ACLs across its inode-replacing rewrite (`getfacl | setfacl --set-file`); warns with the repair command if acl tools are absent.
- **`verify_deployment.py`**: new check `user voice unit can read robot.env` — pure classifier (`diagnose_env_access`) + privilege-dropping probe (`runuser` when root; direct when running as the unit user; **WARN, never PASS**, when unverifiable). Distinguishes untraversable-parent (named live symptom) / missing / unreadable / unknown unit user, each with a precise repair command. "deployment verified" is unreachable while the user unit cannot read its env.
- **`kirra_voice_doctor.sh`**: the `robot.env` check now reports which of the three failure shapes applies and names the helper — still strictly read-only.
- **`robot/install/voice_env_access_test.py`** (new, wired into CI): classifier matrix; ACL behavior needs no root (entries name `root` as subject on tmpdir fixtures) — narrow grant, unrelated secret untouched, base modes unchanged, idempotency, replacement-drops + helper-restores, lint `--fix` preservation; fail-closed paths; root-only integration proving real denial → grant → traverse-without-listing → secret-still-unreadable → rollback for an actual second account (`nobody`), skipping loudly when unsupported.

## Test results

- `voice_env_access_test.py` — ALL OK (root integration included: ran as root with a real second account)
- `deployment_verify_test.py` — 43/43 · `env_quoting_test.py` — ALL OK · `staging_completeness_test.py` — ALL OK · `rabbit_voice_test.py` — 18/18 · `preflight_consumer_env_test.py` — 8/8
- `bash -n` + `shellcheck -S error` clean on all four shell files; `py_compile` clean; `git diff --check` clean; no conflict markers.

## One-time Jetson repair (after merge + pull — not run during this work)

```bash
cd ~/kirra-runtime-sdk && git pull origin main
sudo robot/install/ensure_voice_env_access.sh          # resolves jetson via SUDO_USER
sudo -u jetson test -r /etc/kirra/robot.env; echo "read check=$?"
namei -l /etc/kirra/robot.env
getfacl /etc/kirra /etc/kirra/robot.env

systemctl --user daemon-reload
systemctl --user reset-failed rabbit-voice.service
systemctl --user start rabbit-voice.service
sleep 3
systemctl --user --no-pager --full status rabbit-voice.service
```

Rollback: `sudo robot/install/ensure_voice_env_access.sh --remove --user jetson`

Expected end state: jetson can traverse `/etc/kirra` and read `robot.env`; jetson **cannot** list `/etc/kirra` and **cannot** read `kirra.env`. Not claiming the service fixed on hardware until the repair runs and `rabbit-voice.service` is active with `wake_word.py` + `parec` running.

## Remaining deployment assumptions

- The `acl` package must be present on the robot (stock on Ubuntu; the helper fails loudly with the install command if not).
- The user unit is installed for the invoking user of `install_robot_units.sh`; a different voice account requires `--user`.
- If `robot.env` ever grows a real secret (e.g. `KIRRA_MICK_AUDITOR_TOKEN` uncommented), revisit Option C (a dedicated voice-safe env file) — today it holds calibration only and is 0644, so the ACL model is sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_