### PR TITLE
feat(voice): hybrid wake-driven router — deterministic route to chat stream or the governed /intent door

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1514,6 +1514,17 @@ jobs:
           # unknown user / missing tools, that lint --fix preserves ACLs, and
           # the verifier classifier never PASSes an unverified state.
           python3 robot/install/voice_env_access_test.py
+          # Hybrid voice router (host, pure + stub HTTP servers — no Ollama,
+          # no robot): the deterministic transcript classifier (motion /
+          # conversation / ambiguous, wake-prefix stripping, the substring
+          # traps), endpoint ISOLATION (conversation only ever contacts the
+          # chat sidecar, explicit motion only the governed /intent door,
+          # ambiguous contacts NEITHER; failures never cross-fall-back and
+          # never retry), admission-only acks, transcript-free logs, the
+          # voice-router actuation fence, and the two voice units' mutual
+          # Conflicts= exclusion (one mic owner).
+          python3 robot/voice_route_test.py
+          python3 robot/voice_turn_router_test.py
           # mick_chat.py terminal client (host, stub HTTP server — no Ollama):
           # success/malformed/timeout/4xx-5xx/EOF paths, the service error
           # token surfaced, and the SEPARATION proofs — only /chat is ever

--- a/robot/install/install_robot_units.sh
+++ b/robot/install/install_robot_units.sh
@@ -50,7 +50,9 @@ for f in rabbit_persona.py rabbit_watch.py rabbit_ask.py rabbit_converse.py rabb
          rabbit_model_smoketest.py assistant.py assistant_admission.py \
          assistant_contract.py assistant_report.py assistant_tools.py \
          mick_chat.py mick_voice_chat.py mick_chat_benchmark.py \
-         mick_voice_benchmark.py; do
+         mick_voice_benchmark.py \
+         voice_route.py voice_turn_router.py voice_transcribe.sh \
+         mick_voice_router.sh; do
   [[ -f "${REPO}/robot/${f}" ]] || { echo "  ⚠ missing ${REPO}/robot/${f} — skipped"; continue; }
   sudo install -m 0755 "${REPO}/robot/${f}" "${OPT}/robot/${f}"
   echo "  installed ${OPT}/robot/${f}"
@@ -86,9 +88,13 @@ echo "== 2b. user unit -> ~${ROBOT_USER}/.config/systemd/user =="
 USER_HOME="$(getent passwd "${ROBOT_USER}" | cut -d: -f6)"
 USER_UNIT_DIR="${USER_HOME}/.config/systemd/user"
 sudo -u "${ROBOT_USER}" mkdir -p "${USER_UNIT_DIR}"
-sudo install -m 0644 "${UNITS}/user/rabbit-voice.service" "${USER_UNIT_DIR}/rabbit-voice.service"
-sudo chown "${ROBOT_USER}:" "${USER_UNIT_DIR}/rabbit-voice.service"
-echo "  installed ${USER_UNIT_DIR}/rabbit-voice.service (user unit — Pulse-capable)"
+for uu in rabbit-voice.service mick-voice-router.service; do
+  sudo install -m 0644 "${UNITS}/user/${uu}" "${USER_UNIT_DIR}/${uu}"
+  sudo chown "${ROBOT_USER}:" "${USER_UNIT_DIR}/${uu}"
+  echo "  installed ${USER_UNIT_DIR}/${uu} (user unit — Pulse-capable)"
+done
+echo "  (rabbit-voice and mick-voice-router are MUTUALLY EXCLUSIVE — starting"
+echo "   either stops the other; exactly one voice frontend owns the mic)"
 
 # Stage the access helper next to the doctor so its repair hints work on a
 # robot WITHOUT a repo checkout (the doctor and verifier are run from

--- a/robot/install/rabbit.env.example
+++ b/robot/install/rabbit.env.example
@@ -312,6 +312,23 @@ KIRRA_RABBIT_MODEL="gemma3:4b"
 KIRRA_VERIFIER_URL="http://localhost:8090"
 KIRRA_MICK_URL="http://localhost:8102"
 KIRRA_TAJ_URL="http://localhost:8101"
+
+# ── Hybrid voice router (mick-voice-router.service) — optional ───────────────
+# Wake phrase → follow-up recording → STT → DETERMINISTIC route:
+# conversation → mick_chat_service /chat/stream (streamed, sentence-chunked
+# TTS); explicit motion → TEXT to mick /intent (the same governed door as
+# typing — Mick → Occy → checker → release → consumer, unchanged); ambiguous
+# ("go ahead", "do it") → a fixed spoken clarification, NO endpoint.
+# Mutually exclusive with rabbit-voice.service (Conflicts= both ways).
+# Voice "stop" becomes Mick's typed governed HOLD intent — not a motor
+# cutoff; the physical e-stop is separate hardware.
+# Multi-word values MUST stay double-quoted (systemd + bash source parity).
+#KIRRA_MICK_INTENT_URL="http://127.0.0.1:8102"
+#KIRRA_MICK_CHAT_URL="http://127.0.0.1:8103"
+#KIRRA_VOICE_ROUTER_TIMEOUT_MS=5000
+#KIRRA_VOICE_MOTION_ACK="Request accepted."
+#KIRRA_VOICE_AMBIGUOUS_REPLY="Please say exactly where or how you want me to move."
+#KIRRA_VOICE_ROUTER_LOG=1
 # ROS domain — MUST match the lidar (kirra-lidar.service) so rabbit_converse's
 # rclpy can subscribe to /scan for "what do you see". A systemd service does not
 # inherit your login shell's ROS_DOMAIN_ID, so set it here (rabbit_voice.sh sources

--- a/robot/install/systemd/user/mick-voice-router.service
+++ b/robot/install/systemd/user/mick-voice-router.service
@@ -1,0 +1,56 @@
+# mick-voice-router.service (USER unit) — the HYBRID wake-driven voice
+# frontend: wake phrase → bounded follow-up recording → STT → deterministic
+# route → conversation (mick_chat_service /chat/stream + piper) OR explicit
+# motion (TEXT to mick_service POST /intent → the unchanged governed path:
+# Mick typed parse → Occy → checker → release → consumer).
+#
+# WHY A USER UNIT: same reason as rabbit-voice.service — on a unit with an
+# active user audio session the session sound server OWNS the USB mic, so
+# capture must go through the per-user Pulse socket that only a unit inside
+# the user's systemd manager can reach (pulse_capture.sh → parec).
+#
+# 🔴 MUTUAL EXCLUSION: exactly ONE voice frontend may own the microphone.
+# This unit Conflicts= with the legacy rabbit-voice.service (and vice
+# versa), so starting either stops the other — they can never compete for
+# capture. Rollback = stop this, start rabbit-voice.
+#
+# 🔴 SAFETY: the router holds ZERO motion authority — motion is transcript
+# TEXT handed to the one fail-closed /intent door, identical to a human
+# typing. Ambiguity ("go ahead", "do it") fails closed to a spoken
+# clarification with NO endpoint contacted. Voice "stop" becomes Mick's
+# typed governed hold intent — NOT a motor cutoff; the physical e-stop is
+# separate hardware. Acceptance is spoken as ADMISSION only.
+#
+# OPT-IN: wake_word.py exits 0 immediately unless KIRRA_WAKE_ENABLED=1 in
+# /etc/kirra/robot.env; the default Pulse capture needs KIRRA_PULSE_SOURCE
+# set there. The conversation leg needs mick_chat_service (:8103), the
+# motion leg mick_service (:8102) — each failure is spoken, never retried.
+#
+# Install (install_robot_units.sh stages this into ~/.config/systemd/user/):
+#   systemctl --user daemon-reload
+#   systemctl --user stop rabbit-voice.service     # hand over the mic
+#   systemctl --user start mick-voice-router.service
+#   loginctl enable-linger <user>   # start the user manager at boot (headless)
+
+[Unit]
+Description=KIRRA Mick voice router (user session; wake word -> deterministic route -> chat stream | governed /intent)
+Documentation=https://github.com/kirra-systems/kirra-runtime-sdk
+Conflicts=rabbit-voice.service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/kirra/robot.env
+WorkingDirectory=/opt/kirra/robot
+# The pipeline script (absolute path) runs wake -> transcribe -> route with
+# pipefail; systemd's default control-group kill tears all stages down
+# together on stop. No ROS is sourced — the router has no perception
+# grounding (see mick_voice_router.sh).
+ExecStart=/opt/kirra/robot/mick_voice_router.sh
+# on-failure (NOT always): a disabled listener (KIRRA_WAKE_ENABLED unset)
+# exits 0 and the unit rests inactive; a capture-preflight FATAL exits 1 and
+# retries at RestartSec pace — visible in the journal, never a tight loop.
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target

