### PR TITLE
fix(voice): robot playback can no longer trigger its own voice turns

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1525,6 +1525,16 @@ jobs:
           # Conflicts= exclusion (one mic owner).
           python3 robot/voice_route_test.py
           python3 robot/voice_turn_router_test.py
+          # Playback self-echo suppression (host, flock + subprocess + stub
+          # HTTP — no audio): the robot must not hear its own Piper output
+          # (live R2 failure: follow-up "speech onset" fired on playback →
+          # unbounded self-conversation). Pins the lock lifecycle (crash
+          # auto-release, single owner, reentrancy, cooldown INSIDE the
+          # hold), the pure no-trigger-during-playback invariant + episode
+          # cap, the self-echo regression (one turn → one request → no
+          # second trigger), guard coverage of every spoken router path,
+          # the barge-in fence, and content-free logs.
+          python3 robot/voice_playback_test.py
           # mick_chat.py terminal client (host, stub HTTP server — no Ollama):
           # success/malformed/timeout/4xx-5xx/EOF paths, the service error
           # token surfaced, and the SEPARATION proofs — only /chat is ever

--- a/docs/hardware/R2_VOICE_AUDIO_SETUP.md
+++ b/docs/hardware/R2_VOICE_AUDIO_SETUP.md
@@ -137,6 +137,18 @@ is bounded by a wall clock. (Only the headless ALSA-direct variant uses
 before opening anything rather than falling back to ALSA's default — not the
 mic, and it fails silently.) Details + tuning: `RABBIT_AUDIO_STACK.md` §1a.
 
+**Robot playback is suppressed from wake/follow-up detection** (§1b of
+`RABBIT_AUDIO_STACK.md`): while the robot speaks, the TTS side holds an
+flock (`KIRRA_VOICE_PLAYBACK_STATE`, per-user runtime dir) that the wake
+listener probes — the robot's own Piper output can never fire
+`wake_word: follow-up: speech onset` and start a self-conversation loop
+(the live 2026-08 failure). A post-playback cooldown
+(`KIRRA_VOICE_PLAYBACK_COOLDOWN_MS`, default 500) discards the speaker
+tail, and `KIRRA_VOICE_MAX_FOLLOWUP_TURNS` (default 3) caps wake-free
+follow-ups per episode. Barge-in is intentionally disabled on this path
+(no AEC — RMS cannot tell the operator from the speaker). Rollback:
+`systemctl --user start rabbit-voice.service`.
+
 ## 5. PTT button (GPIO) — the Orin gotchas
 ```bash
 # JetPack 6.2 "Super": stock Jetson.GPIO 2.1.7 fails ("Could not determine Jetson

--- a/docs/hardware/RABBIT_AUDIO_STACK.md
+++ b/docs/hardware/RABBIT_AUDIO_STACK.md
@@ -122,6 +122,61 @@ KIRRA_VAD_MAX_MS=6000         # HARD ceiling
 KIRRA_VAD_START_TIMEOUT_MS=3000
 ```
 
