### PR TITLE
perf(voice): reduce VAD endpoint latency using measured Jetson calibration

### DIFF
--- a/docs/hardware/R2_VOICE_AUDIO_SETUP.md
+++ b/docs/hardware/R2_VOICE_AUDIO_SETUP.md
@@ -125,7 +125,7 @@ a short command vs a flat 4 s window) and pulls its raw stream through the same
 Pulse backend, so no ALSA device var is needed. Tunables if the room needs them:
 
 ```bash
-KIRRA_VAD_SILENCE_MS=650
+KIRRA_VAD_SILENCE_MS=600
 KIRRA_VAD_MIN_SPEECH_MS=250
 KIRRA_VAD_MAX_MS=6000
 KIRRA_VAD_START_TIMEOUT_MS=3000

--- a/docs/hardware/RABBIT_AUDIO_STACK.md
+++ b/docs/hardware/RABBIT_AUDIO_STACK.md
@@ -116,11 +116,27 @@ KIRRA_RECORD_CMD="python3 /opt/kirra/robot/vad_record.py"
 KIRRA_VAD_CAPTURE_CMD="/opt/kirra/robot/pulse_capture.sh"   # + KIRRA_PULSE_SOURCE
 # headless/no-session ALSA-direct variant instead:
 #KIRRA_VAD_DEVICE="plughw:CARD=<YOUR_CARD>,DEV=0"   # REQUIRED then — `arecord -l`
-KIRRA_VAD_SILENCE_MS=650      # trailing silence that ends the utterance
+KIRRA_VAD_SILENCE_MS=600      # trailing silence that ends the utterance
 KIRRA_VAD_MIN_SPEECH_MS=250   # min ACTUAL speech before an endpoint is honored
 KIRRA_VAD_MAX_MS=6000         # HARD ceiling
 KIRRA_VAD_START_TIMEOUT_MS=3000
 ```
+
+**Endpoint defaults are Jetson-calibrated (2026-08).** `vad_record.py` ships
+`KIRRA_VAD_RMS_FLOOR=350` and `KIRRA_VAD_SILENCE_MS=600` as its built-in
+defaults, changed from the original `300` / `800 ms` on hardware evidence:
+
+| | RMS floor | trailing silence | observed on the Orin NX |
+|---|---|---|---|
+| before | 300 | 800 ms | ambient room noise intermittently crossed the 300 floor, so the endpointer kept "hearing speech" and frequent turns ran to `stopped: max (8000 ms)` — the worst case is SLOWER than the old fixed 4 s window |
+| after | **350** | **600 ms** | endpointed reliably; three consecutive successful captures; no clipping of final words; STT transcripts remained correct |
+
+The two knobs move together: the higher floor stops ambient noise from holding
+the clip open (the max-duration failure), and once endpointing is reliable the
+shorter silence tail returns ~200 ms per turn without cutting anyone off. If
+YOUR room differs, the same tuning rule stands: raise `KIRRA_VAD_RMS_FLOOR`
+when captures run to the cap, raise `KIRRA_VAD_SILENCE_MS` if final words get
+clipped — `robot/kirra_voice_doctor.sh` reports the effective settings.
 
 **The microphone is always explicit.** On the ALSA-direct variant
 `KIRRA_VAD_DEVICE` is required with deliberately no default: ALSA's default is
@@ -133,13 +149,13 @@ fallback). This is the same rule the wake listener already enforces on
 `KIRRA_WAKE_RECORD_CMD`, and for the same reason; the wake and turn recorders
 remain separate variables and separate contracts.
 