--- a/robot/install/systemd/user/rabbit-voice.service
+++ b/robot/install/systemd/user/rabbit-voice.service
@@ -29,6 +29,12 @@
 [Unit]
 Description=KIRRA Rabbit voice listener (user session; wake word -> bounded turn -> fenced intent door)
 Documentation=https://github.com/kirra-systems/kirra-runtime-sdk
+# 🔴 MUTUAL EXCLUSION with the hybrid router frontend: exactly one voice
+# service may own the microphone. Reciprocal of the Conflicts= in
+# mick-voice-router.service — starting either stops the other. A Conflicts=
+# on a unit that is not installed is harmless (systemd ignores it), so this
+# is safe on robots that never stage the router.
+Conflicts=mick-voice-router.service
 
 [Service]
 Type=simple

--- a/robot/mick_voice_router.sh
+++ b/robot/mick_voice_router.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# mick_voice_router.sh — the HYBRID wake-driven voice pipeline:
+#
+#   wake_word.py | voice_transcribe.sh | voice_turn_router.py
+#      (trigger)     (record + STT)        (deterministic route)
+#                                            ├─ conversation → /chat/stream → piper
+#                                            └─ explicit motion → POST /intent
+#                                               (Mick → Occy → checker → release
+#                                                → consumer, unchanged)
+#
+# The sibling of rabbit_voice.sh (which keeps the legacy LLM-routed Rabbit
+# dialogue for rollback). Only ONE of the two voice services may run —
+# mick-voice-router.service and rabbit-voice.service declare mutual
+# Conflicts= so they can never compete for the microphone.
+#
+# 🔴 The router NEVER bypasses the governed motion path: motion is TEXT
+# POSTed to mick /intent (exactly what a human typing hits); ambiguity fails
+# closed to a fixed clarification with no endpoint contacted; conversation
+# talks only to the chat sidecar. See voice_turn_router.py.
+#
+# ROS is deliberately NOT sourced here: the router has no perception
+# grounding (chat has no live robot state by design), so the pipeline stays
+# lean. The legacy rabbit_voice.sh keeps its ROS sourcing for
+# rabbit_converse's "what do you see".
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Shared env (STT/RECORD/TTS/chat+intent URLs — robot/install/rabbit.env.example)
+if [ -f /etc/kirra/robot.env ]; then set -a; . /etc/kirra/robot.env; set +a; fi
+
+echo "mick_voice_router: wake phrase → follow-up turn → route (chat | governed /intent). Ctrl-C quits." >&2
+python3 "$HERE/wake_word.py" | "$HERE/voice_transcribe.sh" | python3 "$HERE/voice_turn_router.py"

--- a/robot/rabbit_latency_test.py
+++ b/robot/rabbit_latency_test.py
@@ -214,14 +214,21 @@ def test_the_default_clock_is_monotonic_not_wall_clock():
 # ── wiring: opt-in, observability-only, no new authority ─────────────────────
 
 def test_the_wiring_is_opt_in_everywhere():
+    # The recorder-stage wiring lives in voice_transcribe.sh — the ONE shared
+    # trigger→record→STT producer (extracted verbatim from rabbit_voice.sh),
+    # piped by BOTH voice frontends (rabbit_voice.sh and mick_voice_router.sh)
+    # so each gets identical opt-in staging.
     here = Path(__file__).resolve().parent
-    for name in ("rabbit_voice.sh", "rabbit_converse.py", "wake_word.py"):
+    for name in ("voice_transcribe.sh", "rabbit_converse.py", "wake_word.py"):
         text = (here / name).read_text()
         check(rl.ENV_FLAG in text or "rabbit_latency" in text,
               f"{name} should participate in staging")
     # The shell gate defaults to 0 (off) rather than on.
-    voice = (here / "rabbit_voice.sh").read_text()
+    voice = (here / "voice_transcribe.sh").read_text()
     check("LATENCY=0" in voice, "the shell timing gate must default OFF")
+    for pipeline in ("rabbit_voice.sh", "mick_voice_router.sh"):
+        check("voice_transcribe.sh" in (here / pipeline).read_text(),
+              f"{pipeline} must pipe through the shared staged producer")
 
 
 def test_timing_calls_cannot_affect_routing_or_actuation():

--- a/robot/rabbit_voice.sh
+++ b/robot/rabbit_voice.sh
@@ -40,44 +40,10 @@ if [ -f "${HERE}/ros_env.sh" ]; then
   fi
 fi
 
-if [ -z "${KIRRA_STT_CMD:-}" ]; then
-  echo "FATAL: KIRRA_STT_CMD required (e.g. \"whisper-cli -m models/ggml-base.en.bin -np -nt -f\")" >&2
-  exit 1
-fi
-: "${KIRRA_RECORD_CMD:=arecord -d 4 -f S16_LE -r 16000 -c 1}"
-
-# Opt-in stage timing (KIRRA_RABBIT_LATENCY_LOG=1). Monotonic ms; a shell
-# without EPOCHREALTIME degrades to no timing rather than to wrong timing.
-# Off → `now_ms` is never called and the loop is byte-identical.
-LATENCY=0
-case "${KIRRA_RABBIT_LATENCY_LOG:-}" in 1|true|yes|on|TRUE|YES|ON) LATENCY=1 ;; esac
-now_ms() { date +%s%3N 2>/dev/null || echo 0; }
-
-# Producer: one transcript line per trigger. STT/RECORD are word-split command
-# lists (the house convention: the WAV path is APPENDED as the last argument).
-transcribe() {
-  local wav text t0 t1 t2
-  while IFS= read -r _; do
-    wav="$(mktemp --suffix=.wav)"
-    [ "$LATENCY" = 1 ] && t0="$(now_ms)"
-    # shellcheck disable=SC2086
-    if $KIRRA_RECORD_CMD "$wav" >/dev/null 2>&1; then
-      [ "$LATENCY" = 1 ] && t1="$(now_ms)"
-      # shellcheck disable=SC2086
-      text="$($KIRRA_STT_CMD "$wav" 2>/dev/null | tr '\r\n' '  ' | sed 's/  */ /g;s/^ //;s/ $//')"
-      if [ "$LATENCY" = 1 ]; then
-        t2="$(now_ms)"
-        # Stage NAMES and durations only — never the transcript (the privacy
-        # policy is transcribe-and-discard and this must not widen it).
-        echo "rabbit_latency: capture $((t2 - t0))ms (record $((t1 - t0)), stt $((t2 - t1)))" >&2
-      fi
-      [ -n "${text// /}" ] && printf '%s\n' "$text"
-    else
-      echo "rabbit_voice: recorder failed — nothing captured" >&2
-    fi
-    rm -f "$wav"
-  done
-}
-
+# The trigger → record → STT producer is the SHARED voice_transcribe.sh
+# (extracted verbatim from this script so the hybrid router pipeline —
+# mick_voice_router.sh — reuses the same recorder/STT implementation
+# instead of a drifting copy). Its contract is unchanged: one transcript
+# line per trigger, transcribe-and-discard, stage-names-only latency lines.
 echo "rabbit_voice: trigger to talk (button press or Enter). Ctrl-C / Ctrl-D quits." >&2
-transcribe | python3 "$HERE/rabbit_converse.py"
+"$HERE/voice_transcribe.sh" | python3 "$HERE/rabbit_converse.py"