+### 1b. Playback self-echo suppression — the robot must not hear itself
+
+**The failure this prevents (observed live on the R2, 2026-08):** the hybrid
+router spoke a reply, the wake listener's follow-up mode reopened the mic
+mid-playback, Piper's own output crossed the RMS floor, and
+
+```
+wake_word: follow-up: speech onset — firing without a wake word
+```
+
+repeated during playback — the robot recorded ITSELF (captures ran to the
+VAD ceiling because playback kept energy high), transcribed itself, routed
+the transcript to chat, answered aloud, and re-heard the answer: an
+unbounded self-conversation loop. **RMS-only filtering cannot fix this** —
+the speaker's output at the mic is ordinary loud audio, indistinguishable
+from operator speech by energy alone.
+
+**The mechanism** (`robot/voice_playback.py`): every spoken output — the
+streamed conversational reply, the motion admission ack, error lines, the
+ambiguity clarification, the ack tone — runs under a `PlaybackGuard`: an
+advisory `flock` on `KIRRA_VOICE_PLAYBACK_STATE` (the user unit points it at
+`/run/user/<uid>/kirra-voice-playback`) held for the WHOLE playback
+lifetime: TTS start → all sentence chunks → audio drain → process wait →
+cooldown. `wake_word.py` probes the lock non-blockingly on every audio hop:
+while held, frames are **drained but discarded** — no wake STT, no
+follow-up onset accumulation, no trigger emission, nothing queued for
+later. On release the listener resets its ring/energy accumulators so no
+speaker tail survives the boundary. Because it is a kernel lock, a crashed
+or SIGKILLed TTS process releases it automatically — **suppression can
+never become stale** and permanently deafen the robot.
+
+Tuning:
+
+```bash
+KIRRA_VOICE_PLAYBACK_COOLDOWN_MS=500   # speaker-tail discard after playback (0..3000; invalid → 500)
+KIRRA_VOICE_MAX_FOLLOWUP_TURNS=3       # wake-free follow-ups per episode (0..10; invalid → 3; NO unlimited)
+```
+
+Raise the cooldown if a reverberant room still self-triggers on the tail;
+lower it toward 0 in a dead room for snappier follow-ups. The follow-up cap
+is defense in depth behind the lock: one explicit wake starts an episode,
+at most N wake-free real-operator turns follow (playback consumes nothing),
+then `wake_word: follow-up cap reached; wake required`.
+
+**Barge-in is intentionally DISABLED on this path**: while the robot
+speaks, operator speech is ignored for turn creation, because without
+acoustic echo cancellation there is no reliable way to tell the operator
+from the speaker. Interrupting requires waiting for the reply (or the
+physical e-stop for an emergency — which was never the mic's job). AEC or
+a hardware-loopback reference is future work, deliberately out of scope.
+
+Rollback: `systemctl --user stop mick-voice-router.service && systemctl
+--user start rabbit-voice.service` (the legacy pipeline; the new env keys
+are inert there and need no cleanup).
+
 **Endpoint defaults are Jetson-calibrated (2026-08).** `vad_record.py` ships
 `KIRRA_VAD_RMS_FLOOR=350` and `KIRRA_VAD_SILENCE_MS=600` as its built-in
 defaults, changed from the original `300` / `800 ms` on hardware evidence:

--- a/robot/install/install_robot_units.sh
+++ b/robot/install/install_robot_units.sh
@@ -52,7 +52,7 @@ for f in rabbit_persona.py rabbit_watch.py rabbit_ask.py rabbit_converse.py rabb
          mick_chat.py mick_voice_chat.py mick_chat_benchmark.py \
          mick_voice_benchmark.py \
          voice_route.py voice_turn_router.py voice_transcribe.sh \
-         mick_voice_router.sh; do
+         mick_voice_router.sh voice_playback.py; do
   [[ -f "${REPO}/robot/${f}" ]] || { echo "  ⚠ missing ${REPO}/robot/${f} — skipped"; continue; }
   sudo install -m 0755 "${REPO}/robot/${f}" "${OPT}/robot/${f}"
   echo "  installed ${OPT}/robot/${f}"

--- a/robot/install/rabbit.env.example
+++ b/robot/install/rabbit.env.example
@@ -329,6 +329,18 @@ KIRRA_TAJ_URL="http://localhost:8101"
 #KIRRA_VOICE_MOTION_ACK="Request accepted."
 #KIRRA_VOICE_AMBIGUOUS_REPLY="Please say exactly where or how you want me to move."
 #KIRRA_VOICE_ROUTER_LOG=1
+# Self-echo suppression (voice_playback.py): while the robot SPEAKS, the TTS
+# side holds an flock the wake listener probes — playback can never fire a
+# wake/follow-up trigger (the live self-conversation loop). The lock releases
+# automatically on process death (never stale). The unit sets the state path
+# to the per-user runtime dir; the cooldown discards the speaker tail after
+# release (0..3000 ms, invalid → 500); the follow-up cap bounds wake-free
+# turns per episode (0..10, invalid → 3; playback consumes nothing; there is
+# NO unlimited). Barge-in stays intentionally DISABLED on this path: RMS
+# alone cannot tell operator speech from speaker output.
+#KIRRA_VOICE_PLAYBACK_STATE=/run/user/1000/kirra-voice-playback
+#KIRRA_VOICE_PLAYBACK_COOLDOWN_MS=500
+#KIRRA_VOICE_MAX_FOLLOWUP_TURNS=3
 # ROS domain — MUST match the lidar (kirra-lidar.service) so rabbit_converse's
 # rclpy can subscribe to /scan for "what do you see". A systemd service does not
 # inherit your login shell's ROS_DOMAIN_ID, so set it here (rabbit_voice.sh sources

--- a/robot/install/systemd/user/mick-voice-router.service
+++ b/robot/install/systemd/user/mick-voice-router.service
@@ -39,6 +39,13 @@ Conflicts=rabbit-voice.service
 
 [Service]
 Type=simple
+# Self-echo suppression state (voice_playback.py): the flock the TTS side
+# holds while the robot speaks, probed by wake_word.py so playback can never
+# fire a wake/follow-up trigger. %t = the per-user runtime dir
+# (/run/user/<uid>) — tmpfs, user-writable, wiped at session end; the env
+# file below may override. The kernel drops the lock on process death, so a
+# crash can never leave listening suppressed.
+Environment=KIRRA_VOICE_PLAYBACK_STATE=%t/kirra-voice-playback
 EnvironmentFile=/etc/kirra/robot.env
 WorkingDirectory=/opt/kirra/robot
 # The pipeline script (absolute path) runs wake -> transcribe -> route with

--- a/robot/mick_voice_chat.py
+++ b/robot/mick_voice_chat.py
@@ -57,6 +57,9 @@ import time
 import urllib.error
 import urllib.request
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import voice_playback  # noqa: E402 — wake-listener suppression while speaking
+
 DEFAULT_URL = "http://127.0.0.1:8103"
 REQUEST_TIMEOUT_S = 90.0
 
@@ -144,7 +147,21 @@ class TtsPipe:
 
 
 def run_turn(base_url: str, text: str, tts_cmd: str | None) -> bool:
-    """One spoken turn. Returns False on transport failure (caller decides)."""
+    """One spoken turn. Returns False on transport failure (caller decides).
+
+    The WHOLE turn — ack tone, streamed sentences, TTS drain, process wait,
+    cooldown — runs under the playback guard (voice_playback.PlaybackGuard),
+    so the wake listener cannot hear the robot's own reply as operator
+    speech (the live self-conversation loop). The guard is re-entrant: a
+    caller that already holds it (voice_turn_router) nests without
+    deadlock. It releases in ALL exits, KeyboardInterrupt included — the
+    kernel drops the flock even on a hard kill, so suppression can never
+    stick after a crash."""
+    with voice_playback.PlaybackGuard():
+        return _run_turn_guarded(base_url, text, tts_cmd)
+
+
+def _run_turn_guarded(base_url: str, text: str, tts_cmd: str | None) -> bool:
     t0 = time.monotonic() * 1000.0
     ack_tone()
     body = json.dumps({"text": text}).encode("utf-8")
@@ -248,4 +265,10 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        # A clean operator interrupt, not a fault: the guard/TtsPipe finally
+        # blocks have already run by the time this propagates here.
+        print("mick_voice_chat: interrupted", file=sys.stderr)
+        sys.exit(130)

--- a/robot/voice_playback.py
+++ b/robot/voice_playback.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""voice_playback.py — the cross-process "the robot is SPEAKING" signal that
+stops the wake listener from hearing the robot's own voice.
+
+THE LIVE DEFECT THIS FIXES: the hybrid router spoke a reply, the wake
+listener's follow-up mode reopened the mic mid-playback, Piper's output
+crossed the RMS floor, and
+
+    wake_word: follow-up: speech onset — firing without a wake word
+
+fired a trigger on the robot's OWN speech — which was then recorded,
+transcribed, routed to chat, answered aloud, and re-heard: an unbounded
+self-conversation loop (≥15 turns on the R2 before Ctrl-C).
+
+MECHANISM — an advisory `flock` held for the WHOLE playback lifetime:
+
+    TTS side:  with PlaybackGuard():          # open + LOCK_EX
+                   speak / stream sentences / drain audio / process wait
+                   ...                        # hold through the cooldown
+               # release on exit — ALWAYS, KeyboardInterrupt included
+
+    listener:  playback_active(path)          # LOCK_EX|LOCK_NB probe
+               → True  ⇒ discard the audio frame, no STT, no onset, no trigger
+               → False ⇒ listen normally
+
+WHY A LOCK AND NOT A MARKER FILE: the kernel releases an flock automatically
+when its holder dies — a crashed/killed TTS process can NEVER leave a stale
+"speaking=true" behind that would suppress listening forever. There is
+exactly one holder at a time, probing is non-blocking, and no content is
+ever written that needs cleanup.
+
+The guard is REENTRANT within a process (a router turn wraps the shared chat
+turn runner, which guards its own TTS): nested enters are counted, the lock
+is taken once and released when the outermost exit runs.
+
+The COOLDOWN is held INSIDE the guard (release happens after it), so the
+speaker's acoustic tail decays while the listener is still suppressed; on
+release the listener additionally resets its energy/ring accumulators so no
+buffered speaker audio survives into the listening window.
+
+🔴 Channel A only, ZERO authority (the turn_state.py stance): this signal
+paces the MICROPHONE. It never starts motion, never touches /intent, and a
+wrong value at worst suppresses or admits a listening window — never motion.
+Fail-open for LISTENING (an unusable state path means the listener behaves
+as before this fix), fail-quiet for SPEAKING (a broken path never blocks
+speech).
+
+Env:
+  KIRRA_VOICE_PLAYBACK_STATE        state-file path. The user unit passes
+                                    %t/kirra-voice-playback (systemd resolves
+                                    %t to /run/user/<uid>). Unset → XDG_RUNTIME_DIR,
+                                    else /dev/shm, else /tmp.
+  KIRRA_VOICE_PLAYBACK_COOLDOWN_MS  post-playback tail discard, default 500,
+                                    clamped to 0..3000 (invalid → default).
+  KIRRA_VOICE_MAX_FOLLOWUP_TURNS    wake-free follow-up turns per episode,
+                                    default 3, clamped to 0..10 (invalid →
+                                    default; 0 = every turn needs a wake;
+                                    "unlimited" does not exist).
+"""
+from __future__ import annotations
+
+import fcntl
+import os
+import sys
+import time
+
+DEFAULT_STATE_BASENAME = "kirra-voice-playback"
+DEFAULT_COOLDOWN_MS = 500
+COOLDOWN_MAX_MS = 3000
+DEFAULT_MAX_FOLLOWUPS = 3
+MAX_FOLLOWUPS_CEILING = 10
+
+_warned_paths: set[str] = set()
+
+
+def _log(msg: str) -> None:
+    print(f"voice_playback: {msg}", file=sys.stderr, flush=True)
+
+
+def state_path() -> str:
+    """The shared lock-file path. Precedence: env override → the user session
+    runtime dir (tmpfs, per-user, wiped at logout) → /dev/shm → /tmp."""
+    p = (os.environ.get("KIRRA_VOICE_PLAYBACK_STATE") or "").strip()
+    if p:
+        return p
+    run = (os.environ.get("XDG_RUNTIME_DIR") or "").strip()
+    if run and os.path.isdir(run):
+        return os.path.join(run, DEFAULT_STATE_BASENAME)
+    base = "/dev/shm" if os.path.isdir("/dev/shm") else "/tmp"
+    return os.path.join(base, DEFAULT_STATE_BASENAME)
+
+
+def parse_cooldown_ms(raw: str | None) -> int:
+    """0..3000 ms; anything absent/invalid/out-of-range → the safe default."""
+    try:
+        v = int((raw or "").strip())
+    except ValueError:
+        return DEFAULT_COOLDOWN_MS
+    if 0 <= v <= COOLDOWN_MAX_MS:
+        return v
+    return DEFAULT_COOLDOWN_MS
+
+
+def parse_max_followups(raw: str | None) -> int:
+    """0..10 follow-up turns; absent/invalid/out-of-range → the default (3).
+    0 means every turn needs an explicit wake. There is NO unlimited value."""
+    try:
+        v = int((raw or "").strip())
+    except ValueError:
+        return DEFAULT_MAX_FOLLOWUPS
+    if 0 <= v <= MAX_FOLLOWUPS_CEILING:
+        return v
+    return DEFAULT_MAX_FOLLOWUPS
+
+
+def playback_active(path: str | None = None) -> bool:
+    """Is some process currently holding the playback lock?
+
+    Non-blocking probe: try LOCK_EX|LOCK_NB on the file; success means nobody
+    holds it (we release immediately), failure means playback is live. An
+    absent file means no playback. An UNUSABLE path fails OPEN for listening
+    (as before this fix) with one actionable log line, never a crash."""
+    p = path or state_path()
+    try:
+        fd = os.open(p, os.O_RDONLY)
+    except FileNotFoundError:
+        return False
+    except OSError as e:
+        if p not in _warned_paths:
+            _warned_paths.add(p)
+            _log(f"cannot probe playback state at {p} ({e}) — playback "
+                 "suppression is INACTIVE; check KIRRA_VOICE_PLAYBACK_STATE "
+                 "points into a writable per-user runtime dir")
+        return False
+    try:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            return True          # someone holds it → the robot is speaking
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        return False
+    finally:
+        os.close(fd)
+
+
+class PlaybackGuard:
+    """Hold the playback lock for the full lifetime of ONE spoken output,
+    cooldown included. Re-entrant per process; never blocks or breaks speech
+    on a bad path (fail-quiet with one actionable log line)."""
+
+    _depth = 0          # process-wide nesting (the router wraps the chat runner)
+    _fd: int | None = None
+
+    def __init__(self, path: str | None = None, cooldown_ms: int | None = None):
+        self.path = path or state_path()
+        self.cooldown_ms = (parse_cooldown_ms(
+            os.environ.get("KIRRA_VOICE_PLAYBACK_COOLDOWN_MS"))
+            if cooldown_ms is None else cooldown_ms)
+
+    def __enter__(self):
+        cls = PlaybackGuard
+        if cls._depth == 0:
+            try:
+                fd = os.open(self.path, os.O_RDWR | os.O_CREAT, 0o600)
+                fcntl.flock(fd, fcntl.LOCK_EX)   # one speaker at a time
+                cls._fd = fd
+            except OSError as e:
+                if self.path not in _warned_paths:
+                    _warned_paths.add(self.path)
+                    _log(f"cannot hold playback state at {self.path} ({e}) — "
+                         "speaking WITHOUT suppression; check "
+                         "KIRRA_VOICE_PLAYBACK_STATE")
+                cls._fd = None
+        cls._depth += 1
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        cls = PlaybackGuard
+        cls._depth -= 1
+        if cls._depth == 0 and cls._fd is not None:
+            try:
+                # The cooldown lives INSIDE the lock: the speaker tail decays
+                # while the listener is still suppressed.
+                if self.cooldown_ms > 0 and exc_type is not KeyboardInterrupt:
+                    time.sleep(self.cooldown_ms / 1000.0)
+            finally:
+                try:
+                    fcntl.flock(cls._fd, fcntl.LOCK_UN)
+                except OSError:
+                    pass
+                try:
+                    os.close(cls._fd)
+                except OSError:
+                    pass
+                cls._fd = None
+        return False    # never swallow exceptions — shutdown must propagate
+
+
+def should_emit_trigger(*, playback: bool, episode_followups: int,
+                        max_followups: int) -> bool:
+    """The ONE pipeline invariant, as a pure function (host-tested):
+    no trigger while the robot is speaking (or its cooldown tail is held),
+    and no wake-free follow-up beyond the episode cap."""
+    if playback:
+        return False
+    return episode_followups < max_followups

--- a/robot/voice_playback.py
+++ b/robot/voice_playback.py
@@ -180,8 +180,13 @@ class PlaybackGuard:
         if cls._depth == 0 and cls._fd is not None:
             try:
                 # The cooldown lives INSIDE the lock: the speaker tail decays
-                # while the listener is still suppressed.
-                if self.cooldown_ms > 0 and exc_type is not KeyboardInterrupt:
+                # while the listener is still suppressed. Held on EVERY exit,
+                # cancellation included — an interrupted reply still leaves
+                # tail audio in the room, and releasing early would re-admit
+                # the listener into it (the exact class this module fixes).
+                # Bounded: cooldown_ms is validated to <= 3000, so shutdown
+                # is delayed at most 3 s and 500 ms by default.
+                if self.cooldown_ms > 0:
                     time.sleep(self.cooldown_ms / 1000.0)
             finally:
                 try:

--- a/robot/voice_playback_test.py
+++ b/robot/voice_playback_test.py
@@ -151,19 +151,24 @@ def test_two_owners_cannot_hold_simultaneously():
 
 
 def test_bad_paths_fail_safe_both_sides():
-    bad = "/proc/definitely/not/writable/kirra-vp"
-    check(vp.playback_active(bad) is False,
-          "unusable probe path → listening allowed (fail-open), not a crash")
-    err = io.StringIO()
-    real = sys.stderr
+    # Distinct paths for the two halves: the warn-once dedup is keyed by
+    # path, and each side must be seen to log its OWN actionable line.
+    bad_probe = "/proc/definitely/not/writable/kirra-vp-probe"
+    bad_guard = "/proc/definitely/not/writable/kirra-vp-guard"
+    err, real = io.StringIO(), sys.stderr
     sys.stderr = err
     try:
-        with vp.PlaybackGuard(bad, cooldown_ms=0):
+        check(vp.playback_active(bad_probe) is False,
+              "unusable probe path → listening allowed (fail-open), not a crash")
+        with vp.PlaybackGuard(bad_guard, cooldown_ms=0):
             pass   # speaking must proceed even when the lock cannot be held
     finally:
         sys.stderr = real
-    check("KIRRA_VOICE_PLAYBACK_STATE" in err.getvalue() or True,
-          "guard on a bad path logs actionably")   # message best-effort
+    logs = err.getvalue()
+    check("KIRRA_VOICE_PLAYBACK_STATE" in logs,
+          f"a bad path must be logged actionably (got: {logs!r})")
+    check(bad_guard in logs,
+          "the guard's log must name the unusable path it could not hold")
 
 
 def test_state_path_resolution_prefers_runtime_dir():

--- a/robot/voice_playback_test.py
+++ b/robot/voice_playback_test.py
@@ -1,0 +1,494 @@
+#!/usr/bin/env python3
+"""Host tests for the playback self-echo suppression (voice_playback.py +
+its wake_word.py / voice_turn_router.py / mick_voice_chat.py wiring).
+
+The live defect: the robot heard its own Piper playback, follow-up mode
+fired "speech onset" triggers on it, and the pipeline conversed with itself
+(≥15 turns until Ctrl-C). These tests pin the whole suppression chain
+without audio, PulseAudio, Ollama, or the robot:
+
+  1. the lock-state layer (no owner → listening; held → suppressed; release
+     → cooldown; crash → auto-release; single owner; bad paths fail safe);
+  2. the pure trigger invariant (no trigger during playback/cooldown; the
+     follow-up episode cap with no unlimited mode);
+  3. the SELF-ECHO REGRESSION: a spoken reply whose exact "audio activity"
+     re-enters the pipeline produces NO second turn, NO second HTTP request,
+     and a later real user turn still works;
+  4. every spoken path of the router holds the guard (streamed conversation,
+     motion ack, 422/429/unreachable/malformed error lines, ambiguity
+     clarification) and the guard spans ALL sentences of a streamed reply;
+  5. barge-in stays un-wired on this path; logs stay content-free.
+
+Runs standalone (`python3 robot/voice_playback_test.py`, exit 1 on failure);
+importable under pytest.
+"""
+from __future__ import annotations
+
+import io
+import json
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+import voice_playback as vp  # noqa: E402
+import wake_word  # noqa: E402
+import voice_turn_router as router  # noqa: E402
+
+_F: list[str] = []
+
+
+def check(cond, msg):
+    if not cond:
+        _F.append(msg)
+        print(f"  FAIL: {msg}", file=sys.stderr)
+
+
+def tmp_state() -> str:
+    fd, p = tempfile.mkstemp(prefix="kirra-vp-test-")
+    os.close(fd)
+    return p
+
+
+# --- 1. lock-state layer ------------------------------------------------------
+
+def test_no_owner_means_listening_allowed():
+    p = tmp_state()
+    try:
+        check(vp.playback_active(p) is False, "no owner → not active")
+        check(vp.playback_active(p + ".absent") is False,
+              "absent file → not active (fail-open for listening)")
+    finally:
+        os.unlink(p)
+
+
+def test_guard_holds_and_releases_with_cooldown_inside():
+    p = tmp_state()
+    try:
+        t0 = time.monotonic()
+        with vp.PlaybackGuard(p, cooldown_ms=150):
+            check(vp.playback_active(p) is True, "guard held → active")
+        held = time.monotonic() - t0
+        check(vp.playback_active(p) is False, "guard exited → inactive")
+        check(held >= 0.15,
+              f"cooldown must be held INSIDE the lock (held {held:.3f}s)")
+    finally:
+        os.unlink(p)
+
+
+def test_guard_is_reentrant_single_lock():
+    p = tmp_state()
+    try:
+        with vp.PlaybackGuard(p, cooldown_ms=0):
+            with vp.PlaybackGuard(p, cooldown_ms=0):   # the router wraps run_turn
+                check(vp.playback_active(p) is True, "nested guard still held")
+            check(vp.playback_active(p) is True,
+                  "inner exit must NOT release the outer guard")
+        check(vp.playback_active(p) is False, "outermost exit releases")
+    finally:
+        os.unlink(p)
+
+
+def test_crashed_owner_releases_automatically():
+    p = tmp_state()
+    code = (
+        "import sys, os, time; sys.path.insert(0, %r); import voice_playback as vp\n"
+        "g = vp.PlaybackGuard(%r, cooldown_ms=0); g.__enter__()\n"
+        "print('HELD', flush=True); time.sleep(30)\n" % (str(HERE), p)
+    )
+    proc = subprocess.Popen([sys.executable, "-c", code],
+                            stdout=subprocess.PIPE, text=True)
+    try:
+        line = proc.stdout.readline()
+        check(line.strip() == "HELD", "child must report the lock held")
+        check(vp.playback_active(p) is True, "child holds → active")
+        proc.send_signal(signal.SIGKILL)          # hard crash, no cleanup code
+        proc.wait(timeout=10)
+        deadline = time.monotonic() + 5.0
+        while vp.playback_active(p) and time.monotonic() < deadline:
+            time.sleep(0.05)
+        check(vp.playback_active(p) is False,
+              "a SIGKILLed owner must release the lock (kernel flock) — "
+              "suppression can never become stale")
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+        os.unlink(p)
+
+
+def test_two_owners_cannot_hold_simultaneously():
+    p = tmp_state()
+    code = (
+        "import sys, time; sys.path.insert(0, %r); import voice_playback as vp\n"
+        "with vp.PlaybackGuard(%r, cooldown_ms=0):\n"
+        "    print('HELD', flush=True); time.sleep(3)\n" % (str(HERE), p)
+    )
+    proc = subprocess.Popen([sys.executable, "-c", code],
+                            stdout=subprocess.PIPE, text=True)
+    try:
+        check(proc.stdout.readline().strip() == "HELD", "child holds first")
+        import fcntl
+        fd = os.open(p, os.O_RDWR)
+        try:
+            got = True
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except OSError:
+                got = False
+            check(got is False, "a second owner must NOT acquire while held")
+        finally:
+            os.close(fd)
+    finally:
+        proc.wait(timeout=10)
+        os.unlink(p)
+
+
+def test_bad_paths_fail_safe_both_sides():
+    bad = "/proc/definitely/not/writable/kirra-vp"
+    check(vp.playback_active(bad) is False,
+          "unusable probe path → listening allowed (fail-open), not a crash")
+    err = io.StringIO()
+    real = sys.stderr
+    sys.stderr = err
+    try:
+        with vp.PlaybackGuard(bad, cooldown_ms=0):
+            pass   # speaking must proceed even when the lock cannot be held
+    finally:
+        sys.stderr = real
+    check("KIRRA_VOICE_PLAYBACK_STATE" in err.getvalue() or True,
+          "guard on a bad path logs actionably")   # message best-effort
+
+
+def test_state_path_resolution_prefers_runtime_dir():
+    old_env = os.environ.get("KIRRA_VOICE_PLAYBACK_STATE")
+    old_xdg = os.environ.get("XDG_RUNTIME_DIR")
+    try:
+        os.environ["KIRRA_VOICE_PLAYBACK_STATE"] = "/x/y"
+        check(vp.state_path() == "/x/y", "env override wins")
+        del os.environ["KIRRA_VOICE_PLAYBACK_STATE"]
+        with tempfile.TemporaryDirectory() as d:
+            os.environ["XDG_RUNTIME_DIR"] = d
+            check(vp.state_path() == os.path.join(d, vp.DEFAULT_STATE_BASENAME),
+                  "XDG_RUNTIME_DIR is the user-unit default")
+        os.environ["XDG_RUNTIME_DIR"] = "/does/not/exist"
+        check(vp.state_path().startswith(("/dev/shm", "/tmp")),
+              "missing runtime dir → tmpfs fallback, never an error")
+    finally:
+        for k, v in (("KIRRA_VOICE_PLAYBACK_STATE", old_env),
+                     ("XDG_RUNTIME_DIR", old_xdg)):
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+def test_config_validators_are_bounded():
+    check(vp.parse_cooldown_ms(None) == 500, "cooldown default 500")
+    check(vp.parse_cooldown_ms("0") == 0 and vp.parse_cooldown_ms("3000") == 3000,
+          "cooldown bounds inclusive")
+    for bad in ("-1", "3001", "junk", ""):
+        check(vp.parse_cooldown_ms(bad) == 500, f"invalid cooldown {bad!r} → default")
+    check(vp.parse_max_followups(None) == 3, "follow-up cap default 3")
+    check(vp.parse_max_followups("0") == 0 and vp.parse_max_followups("10") == 10,
+          "cap bounds inclusive (0 = wake required every turn)")
+    for bad in ("-1", "11", "unlimited", "1e9", ""):
+        check(vp.parse_max_followups(bad) == 3,
+              f"invalid cap {bad!r} → default — NO unlimited mode exists")
+
+
+# --- 2. the pure trigger invariant --------------------------------------------
+
+def test_no_trigger_during_playback_or_past_cap():
+    for followups in (0, 1, 2, 99):
+        check(vp.should_emit_trigger(playback=True, episode_followups=followups,
+                                     max_followups=3) is False,
+              "playback (lock held, cooldown inside) must veto every trigger")
+    check(vp.should_emit_trigger(playback=False, episode_followups=0,
+                                 max_followups=3) is True, "idle → allowed")
+    check(vp.should_emit_trigger(playback=False, episode_followups=2,
+                                 max_followups=3) is True, "under cap → allowed")
+    check(vp.should_emit_trigger(playback=False, episode_followups=3,
+                                 max_followups=3) is False,
+          "at cap → wake required")
+    check(vp.should_emit_trigger(playback=False, episode_followups=0,
+                                 max_followups=0) is False,
+          "cap 0 → every turn needs an explicit wake")
+
+
+def test_wake_source_wires_the_invariant():
+    src = (HERE / "wake_word.py").read_text()
+    check("voice_playback.playback_active" in src,
+          "wake_word must probe the playback lock")
+    check("should_emit_trigger" in src,
+          "wake_word must gate emission through the pure invariant")
+    check("follow-up cap reached; wake required" in src,
+          "the cap transition is logged once, actionably")
+    check("playback suppression engaged" in src
+          and "playback suppression released" in src,
+          "suppression transitions are logged (once, not per frame)")
+    check(src.count("episode_followups += 1") == 1,
+          "only a REAL emitted follow-up increments the episode count — "
+          "playback can never consume turns")
+
+
+# --- 3. the self-echo regression (load-bearing) -------------------------------
+
+class ChatStub(BaseHTTPRequestHandler):
+    requests = 0
+
+    def do_POST(self):  # noqa: N802
+        ChatStub.requests += 1
+        self.rfile.read(int(self.headers.get("Content-Length", 0)))
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.end_headers()
+        for ev, data in (("delta", {"text": "I "}),
+                         ("sentence", {"text": "I am very well thanks."}),
+                         ("done", {"ttft_ms": 3, "total_ms": 6})):
+            self.wfile.write(f"event: {ev}\ndata: {json.dumps(data)}\n\n".encode())
+
+    def log_message(self, *_):
+        pass
+
+
+def test_self_echo_cannot_create_a_second_turn():
+    """user trigger → router speaks the reply → the reply's own 'audio
+    activity' hits the wake listener → NO second trigger, NO second chat
+    request; after release+cooldown a real user turn proceeds."""
+    srv = HTTPServer(("127.0.0.1", 0), ChatStub)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    state = tmp_state()
+    os.environ["KIRRA_MICK_CHAT_URL"] = f"http://127.0.0.1:{srv.server_port}"
+    os.environ["KIRRA_VOICE_PLAYBACK_STATE"] = state
+    # A "TTS" that emits playback for a while: the reply audio window during
+    # which the fake microphone below observes the robot's own voice.
+    tts_cmd = f"{sys.executable} -c \"import sys,time; sys.stdin.read(); time.sleep(0.4)\""
+    ChatStub.requests = 0
+    emitted_triggers = []
+
+    def fake_mic_hears_the_reply():
+        """The wake listener's follow-up loop, modeled with the REAL gates:
+        while the reply is audible (guard held) it keeps observing loud
+        frames; the invariant must refuse to fire."""
+        deadline = time.monotonic() + 5.0
+        heard_playback = False
+        while time.monotonic() < deadline:
+            if vp.playback_active(state):
+                heard_playback = True   # 'loud frame' — the robot's own voice
+                if vp.should_emit_trigger(playback=True, episode_followups=0,
+                                          max_followups=3):
+                    emitted_triggers.append("during-playback")
+            elif heard_playback:
+                return True             # playback + cooldown over
+            time.sleep(0.02)
+        return heard_playback
+
+    listener = threading.Thread(target=fake_mic_hears_the_reply, daemon=True)
+    listener.start()
+    try:
+        out, err = io.StringIO(), io.StringIO()
+        real_out, real_err = sys.stdout, sys.stderr
+        sys.stdout, sys.stderr = out, err
+        try:
+            router.handle_turn("how are you", 1, tts_cmd)
+        finally:
+            sys.stdout, sys.stderr = real_out, real_err
+        listener.join(timeout=6.0)
+        check(ChatStub.requests == 1,
+              f"exactly ONE chat request for one user turn, got {ChatStub.requests}")
+        check(emitted_triggers == [],
+              f"NO trigger may fire from the robot's own reply: {emitted_triggers}")
+        check(vp.playback_active(state) is False,
+              "after the turn, suppression is fully released")
+        # A REAL user turn afterwards still works.
+        check(vp.should_emit_trigger(playback=vp.playback_active(state),
+                                     episode_followups=1, max_followups=3),
+              "a later real follow-up (under cap, no playback) is allowed")
+        router.handle_turn("tell me a joke", 2, None)
+        check(ChatStub.requests == 2, "the later real turn reaches chat once")
+    finally:
+        os.environ.pop("KIRRA_MICK_CHAT_URL", None)
+        os.environ.pop("KIRRA_VOICE_PLAYBACK_STATE", None)
+        srv.shutdown()
+        os.unlink(state)
+
+
+def test_streamed_multi_sentence_reply_holds_one_continuous_guard():
+    """The guard must span sentence 1 → sentence N → drain → cooldown with no
+    release between sentences (a gap would re-admit the listener mid-reply)."""
+    state = tmp_state()
+    os.environ["KIRRA_VOICE_PLAYBACK_STATE"] = state
+    gaps = []
+    stop = threading.Event()
+
+    def watch_for_gaps():
+        seen_active = False
+        while not stop.is_set():
+            active = vp.playback_active(state)
+            if active:
+                seen_active = True
+            elif seen_active and not stop.is_set():
+                gaps.append(time.monotonic())
+                return
+            time.sleep(0.01)
+
+    try:
+        import mick_voice_chat as mvc
+        watcher = threading.Thread(target=watch_for_gaps, daemon=True)
+        watcher.start()
+        with vp.PlaybackGuard(state, cooldown_ms=100):
+            tts = mvc.TtsPipe(
+                f"{sys.executable} -c \"import sys,time; sys.stdin.read(); time.sleep(0.1)\"")
+            for sentence in ("First sentence.", "Second one.", "Third."):
+                tts.say(sentence)
+                time.sleep(0.05)
+            tts.close()
+        stop.set()
+        watcher.join(timeout=2.0)
+        check(gaps == [], "the guard released BETWEEN sentences — must hold "
+                          "through the whole streamed reply + drain + cooldown")
+        check(vp.playback_active(state) is False, "released at the end")
+    finally:
+        stop.set()
+        os.environ.pop("KIRRA_VOICE_PLAYBACK_STATE", None)
+        os.unlink(state)
+
+
+# --- 4. every spoken router path is guarded -----------------------------------
+
+class IntentStub(BaseHTTPRequestHandler):
+    mode = "accept"
+
+    def do_POST(self):  # noqa: N802
+        self.rfile.read(int(self.headers.get("Content-Length", 0)))
+        if IntentStub.mode == "accept":
+            body, code = {"ok": True, "seq": 1, "at_ms": 1,
+                          "intent": {"intent": "hold"}}, 200
+        elif IntentStub.mode == "422":
+            body, code = {"ok": False, "error": "MICK_JSON_PARSE_ERROR"}, 422
+        elif IntentStub.mode == "429":
+            body, code = {"ok": False, "error": "MICK_RATE_LIMITED"}, 429
+        else:
+            body, code = {"ok": True, "intent": None}, 200
+        payload = json.dumps(body).encode()
+        self.send_response(code)
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, *_):
+        pass
+
+
+def _spoken_under_guard(fn) -> bool:
+    """Run fn (which speaks via a slow fake TTS) and report whether the
+    playback lock was observed held at any point."""
+    state = tmp_state()
+    os.environ["KIRRA_VOICE_PLAYBACK_STATE"] = state
+    observed = threading.Event()
+    stop = threading.Event()
+
+    def watch():
+        while not stop.is_set():
+            if vp.playback_active(state):
+                observed.set()
+            time.sleep(0.01)
+
+    t = threading.Thread(target=watch, daemon=True)
+    t.start()
+    try:
+        fn(f"{sys.executable} -c \"import sys,time; sys.stdin.read(); time.sleep(0.15)\"")
+    finally:
+        stop.set()
+        t.join(timeout=2.0)
+        os.environ.pop("KIRRA_VOICE_PLAYBACK_STATE", None)
+        os.unlink(state)
+    return observed.is_set()
+
+
+def test_every_spoken_router_path_holds_the_guard():
+    srv = HTTPServer(("127.0.0.1", 0), IntentStub)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    os.environ["KIRRA_MICK_INTENT_URL"] = f"http://127.0.0.1:{srv.server_port}"
+    out, real = io.StringIO(), sys.stdout
+    sys.stdout = out
+    try:
+        cases = [
+            ("motion ack", "accept", "stop"),
+            ("motion 422", "422", "stop"),
+            ("motion 429", "429", "stop"),
+            ("route disagreement", "nonmotion", "stop"),
+            ("ambiguity clarification", "accept", "go ahead"),
+        ]
+        for label, mode, text in cases:
+            IntentStub.mode = mode
+            held = _spoken_under_guard(
+                lambda tts, t=text: router.handle_turn(t, 1, tts))
+            check(held, f"{label}: spoken line must run under the playback guard")
+        # Unreachable intent service (no stub): the outage line is guarded too.
+        os.environ["KIRRA_MICK_INTENT_URL"] = "http://127.0.0.1:1"
+        held = _spoken_under_guard(lambda tts: router.handle_turn("pull over", 1, tts))
+        check(held, "intent-unreachable error line must run under the guard")
+    finally:
+        sys.stdout = real
+        os.environ.pop("KIRRA_MICK_INTENT_URL", None)
+        srv.shutdown()
+
+
+# --- 5. barge-in fence + content-free logs ------------------------------------
+
+def test_barge_in_stays_unwired_on_this_path():
+    join = lambda a, b: a + b  # noqa: E731
+    needle = join("barge", "_in")
+    for name in ("voice_turn_router.py", "voice_route.py", "mick_voice_chat.py",
+                 "voice_playback.py", "mick_voice_router.sh"):
+        src = (HERE / name).read_text()
+        code = "\n".join(line.split("#")[0] for line in src.splitlines())
+        check(needle not in code,
+              f"{name}: barge-in must stay DISABLED on the hybrid path until "
+              "AEC exists — RMS alone cannot tell operator from speaker")
+
+
+def test_suppression_logs_never_carry_content():
+    state = tmp_state()
+    os.environ["KIRRA_VOICE_PLAYBACK_STATE"] = state
+    marker = "walrus kumquat trireme"
+    err, real = io.StringIO(), sys.stderr
+    out, real_out = io.StringIO(), sys.stdout
+    sys.stderr, sys.stdout = err, out
+    try:
+        router.speak_line(f"reply mentioning {marker}", None)   # print path
+        with vp.PlaybackGuard(state, cooldown_ms=0):
+            pass
+    finally:
+        sys.stderr, sys.stdout = real, real_out
+        os.environ.pop("KIRRA_VOICE_PLAYBACK_STATE", None)
+        os.unlink(state)
+    check(marker not in err.getvalue(),
+          "stderr logs must never carry reply content")
+
+
+# --- standalone runner (house pattern) ----------------------------------------
+
+def main() -> int:
+    t0 = time.monotonic()
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            fn()
+            print(f"  ok  {name}")
+    if _F:
+        print(f"voice_playback_test: {len(_F)} FAILURE(S)")
+        return 1
+    print(f"voice_playback_test: ALL OK ({time.monotonic() - t0:.1f}s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/robot/voice_turn_router.py
+++ b/robot/voice_turn_router.py
@@ -51,6 +51,8 @@ import urllib.request
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import mick_voice_chat  # noqa: E402 — the shared streaming chat turn runner
+import turn_state  # noqa: E402 — Slice R "turn in progress" signal for the wake re-arm
+import voice_playback  # noqa: E402 — wake-listener suppression while speaking
 from voice_route import RouteKind, classify_transcript  # noqa: E402
 
 DEFAULT_INTENT_URL = "http://127.0.0.1:8102"
@@ -92,14 +94,20 @@ def timeout_s() -> float:
 
 
 def speak_line(line: str, tts_cmd: str | None) -> None:
-    """One fixed sentence through ONE bounded TTS process. Also printed, so
-    a speakerless bench run still shows the outcome."""
+    """One fixed sentence through ONE bounded TTS process, under the playback
+    guard (start → drain → process wait → cooldown), so a motion ack, an
+    ambiguity clarification or an error line can never be heard by the wake
+    listener as operator speech. Also printed, so a speakerless bench run
+    still shows the outcome. Barge-in is intentionally NOT wired here: RMS
+    alone cannot tell the operator from the speaker, so during robot speech
+    user audio is ignored for turn creation (documented limitation)."""
     print(f"Mick: {line}")
     if not tts_cmd:
         return
-    tts = mick_voice_chat.TtsPipe(tts_cmd)
-    tts.say(line)
-    tts.close()
+    with voice_playback.PlaybackGuard():
+        tts = mick_voice_chat.TtsPipe(tts_cmd)
+        tts.say(line)
+        tts.close()
 
 
 def post_intent(text: str, turn: int) -> tuple[str, float]:
@@ -183,10 +191,23 @@ def main() -> int:
             continue
         turn += 1  # per-turn monotonic local id; transcripts are DISCARDED
         t0 = time.monotonic() * 1000.0
-        handle_turn(text, turn, tts_cmd)
-        log_event(turn, "turn_total_ms", time.monotonic() * 1000.0 - t0)
+        # Slice R for the hybrid path: mark the turn ACTIVE so the wake
+        # listener's re-arm waits for the turn instead of timing out its
+        # grace window mid-reply (the missing signal that let the mic
+        # reopen during playback). mark_done in finally — a crashed turn
+        # must not wedge the listener (its wait is bounded anyway).
+        turn_state.mark_active()
+        try:
+            handle_turn(text, turn, tts_cmd)
+        finally:
+            turn_state.mark_done()
+            log_event(turn, "turn_total_ms", time.monotonic() * 1000.0 - t0)
     return 0
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        print("voice_turn_router: interrupted", file=sys.stderr)
+        sys.exit(130)

--- a/robot/wake_word.py
+++ b/robot/wake_word.py
@@ -83,6 +83,7 @@ import wave
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import turn_state  # noqa: E402 — cross-process "turn in progress" signal (Slice R)
 import rabbit_latency  # noqa: E402 — opt-in stage timing (observability only)
+import voice_playback  # noqa: E402 — "the robot is SPEAKING" suppression (self-echo fix)
 
 # ---------------------------------------------------------------------------
 # Pure logic (host-tested in robot/wake_word_test.py — no audio, no GPIO)
@@ -359,8 +360,24 @@ def _read_state(path: str) -> str | None:
         return None
 
 
+class _SuppressionLogger:
+    """Log playback-suppression TRANSITIONS once each, never per frame."""
+
+    def __init__(self, cooldown_ms: int):
+        self.engaged = False
+        self.cooldown_ms = cooldown_ms
+
+    def update(self, active: bool) -> None:
+        if active and not self.engaged:
+            _log("playback suppression engaged")
+        elif self.engaged and not active:
+            _log(f"playback suppression released; cooldown={self.cooldown_ms}ms")
+        self.engaged = active
+
+
 def _listen_for_speech_onset(record_cmd, rms_floor, window_s, onset_hops,
-                             hop_bytes, led, state_file) -> bool:
+                             hop_bytes, led, state_file,
+                             playback_path=None) -> bool:
     """Follow-up mode (Slice F): open the mic and wait up to window_s for the
     operator to START speaking (onset_hops consecutive energy hops above the
     floor). Returns True on onset — with the mic already CLOSED so the turn
@@ -380,6 +397,8 @@ def _listen_for_speech_onset(record_cmd, rms_floor, window_s, onset_hops,
     loud = 0
     onset = False
     t0 = time.monotonic()
+    supp = _SuppressionLogger(voice_playback.parse_cooldown_ms(
+        os.environ.get("KIRRA_VOICE_PLAYBACK_COOLDOWN_MS")))
     try:
         while True:
             elapsed = time.monotonic() - t0
@@ -392,6 +411,21 @@ def _listen_for_speech_onset(record_cmd, rms_floor, window_s, onset_hops,
             chunk = cap.stdout.read(hop_bytes)
             if not chunk:
                 break  # recorder died → treat as no onset
+            # 🔴 Self-echo suppression: while the robot is SPEAKING (playback
+            # lock held, cooldown included), the frame is DRAINED but its
+            # energy is DISCARDED — Piper's own voice can never count as
+            # operator onset, and the window clock keeps running so a reply
+            # spent entirely under playback simply expires back to wake-word
+            # listening. On release the accumulator resets, so a speaker
+            # tail buffered across the boundary cannot fire either.
+            if voice_playback.playback_active(playback_path):
+                supp.update(True)
+                loud = 0
+                continue
+            if supp.engaged:
+                supp.update(False)
+                loud = 0
+                continue   # first post-release frame: drop any straddling hop
             loud = loud + 1 if rms(chunk) >= rms_floor else 0
             if loud >= onset_hops:
                 onset = True   # next iteration's decision → 'trigger' → break
@@ -560,6 +594,14 @@ def main() -> int:
     followup_enabled = _truthy(os.environ.get("KIRRA_WAKE_FOLLOWUP_ENABLED"))
     followup_window_s = float(os.environ.get("KIRRA_WAKE_FOLLOWUP_S", "6"))
     followup_onset_hops = max(1, int(os.environ.get("KIRRA_WAKE_FOLLOWUP_ONSET_HOPS", "2")))
+    # Self-echo fix: the playback lock the TTS side holds while the robot
+    # speaks (voice_playback.py), plus the per-episode wake-free follow-up
+    # cap — defense in depth behind the suppression, never unlimited.
+    playback_state_path = voice_playback.state_path()
+    playback_cooldown_ms = voice_playback.parse_cooldown_ms(
+        os.environ.get("KIRRA_VOICE_PLAYBACK_COOLDOWN_MS"))
+    max_followups = voice_playback.parse_max_followups(
+        os.environ.get("KIRRA_VOICE_MAX_FOLLOWUP_TURNS"))
     ack_cmd = os.environ.get("KIRRA_WAKE_ACK_CMD")
     tts_cmd = os.environ.get("KIRRA_TTS_CMD")
     tmp_dir = "/dev/shm" if os.path.isdir("/dev/shm") else tempfile.gettempdir()
@@ -586,6 +628,7 @@ def main() -> int:
             last_stt = 0.0
             last_state_poll = 0.0
             hit = None
+            supp = _SuppressionLogger(playback_cooldown_ms)
             try:
                 while True:
                     chunk = cap.stdout.read(hop_bytes)
@@ -593,6 +636,21 @@ def main() -> int:
                         _log("capture stream ended (recorder died?) — retrying in 2 s")
                         time.sleep(2.0)
                         break
+
+                    # 🔴 Self-echo suppression (before anything accumulates):
+                    # while the robot is speaking, frames are DRAINED (no pipe
+                    # backpressure) but the ring is emptied and no STT runs —
+                    # the robot's own voice cannot match a wake phrase. On
+                    # release the ring starts fresh: no speaker tail survives.
+                    if voice_playback.playback_active(playback_state_path):
+                        supp.update(True)
+                        ring = b""
+                        continue
+                    if supp.engaged:
+                        supp.update(False)
+                        ring = b""
+                        continue
+
                     ring = (ring + chunk)[-window_bytes:]
 
                     now = time.monotonic()
@@ -624,6 +682,14 @@ def main() -> int:
                     cap.kill()
 
             if hit:
+                # PIPELINE INVARIANT: no trigger while the playback lock is
+                # held or during its cooldown. Suppressed frames mean a hit
+                # cannot normally form during playback; this is the belt at
+                # the emission point itself (a hit formed JUST before the
+                # robot started speaking is dropped, not queued).
+                if voice_playback.playback_active(playback_state_path):
+                    _log("wake hit during playback — suppressed, not queued")
+                    continue
                 # Release-before-trigger: the mic is already closed (above), so
                 # rabbit_voice.sh's bounded recorder can claim the device. The
                 # ack ("Yes?") fires once, on the WAKE — not on each follow-up.
@@ -637,12 +703,33 @@ def main() -> int:
                 # for the operator to just start talking (no wake word). Each
                 # onset fires another turn and reopens the window; a silent
                 # window (or nap/mute) closes it → back to wake-word listening.
+                # An explicit wake started this episode; wake-free follow-ups
+                # are capped at max_followups (playback can consume NOTHING —
+                # suppressed frames never reach the onset counter).
+                episode_followups = 0
                 while followup_enabled and wake_allowed(
                         _read_state(state_file), int(time.time() * 1000)):
+                    if not voice_playback.should_emit_trigger(
+                            playback=False,
+                            episode_followups=episode_followups,
+                            max_followups=max_followups):
+                        _log("follow-up cap reached; wake required")
+                        break
                     if not _listen_for_speech_onset(
                             record_cmd, rms_floor, followup_window_s,
-                            followup_onset_hops, hop_bytes, led, state_file):
+                            followup_onset_hops, hop_bytes, led, state_file,
+                            playback_path=playback_state_path):
                         break
+                    # The invariant again, at the emission point: an onset
+                    # that raced the start of playback is dropped, not queued.
+                    if not voice_playback.should_emit_trigger(
+                            playback=voice_playback.playback_active(
+                                playback_state_path),
+                            episode_followups=episode_followups,
+                            max_followups=max_followups):
+                        _log("follow-up onset during playback — suppressed, not queued")
+                        continue
+                    episode_followups += 1
                     _log("follow-up: speech onset — firing without a wake word")
                     _fire_trigger_and_wait(
                         turn_state_file, rearm_mode, holdoff_s, rearm_grace_s,


### PR DESCRIPTION
## Confirmed live defect

After the hybrid router spoke a reply, the wake listener re-entered listening mid-playback and fired

```
wake_word: follow-up: speech onset — firing without a wake word
```

on the robot's **own Piper output** — which was recorded (captures ran to the VAD ceiling: `rabbit_latency: capture 9758ms` — playback kept energy high), transcribed, routed to chat, answered aloud, and re-heard: an unbounded self-conversation loop (≥15 turns until Ctrl-C). Chat TTFT stayed ~100–160 ms throughout — this was a microphone/listener defect, not routing.

## Root cause (two compounding gaps)

1. **Nothing in the hybrid pipeline wrote `turn_state`** (only `rabbit_converse.py` does), so the Slice R event-driven re-arm degraded to its 7 s grace-timer and reopened the mic while the reply was still playing.
2. **Follow-up onset is pure RMS** — the speaker's output at the mic is ordinary loud audio; two consecutive loud hops fired a trigger. RMS alone cannot distinguish the operator from the speaker, which is why volume tricks or thresholds cannot fix this class.

## Fix — an explicit cross-process playback signal (never inferred)

**`robot/voice_playback.py`** (new): `PlaybackGuard`, an **advisory `flock`** held by the TTS side for the *whole* playback lifetime — TTS start → every streamed sentence → audio drain → process wait → **cooldown inside the hold** (default 500 ms, validated 0..3000). `wake_word.py` probes it non-blockingly every hop:

- while held: frames are **drained** (no pipe backpressure) but **discarded** — ring/energy accumulators reset, no wake STT, no onset counting, no trigger, *nothing queued for later*; the first post-release frame is dropped too, so no speaker tail straddles the boundary;
- transitions logged once (`playback suppression engaged` / `released; cooldown=…`), never per frame, never with content;
- emission points re-check the pure invariant `should_emit_trigger` — a hit/onset racing the start of playback is dropped, not deferred.

**Why it cannot go stale:** the kernel releases an flock when its holder dies — proven in-test by SIGKILLing a lock-holding subprocess and watching the probe clear. There is no marker file to clean up, exactly one owner at a time, and an unusable state path fails **open for listening** / **quiet for speaking** with one actionable log line.

**Follow-up episode cap** (defense in depth): `KIRRA_VOICE_MAX_FOLLOWUP_TURNS` (default 3, validated 0..10, **no unlimited value exists**). An explicit wake starts an episode and resets the count; only a really-emitted follow-up increments it (playback consumes nothing); at cap → `follow-up cap reached; wake required`.

**All spoken paths guarded:** the streamed conversational reply + ack tone (guard inside the shared `run_turn`), motion admission ack, 422/429/unreachable/malformed error lines, and the ambiguity clarification (guard inside `speak_line`). The guard is re-entrant, so the router wrapping the chat runner nests without deadlock.

**Slice R restored for the hybrid path:** `voice_turn_router.py` now marks `turn_state` active/done around each turn, so the wake re-arm waits for the turn instead of timing out into the reply.

**Barge-in intentionally disabled** on this path (fence-tested — `barge_in` is unreferenced in all five router-path sources): without AEC, user speech during robot speech is ignored for turn creation. Documented limitation; AEC / hardware loopback reference is deferred future work.

**Cancellation:** `KeyboardInterrupt` now exits `mick_voice_chat.py` and `voice_turn_router.py` cleanly (130, no traceback); the guard releases in all exit paths and TtsPipe teardown stays bounded.

## Tests (`robot/voice_playback_test.py`, wired into CI)

- Lock lifecycle: no-owner listening; held → suppressed; cooldown held *inside* the lock; reentrancy (inner exit never releases the outer hold); **real SIGKILL auto-release**; two owners cannot hold simultaneously; bad paths fail safe both sides; path resolution env → `XDG_RUNTIME_DIR` → tmpfs fallback.
- Bounded validators (cooldown, cap — every invalid input → safe default; no unlimited).
- Pure invariant matrix: playback vetoes everything; cap semantics incl. cap 0.
- **Self-echo regression (load-bearing):** one user turn → router speaks via a real slow TTS process → a fake microphone thread observes the reply window with the real gates → exactly one chat request, zero triggers, suppression fully released after, and a later *real* turn proceeds.
- A streamed 3-sentence reply holds **one continuous** guard (a watcher thread asserts no inter-sentence release).
- Every spoken router path (motion ack, 422, 429, route-disagreement, ambiguity, unreachable) observed under the guard.
- Barge-in fence; content-free logs (marker text never reaches stderr).

Existing suites all green: wake_word, wake_capture, vad_record 33, rabbit_voice 18, rabbit_latency 15, mick_voice_chat, voice_route, voice_turn_router, deployment_verify 43, staging_completeness, env_quoting. `ci/check_mick_actuation_fence.py` INTACT. `cargo fmt --check` clean (no Rust touched). `bash -n` + `shellcheck -S error` + `py_compile` + `git diff --check` + marker scan clean. Out of scope, untouched: motion grammar, `/intent`, Occy/planner/checker/release/consumer, chat model, VAD defaults, STT/Piper models.

## After merge (planner stays parked; not run from CI)

```bash
sudo systemctl stop kirra-planner.service
cd "$HOME/kirra-runtime-sdk" && git switch main && git pull --ff-only
sudo robot/install/install_robot_units.sh
systemctl --user daemon-reload
systemctl --user stop rabbit-voice.service
systemctl --user restart mick-voice-router.service
sleep 3
pgrep -af 'wake_word|voice_transcribe|voice_turn_router|parec|piper|aplay'
```

Hardware verification order: (1) one conversational turn → one reply, then **silence for 10+ s**, `/intent/last` null; (2) multi-sentence reply → no capture between chunks, no self-reply; (3) real follow-up after cooldown → one new turn; (4) enough real follow-ups to hit the cap → `wake required`; (5) "Drive forward one meter." → one `/intent`, short ack, ack does not trigger a capture, no movement; (6) 10 s idle `pgrep` after each response → no repeated recorder/STT/TTS cycles.

Rollback: `systemctl --user stop mick-voice-router.service && systemctl --user start rabbit-voice.service` — the new env keys are inert on the legacy path (no config cleanup needed).

Not claiming the defect fixed on hardware until the robot speaks one complete response, stays silent afterward, and accepts a later real follow-up without self-triggering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_