-What the ~2.6 s saving looks like on a short command ("how are you?", ~690 ms of
+What the ~2.7 s saving looks like on a short command ("how are you?", ~690 ms of
 speech):
 
 | | capture | note |
 |---|---|---|
 | `arecord -d 4` | **4000 ms** | every turn, however short |
-| VAD (`silence 650`) | **~1340 ms** | 690 ms speech + 650 ms trailing silence |
+| VAD (`silence 600`) | **~1290 ms** | 690 ms speech + 600 ms trailing silence |
 
 It stays a **bounded** mic, not an open one, and there are now three bounds, not
 one:

--- a/robot/install/rabbit.env.example
+++ b/robot/install/rabbit.env.example
@@ -129,8 +129,8 @@ KIRRA_VAD_CAPTURE_CMD="/opt/kirra/robot/pulse_capture.sh"
 # empty/garbled clip still dead-ends at the fenced /intent door (no intent, no
 # motion). Tunables (defaults shown):
 #KIRRA_VAD_BACKEND=energy         # 'energy' (RMS, zero deps); silero/webrtc = later slice
-#KIRRA_VAD_RMS_FLOOR=300          # speech energy threshold (16-bit FS = 32767)
-#KIRRA_VAD_SILENCE_MS=650         # trailing silence that ends the utterance
+#KIRRA_VAD_RMS_FLOOR=350          # speech energy threshold (16-bit FS = 32767)
+#KIRRA_VAD_SILENCE_MS=600         # trailing silence that ends the utterance
 #KIRRA_VAD_MIN_SPEECH_MS=250      # min actual speech before an endpoint is honored
 #KIRRA_VAD_MAX_MS=6000            # HARD ceiling (the bounded-mic guarantee; <= 30000)
 #KIRRA_VAD_START_TIMEOUT_MS=3000  # if speech never starts, give up (empty clip → no-op)

--- a/robot/kirra_voice_doctor.sh
+++ b/robot/kirra_voice_doctor.sh
@@ -196,7 +196,7 @@ case "$turn_prog" in
     elif [ "$vsto" -gt "$vmax" ]; then
       bad "KIRRA_VAD_START_TIMEOUT_MS=$vsto exceeds KIRRA_VAD_MAX_MS=$vmax (it could never fire)"; fix "set the start timeout below the ceiling"
     else
-      ok "VAD bounds sane: max ${vmax}ms, start timeout ${vsto}ms, silence ${KIRRA_VAD_SILENCE_MS:-800}ms"
+      ok "VAD bounds sane: max ${vmax}ms, start timeout ${vsto}ms, silence ${KIRRA_VAD_SILENCE_MS:-600}ms"
     fi
     ;;
   arecord)

--- a/robot/vad_record.py
+++ b/robot/vad_record.py
@@ -45,10 +45,14 @@ Env:
                            is left alone — it has its own device convention and
                            this module has no business guessing it.
   KIRRA_VAD_BACKEND        'energy' (default); other → refuse
-  KIRRA_VAD_RMS_FLOOR      speech energy threshold (default 300; 16-bit FS=32767)
+  KIRRA_VAD_RMS_FLOOR      speech energy threshold (default 350; 16-bit FS=32767;
+                           Jetson-measured 2026-08: 300 let ambient noise hold
+                           the clip open to the max_ms cap)
   KIRRA_VAD_FRAME_MS       analysis frame (default 30 ms)
   KIRRA_VAD_MIN_SPEECH_MS  min speech before an endpoint is honored (default 300)
-  KIRRA_VAD_SILENCE_MS     trailing silence that ends the utterance (default 800)
+  KIRRA_VAD_SILENCE_MS     trailing silence that ends the utterance (default 600;
+                           Jetson-measured 2026-08: 600 endpoints reliably with
+                           no clipping of final words)
   KIRRA_VAD_MAX_MS         HARD ceiling — always stop by here (default 8000;
                            must be positive and <= VAD_ABSOLUTE_MAX_MS)
   KIRRA_VAD_START_TIMEOUT_MS  if speech never starts, give up (default 3000)
@@ -304,9 +308,9 @@ def main(argv):
 
     sample_rate = _env_int("KIRRA_VAD_SAMPLE_RATE", 16000)
     frame_ms = _env_int("KIRRA_VAD_FRAME_MS", 30)
-    floor = _env_int("KIRRA_VAD_RMS_FLOOR", 300)
+    floor = _env_int("KIRRA_VAD_RMS_FLOOR", 350)
     min_speech_ms = _env_int("KIRRA_VAD_MIN_SPEECH_MS", 300)
-    silence_ms = _env_int("KIRRA_VAD_SILENCE_MS", 800)
+    silence_ms = _env_int("KIRRA_VAD_SILENCE_MS", 600)
     max_ms = _env_int("KIRRA_VAD_MAX_MS", 8000)
     start_timeout_ms = _env_int("KIRRA_VAD_START_TIMEOUT_MS", 3000)
 