--- a/robot/voice_route.py
+++ b/robot/voice_route.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""voice_route.py — the PURE deterministic transcript router (no I/O, no LLM).
+
+One question, answered conservatively: is this utterance an EXPLICIT robot
+motion request (→ the governed /intent door), ordinary conversation (→ the
+chat sidecar), or too ambiguous to move on (→ a fixed local clarification,
+NO endpoint)?
+
+🔴 Routing philosophy (the safety half of the design):
+  * An LLM is never asked whether text is motion — the decision is a small
+    explicit grammar, testable and stable.
+  * Motion requires ACTION STRUCTURE: an imperative motion verb as the FIRST
+    token of the (wake-prefix-stripped) utterance plus a recognized
+    direction/destination complement, or an enumerated whole-utterance form
+    ("stop", "hold position", "pull over", …). Unrestricted substring matches
+    are banned — "explain how a motor drive works", "why did we stop
+    talking", "turn the explanation into a summary" and "go over that again"
+    are conversation, and the tests pin them.
+  * Ambiguity fails CLOSED for motion: "go ahead", "do it", "proceed",
+    "take me there" never route to /intent — the robot asks for specifics.
+  * This layer only chooses an ENDPOINT. Mick's own deterministic non-motion
+    fence and typed parse remain the authority behind /intent; the chat
+    sidecar's motion-shape refusal remains behind /chat. Defense in depth,
+    not replaced.
+
+Reasons are STABLE TOKENS (never transcript text) so they are loggable
+without widening the transcribe-and-discard privacy policy.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+
+
+class RouteKind(Enum):
+    CONVERSATION = "conversation"
+    MOTION = "motion"
+    AMBIGUOUS = "ambiguous"
+
+
+@dataclass(frozen=True)
+class RouteDecision:
+    kind: RouteKind
+    reason: str
+
+
+# Wake phrases (mirrors wake_word.py's set) plus bare honorifics. Stripped
+# repeatedly from the front so "hey parker rabbit stop" still classifies the
+# remainder. Stripping NEVER changes the decision grammar itself.
+_WAKE_PREFIXES = (
+    "hey parker", "hello parker", "hey rabbit", "hello rabbit",
+    "okay parker", "ok parker", "okay rabbit", "ok rabbit",
+    "parker", "rabbit",
+)
+
+# Leading courtesy that must not hide the imperative underneath.
+_COURTESY_PREFIXES = ("please", "could you", "can you", "would you", "now")
+
+# Whole-utterance forms that are motion-shaped but carry NO usable direction
+# or destination — never enough to move on. (Bare "move" included: direction
+# unknown.)
+_AMBIGUOUS_FORMS = frozenset({
+    "go", "go ahead", "do it", "proceed", "continue", "keep going",
+    "take me there", "lets go", "let s go", "move", "okay move", "ok move",
+    "carry on", "onward",
+})
+
+# Whole-utterance STOP/HOLD forms → the governed hold intent (Mick's typed
+# `hold`; Occy decelerates and holds). This is deliberately NOT a motor
+# cutoff and NOT the e-stop — the physical e-stop is separate hardware.
+_HOLD_FORMS = frozenset({
+    "stop", "halt", "hold", "hold position", "stop now", "stop moving",
+    "stop the robot", "stop driving", "stay put", "stand by",
+})
+
+# Direction complements per verb (the complement is what makes an imperative
+# verb a MOTION order rather than table talk).
+_DIR_WORDS = frozenset({
+    "forward", "forwards", "ahead", "straight", "back", "backward",
+    "backwards", "left", "right", "around",
+})
+_PRONOUN_DESTS = frozenset({"there", "here", "it", "that", "them", "away"})
+
+_WS = re.compile(r"\s+")
+_PUNCT = re.compile(r"[^a-z0-9 ]+")
+
+
+def normalize(text: str) -> str:
+    """Lowercase, strip punctuation to spaces, collapse whitespace."""
+    t = _PUNCT.sub(" ", text.lower())
+    return _WS.sub(" ", t).strip()
+
+
+def strip_wake_prefixes(norm: str) -> str:
+    """Remove leading wake phrases / honorifics / courtesy, repeatedly."""
+    changed = True
+    while changed and norm:
+        changed = False
+        for p in _WAKE_PREFIXES + _COURTESY_PREFIXES:
+            if norm == p:
+                return ""
+            if norm.startswith(p + " "):
+                norm = norm[len(p) + 1:]
+                changed = True
+    return norm
+
+
+def _dest_after_to(tokens: list[str], to_idx: int) -> str | None:
+    """The destination tokens after a 'to', or None if absent/pronoun-only.
+
+    'go to the loading dock' → 'the loading dock'; 'take me to there' → None
+    (a pronoun is not a destination the robot can resolve from this
+    utterance alone — ambiguous, do not move).
+    """
+    rest = tokens[to_idx + 1:]
+    if not rest:
+        return None
+    content = [w for w in rest if w not in ("the", "a", "an", "my", "our")]
+    if not content or all(w in _PRONOUN_DESTS for w in content):
+        return None
+    return " ".join(rest)
+
+
+def classify_transcript(text: str) -> RouteDecision:
+    """Classify ONE transcript. Pure; call exactly once per turn."""
+    norm = strip_wake_prefixes(normalize(text))
+    if not norm:
+        return RouteDecision(RouteKind.AMBIGUOUS, "empty_after_normalization")
+    tokens = norm.split(" ")
+
+    if norm in _HOLD_FORMS:
+        return RouteDecision(RouteKind.MOTION, "explicit_hold")
+    if norm in _AMBIGUOUS_FORMS:
+        return RouteDecision(RouteKind.AMBIGUOUS, "ambiguous_motion_phrase")
+
+    verb, rest = tokens[0], tokens[1:]
+
+    # Enumerated multi-word motion forms (verb-first, bounded complements).
+    if verb in ("drive", "move", "head") and rest:
+        if rest[0] in _DIR_WORDS:
+            return RouteDecision(RouteKind.MOTION, "explicit_motion_verb")
+        if rest[0] == "to":
+            if _dest_after_to(tokens, 1):
+                return RouteDecision(RouteKind.MOTION, "explicit_destination")
+            return RouteDecision(RouteKind.AMBIGUOUS, "motion_without_destination")
+    if verb == "go" and rest:
+        if rest[0] in _DIR_WORDS:
+            return RouteDecision(RouteKind.MOTION, "explicit_motion_verb")
+        if rest[0] == "to":
+            if _dest_after_to(tokens, 1):
+                return RouteDecision(RouteKind.MOTION, "explicit_destination")
+            return RouteDecision(RouteKind.AMBIGUOUS, "motion_without_destination")
+        # "go over that again", "go on" … → conversation (default below)
+    if verb == "turn" and rest and rest[0] in ("left", "right", "around"):
+        return RouteDecision(RouteKind.MOTION, "explicit_motion_verb")
+    if verb == "back" and rest and rest[0] == "up":
+        return RouteDecision(RouteKind.MOTION, "explicit_motion_verb")
+    if verb == "reverse" and (not rest or rest[0] in _DIR_WORDS | {"slowly", "a", "one", "two"}):
+        return RouteDecision(RouteKind.MOTION, "explicit_motion_verb")
+    if verb == "pull" and rest and rest[0] == "over":
+        return RouteDecision(RouteKind.MOTION, "explicit_motion_verb")
+    if verb == "cruise":
+        return RouteDecision(RouteKind.MOTION, "explicit_motion_verb")
+    if verb == "change" and rest and rest[0] in ("lane", "lanes"):
+        return RouteDecision(RouteKind.MOTION, "explicit_motion_verb")
+    if norm.startswith("lane change"):
+        return RouteDecision(RouteKind.MOTION, "explicit_motion_verb")
+    if verb == "take" and rest and rest[0] == "me":
+        if len(rest) >= 2 and rest[1] == "to" and _dest_after_to(tokens, 2):
+            return RouteDecision(RouteKind.MOTION, "explicit_destination")
+        return RouteDecision(RouteKind.AMBIGUOUS, "motion_without_destination")
+
+    return RouteDecision(RouteKind.CONVERSATION, "default_conversation")

