### PR TITLE
fix(voice): route common Whisper drive-distance variants

### DIFF
--- a/robot/voice_route.py
+++ b/robot/voice_route.py
@@ -85,6 +85,25 @@ _PRONOUN_DESTS = frozenset({"there", "here", "it", "that", "them", "away"})
 _WS = re.compile(r"\s+")
 _PUNCT = re.compile(r"[^a-z0-9 ]+")
 
+# Bounded distance expressions — the ONLY complement (besides a direction or
+# destination) that makes a bare "drive" an explicit motion order. Narrow on
+# purpose: a small-number word or a plain numeric literal, followed by a
+# meter unit (the router is meters-only today; no other unit is admitted and
+# no conversion logic exists). "one hour", "better performance", "me crazy"
+# and every prose complement fail this shape and stay conversation.
+_NUMBER_WORDS = frozenset({
+    "one", "two", "three", "four", "five", "six", "seven", "eight", "nine",
+    "ten",
+})
+_DISTANCE_UNITS = frozenset({"meter", "meters"})
+
+
+def _is_bounded_distance(tokens: list[str]) -> bool:
+    """Exactly `<number> <meter unit>` — nothing more, nothing less."""
+    return (len(tokens) == 2
+            and (tokens[0] in _NUMBER_WORDS or tokens[0].isdigit())
+            and tokens[1] in _DISTANCE_UNITS)
+
 
 def normalize(text: str) -> str:
     """Lowercase, strip punctuation to spaces, collapse whitespace."""
@@ -137,6 +156,17 @@ def classify_transcript(text: str) -> RouteDecision:
     verb, rest = tokens[0], tokens[1:]
 
     # Enumerated multi-word motion forms (verb-first, bounded complements).
+    if verb == "drive" and rest:
+        # "drive one meter" — Whisper commonly drops the direction word from
+        # "drive forward one meter"; a bounded distance IS the complement.
+        if _is_bounded_distance(rest):
+            return RouteDecision(RouteKind.MOTION, "explicit_motion_verb")
+        # "drive for one meter" — the known STT substitution of "forward" →
+        # "for". Admitted ONLY when the remainder is a bounded distance:
+        # "drive for one hour" / "drive for better performance" and every
+        # duration/purpose/prose complement stay conversation.
+        if rest[0] == "for" and _is_bounded_distance(rest[1:]):
+            return RouteDecision(RouteKind.MOTION, "explicit_motion_verb")
     if verb in ("drive", "move", "head") and rest:
         if rest[0] in _DIR_WORDS:
             return RouteDecision(RouteKind.MOTION, "explicit_motion_verb")

--- a/robot/voice_route.py
+++ b/robot/voice_route.py
@@ -99,10 +99,18 @@ _DISTANCE_UNITS = frozenset({"meter", "meters"})
 
 
 def _is_bounded_distance(tokens: list[str]) -> bool:
-    """Exactly `<number> <meter unit>` — nothing more, nothing less."""
-    return (len(tokens) == 2
-            and (tokens[0] in _NUMBER_WORDS or tokens[0].isdigit())
-            and tokens[1] in _DISTANCE_UNITS)
+    """Exactly `<number> <meter unit>` — nothing more, nothing less.
+
+    Numeric literals are bounded to the SAME 1..10 range as the word list:
+    "0 meters" is a no-op nobody dictates, and an out-of-range figure
+    ("9999 meters") is more plausibly a mis-transcription than a real order
+    — either way, admission stays narrow and the utterance falls through to
+    conversation rather than the motion door."""
+    if len(tokens) != 2 or tokens[1] not in _DISTANCE_UNITS:
+        return False
+    if tokens[0] in _NUMBER_WORDS:
+        return True
+    return tokens[0].isdigit() and 1 <= int(tokens[0]) <= 10
 
 
 def normalize(text: str) -> str:

--- a/robot/voice_route_test.py
+++ b/robot/voice_route_test.py
@@ -194,11 +194,22 @@ def test_broad_drive_phrases_stay_conversation():
         "the drive is one meter long",
         "what is a drive",
         "can you explain drive-by-wire",
+        # numeric literals are bounded to the word list's 1..10 range: a
+        # zero is a no-op and an out-of-range figure is more plausibly a
+        # mis-transcription than a real order (review: Copilot on #1292)
+        "drive 0 meters",
+        "drive 11 meters",
+        "drive 9999 meters",
+        "drive for 0 meters",
+        "drive for 9999 meters",
     ]
     for t in negatives:
         d = classify_transcript(t)
         check(d.kind is RouteKind.CONVERSATION,
               f"must stay CONVERSATION, got {d.kind.value} ({d.reason}): {t!r}")
+    d = classify_transcript("drive 10 meters")
+    check(d.kind is RouteKind.MOTION,
+          "the numeric bound is inclusive: 'drive 10 meters' is motion")
 
 
 def test_hold_forms_are_exact_not_prefix():

--- a/robot/voice_route_test.py
+++ b/robot/voice_route_test.py
@@ -149,6 +149,58 @@ def test_pronoun_destinations_stay_ambiguous():
               f"pronoun destination must be AMBIGUOUS: {t!r} → {d.kind.value}")
 
 
+def test_whisper_drive_distance_variants_route_to_motion():
+    # Whisper renders "drive forward one meter" as "drive one meter" or
+    # "drive for one meter" (the known "forward"→"for" substitution). Both
+    # are explicit motion orders; the grammar admits drive + bounded
+    # distance and drive + "for" + bounded distance, nothing wider.
+    positives = [
+        "drive one meter",
+        "drive for one meter",
+        "drive two meters",
+        "drive for two meters",
+        "drive 1 meter",
+        "drive for 1 meter",
+        "please drive one meter",
+        "please drive for two meters",
+        "hey parker drive one meter",
+        "hello rabbit drive for one meter",
+        # normalization: punctuation/case must not change the route
+        "Drive one meter.",
+        "DRIVE FOR ONE METER",
+        "drive, one meter",
+        "hey parker, drive for one meter",
+    ]
+    for t in positives:
+        d = classify_transcript(t)
+        check(d.kind is RouteKind.MOTION,
+              f"drive-distance variant must be MOTION, got {d.kind.value} "
+              f"({d.reason}): {t!r}")
+        check(d.reason == "explicit_motion_verb",
+              f"variant keeps the stable reason token: {t!r} → {d.reason}")
+
+
+def test_broad_drive_phrases_stay_conversation():
+    # The "for" substitution is admitted ONLY before a bounded distance —
+    # durations, purposes, idioms and prose about drives never move a robot.
+    negatives = [
+        "how does a motor drive work",
+        "explain a hard drive",
+        "drive me crazy",
+        "drive for one hour",
+        "drive for better performance",
+        "drive the discussion forward",
+        "drive innovation",
+        "the drive is one meter long",
+        "what is a drive",
+        "can you explain drive-by-wire",
+    ]
+    for t in negatives:
+        d = classify_transcript(t)
+        check(d.kind is RouteKind.CONVERSATION,
+              f"must stay CONVERSATION, got {d.kind.value} ({d.reason}): {t!r}")
+
+
 def test_hold_forms_are_exact_not_prefix():
     # "stop talking" is not a robot-motion order; only enumerated hold
     # forms qualify.

--- a/robot/voice_turn_router_test.py
+++ b/robot/voice_turn_router_test.py
@@ -200,6 +200,35 @@ def test_ambiguous_contacts_neither_endpoint():
         is_.shutdown()
 
 