--- a/robot/vad_record_test.py
+++ b/robot/vad_record_test.py
@@ -170,26 +170,41 @@ def test_a_short_command_endpoints_well_before_the_old_fixed_window():
     (30 ms), so this is the recorder's own timing model, not wall clock.
     """
     OLD_FIXED_MS = 4000
-    ep = Endpointer(min_speech_ms=250, silence_ms=650, max_ms=6000,
+    ep = Endpointer(min_speech_ms=250, silence_ms=600, max_ms=6000,
                     start_timeout_ms=3000)     # the deployed settings
     speech_frames = 23                          # ~690 ms of speech
     reason, t = _run(ep, [True] * speech_frames + [False] * 100)
     check(reason == STOP_ENDPOINTED, f"a normal short command must endpoint, got {reason}")
     check(t < OLD_FIXED_MS,
           f"VAD took {t} ms — no better than the fixed {OLD_FIXED_MS} ms window")
-    # Speech ends at 690 ms; +650 ms silence ⇒ ~1340 ms, a ~2.6 s saving.
-    check(1300 <= t <= 1400, f"expected ~1340 ms, got {t}")
+    # Speech ends at 690 ms; +600 ms silence ⇒ ~1290 ms, a ~2.7 s saving.
+    check(1250 <= t <= 1350, f"expected ~1290 ms, got {t}")
     check(OLD_FIXED_MS - t > 2000, f"saving only {OLD_FIXED_MS - t} ms; expected > 2 s")
 
 
 def test_a_long_utterance_still_gets_its_time_up_to_the_cap():
     # The flip side: VAD must not truncate someone speaking a full sentence.
-    ep = Endpointer(min_speech_ms=250, silence_ms=650, max_ms=6000,
+    ep = Endpointer(min_speech_ms=250, silence_ms=600, max_ms=6000,
                     start_timeout_ms=3000)
     reason, t = _run(ep, [True] * 150 + [False] * 40)   # 4.5 s of speech
     check(reason == STOP_ENDPOINTED, f"expected endpoint, got {reason}")
     check(t > 4500, f"a 4.5 s utterance was cut at {t} ms")
     check(t <= 6000, f"must never exceed the hard cap, got {t} ms")
+
+
+def test_shipped_endpoint_defaults_are_the_jetson_calibrated_values():
+    """The 2026-08 Orin calibration: RMS floor 350 (300 let ambient noise
+    hold the clip open to the max_ms cap — 'stopped: max (8000 ms)') and
+    trailing silence 600 ms (endpointed reliably, no clipping of final
+    words, STT accuracy preserved across three consecutive captures). A
+    silent revert of either default reintroduces the max-duration failure,
+    so the shipped literals are pinned here."""
+    import pathlib
+    src = (pathlib.Path(__file__).resolve().parent / "vad_record.py").read_text()
+    check('_env_int("KIRRA_VAD_RMS_FLOOR", 350)' in src,
+          "shipped RMS floor default must be the calibrated 350")
+    check('_env_int("KIRRA_VAD_SILENCE_MS", 600)' in src,
+          "shipped trailing-silence default must be the calibrated 600 ms")
 
 
 # ── explicit capture device required (fail-closed, before any mic opens) ─────


### PR DESCRIPTION
Problem
--------
Jetson Orin NX hardware measurements showed the default VAD configuration frequently ran to the 8 s capture limit (`stopped: max (8000 ms)`) because ambient room RMS occasionally crossed the 300 threshold — the endpointer kept "hearing speech", so the worst case was *slower* than the old fixed 4 s `arecord` window.

Solution
--------
Change the shipped defaults at their canonical source (`robot/vad_record.py`'s built-in `_env_int` defaults — not a machine-specific `robot.env`):

- `KIRRA_VAD_RMS_FLOOR`: **300 → 350**
- `KIRRA_VAD_SILENCE_MS`: **800 → 600**

The two move together: the higher floor stops ambient noise from holding the clip open (the max-duration failure), and once endpointing is reliable the shorter silence tail returns ~200 ms per turn without clipping.

Mirrors updated to stay in agreement: `kirra_voice_doctor.sh`'s fallback display (`:-800` → `:-600`), `rabbit.env.example`'s commented defaults, and both hardware docs (`RABBIT_AUDIO_STACK.md` §1a gains the measured before/after table; the `650` example blocks in both docs move to `600`; the short-command math updates 690+650≈1340 → 690+600≈1290 ms).

Measured Results
----------------
Before (RMS 300 / silence 800):
- frequent max-duration captures (`stopped: max (8000 ms)`)

After (RMS 350 / silence 600):
- three consecutive endpointed captures
- no clipping of final words
- STT transcripts remained correct

Tests
-----
- `vad_record_test.py`: the two "deployed settings" latency tests now track the tuned values (short command endpoints at ~1290 ms, still >2 s better than the fixed window; a 4.5 s utterance is still never truncated), and a new regression test pins the shipped literals so a silent revert of either calibrated default fails loudly.
- Full runs: `vad_record_test` 33/33, `env_quoting_test`, `rabbit_voice_test` 18/18, `wake_word_test`, `deployment_verify_test` 43/43 — all green; `cargo fmt --check` + `clippy -D warnings` (no Rust touched), `bash -n`/`shellcheck -S error` on the doctor, `py_compile`, `git diff --check` — clean.

Safety
------
No actuation path changed. Only microphone endpoint-detection defaults changed; the bounded-mic guarantees (hard `max_ms` ceiling, wall-clock stall bound, start timeout, explicit-device requirement) are untouched. An already-deployed robot keeps its own `robot.env` overrides — this changes what a *fresh* install ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_