--- a/robot/voice_route_test.py
+++ b/robot/voice_route_test.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Host tests for voice_route.classify_transcript — the pure deterministic
+transcript router. No I/O, no network, no LLM: every case is a fixed string
+in, a (RouteKind, reason-token) out.
+
+The safety cases pinned here:
+  * every REQUIRED motion phrase routes to MOTION (wake prefixes, courtesy,
+    punctuation and case must not change that);
+  * every REQUIRED conversation phrase — including the substring traps
+    ("motor drive", "stop talking", "turn the explanation", "go over that
+    again") — routes to CONVERSATION;
+  * every REQUIRED ambiguous phrase fails CLOSED (never motion);
+  * reasons are stable tokens that never contain the transcript.
+
+Runs standalone (`python3 robot/voice_route_test.py`, exit 1 on failure);
+importable under pytest.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from voice_route import (  # noqa: E402
+    RouteKind, classify_transcript, normalize, strip_wake_prefixes,
+)
+
+_F: list[str] = []
+
+
+def check(cond, msg):
+    if not cond:
+        _F.append(msg)
+        print(f"  FAIL: {msg}", file=sys.stderr)
+
+
+def kind_of(text: str) -> RouteKind:
+    return classify_transcript(text).kind
+
+
+MOTION_REQUIRED = [
+    "Drive forward one meter.",
+    "Hey Parker, turn left.",
+    "Rabbit, stop.",
+    "Please go to the loading dock.",
+    "Back up slowly.",
+    "Cruise at two meters per second.",
+    "Pull over.",
+    # extra coverage from the design examples
+    "move forward",
+    "go to the loading dock",
+    "turn right",
+    "hold position",
+    "change lanes",
+    "reverse",
+    "go straight",
+    "take me to the dock",
+    "hey parker drive forward one meter",
+    "hello rabbit turn left",
+    "parker stop",
+    "HALT",
+]
+
+CONVERSATION_REQUIRED = [
+    "How are you?",
+    "Tell me a joke.",
+    "Why did we stop talking?",
+    "Explain how a motor drive works.",
+    "Turn the explanation into a summary.",
+    "Go over that again.",
+    "What do you see?",
+    # read-only robot questions stay conversation
+    "what is your status",
+    "why did you stop",
+    "are your systems okay",
+    "what can you do",
+    "thank you",
+    "good morning",
+    "explain water treatment",
+    "what is your name",
+    # more substring traps
+    "how does a motor drive work",
+    "turn the summary into bullet points",
+    "tell me about the loading dock",
+]
+
+AMBIGUOUS_REQUIRED = [
+    "Go ahead.",
+    "Do it.",
+    "Proceed.",
+    "Take me there.",
+    "Keep going.",
+    "okay move",
+    "continue",
+    "let's go",
+    "go",
+    "move",
+]
+
+
+def test_required_motion_phrases():
+    for t in MOTION_REQUIRED:
+        d = classify_transcript(t)
+        check(d.kind is RouteKind.MOTION,
+              f"must be MOTION, got {d.kind.value} ({d.reason}): {t!r}")
+
+
+def test_required_conversation_phrases():
+    for t in CONVERSATION_REQUIRED:
+        d = classify_transcript(t)
+        check(d.kind is RouteKind.CONVERSATION,
+              f"must be CONVERSATION, got {d.kind.value} ({d.reason}): {t!r}")
+
+
+def test_required_ambiguous_phrases():
+    for t in AMBIGUOUS_REQUIRED:
+        d = classify_transcript(t)
+        check(d.kind is RouteKind.AMBIGUOUS,
+              f"must be AMBIGUOUS, got {d.kind.value} ({d.reason}): {t!r}")
+        check(d.kind is not RouteKind.MOTION,
+              f"ambiguous must NEVER become motion: {t!r}")
+
+
+def test_wake_prefixes_do_not_change_classification():
+    pairs = [
+        ("drive forward one meter", "hey parker drive forward one meter"),
+        ("turn left", "hello rabbit, turn left"),
+        ("stop", "Parker, stop!"),
+        ("how are you", "hey rabbit how are you"),
+        ("go ahead", "okay parker go ahead"),
+    ]
+    for bare, wrapped in pairs:
+        check(kind_of(bare) is kind_of(wrapped),
+              f"wake prefix changed the route: {bare!r} vs {wrapped!r}")
+
+
+def test_punctuation_case_and_honorifics():
+    variants = ["STOP", "Stop.", "stop!", "  stop  ", "Rabbit... stop?!"]
+    for v in variants:
+        check(kind_of(v) is RouteKind.MOTION, f"hold form missed: {v!r}")
+    check(kind_of("PLEASE PULL OVER!") is RouteKind.MOTION,
+          "courtesy + case must not hide 'pull over'")
+
+
+def test_pronoun_destinations_stay_ambiguous():
+    for t in ("go to there", "take me to it", "drive to that"):
+        d = classify_transcript(t)
+        check(d.kind is RouteKind.AMBIGUOUS,
+              f"pronoun destination must be AMBIGUOUS: {t!r} → {d.kind.value}")
+
+
+def test_hold_forms_are_exact_not_prefix():
+    # "stop talking" is not a robot-motion order; only enumerated hold
+    # forms qualify.
+    check(kind_of("stop talking") is RouteKind.CONVERSATION,
+          "'stop talking' must not create a hold intent")
+    check(kind_of("stop moving") is RouteKind.MOTION,
+          "'stop moving' is the hold order")
+
+
+def test_reasons_are_stable_tokens_without_transcript():
+    for t in MOTION_REQUIRED + CONVERSATION_REQUIRED + AMBIGUOUS_REQUIRED:
+        d = classify_transcript(t)
+        check(" " not in d.reason and d.reason.replace("_", "").isalnum(),
+              f"reason must be a bare token: {d.reason!r}")
+        # No transcript word longer than 3 chars may leak into the reason —
+        # except the fixed CATEGORY vocabulary the reason tokens are built
+        # from ("hold"/"motion"/"destination" name the rule, not the words).
+        for w in normalize(t).split():
+            if len(w) > 3 and w not in ("motion", "hold", "destination"):
+                check(w not in d.reason,
+                      f"transcript word {w!r} leaked into reason {d.reason!r}")
+
+
+def test_normalize_and_strip_helpers():
+    check(normalize("Hey, Parker!!") == "hey parker", "normalize basic")
+    check(strip_wake_prefixes("hey parker turn left") == "turn left",
+          "single prefix strip")
+    check(strip_wake_prefixes("okay parker please go ahead") == "go ahead",
+          "stacked prefix strip")
+    check(strip_wake_prefixes("hey parker") == "", "pure wake → empty")
+    d = classify_transcript("hey parker")
+    check(d.kind is RouteKind.AMBIGUOUS and d.reason == "empty_after_normalization",
+          "bare wake phrase fails closed with no endpoint")
+
+
+def test_every_kind_has_disjoint_membership():
+    # One transcript, one classification — sanity that the three required
+    # sets do not overlap under classification.
+    seen = {}
+    for t in MOTION_REQUIRED + CONVERSATION_REQUIRED + AMBIGUOUS_REQUIRED:
+        k = kind_of(t)
+        n = normalize(t)
+        check(seen.setdefault(n, k) is k, f"unstable classification: {t!r}")
+
+
+# --- standalone runner (house pattern) ----------------------------------------
+
+def main() -> int:
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            fn()
+            print(f"  ok  {name}")
+    if _F:
+        print(f"voice_route_test: {len(_F)} FAILURE(S)")
+        return 1
+    print("voice_route_test: ALL OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/robot/voice_transcribe.sh
+++ b/robot/voice_transcribe.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# voice_transcribe.sh — the ONE shared trigger → record → STT producer.
+#
+# Extracted VERBATIM from rabbit_voice.sh so both voice frontends share a
+# single recorder/STT implementation instead of drifting copies:
+#
+#   rabbit_voice.sh      → voice_transcribe.sh | rabbit_converse.py   (legacy)
+#   mick_voice_router.sh → voice_transcribe.sh | voice_turn_router.py (hybrid)
+#
+# Contract: each line on stdin is a TRIGGER (wake_word.py / ptt_button.py /
+# Enter); each trigger records ONE bounded clip ($KIRRA_RECORD_CMD, WAV path
+# appended), transcribes it ($KIRRA_STT_CMD, WAV path appended) and emits ONE
+# transcript line on stdout. Empty/failed captures emit nothing. The WAV is
+# deleted after STT; the transcript is never written to disk and never logged
+# (opt-in latency lines carry stage names + durations ONLY).
+#
+# The caller sources /etc/kirra/robot.env (and ROS, if its consumer needs
+# it) BEFORE piping in — this producer reads only its two commands from the
+# environment and stays session-agnostic.
+set -euo pipefail
+
+if [ -z "${KIRRA_STT_CMD:-}" ]; then
+  echo "FATAL: KIRRA_STT_CMD required (e.g. \"whisper-cli -m models/ggml-base.en.bin -np -nt -f\")" >&2
+  exit 1
+fi
+: "${KIRRA_RECORD_CMD:=arecord -d 4 -f S16_LE -r 16000 -c 1}"
+
+LATENCY=0
+case "${KIRRA_RABBIT_LATENCY_LOG:-}" in 1|true|yes|on|TRUE|YES|ON) LATENCY=1 ;; esac
+now_ms() { date +%s%3N 2>/dev/null || echo 0; }
+
+while IFS= read -r _; do
+  wav="$(mktemp --suffix=.wav)"
+  [ "$LATENCY" = 1 ] && t0="$(now_ms)"
+  # shellcheck disable=SC2086
+  if $KIRRA_RECORD_CMD "$wav" >/dev/null 2>&1; then
+    [ "$LATENCY" = 1 ] && t1="$(now_ms)"
+    # shellcheck disable=SC2086
+    text="$($KIRRA_STT_CMD "$wav" 2>/dev/null | tr '\r\n' '  ' | sed 's/  */ /g;s/^ //;s/ $//')"
+    if [ "$LATENCY" = 1 ]; then
+      t2="$(now_ms)"
+      # Stage NAMES and durations only — never the transcript.
+      echo "rabbit_latency: capture $((t2 - t0))ms (record $((t1 - t0)), stt $((t2 - t1)))" >&2
+    fi
+    [ -n "${text// /}" ] && printf '%s\n' "$text"
+  else
+    echo "voice_transcribe: recorder failed — nothing captured" >&2
+  fi
+  rm -f "$wav"
+done

--- a/robot/voice_turn_router.py
+++ b/robot/voice_turn_router.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""voice_turn_router.py — wake-driven hybrid voice frontend: one transcript
+per stdin line → deterministic route → EXACTLY ONE endpoint (or none).
+
+    conversation → POST /chat/stream (mick_chat_service) → streamed sentences
+                   → piper, via the existing mick_voice_chat turn runner
+    motion       → POST /intent (mick_service) — TEXT ONLY; Mick's typed
+                   parse, Occy, the checker, release and the consumer are
+                   unchanged downstream
+    ambiguous    → a FIXED local clarification; NO endpoint is contacted
+
+🔴 SEPARATION (all host-tested):
+  * this process knows exactly two HTTP endpoints — the chat sidecar and the
+    intent door. No planner, ROS, verifier, release-token, serial, or motor
+    API is imported or addressed, and the actuation-fence test pins that;
+  * a transcript goes to AT MOST one endpoint, never both;
+  * NO automatic retry anywhere on the motion path (a retry could duplicate
+    an accepted intent); every failure is spoken and the turn ends;
+  * an explicit motion request that fails at /intent is NEVER re-routed to
+    chat (and conversational text is never re-routed to /intent);
+  * transcripts are transcribe-and-discard: never persisted, never logged —
+    stage names, stable reason tokens and durations only;
+  * acceptance is ADMISSION, not execution: the ack must not claim the robot
+    moved (the checker + consumer govern that downstream).
+
+Voice "stop" routes to /intent like any motion text and becomes Mick's typed
+`hold` intent (governed decel-and-hold) — it is NOT a motor cutoff and NOT
+the e-stop, which remains separate physical hardware.
+
+Env (all optional; multi-word values quoted in robot.env):
+  KIRRA_MICK_INTENT_URL          default http://127.0.0.1:8102 (falls back to
+                                 the existing KIRRA_MICK_URL convention)
+  KIRRA_MICK_CHAT_URL            default http://127.0.0.1:8103 (read by the
+                                 shared chat turn runner)
+  KIRRA_VOICE_ROUTER_TIMEOUT_MS  /intent POST timeout, default 5000
+  KIRRA_VOICE_MOTION_ACK         default "Request accepted."
+  KIRRA_VOICE_AMBIGUOUS_REPLY    default "Please say exactly where or how
+                                 you want me to move."
+  KIRRA_TTS_CMD                  text lines on stdin → audio (speak.sh)
+  KIRRA_VOICE_ROUTER_LOG         1 → stage/timing lines on stderr (default on;
+                                 0 disables — content is never logged either way)
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import mick_voice_chat  # noqa: E402 — the shared streaming chat turn runner
+from voice_route import RouteKind, classify_transcript  # noqa: E402
+
+DEFAULT_INTENT_URL = "http://127.0.0.1:8102"
+DEFAULT_MOTION_ACK = "Request accepted."
+DEFAULT_AMBIGUOUS_REPLY = "Please say exactly where or how you want me to move."
+LINE_INTENT_INVALID = "I couldn't turn that into a valid motion request."
+LINE_INTENT_RATE = "Please wait a moment before giving another motion request."
+LINE_INTENT_DOWN = "The governed motion service is unavailable."
+LINE_ROUTE_DISAGREE = ("That didn't register as a motion request. "
+                       "Please say exactly where or how you want me to move.")
+
+
+def _log_enabled() -> bool:
+    return (os.environ.get("KIRRA_VOICE_ROUTER_LOG") or "1") not in ("0", "false")
+
+
+def log_event(turn: int, token: str, ms: float | None = None) -> None:
+    """Stable tokens + durations only. NEVER transcript or reply text."""
+    if not _log_enabled():
+        return
+    tail = f" {ms:.0f}ms" if ms is not None else ""
+    print(f"voice_turn_router: turn={turn} {token}{tail}",
+          file=sys.stderr, flush=True)
+
+
+def intent_url() -> str:
+    base = (os.environ.get("KIRRA_MICK_INTENT_URL")
+            or os.environ.get("KIRRA_MICK_URL") or DEFAULT_INTENT_URL)
+    return base.rstrip("/")
+
+
+def timeout_s() -> float:
+    raw = os.environ.get("KIRRA_VOICE_ROUTER_TIMEOUT_MS") or "5000"
+    try:
+        ms = int(raw)
+    except ValueError:
+        ms = 5000
+    return max(0.5, ms / 1000.0)
+
+
+def speak_line(line: str, tts_cmd: str | None) -> None:
+    """One fixed sentence through ONE bounded TTS process. Also printed, so
+    a speakerless bench run still shows the outcome."""
+    print(f"Mick: {line}")
+    if not tts_cmd:
+        return
+    tts = mick_voice_chat.TtsPipe(tts_cmd)
+    tts.say(line)
+    tts.close()
+
+
+def post_intent(text: str, turn: int) -> tuple[str, float]:
+    """POST the transcript to the governed intent door. ONE request, NO
+    retry. Returns (spoken line, http_ms)."""
+    body = json.dumps({"text": text}).encode("utf-8")
+    req = urllib.request.Request(
+        intent_url() + "/intent", data=body,
+        headers={"Content-Type": "application/json"}, method="POST")
+    t0 = time.monotonic() * 1000.0
+    try:
+        with urllib.request.urlopen(req, timeout=timeout_s()) as resp:
+            raw = resp.read()
+    except urllib.error.HTTPError as e:
+        ms = time.monotonic() * 1000.0 - t0
+        if e.code == 429:
+            log_event(turn, "intent_rate_limited", ms)
+            return LINE_INTENT_RATE, ms
+        log_event(turn, f"intent_rejected_{e.code}", ms)
+        return LINE_INTENT_INVALID, ms
+    except (urllib.error.URLError, TimeoutError, OSError):
+        ms = time.monotonic() * 1000.0 - t0
+        log_event(turn, "intent_unreachable", ms)
+        return LINE_INTENT_DOWN, ms
+    ms = time.monotonic() * 1000.0 - t0
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        log_event(turn, "intent_malformed_response", ms)
+        return LINE_INTENT_DOWN, ms
+    if payload.get("ok") and payload.get("intent") is not None:
+        # ADMISSION only — never claim motion started or completed. The
+        # intent JSON is deliberately not read aloud.
+        log_event(turn, "intent_accepted", ms)
+        return os.environ.get("KIRRA_VOICE_MOTION_ACK") or DEFAULT_MOTION_ACK, ms
+    if payload.get("ok") and payload.get("intent") is None:
+        # The router said motion, Mick's own fence said non-motion. Fail
+        # closed: no retry, no chat fallback — a fixed clarification.
+        log_event(turn, "route_disagreement_non_motion", ms)
+        return LINE_ROUTE_DISAGREE, ms
+    log_event(turn, "intent_error_body", ms)
+    return LINE_INTENT_INVALID, ms
+
+
+def handle_turn(text: str, turn: int, tts_cmd: str | None) -> None:
+    t0 = time.monotonic() * 1000.0
+    decision = classify_transcript(text)
+    route_ms = time.monotonic() * 1000.0 - t0
+    log_event(turn, f"route={decision.kind.value} reason={decision.reason} "
+                    f"route_decision_ms", route_ms)
+
+    if decision.kind is RouteKind.CONVERSATION:
+        # The optimized streaming path, shared with mick_voice_chat:
+        # /chat/stream SSE → sentence chunks → one TTS process. Its stage
+        # logs (first sentence, first audio, totals) are content-free.
+        mick_voice_chat.run_turn(mick_voice_chat.chat_url(), text, tts_cmd)
+        return
+    if decision.kind is RouteKind.MOTION:
+        line, http_ms = post_intent(text, turn)
+        log_event(turn, "intent_http_ms", http_ms)
+        speak_line(line, tts_cmd)
+        return
+    # AMBIGUOUS — no endpoint is contacted at all; a fixed local reply.
+    log_event(turn, "ambiguous_local_clarification")
+    speak_line(os.environ.get("KIRRA_VOICE_AMBIGUOUS_REPLY")
+               or DEFAULT_AMBIGUOUS_REPLY, tts_cmd)
+
+
+def main() -> int:
+    tts_cmd = os.environ.get("KIRRA_TTS_CMD")
+    if not tts_cmd:
+        print("voice_turn_router: KIRRA_TTS_CMD unset — printing only",
+              file=sys.stderr)
+    print("voice_turn_router: transcript lines on stdin → conversation via "
+          "chat, explicit motion via the governed /intent door. Ctrl-D quits.",
+          file=sys.stderr)
+    turn = 0
+    for raw in sys.stdin:
+        text = " ".join(raw.split()).strip()
+        if not text:
+            continue
+        turn += 1  # per-turn monotonic local id; transcripts are DISCARDED
+        t0 = time.monotonic() * 1000.0
+        handle_turn(text, turn, tts_cmd)
+        log_event(turn, "turn_total_ms", time.monotonic() * 1000.0 - t0)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/robot/voice_turn_router_test.py
+++ b/robot/voice_turn_router_test.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+"""Host tests for voice_turn_router.py — endpoint isolation, fail-safety,
+speech behavior, privacy, the source-level actuation fence, and the service
+units' mutual exclusion. Stub HTTP servers stand in for mick_chat_service
+(:chat) and mick_service (:intent); no Ollama, no robot, loopback only.
+
+The safety proofs:
+  * conversation contacts ONLY the chat stub; motion ONLY the intent stub;
+    ambiguous contacts NEITHER; one transcript → at most one HTTP request;
+  * motion never touches /chat and conversation never touches /intent —
+    including when the chosen endpoint FAILS (no cross-fallback);
+  * 422 / 429 / connection-refused / malformed JSON / {"intent":null}
+    (route disagreement) each speak a fixed safe line, with NO retry;
+  * the acceptance ack claims ADMISSION only — never execution;
+  * transcripts never appear on stderr/stdout logging (stage tokens only);
+  * the router is stateless — no transcript persistence, so a restart
+    cannot replay prior turns (asserted at the source level: no file
+    writes at all);
+  * the router source references no ROS/serial/motor/planner/release
+    machinery (the voice-router fence);
+  * rabbit-voice.service and mick-voice-router.service declare mutual
+    Conflicts=, run in the user session, use absolute paths and bounded
+    on-failure restarts.
+
+Runs standalone (`python3 robot/voice_turn_router_test.py`, exit 1 on any
+failure); importable under pytest.
+"""
+from __future__ import annotations
+
+import io
+import json
+import os
+import subprocess
+import sys
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+import voice_turn_router as router  # noqa: E402
+
+_F: list[str] = []
+
+
+def check(cond, msg):
+    if not cond:
+        _F.append(msg)
+        print(f"  FAIL: {msg}", file=sys.stderr)
+
+
+# --- stub endpoints -----------------------------------------------------------
+
+class StubState:
+    chat_paths: list[str] = []
+    intent_paths: list[str] = []
+    intent_mode = "accept"
+    intent_bodies: list[dict] = []
+
+
+def _sse(handler, events):
+    handler.send_response(200)
+    handler.send_header("Content-Type", "text/event-stream")
+    handler.end_headers()
+    for ev, data in events:
+        handler.wfile.write(
+            f"event: {ev}\ndata: {json.dumps(data)}\n\n".encode())
+
+
+class ChatStub(BaseHTTPRequestHandler):
+    def do_POST(self):  # noqa: N802
+        StubState.chat_paths.append(self.path)
+        length = int(self.headers.get("Content-Length", 0))
+        self.rfile.read(length)
+        _sse(self, [
+            ("start", {}),
+            ("delta", {"text": "Doing "}),
+            ("sentence", {"text": "Doing well, thanks for asking."}),
+            ("done", {"ttft_ms": 5, "total_ms": 9}),
+        ])
+
+    def log_message(self, *_):
+        pass
+
+
+class IntentStub(BaseHTTPRequestHandler):
+    def do_POST(self):  # noqa: N802
+        StubState.intent_paths.append(self.path)
+        length = int(self.headers.get("Content-Length", 0))
+        StubState.intent_bodies.append(
+            json.loads(self.rfile.read(length) or b"{}"))
+        mode = StubState.intent_mode
+        if mode == "accept":
+            body, code = {"ok": True, "seq": 12, "at_ms": 1,
+                          "intent": {"intent": "go_to", "x_m": 1.0}}, 200
+        elif mode == "nonmotion":
+            body, code = {"ok": True, "intent": None}, 200
+        elif mode == "422":
+            body, code = {"ok": False, "error": "MICK_JSON_PARSE_ERROR"}, 422
+        elif mode == "429":
+            body, code = {"ok": False, "error": "MICK_RATE_LIMITED"}, 429
+        elif mode == "garbage":
+            payload = b"not json"
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+            return
+        else:  # pragma: no cover
+            raise AssertionError(mode)
+        payload = json.dumps(body).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, *_):
+        pass
+
+
+def serve(handler):
+    srv = HTTPServer(("127.0.0.1", 0), handler)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    return srv, f"http://127.0.0.1:{srv.server_port}"
+
+
+class Turn:
+    """Run one router turn against the stubs, capturing stdout/stderr."""
+
+    def __init__(self, chat_url, intent_url, text, turn=1):
+        os.environ["KIRRA_MICK_CHAT_URL"] = chat_url
+        os.environ["KIRRA_MICK_INTENT_URL"] = intent_url
+        os.environ.pop("KIRRA_TTS_CMD", None)
+        StubState.chat_paths.clear()
+        StubState.intent_paths.clear()
+        StubState.intent_bodies.clear()
+        out, err = io.StringIO(), io.StringIO()
+        real_out, real_err = sys.stdout, sys.stderr
+        sys.stdout, sys.stderr = out, err
+        try:
+            router.handle_turn(text, turn, tts_cmd=None)
+        finally:
+            sys.stdout, sys.stderr = real_out, real_err
+            for k in ("KIRRA_MICK_CHAT_URL", "KIRRA_MICK_INTENT_URL"):
+                os.environ.pop(k, None)
+        self.out, self.err = out.getvalue(), err.getvalue()
+        self.chat = list(StubState.chat_paths)
+        self.intent = list(StubState.intent_paths)
+
+
+# --- endpoint isolation -------------------------------------------------------
+
+def test_conversation_contacts_only_chat():
+    cs, cu = serve(ChatStub)
+    is_, iu = serve(IntentStub)
+    try:
+        t = Turn(cu, iu, "how are you")
+        check(t.chat == ["/chat/stream"], f"conversation must hit /chat/stream once: {t.chat}")
+        check(t.intent == [], f"conversation must NEVER touch /intent: {t.intent}")
+        check("Doing well" in t.out, "streamed sentence must be spoken/printed")
+    finally:
+        cs.shutdown()
+        is_.shutdown()
+
+
+def test_motion_contacts_only_intent_and_acks_admission():
+    cs, cu = serve(ChatStub)
+    is_, iu = serve(IntentStub)
+    try:
+        StubState.intent_mode = "accept"
+        t = Turn(cu, iu, "drive forward one meter")
+        check(t.intent == ["/intent"], f"motion must hit /intent once: {t.intent}")
+        check(t.chat == [], f"motion must NEVER touch chat: {t.chat}")
+        check(StubState.intent_bodies == [{"text": "drive forward one meter"}],
+              "the transcript text is the only payload")
+        check("Request accepted." in t.out, "the short ack is spoken")
+        for banned in ("go_to", "x_m", "moving", "moved", "executing",
+                       "complete", "started"):
+            check(banned not in t.out,
+                  f"ack must claim ADMISSION only, not {banned!r}: {t.out!r}")
+    finally:
+        cs.shutdown()
+        is_.shutdown()
+
+
+def test_ambiguous_contacts_neither_endpoint():
+    cs, cu = serve(ChatStub)
+    is_, iu = serve(IntentStub)
+    try:
+        for text in ("go ahead", "do it", "take me there"):
+            t = Turn(cu, iu, text)
+            check(t.chat == [] and t.intent == [],
+                  f"ambiguous must contact NOTHING: {text!r} → chat={t.chat} intent={t.intent}")
+            check("Please say exactly where or how you want me to move." in t.out,
+                  "the fixed clarification is spoken")
+    finally:
+        cs.shutdown()
+        is_.shutdown()
+
+
+def test_one_transcript_one_request_and_no_replay():
+    cs, cu = serve(ChatStub)
+    is_, iu = serve(IntentStub)
+    try:
+        StubState.intent_mode = "accept"
+        t1 = Turn(cu, iu, "turn left", turn=1)
+        t2 = Turn(cu, iu, "turn left", turn=2)
+        check(len(t1.intent) == 1 and len(t2.intent) == 1,
+              "each spoken turn maps to exactly ONE request — the router "
+              "itself never replays or retries")
+    finally:
+        cs.shutdown()
+        is_.shutdown()
+
+
+# --- fail-safety --------------------------------------------------------------
+
+def test_intent_failures_speak_safe_lines_without_retry_or_chat_fallback():
+    cs, cu = serve(ChatStub)
+    is_, iu = serve(IntentStub)
+    try:
+        cases = [
+            ("nonmotion", router.LINE_ROUTE_DISAGREE),
+            ("422", router.LINE_INTENT_INVALID),
+            ("429", router.LINE_INTENT_RATE),
+            ("garbage", router.LINE_INTENT_DOWN),
+        ]
+        for mode, line in cases:
+            StubState.intent_mode = mode
+            t = Turn(cu, iu, "drive forward one meter")
+            check(len(t.intent) == 1,
+                  f"{mode}: exactly one attempt, no retry: {t.intent}")
+            check(t.chat == [],
+                  f"{mode}: a failed motion request must NOT fall back to chat")
+            check(line in t.out, f"{mode}: must speak {line!r}, got {t.out!r}")
+        StubState.intent_mode = "accept"
+    finally:
+        cs.shutdown()
+        is_.shutdown()
+
+
+def test_unreachable_intent_service_fails_safe():
+    cs, cu = serve(ChatStub)
+    try:
+        t = Turn(cu, "http://127.0.0.1:1", "pull over")
+        check(router.LINE_INTENT_DOWN in t.out,
+              f"unreachable /intent must speak the outage line: {t.out!r}")
+        check(t.chat == [], "an /intent outage must not reroute to chat")
+    finally:
+        cs.shutdown()
+
+
+def test_unreachable_chat_service_fails_safe_without_intent_fallback():
+    is_, iu = serve(IntentStub)
+    try:
+        t = Turn("http://127.0.0.1:1", iu, "tell me a joke")
+        check(t.intent == [],
+              "a chat outage must never reroute conversation to /intent")
+    finally:
+        is_.shutdown()
+
+
+# --- privacy ------------------------------------------------------------------
+
+def test_transcript_never_appears_in_logs():
+    cs, cu = serve(ChatStub)
+    is_, iu = serve(IntentStub)
+    try:
+        StubState.intent_mode = "accept"
+        marker = "zebra unicorn waffle"  # distinctive transcript content
+        for text in (f"drive forward {marker}", f"explain {marker}",
+                     f"go ahead {marker}"):
+            t = Turn(cu, iu, text)
+            check(marker not in t.err,
+                  f"transcript leaked to stderr logs for {text!r}")
+        StubState.intent_mode = "accept"
+    finally:
+        cs.shutdown()
+        is_.shutdown()
+
+
+def _code_only(src: str) -> str:
+    """Strip # comments AND docstrings — commentary may (and does) explain
+    what the router is fenced FROM; only code touching it is a breach."""
+    import re
+    no_doc = re.sub(r'"""[\s\S]*?"""', "", src)
+    return "\n".join(line.split("#")[0] for line in no_doc.splitlines())
+
+
+def test_router_is_stateless_no_persistence():
+    import re
+    code = _code_only((HERE / "voice_turn_router.py").read_text())
+    # A BARE open( is a file access; urlopen( is the network call and fine.
+    check(not re.search(r"(?<![\w.])open\(", code),
+          "router must not open files — restart safety depends on statelessness")
+    for token in ("Path(", "tempfile", "pickle", "sqlite", "shelve"):
+        check(token not in code,
+              f"router must not persist anything (found {token!r})")
+
+
+# --- the voice-router fence ---------------------------------------------------
+
+def test_router_sources_know_only_the_two_http_doors():
+    join = lambda a, b: a + b  # noqa: E731 — needles built by concat so the
+    #                            fence test cannot match its own text
+    forbidden = [
+        join("rcl", "py"), join("ro", "s2"), join("ser", "ial"),
+        join("Motor", "Serial"), join("cmd", "_vel"), join("Twi", "st"),
+        join("release", "_token"), join("issue_ros", "_release"),
+        join("kirra_", "ffi"), join("plan", "ner_service"),
+        join("/pl", "an"), join("81", "00"),  # planner port
+        join("80", "90"),                     # verifier port
+        "subprocess.call", "os.system",
+    ]
+    for name in ("voice_turn_router.py", "voice_route.py"):
+        code = _code_only((HERE / name).read_text())
+        for needle in forbidden:
+            check(needle not in code,
+                  f"{name} references {needle!r} — the router may know ONLY "
+                  "the chat and intent HTTP doors")
+    # The chat client the router reuses is itself fenced (its own test), but
+    # pin the property here too: no /intent in the chat path.
+    code = _code_only((HERE / "mick_voice_chat.py").read_text())
+    check(join("/int", "ent") not in code,
+          "the shared chat client must stay motion-free")
+
+
+def test_explicit_motion_cannot_reach_chat_under_normal_routing():
+    # Belt and suspenders with the chat sidecar's own refusal: the router
+    # classifies first, so a motion order never even reaches /chat.
+    from voice_route import RouteKind, classify_transcript
+    for t in ("drive forward one meter", "stop", "pull over",
+              "hey parker turn left"):
+        check(classify_transcript(t).kind is RouteKind.MOTION,
+              f"motion order must classify MOTION before chat: {t!r}")
+
+
+# --- service units ------------------------------------------------------------
+
+def unit(name: str) -> str:
+    return (HERE / "install" / "systemd" / "user" / name).read_text()
+
+
+def test_units_declare_mutual_exclusion():
+    rv = unit("rabbit-voice.service")
+    mv = unit("mick-voice-router.service")
+    check("Conflicts=mick-voice-router.service" in rv,
+          "rabbit-voice must conflict with the router")
+    check("Conflicts=rabbit-voice.service" in mv,
+          "the router must conflict with rabbit-voice")
+
+
+def test_router_unit_shape():
+    mv = unit("mick-voice-router.service")
+    check("EnvironmentFile=/etc/kirra/robot.env" in mv, "env file consumed")
+    check("ExecStart=/opt/kirra/robot/mick_voice_router.sh" in mv,
+          "absolute ExecStart path")
+    check("Restart=on-failure" in mv, "bounded restart policy")
+    check("RestartSec=" in mv, "bounded restart delay")
+    check("WantedBy=default.target" in mv, "user-session unit")
+    check("Restart=always" not in mv, "never an unconditional restart loop")
+
+
+def test_installer_stages_router_pipeline():
+    src = (HERE / "install" / "install_robot_units.sh").read_text()
+    for f in ("voice_route.py", "voice_turn_router.py",
+              "voice_transcribe.sh", "mick_voice_router.sh",
+              "mick-voice-router.service"):
+        check(f in src, f"installer must stage {f}")
+
+
+def test_shared_transcriber_is_the_single_recorder():
+    rv = (HERE / "rabbit_voice.sh").read_text()
+    check("voice_transcribe.sh" in rv,
+          "rabbit_voice.sh must use the shared transcriber")
+    check("KIRRA_RECORD_CMD" not in rv.split("voice_transcribe.sh")[0]
+          or "transcribe()" not in rv,
+          "the inline recorder copy must be gone from rabbit_voice.sh")
+    mr = (HERE / "mick_voice_router.sh").read_text()
+    check("voice_transcribe.sh" in mr and "wake_word.py" in mr,
+          "the router pipeline must reuse wake + the shared transcriber")
+
+
+# --- standalone runner (house pattern) ----------------------------------------
+
+def main() -> int:
+    t0 = time.monotonic()
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            fn()
+            print(f"  ok  {name}")
+    if _F:
+        print(f"voice_turn_router_test: {len(_F)} FAILURE(S)")
+        return 1
+    print(f"voice_turn_router_test: ALL OK ({time.monotonic() - t0:.1f}s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Architecture

```
wake_word.py | voice_transcribe.sh | voice_turn_router.py
  (trigger)     (record + STT,        (deterministic route, EXACTLY ONE endpoint)
                 shared producer)       ├─ conversation → /chat/stream → sentence-chunked piper
                                        │                 (the existing mick_voice_chat turn runner)
                                        ├─ explicit motion → TEXT to mick POST /intent
                                        │                 → typed MickIntent → Occy → checker
                                        │                 → release → consumer (ALL UNCHANGED)
                                        └─ ambiguous → fixed spoken clarification, NO endpoint
```

The legacy pipeline is preserved for rollback: `rabbit_voice.sh` now pipes the extracted shared producer into `rabbit_converse.py` unchanged. The two frontends are mutually exclusive services.

## Routing rules (pure, no LLM — `robot/voice_route.py`)

1. Normalize (lowercase, punctuation → spaces) and strip wake prefixes (`hey/hello/ok(ay) parker|rabbit`, bare honorifics) + leading courtesy (`please`, `could you`, …) repeatedly. Wake prefixes provably never change the decision.
2. Enumerated whole-utterance **hold** forms (`stop`, `halt`, `hold position`, `stop moving`, …) → MOTION (`explicit_hold`). Voice "stop" becomes **Mick's typed governed HOLD intent** — documented as *not* a motor cutoff; the physical e-stop remains separate hardware.
3. Enumerated whole-utterance **ambiguous** forms (`go`, `go ahead`, `do it`, `proceed`, `continue`, `keep going`, `take me there`, bare `move`, …) → AMBIGUOUS, never motion.
4. Motion otherwise requires **action structure**: an imperative motion verb as the *first* token plus a bounded complement — `drive/move/go/head + direction`, `turn left|right|around`, `back up`, `pull over`, `reverse`, `cruise`, `change lanes`, or `go to/drive to/take me to + real destination` (a pronoun-only destination → AMBIGUOUS, `motion_without_destination`).
5. Everything else → CONVERSATION (`default_conversation`), including read-only robot questions ("what do you see", "why did you stop").

Substring traps pinned by test: *"explain how a motor drive works"*, *"why did we stop talking"*, *"turn the explanation into a summary"*, *"go over that again"* are conversation. Reasons are stable tokens (`explicit_motion_verb`, `explicit_hold`, `ambiguous_motion_phrase`, …) that never contain transcript text.

## Fail-closed behavior (`robot/voice_turn_router.py`)

- One transcript → classified **once** → **at most one** HTTP request. No retry anywhere on the motion path (a retry could duplicate an accepted intent).
- `/intent` outcomes: **accepted** → short configurable ack (default "Request accepted.") that claims **admission only** — the test bans "moving/executed/completed" wording and reading the intent JSON aloud; **`{"intent":null}`** (router vs Mick-fence disagreement) → fixed clarification, logged as a `route_disagreement_non_motion` token, no retry, no chat fallback; **422** → "I couldn't turn that into a valid motion request."; **429** → "Please wait a moment…"; **unreachable/malformed** → "The governed motion service is unavailable." — never a chat fallback.
- Ambiguous → fixed local clarification; *neither* endpoint contacted.
- A chat outage never reroutes conversation to `/intent`.
- Stateless by construction (no file I/O at all, test-pinned) — restart cannot replay prior turns; transcripts are transcribe-and-discard and never logged (stage tokens + durations only, leak-tested with a marker transcript).
- Defense in depth retained: Mick's own deterministic non-motion fence sits behind `/intent`, the chat sidecar's motion-shape refusal behind `/chat` — this router is an *additional* admission layer, not a replacement.

## Isolation proofs (all host-tested with stub servers)

conversation → only `/chat/stream`; motion → only `/intent`; ambiguous → neither; every `/intent` failure mode → exactly one attempt, correct spoken line, zero chat contact; the voice-router **fence**: router sources reference no ROS/rclpy/serial/Twist/release-token/planner/verifier tokens or ports (needles built by concatenation, docstrings excluded); `ci/check_mick_actuation_fence.py` INTACT.

## Service mutual exclusion

`mick-voice-router.service` (new user unit, opt-in) declares `Conflicts=rabbit-voice.service` and rabbit-voice declares the reciprocal — starting either stops the other, so exactly one frontend owns the microphone (a `Conflicts=` on an uninstalled unit is inert, so the reciprocal is safe on router-less robots). Unit shape test-pinned: user session (`WantedBy=default.target`), `EnvironmentFile=/etc/kirra/robot.env`, absolute `ExecStart`, `Restart=on-failure` + `RestartSec=5`, never `Restart=always`. No ROS is sourced in the router pipeline (no perception grounding by design).

## Latency instrumentation (content-free)

`route_decision_ms`, `intent_http_ms`, and per-turn `turn_total_ms` from the router; `chat_ttft_ms` / `first_sentence_ms` / `tts_first_audio_ms` / `voice_to_first_audio_ms` from the shared `mick_voice_chat` turn runner. The conversation leg preserves the measured optimized path (phi3 streaming + sentence-chunked single piper process); model selection untouched.

## Files changed

New: `robot/voice_route.py`, `robot/voice_turn_router.py`, `robot/voice_transcribe.sh`, `robot/mick_voice_router.sh`, `robot/install/systemd/user/mick-voice-router.service`, `robot/voice_route_test.py`, `robot/voice_turn_router_test.py`. Modified: `robot/rabbit_voice.sh` (extracted producer, behavior preserved), `robot/install/systemd/user/rabbit-voice.service` (reciprocal Conflicts), `robot/install/install_robot_units.sh` (stage the pipeline + both units), `robot/install/rabbit.env.example` (new vars, quoted), `.github/workflows/ci.yml` (run both suites).

## Test results

- `voice_route_test.py` — ALL OK (all required motion/conversation/ambiguous sets, wake-prefix invariance, punctuation/case, pronoun destinations, exact hold forms, token-only reasons)
- `voice_turn_router_test.py` — ALL OK (endpoint isolation, failure matrix, no-retry/no-replay, admission-only ack, privacy, fence, unit exclusion + shape, installer staging)
- Existing: wake_word / wake_capture / vad_record (32) / rabbit_voice (18) / mick_voice_chat / env_quoting / deployment_verify (43) / staging_completeness / voice_env_access — all green
- Rust: `kirra-sidecars` + `kirra-mick` (all green incl. 189 sidecar tests), `kirra-planner mick` (75), `kirra-actuation-consumer --test spoken_governed_loop` (3) and `--test mick_governed_loop` (3) — green
- `cargo fmt --check`, `clippy -D warnings`, `bash -n`, `shellcheck -S error`, `py_compile`, `git diff --check`, conflict-marker scan — clean

## Intentionally unsupported phrases

Bare directions ("forward one meter" with no verb), "come here", "follow me", "slow down"/"speed up", non-English, and any utterance without explicit action structure — all route to conversation or ambiguous by design; the vocabulary can be extended later with tests.

## After merge (not run from CI — no live-robot changes were made)

```bash
cd "$HOME/kirra-runtime-sdk" && git switch main && git pull --ff-only
sudo robot/install/install_robot_units.sh
systemctl --user daemon-reload
sudo systemctl stop kirra-planner.service        # keep the planner parked
systemctl --user stop rabbit-voice.service
systemctl --user start mick-voice-router.service
sleep 3
pgrep -af 'wake_word|parec|rabbit_voice|voice_turn_router|mick_voice_chat'   # ONE mic owner
```

Then verify in order: (1) "Hey Parker" → "How are you?" → streamed reply, `/intent/last` stays null; (2) "Go ahead." → fixed clarification, latch unchanged; (3) "Drive forward one meter." → `/intent` only, typed intent may latch, short ack, **no motion** (planner parked); (4) only then inspect the governed chain separately. Acceptance is admission — no motion-execution claim is made from CI or from the ack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_