+def test_whisper_drive_variants_contact_only_intent():
+    # The two known Whisper renderings of "drive forward one meter" must
+    # reach the governed door exactly once each — never chat, never a
+    # retry — and the spoken line stays the admission-only ack.
+    cs, cu = serve(ChatStub)
+    is_, iu = serve(IntentStub)
+    try:
+        StubState.intent_mode = "accept"
+        for text in ("drive one meter", "drive for one meter"):
+            t = Turn(cu, iu, text)
+            check(t.intent == ["/intent"],
+                  f"{text!r} must hit /intent exactly once: {t.intent}")
+            check(t.chat == [],
+                  f"{text!r} must NEVER touch chat: {t.chat}")
+            check("Request accepted." in t.out,
+                  f"{text!r}: admission-only ack spoken")
+            for banned in ("moving", "moved", "executing", "complete"):
+                check(banned not in t.out,
+                      f"{text!r}: ack must not claim execution ({banned!r})")
+        # And a broad drive phrase goes ONLY to chat (never /intent).
+        t = Turn(cu, iu, "how does a motor drive work")
+        check(t.chat == ["/chat/stream"] and t.intent == [],
+              f"broad drive prose must go to chat only: "
+              f"chat={t.chat} intent={t.intent}")
+    finally:
+        cs.shutdown()
+        is_.shutdown()
+
+
 def test_one_transcript_one_request_and_no_replay():
     cs, cu = serve(ChatStub)
     is_, iu = serve(IntentStub)


### PR DESCRIPTION
## Problem

Whisper can render "drive forward one meter" as **"drive one meter"** or **"drive for one meter"** (the known "forward" → "for" substitution). The deterministic router's verb-first grammar required a direction/destination complement after `drive`, so both variants fell through to conversation — the chat sidecar then correctly *refused* the motion request instead of the router sending it to the governed `/intent` door. Confirmed on hardware with the planner parked.

## Fix

Two new drive-only forms in the pure grammar (`robot/voice_route.py`), nothing wider:

```
drive + <bounded distance>
drive + for + <bounded distance>
```

where *bounded distance* is exactly `<number word one..ten | numeric literal> <meter|meters>` via a new pure helper `_is_bounded_distance`. The router is **meters-only** today — no other units admitted, no conversion logic invented. `for` is treated as the known STT substitution for "forward" and admitted **only** when a bounded distance follows. The stable reason token stays `explicit_motion_verb`.

## Why false positives remain bounded

The distance shape is exact-length (`len == 2`) and unit-closed, and the verb-first rule still applies, so every phrase in the false-positive battery stays conversation — each test-pinned:

- durations: *drive for one hour*
- purposes: *drive for better performance*, *drive innovation*
- idioms: *drive me crazy*, *drive the discussion forward*
- drive-as-noun prose: *how does a motor drive work*, *explain a hard drive*, *the drive is one meter long*, *what is a drive*, *can you explain drive-by-wire*

## Safety

Router still has zero motion authority; requests go only through `/intent`; no changes to `/intent` semantics, Mick parsing, Occy, planner, checker, release-token path, consumer, motion-ack behavior, chat routing, ambiguity handling, wake behavior, or playback suppression. `ci/check_mick_actuation_fence.py` → INTACT.

## Tests

- Pure classifier: both variants + plurals + numeric literals + wake-prefix/courtesy/punctuation/case normalization (`Drive one meter.`, `DRIVE FOR ONE METER`, `drive, one meter`, `hey parker, drive for one meter`) → MOTION; all ten false-positive phrases → CONVERSATION.
- Endpoint isolation (stub servers): each variant contacts `/intent` **exactly once** — never `/chat/stream`, no retry, no duplicate — and the spoken line remains the admission-only ack (execution-claim words banned); a broad drive phrase contacts chat only.
- Full suites green: `voice_route_test`, `voice_turn_router_test`, `voice_playback_test`, `wake_word_test`, `rabbit_voice_test` 18/18; `py_compile`, `git diff --check`, conflict-marker scan clean.

## Hardware state

Planner remained stopped during diagnosis. No physical motion was tested; acceptance remains admission-only.

Do not merge automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_