### PR TITLE
feat(navigation): typed destination resolution — language picks the type, a trusted resolver picks the coordinates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1575,6 +1575,13 @@ jobs:
           # and THE single-door invariant — execute_skill_decisions routes motion
           # ONLY through the injected fence sink. See robot/skill_registry.py.
           python3 robot/skill_registry_test.py
+          # Typed-destination registry CLI (pure, read-only): normalization
+          # mirrors the Rust resolver, validation catches every defect class
+          # the resolver refuses (version/map_id/duplicate-key/non-finite/
+          # empty-waypoints), lookup is exact-key-only, and the shipped
+          # example registries are valid AND self-identify as uncalibrated.
+          # See robot/location_registry.py + docs/hardware/R2_DESTINATIONS.md.
+          python3 robot/location_registry_test.py
           # Robot Command Language voice bridge (pure; fake executor): the
           # two-item intent allow-list, the deterministic paraphrase resolver,
           # ambiguity/unknown executing NOTHING, exit-code → structured result,

--- a/crates/kirra-planner/src/lib.rs
+++ b/crates/kirra-planner/src/lib.rs
@@ -60,8 +60,8 @@ pub use lanelet2::{parse_lanelet2_osm, Lanelet2ParseError};
 
 pub mod mick;
 pub use mick::{
-    mick_drive_once, plan_for_intent, MickBrain, MickDriver, MickError, MickIntent, ObjectView,
-    ScriptedBrain, TurnDirection, WorldContext, DEFAULT_DECIDE_INTERVAL_MS,
+    extract_first_json_object, mick_drive_once, plan_for_intent, MickBrain, MickDriver, MickError,
+    MickIntent, ObjectView, ScriptedBrain, TurnDirection, WorldContext, DEFAULT_DECIDE_INTERVAL_MS,
     DEFAULT_INTENT_STALENESS_MS, MICK_MAX_OBJECTS,
 };
 

--- a/crates/kirra-planner/src/mick.rs
+++ b/crates/kirra-planner/src/mick.rs
@@ -258,7 +258,11 @@ impl MickIntent {
 ///
 /// All structural bytes (`{` `}` `"` `\`) are ASCII, so the byte offsets used for
 /// slicing always fall on `char` boundaries even when the prose is multi-byte UTF-8.
-fn extract_first_json_object(raw: &str) -> Option<&str> {
+///
+/// Public so every OTHER fail-closed LLM-JSON parser (the sidecars' typed
+/// destination parse) recovers an object from model framing with THE SAME
+/// tolerant extraction — one extractor, no drift in what counts as "an object".
+pub fn extract_first_json_object(raw: &str) -> Option<&str> {
     let bytes = raw.as_bytes();
     let start = raw.find('{')?;
     let mut depth = 0usize;

--- a/crates/kirra-sidecars/src/bin/planner_service.rs
+++ b/crates/kirra-sidecars/src/bin/planner_service.rs
@@ -12,19 +12,94 @@
 //! Config (boot-validated, fail-closed on malformed — the env_config
 //! convention): `KIRRA_PLANNER_ADDR` (default 127.0.0.1:8100);
 //! `KIRRA_SIDECAR_ALLOW_NONLOCAL=1` to permit a routable bind.
+//!
+//! Typed destinations (all optional; a malformed value ABORTS startup —
+//! never a silent default):
+//!   `KIRRA_DEST_PLACES_PATH` / `KIRRA_DEST_ROUTES_PATH` — the operator-
+//!     calibrated registry JSON files (fail-closed load; absent → the
+//!     matching destination kinds refuse `DEST_NO_REGISTRY`);
+//!   `KIRRA_DEST_OBJECT_MAX_AGE_MS` (default 2000),
+//!   `KIRRA_DEST_OBJECT_MIN_CONFIDENCE` (default 0.70),
+//!   `KIRRA_DEST_OBJECT_STANDOFF_M` (default 0.75) — the tracked-object
+//!     resolution policy (bounds-checked by `ObjectPolicy::validated`).
 
 use std::net::{TcpListener, TcpStream};
 
+use kirra_sidecars::destination::{
+    DestinationResolver, ObjectPolicy, PlaceRegistry, RouteRegistry, DEFAULT_OBJECT_MAX_AGE_MS,
+    DEFAULT_OBJECT_MIN_CONFIDENCE, DEFAULT_OBJECT_STANDOFF_M,
+};
 use kirra_sidecars::http::{read_request, respond, respond_error};
 use kirra_sidecars::net::{allow_nonlocal_from_env, enforce_bind_policy, now_ms, RateLimiter};
-use kirra_sidecars::planner::{handle_plan, PlanRequest};
+use kirra_sidecars::planner::{handle_plan_with_destinations, PlanRequest};
 
 /// /plan rate bound (burst / per-second). Plumbing: each request runs a full
 /// plan + slow-loop check; the doer bridge plans at ≤ 20 Hz.
 const PLAN_RATE_BURST: f64 = 40.0;
 const PLAN_RATE_PER_S: f64 = 20.0;
 
-fn serve(mut stream: TcpStream, limiter: &mut RateLimiter) {
+/// Read one env var, parsed by `parse`, defaulting when absent/empty.
+/// Malformed → `Err` (the caller aborts startup) — never a silent default.
+fn env_parsed<T>(
+    key: &str,
+    default: T,
+    parse: impl FnOnce(&str) -> Option<T>,
+) -> Result<T, String> {
+    match std::env::var(key) {
+        Ok(raw) if !raw.trim().is_empty() => {
+            parse(raw.trim()).ok_or_else(|| format!("{key}: malformed value {raw:?}"))
+        }
+        _ => Ok(default),
+    }
+}
+
+/// Build the trusted destination resolver from env at boot. Fail-closed
+/// throughout: a configured registry path that is unreadable or fails
+/// validation, or a malformed policy knob, ABORTS startup — a planner with a
+/// half-loaded registry must not come up looking healthy.
+fn resolver_from_env() -> Result<DestinationResolver, String> {
+    let places = match std::env::var("KIRRA_DEST_PLACES_PATH") {
+        Ok(path) if !path.trim().is_empty() => {
+            let raw = std::fs::read_to_string(path.trim())
+                .map_err(|e| format!("KIRRA_DEST_PLACES_PATH {path:?}: {e}"))?;
+            PlaceRegistry::from_json_str(&raw)
+                .map_err(|e| format!("KIRRA_DEST_PLACES_PATH {path:?}: {e}"))?
+        }
+        _ => PlaceRegistry::empty(),
+    };
+    let routes = match std::env::var("KIRRA_DEST_ROUTES_PATH") {
+        Ok(path) if !path.trim().is_empty() => {
+            let raw = std::fs::read_to_string(path.trim())
+                .map_err(|e| format!("KIRRA_DEST_ROUTES_PATH {path:?}: {e}"))?;
+            RouteRegistry::from_json_str(&raw)
+                .map_err(|e| format!("KIRRA_DEST_ROUTES_PATH {path:?}: {e}"))?
+        }
+        _ => RouteRegistry::empty(),
+    };
+    let max_age_ms = env_parsed(
+        "KIRRA_DEST_OBJECT_MAX_AGE_MS",
+        DEFAULT_OBJECT_MAX_AGE_MS,
+        |s| s.parse::<u64>().ok(),
+    )?;
+    let min_confidence = env_parsed(
+        "KIRRA_DEST_OBJECT_MIN_CONFIDENCE",
+        DEFAULT_OBJECT_MIN_CONFIDENCE,
+        |s| s.parse::<f32>().ok(),
+    )?;
+    let standoff_m = env_parsed(
+        "KIRRA_DEST_OBJECT_STANDOFF_M",
+        DEFAULT_OBJECT_STANDOFF_M,
+        |s| s.parse::<f64>().ok(),
+    )?;
+    let object_policy = ObjectPolicy::validated(max_age_ms, min_confidence, standoff_m)?;
+    Ok(DestinationResolver {
+        places,
+        routes,
+        object_policy,
+    })
+}
+
+fn serve(mut stream: TcpStream, limiter: &mut RateLimiter, resolver: &DestinationResolver) {
     let req = match read_request(&mut stream) {
         Ok(r) => r,
         Err(status) => return respond_error(&mut stream, status),
@@ -40,7 +115,7 @@ fn serve(mut stream: TcpStream, limiter: &mut RateLimiter) {
                 );
             }
             match serde_json::from_slice::<PlanRequest>(&req.body) {
-                Ok(plan_req) => match handle_plan(&plan_req) {
+                Ok(plan_req) => match handle_plan_with_destinations(&plan_req, resolver) {
                     Ok(resp) => respond(
                         &mut stream,
                         "200 OK",
@@ -71,6 +146,10 @@ fn main() {
         eprintln!("planner_service: {e}");
         std::process::exit(1);
     }
+    let resolver = resolver_from_env().unwrap_or_else(|e| {
+        eprintln!("planner_service: destination config: {e}");
+        std::process::exit(1);
+    });
     let listener = TcpListener::bind(&addr).unwrap_or_else(|e| {
         eprintln!("planner_service: bind {addr}: {e}");
         std::process::exit(1);
@@ -79,7 +158,7 @@ fn main() {
     let mut limiter = RateLimiter::new(PLAN_RATE_BURST, PLAN_RATE_PER_S);
     for stream in listener.incoming() {
         match stream {
-            Ok(s) => serve(s, &mut limiter),
+            Ok(s) => serve(s, &mut limiter, &resolver),
             Err(e) => eprintln!("planner_service: accept error: {e}"),
         }
     }

--- a/crates/kirra-sidecars/src/destination.rs
+++ b/crates/kirra-sidecars/src/destination.rs
@@ -1,0 +1,1517 @@
+//! Typed destination resolution — **language chooses the destination TYPE; a
+//! trusted resolver chooses the actual coordinates.**
+//!
+//! The problem this module exists to close: "drive to the kitchen" must never
+//! become an LLM-invented coordinate pair. An LLM (or the deterministic voice
+//! router) may only pick a typed [`DestinationRef`] — a KIND plus the
+//! operator's words — and the [`DestinationResolver`] grounds it against
+//! trusted sources:
+//!
+//! | kind             | trusted source                              | outcome        |
+//! |------------------|---------------------------------------------|----------------|
+//! | `named_place`    | operator-calibrated [`PlaceRegistry`] JSON  | registry pose  |
+//! | `saved_route`    | operator-calibrated [`RouteRegistry`] JSON  | waypoint list  |
+//! | `tracked_object` | live camera targets (`kirra_taj::object_goal`) | standoff pose |
+//! | `address`        | none (no geocoder exists)                   | **Unsupported**|
+//!
+//! Every resolution returns an explicit [`ResolveOutcome`] — Resolved /
+//! Ambiguous / NotFound / Stale / Unsupported — never an `Option`, so a caller
+//! cannot conflate "no such place" with "the camera view is stale" with "we
+//! don't do street addresses". Every non-Resolved arm is a REFUSAL to drive:
+//! the caller speaks the reason ([`ResolveOutcome::sentence`]) instead of
+//! moving.
+//!
+//! 🔴 **Coordinates never enter through language.** [`DestinationRef::parse_json`]
+//! is the ONE fail-closed parser for destination JSON: it rejects any object
+//! carrying a coordinate-shaped key outright (`DEST_COORDINATES_FORBIDDEN`),
+//! and [`destination_schema`] (the constrained-decode form handed to an LLM
+//! backend) has NO numeric property at all — the model structurally cannot
+//! emit a coordinate even before the parse refuses one.
+//!
+//! 🔴 **A grounded destination asserts nothing about drivability.** Like the
+//! `object_goal` channel this generalizes, a [`GroundedDestination`] is a
+//! DESTINATION ONLY: the caller grounds it as an ordinary `MickIntent::GoTo`,
+//! Occy plans inside the lidar corridor, and the KIRRA checker bounds the
+//! trajectory — a registered place behind an obstacle produces a robot that
+//! stops short, never one that drives at the registry entry.
+//!
+//! This module lives in `kirra-sidecars` deliberately: the crate is FENCED by
+//! `ci/check_mick_actuation_fence.py`, so "the resolver has no dependency
+//! route to the release-token mint, the serial seam, or any ROS/DDS
+//! transport" is an existing CI invariant, not a promise.
+
+use std::collections::HashMap;
+
+use kirra_planner::{extract_first_json_object, Pose};
+use kirra_taj::object_goal::{
+    resolve_object_goal, GoalRefusal, LabeledTarget, ObjectGoal, DEFAULT_TIE_EPSILON_M,
+};
+use serde::Deserialize;
+
+/// Upper bound on a destination query (characters) — a plumbing bound against
+/// prompt/transcript pathologies, not a safety number.
+pub const MAX_QUERY_CHARS: usize = 120;
+
+/// The one registry file format version this build reads. A future version is
+/// REFUSED at load (fail-closed), never best-effort parsed.
+pub const DEST_REGISTRY_VERSION: u64 = 1;
+
+/// Default freshness budget for a tracked-object destination (ms). Wider than
+/// the `object_goal` channel's 750 ms because a spoken "drive to the red cup"
+/// round-trips STT + routing before it reaches the resolver; still tight
+/// enough that a moved object cannot be chased on an old sighting.
+pub const DEFAULT_OBJECT_MAX_AGE_MS: u64 = 2_000;
+
+/// Default minimum detector confidence for a tracked-object destination.
+pub const DEFAULT_OBJECT_MIN_CONFIDENCE: f32 = 0.70;
+
+/// Default standoff (m): the grounded goal stops this far SHORT of the object
+/// along the ego→object ray — the robot approaches a thing, it does not park
+/// on top of it.
+pub const DEFAULT_OBJECT_STANDOFF_M: f64 = 0.75;
+
+/// Registry parse bounds (fail-closed: an oversized file is refused, never
+/// truncated). Plumbing bounds sized far above any real deployment.
+const MAX_REGISTRY_ENTRIES: usize = 4_096;
+const MAX_ALIASES_PER_ENTRY: usize = 32;
+const MAX_ROUTE_WAYPOINTS: usize = 1_024;
+
+// ---------------------------------------------------------------------------
+// The typed destination reference — what LANGUAGE is allowed to choose.
+// ---------------------------------------------------------------------------
+
+/// A typed destination request: a KIND plus the operator's words. Carries no
+/// coordinates by construction — the resolver supplies those.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DestinationRef {
+    /// A place from the operator-calibrated place registry ("the kitchen").
+    NamedPlace { query: String },
+    /// A saved multi-waypoint route from the route registry ("route A").
+    SavedRoute { query: String },
+    /// A live camera-tracked labelled object ("the red cup").
+    TrackedObject { query: String },
+    /// A street address ("125 Main Street") — a typed seam that resolves
+    /// [`ResolveOutcome::Unsupported`] until a real, trusted geocoding source
+    /// exists. Deliberately present so address requests fail CLOSED with an
+    /// honest reason instead of being mis-bucketed into another kind.
+    Address { query: String },
+}
+
+/// The wire form: `{"kind":"named_place","query":"kitchen"}`. Strict —
+/// unknown fields are a parse error, so nothing can ride alongside the query.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct DestinationJson {
+    kind: String,
+    query: String,
+}
+
+/// Keys whose presence in a destination object means someone (a model, a
+/// caller) tried to smuggle geometry through the language channel. Refused
+/// with a DISTINCT code so the violation is loud in telemetry, not folded
+/// into generic parse noise.
+const COORDINATE_KEYS: &[&str] = &[
+    "x_m",
+    "y_m",
+    "x",
+    "y",
+    "lat",
+    "lon",
+    "latitude",
+    "longitude",
+    "heading_rad",
+    "pose",
+    "waypoints",
+];
+
+impl DestinationRef {
+    /// Parse destination JSON — THE one fail-closed parser for the typed
+    /// destination wire form. Tolerant of LLM framing (fences/preamble) via
+    /// the same extractor as the intent parse; strict on everything else:
+    /// unknown kind, unknown fields, empty/oversized query, and — loudest —
+    /// any coordinate-shaped key (`DEST_COORDINATES_FORBIDDEN`).
+    ///
+    /// Returns the typed ref AND the exact accepted `{…}` slice (the
+    /// re-publishable wire artifact, mirroring `MickIntent::parse_llm_json`).
+    pub fn parse_json(raw: &str) -> Result<(Self, &str), &'static str> {
+        let json = extract_first_json_object(raw).ok_or("DEST_JSON_PARSE_ERROR")?;
+        let value: serde_json::Value =
+            serde_json::from_str(json).map_err(|_| "DEST_JSON_PARSE_ERROR")?;
+        let obj = value.as_object().ok_or("DEST_JSON_PARSE_ERROR")?;
+        if obj.keys().any(|k| COORDINATE_KEYS.contains(&k.as_str())) {
+            return Err("DEST_COORDINATES_FORBIDDEN");
+        }
+        let parsed: DestinationJson =
+            serde_json::from_str(json).map_err(|_| "DEST_JSON_PARSE_ERROR")?;
+        let query = parsed.query.trim();
+        if query.is_empty() {
+            return Err("DEST_EMPTY_QUERY");
+        }
+        if query.chars().count() > MAX_QUERY_CHARS {
+            return Err("DEST_QUERY_TOO_LONG");
+        }
+        let query = query.to_string();
+        let dref = match parsed.kind.as_str() {
+            "named_place" => DestinationRef::NamedPlace { query },
+            "saved_route" => DestinationRef::SavedRoute { query },
+            "tracked_object" => DestinationRef::TrackedObject { query },
+            "address" => DestinationRef::Address { query },
+            _ => return Err("DEST_UNKNOWN_KIND"),
+        };
+        Ok((dref, json))
+    }
+
+    /// As [`parse_json`](Self::parse_json), discarding the slice.
+    pub fn from_json(raw: &str) -> Result<Self, &'static str> {
+        Self::parse_json(raw).map(|(dref, _)| dref)
+    }
+
+    /// The wire kind token.
+    #[must_use]
+    pub fn kind_str(&self) -> &'static str {
+        match self {
+            DestinationRef::NamedPlace { .. } => "named_place",
+            DestinationRef::SavedRoute { .. } => "saved_route",
+            DestinationRef::TrackedObject { .. } => "tracked_object",
+            DestinationRef::Address { .. } => "address",
+        }
+    }
+
+    /// The operator's words.
+    #[must_use]
+    pub fn query(&self) -> &str {
+        match self {
+            DestinationRef::NamedPlace { query }
+            | DestinationRef::SavedRoute { query }
+            | DestinationRef::TrackedObject { query }
+            | DestinationRef::Address { query } => query,
+        }
+    }
+}
+
+/// Normalize a query / registry key for matching: ASCII-lowercase,
+/// non-alphanumerics collapse to single spaces, trimmed. Mirrors the voice
+/// router's `normalize` so "The Kitchen!" and "the kitchen" are one key.
+#[must_use]
+pub fn normalize_query(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut pending_space = false;
+    for c in text.chars() {
+        if c.is_ascii_alphanumeric() {
+            if pending_space && !out.is_empty() {
+                out.push(' ');
+            }
+            pending_space = false;
+            out.push(c.to_ascii_lowercase());
+        } else {
+            pending_space = true;
+        }
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Registries — the trusted, operator-calibrated coordinate sources.
+// ---------------------------------------------------------------------------
+
+/// One calibrated named place.
+#[derive(Debug, Clone, PartialEq)]
+pub struct NamedPlace {
+    pub id: String,
+    pub name: String,
+    pub aliases: Vec<String>,
+    /// Pose in the registry's map frame.
+    pub pose: Pose,
+}
+
+/// One saved route: an ordered waypoint list in the registry's map frame.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SavedRoute {
+    pub id: String,
+    pub name: String,
+    pub aliases: Vec<String>,
+    pub waypoints: Vec<Pose>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PlaceFile {
+    version: u64,
+    map_id: String,
+    places: Vec<PlaceEntry>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PlaceEntry {
+    id: String,
+    name: String,
+    #[serde(default)]
+    aliases: Vec<String>,
+    x_m: f64,
+    y_m: f64,
+    #[serde(default)]
+    heading_rad: f64,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RouteFile {
+    version: u64,
+    map_id: String,
+    routes: Vec<RouteEntry>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RouteEntry {
+    id: String,
+    name: String,
+    #[serde(default)]
+    aliases: Vec<String>,
+    waypoints: Vec<WaypointEntry>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct WaypointEntry {
+    x_m: f64,
+    y_m: f64,
+    #[serde(default)]
+    heading_rad: f64,
+}
+
+/// Validate one entry's identity + collect its normalized lookup keys into
+/// `keys`, refusing (fail-closed) on empties, duplicates across the WHOLE
+/// registry (ids, names, and aliases share one key space, so a lookup can
+/// never be ambiguous by construction), or too many aliases.
+fn index_entry_keys(
+    keys: &mut HashMap<String, usize>,
+    idx: usize,
+    id: &str,
+    name: &str,
+    aliases: &[String],
+    what: &str,
+) -> Result<(), String> {
+    if aliases.len() > MAX_ALIASES_PER_ENTRY {
+        return Err(format!(
+            "{what} {id:?}: {} aliases exceeds the {MAX_ALIASES_PER_ENTRY} bound",
+            aliases.len()
+        ));
+    }
+    for raw in [id, name]
+        .into_iter()
+        .chain(aliases.iter().map(|a| a.as_str()))
+    {
+        let key = normalize_query(raw);
+        if key.is_empty() {
+            return Err(format!(
+                "{what} {id:?}: key {raw:?} is empty after normalization"
+            ));
+        }
+        if let Some(prev) = keys.insert(key.clone(), idx) {
+            if prev != idx {
+                return Err(format!(
+                    "{what} {id:?}: key {raw:?} collides with another entry — \
+                     ids, names and aliases must be unique across the registry"
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn check_finite_pose(x: f64, y: f64, heading: f64, what: &str, id: &str) -> Result<(), String> {
+    if x.is_finite() && y.is_finite() && heading.is_finite() {
+        Ok(())
+    } else {
+        Err(format!("{what} {id:?}: non-finite coordinate"))
+    }
+}
+
+/// The named-place registry: a validated, immutable lookup table loaded once
+/// at boot from operator-calibrated JSON. Load is FAIL-CLOSED — any defect
+/// (wrong version, empty/duplicate keys, non-finite coordinates, unknown
+/// fields, missing `map_id`) refuses the whole file with a description; a
+/// partially-usable registry is never constructed.
+#[derive(Debug, Clone, Default)]
+pub struct PlaceRegistry {
+    map_id: String,
+    places: Vec<NamedPlace>,
+    keys: HashMap<String, usize>,
+}
+
+impl PlaceRegistry {
+    /// An empty registry (no file configured): every lookup refuses with
+    /// `DEST_NO_REGISTRY`.
+    #[must_use]
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    /// Parse + validate a registry file. Fail-closed on any defect.
+    pub fn from_json_str(raw: &str) -> Result<Self, String> {
+        let file: PlaceFile =
+            serde_json::from_str(raw).map_err(|e| format!("place registry: {e}"))?;
+        if file.version != DEST_REGISTRY_VERSION {
+            return Err(format!(
+                "place registry: version {} is not the supported version {DEST_REGISTRY_VERSION}",
+                file.version
+            ));
+        }
+        if normalize_query(&file.map_id).is_empty() {
+            return Err("place registry: map_id is required and must be non-empty".to_string());
+        }
+        if file.places.len() > MAX_REGISTRY_ENTRIES {
+            return Err(format!(
+                "place registry: {} entries exceeds the {MAX_REGISTRY_ENTRIES} bound",
+                file.places.len()
+            ));
+        }
+        let mut keys = HashMap::new();
+        let mut places = Vec::with_capacity(file.places.len());
+        for (idx, e) in file.places.iter().enumerate() {
+            check_finite_pose(e.x_m, e.y_m, e.heading_rad, "place", &e.id)?;
+            index_entry_keys(&mut keys, idx, &e.id, &e.name, &e.aliases, "place")?;
+            places.push(NamedPlace {
+                id: e.id.clone(),
+                name: e.name.clone(),
+                aliases: e.aliases.clone(),
+                pose: Pose {
+                    x_m: e.x_m,
+                    y_m: e.y_m,
+                    heading_rad: e.heading_rad,
+                },
+            });
+        }
+        Ok(Self {
+            map_id: file.map_id,
+            places,
+            keys,
+        })
+    }
+
+    /// Exact lookup by normalized id / name / alias. Registry-load uniqueness
+    /// makes a hit structurally unambiguous.
+    #[must_use]
+    pub fn lookup(&self, query: &str) -> Option<&NamedPlace> {
+        self.keys
+            .get(&normalize_query(query))
+            .map(|&i| &self.places[i])
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.places.is_empty()
+    }
+
+    #[must_use]
+    pub fn map_id(&self) -> &str {
+        &self.map_id
+    }
+
+    /// Display names (for prompt rendering / the CLI). NAMES ONLY — a
+    /// coordinate never leaves the registry through this.
+    #[must_use]
+    pub fn names(&self) -> Vec<String> {
+        self.places.iter().map(|p| p.name.clone()).collect()
+    }
+}
+
+/// The saved-route registry — same load/validation contract as
+/// [`PlaceRegistry`], plus: every route needs 1..=[`MAX_ROUTE_WAYPOINTS`]
+/// finite waypoints.
+#[derive(Debug, Clone, Default)]
+pub struct RouteRegistry {
+    map_id: String,
+    routes: Vec<SavedRoute>,
+    keys: HashMap<String, usize>,
+}
+
+impl RouteRegistry {
+    #[must_use]
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    /// Parse + validate a route registry file. Fail-closed on any defect.
+    pub fn from_json_str(raw: &str) -> Result<Self, String> {
+        let file: RouteFile =
+            serde_json::from_str(raw).map_err(|e| format!("route registry: {e}"))?;
+        if file.version != DEST_REGISTRY_VERSION {
+            return Err(format!(
+                "route registry: version {} is not the supported version {DEST_REGISTRY_VERSION}",
+                file.version
+            ));
+        }
+        if normalize_query(&file.map_id).is_empty() {
+            return Err("route registry: map_id is required and must be non-empty".to_string());
+        }
+        if file.routes.len() > MAX_REGISTRY_ENTRIES {
+            return Err(format!(
+                "route registry: {} entries exceeds the {MAX_REGISTRY_ENTRIES} bound",
+                file.routes.len()
+            ));
+        }
+        let mut keys = HashMap::new();
+        let mut routes = Vec::with_capacity(file.routes.len());
+        for (idx, e) in file.routes.iter().enumerate() {
+            if e.waypoints.is_empty() || e.waypoints.len() > MAX_ROUTE_WAYPOINTS {
+                return Err(format!(
+                    "route {:?}: {} waypoints outside 1..={MAX_ROUTE_WAYPOINTS}",
+                    e.id,
+                    e.waypoints.len()
+                ));
+            }
+            for w in &e.waypoints {
+                check_finite_pose(w.x_m, w.y_m, w.heading_rad, "route", &e.id)?;
+            }
+            index_entry_keys(&mut keys, idx, &e.id, &e.name, &e.aliases, "route")?;
+            routes.push(SavedRoute {
+                id: e.id.clone(),
+                name: e.name.clone(),
+                aliases: e.aliases.clone(),
+                waypoints: e
+                    .waypoints
+                    .iter()
+                    .map(|w| Pose {
+                        x_m: w.x_m,
+                        y_m: w.y_m,
+                        heading_rad: w.heading_rad,
+                    })
+                    .collect(),
+            });
+        }
+        Ok(Self {
+            map_id: file.map_id,
+            routes,
+            keys,
+        })
+    }
+
+    /// Exact lookup by normalized id / name / alias.
+    #[must_use]
+    pub fn lookup(&self, query: &str) -> Option<&SavedRoute> {
+        self.keys
+            .get(&normalize_query(query))
+            .map(|&i| &self.routes[i])
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.routes.is_empty()
+    }
+
+    #[must_use]
+    pub fn map_id(&self) -> &str {
+        &self.map_id
+    }
+
+    /// Display names only — never coordinates.
+    #[must_use]
+    pub fn names(&self) -> Vec<String> {
+        self.routes.iter().map(|r| r.name.clone()).collect()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Object policy + the resolver.
+// ---------------------------------------------------------------------------
+
+/// Tracked-object resolution policy — validated at construction so a
+/// malformed configuration aborts boot rather than silently defaulting.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ObjectPolicy {
+    /// A sighting older than this (ms) is [`ResolveOutcome::Stale`].
+    pub max_age_ms: u64,
+    /// Matches below this confidence never become a destination.
+    pub min_confidence: f32,
+    /// The grounded goal stops this far short of the object (m).
+    pub standoff_m: f64,
+}
+
+impl Default for ObjectPolicy {
+    fn default() -> Self {
+        Self {
+            max_age_ms: DEFAULT_OBJECT_MAX_AGE_MS,
+            min_confidence: DEFAULT_OBJECT_MIN_CONFIDENCE,
+            standoff_m: DEFAULT_OBJECT_STANDOFF_M,
+        }
+    }
+}
+
+impl ObjectPolicy {
+    /// Bounds-checked constructor. `max_age_ms >= 1`; confidence in `[0, 1]`;
+    /// standoff finite in `[0, 5]` m (a standoff wider than that is a config
+    /// typo, not a policy).
+    pub fn validated(
+        max_age_ms: u64,
+        min_confidence: f32,
+        standoff_m: f64,
+    ) -> Result<Self, String> {
+        if max_age_ms == 0 {
+            return Err("object policy: max_age_ms must be >= 1".to_string());
+        }
+        if !min_confidence.is_finite() || !(0.0..=1.0).contains(&min_confidence) {
+            return Err(format!(
+                "object policy: min_confidence {min_confidence} outside [0, 1]"
+            ));
+        }
+        if !standoff_m.is_finite() || !(0.0..=5.0).contains(&standoff_m) {
+            return Err(format!(
+                "object policy: standoff_m {standoff_m} outside [0, 5]"
+            ));
+        }
+        Ok(Self {
+            max_age_ms,
+            min_confidence,
+            standoff_m,
+        })
+    }
+}
+
+/// Which trusted source produced a grounded destination.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DestinationSource {
+    PlaceRegistry,
+    RouteRegistry,
+    ObjectTrack,
+}
+
+impl DestinationSource {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            DestinationSource::PlaceRegistry => "place_registry",
+            DestinationSource::RouteRegistry => "route_registry",
+            DestinationSource::ObjectTrack => "object_track",
+        }
+    }
+}
+
+/// A resolver-grounded navigation target. A DESTINATION ONLY — it asserts
+/// nothing about drivability; the governed planner path adjudicates the way
+/// there exactly as for any other goal.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GroundedDestination {
+    /// The registry id (place/route) or the matched detector label (object).
+    pub destination_id: String,
+    /// The registry's map frame id. `None` for an object track — a live
+    /// sighting is in the request's world frame and has no persistent map
+    /// identity. A caller that carries map identity MUST check this against
+    /// its active map before acting.
+    pub map_id: Option<String>,
+    /// The goal pose (for a route: its FIRST waypoint — sequencing the rest
+    /// is the mission layer's job, see `route_waypoints`).
+    pub goal_pose: Pose,
+    /// The full ordered waypoint list (empty unless a saved route).
+    pub route_waypoints: Vec<Pose>,
+    pub source: DestinationSource,
+    /// The resolver clock at resolution (the caller's `now_ms`).
+    pub resolved_at_ms: u64,
+}
+
+/// The explicit resolution outcome. Deliberately an enum, not an `Option`:
+/// each non-Resolved arm is a DIFFERENT refusal with its own stable code and
+/// operator sentence, and collapsing them would let a caller mistake "stale
+/// camera" for "no such place".
+#[derive(Debug, Clone, PartialEq)]
+pub enum ResolveOutcome {
+    Resolved(GroundedDestination),
+    /// More than one equally-good match — refuse rather than silently pick.
+    /// `candidates` (possibly empty) names what tied, for narration.
+    Ambiguous {
+        candidates: Vec<String>,
+    },
+    /// Nothing matched; `code` carries the specific reason
+    /// (`DEST_NOT_FOUND` / `DEST_NO_REGISTRY` / `DEST_NOT_SEEN` /
+    /// `DEST_LOW_CONFIDENCE` / `DEST_BEHIND_EGO` / `DEST_NON_FINITE`).
+    NotFound {
+        code: &'static str,
+    },
+    /// The evidence is too old (or absent) to drive on.
+    Stale,
+    /// The destination kind has no trusted resolution source (`address`
+    /// today); `code` carries the specific seam.
+    Unsupported {
+        code: &'static str,
+    },
+}
+
+impl ResolveOutcome {
+    /// Stable machine code — the telemetry/seam-rejection token.
+    #[must_use]
+    pub fn code(&self) -> &'static str {
+        match self {
+            ResolveOutcome::Resolved(_) => "DEST_RESOLVED",
+            ResolveOutcome::Ambiguous { .. } => "DEST_AMBIGUOUS",
+            ResolveOutcome::NotFound { code } | ResolveOutcome::Unsupported { code } => code,
+            ResolveOutcome::Stale => "DEST_STALE",
+        }
+    }
+
+    /// One operator-facing sentence for a refusal — the robot SAYS why it is
+    /// not driving instead of silently holding. (Resolved has no refusal
+    /// sentence; it returns an empty string.)
+    #[must_use]
+    pub fn sentence(&self, query: &str) -> String {
+        match self {
+            ResolveOutcome::Resolved(_) => String::new(),
+            ResolveOutcome::Ambiguous { candidates } => {
+                if candidates.is_empty() {
+                    format!("I can see more than one {query} — which one did you mean?")
+                } else {
+                    format!(
+                        "More than one destination matches {query} ({}) — which one did you mean?",
+                        candidates.join(", ")
+                    )
+                }
+            }
+            ResolveOutcome::NotFound { code } => match *code {
+                "DEST_NO_REGISTRY" => {
+                    format!("I don't have any saved places or routes yet, so I can't find {query}.")
+                }
+                "DEST_NOT_SEEN" => {
+                    format!("I can't see {query} from here, so I'm staying put.")
+                }
+                "DEST_LOW_CONFIDENCE" => {
+                    format!("I might be seeing {query}, but not clearly enough to drive to it.")
+                }
+                "DEST_BEHIND_EGO" => {
+                    format!("{query} is behind me, and I only drive forward to a target.")
+                }
+                "DEST_NON_FINITE" => {
+                    format!("My reading of {query} doesn't make sense, so I'm not moving.")
+                }
+                _ => format!("I don't know a destination called {query}."),
+            },
+            ResolveOutcome::Stale => {
+                format!("My view of {query} is stale, so I won't drive on it.")
+            }
+            ResolveOutcome::Unsupported { .. } => {
+                "I can't navigate to street addresses yet, so I'm staying put.".to_string()
+            }
+        }
+    }
+}
+
+/// The live camera-target view a resolution runs against (the tracked-object
+/// arm's evidence). `stamp_ms: None` means "the detector did not look", which
+/// is Stale — never "it isn't there".
+pub struct TargetView<'a> {
+    pub targets: &'a [LabeledTarget],
+    pub stamp_ms: Option<u64>,
+}
+
+/// The ego pose in the request's world frame (for grounding an ego-frame
+/// object sighting and applying the standoff).
+#[derive(Debug, Clone, Copy)]
+pub struct EgoView {
+    pub x_m: f64,
+    pub y_m: f64,
+    pub heading_rad: f64,
+}
+
+/// The trusted resolver: registries + object policy. Language hands it a
+/// [`DestinationRef`]; it alone chooses coordinates.
+#[derive(Debug, Clone, Default)]
+pub struct DestinationResolver {
+    pub places: PlaceRegistry,
+    pub routes: RouteRegistry,
+    pub object_policy: ObjectPolicy,
+}
+
+impl DestinationResolver {
+    /// Resolve one typed destination against the trusted sources. Pure: all
+    /// evidence and clocks are parameters.
+    #[must_use]
+    pub fn resolve(
+        &self,
+        dref: &DestinationRef,
+        view: &TargetView<'_>,
+        ego: EgoView,
+        now_ms: u64,
+    ) -> ResolveOutcome {
+        match dref {
+            DestinationRef::NamedPlace { query } => {
+                if self.places.is_empty() {
+                    return ResolveOutcome::NotFound {
+                        code: "DEST_NO_REGISTRY",
+                    };
+                }
+                match self.places.lookup(query) {
+                    Some(place) => ResolveOutcome::Resolved(GroundedDestination {
+                        destination_id: place.id.clone(),
+                        map_id: Some(self.places.map_id().to_string()),
+                        goal_pose: place.pose,
+                        route_waypoints: Vec::new(),
+                        source: DestinationSource::PlaceRegistry,
+                        resolved_at_ms: now_ms,
+                    }),
+                    None => ResolveOutcome::NotFound {
+                        code: "DEST_NOT_FOUND",
+                    },
+                }
+            }
+            DestinationRef::SavedRoute { query } => {
+                if self.routes.is_empty() {
+                    return ResolveOutcome::NotFound {
+                        code: "DEST_NO_REGISTRY",
+                    };
+                }
+                match self.routes.lookup(query) {
+                    Some(route) => ResolveOutcome::Resolved(GroundedDestination {
+                        destination_id: route.id.clone(),
+                        map_id: Some(self.routes.map_id().to_string()),
+                        goal_pose: route.waypoints[0],
+                        route_waypoints: route.waypoints.clone(),
+                        source: DestinationSource::RouteRegistry,
+                        resolved_at_ms: now_ms,
+                    }),
+                    None => ResolveOutcome::NotFound {
+                        code: "DEST_NOT_FOUND",
+                    },
+                }
+            }
+            DestinationRef::TrackedObject { query } => {
+                self.resolve_object(query, view, ego, now_ms)
+            }
+            DestinationRef::Address { .. } => ResolveOutcome::Unsupported {
+                code: "DEST_UNSUPPORTED_ADDRESS",
+            },
+        }
+    }
+
+    /// The tracked-object arm: delegate the match/freshness/confidence/tie
+    /// policy to the proven `object_goal` resolver, then apply the standoff
+    /// and lift into the world frame.
+    fn resolve_object(
+        &self,
+        query: &str,
+        view: &TargetView<'_>,
+        ego: EgoView,
+        now_ms: u64,
+    ) -> ResolveOutcome {
+        let goal = match resolve_object_goal(
+            query,
+            view.targets,
+            view.stamp_ms,
+            now_ms,
+            self.object_policy.max_age_ms,
+            self.object_policy.min_confidence,
+            DEFAULT_TIE_EPSILON_M,
+        ) {
+            Ok(goal) => goal,
+            Err(GoalRefusal::Stale) => return ResolveOutcome::Stale,
+            Err(GoalRefusal::Ambiguous) => {
+                return ResolveOutcome::Ambiguous {
+                    candidates: Vec::new(),
+                }
+            }
+            Err(GoalRefusal::NoRequestedLabel) | Err(GoalRefusal::NotSeen) => {
+                return ResolveOutcome::NotFound {
+                    code: "DEST_NOT_SEEN",
+                }
+            }
+            Err(GoalRefusal::LowConfidence) => {
+                return ResolveOutcome::NotFound {
+                    code: "DEST_LOW_CONFIDENCE",
+                }
+            }
+            Err(GoalRefusal::BehindEgo) => {
+                return ResolveOutcome::NotFound {
+                    code: "DEST_BEHIND_EGO",
+                }
+            }
+            Err(GoalRefusal::NonFinite) => {
+                return ResolveOutcome::NotFound {
+                    code: "DEST_NON_FINITE",
+                }
+            }
+        };
+
+        // Standoff in the EGO frame: pull the goal back along the ego→object
+        // ray so the robot approaches the thing, never parks on it. Within
+        // the standoff already → the goal is the ego's own position (a no-op
+        // approach), still Resolved so the caller can narrate "I'm already
+        // there".
+        let range = goal.x_m.hypot(goal.y_m);
+        let scale = if range <= self.object_policy.standoff_m {
+            0.0
+        } else {
+            (range - self.object_policy.standoff_m) / range
+        };
+        let standoff_goal = ObjectGoal {
+            label: goal.label.clone(),
+            x_m: goal.x_m * scale,
+            y_m: goal.y_m * scale,
+            confidence: goal.confidence,
+        };
+        let (x_w, y_w) = standoff_goal.to_world(ego.x_m, ego.y_m, ego.heading_rad);
+        // Face the object from the standoff point.
+        let heading_w = ego.heading_rad + goal.y_m.atan2(goal.x_m);
+
+        ResolveOutcome::Resolved(GroundedDestination {
+            destination_id: goal.label,
+            map_id: None,
+            goal_pose: Pose {
+                x_m: x_w,
+                y_m: y_w,
+                heading_rad: heading_w,
+            },
+            route_waypoints: Vec::new(),
+            source: DestinationSource::ObjectTrack,
+            resolved_at_ms: now_ms,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The LLM seam — schema + prompt. The model can choose a KIND and repeat the
+// operator's words; it structurally cannot emit a coordinate.
+// ---------------------------------------------------------------------------
+
+/// The constrained-decode JSON Schema for a destination choice (the
+/// `destination` sibling of `kirra_planner::intent_schema`). Two string
+/// fields, both required, nothing else admitted — there is NO numeric
+/// property, so a schema-constrained backend cannot emit a coordinate at
+/// all, and [`DestinationRef::parse_json`] refuses one after the fact anyway.
+#[must_use]
+pub fn destination_schema() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "properties": {
+            "kind": {
+                "type": "string",
+                "enum": ["named_place", "saved_route", "tracked_object", "address"]
+            },
+            "query": { "type": "string" }
+        },
+        "required": ["kind", "query"],
+        "additionalProperties": false
+    })
+}
+
+/// Render the destination-choice prompt: the operator's (sanitized) request
+/// plus the KNOWN place/route NAMES — names only; a coordinate never enters a
+/// prompt. The model's whole job is to pick the kind and echo the operator's
+/// naming of it; the trusted resolver does everything else.
+#[must_use]
+pub fn build_destination_prompt(
+    request: &str,
+    place_names: &[String],
+    route_names: &[String],
+) -> String {
+    let request = kirra_planner::sanitize_request(request);
+    let places = if place_names.is_empty() {
+        "(none saved)".to_string()
+    } else {
+        place_names.join(", ")
+    };
+    let routes = if route_names.is_empty() {
+        "(none saved)".to_string()
+    } else {
+        route_names.join(", ")
+    };
+    format!(
+        "You classify ONE navigation request into a typed destination. You do NOT know any \
+coordinates and must never invent one — a separate trusted resolver owns all geometry.\n\
+\n\
+Respond with ONLY one JSON object (no prose, no code fence):\n\
+  {{\"kind\":\"named_place\",\"query\":\"<the place the operator named>\"}}\n\
+  {{\"kind\":\"saved_route\",\"query\":\"<the route the operator named>\"}}\n\
+  {{\"kind\":\"tracked_object\",\"query\":\"<the visible thing the operator named>\"}}\n\
+  {{\"kind\":\"address\",\"query\":\"<the street address the operator gave>\"}}\n\
+\n\
+Known place names: {places}\n\
+Known route names: {routes}\n\
+\n\
+Pick named_place or saved_route when the request names one of those; tracked_object for a \
+physical thing the robot might see (a cup, a chair, a person); address for a street \
+address. Put the operator's own words for the destination in query — nothing else.\n\
+\n\
+Request:\n  \"{request}\"\n\
+\n\
+Destination:"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PLACES_JSON: &str = r#"{
+        "version": 1,
+        "map_id": "r2-lab-01",
+        "places": [
+            {"id": "kitchen", "name": "Kitchen", "aliases": ["the kitchen"],
+             "x_m": 3.2, "y_m": -1.4, "heading_rad": 0.0},
+            {"id": "charging-dock", "name": "Charging Dock",
+             "aliases": ["the dock", "charger"], "x_m": 0.5, "y_m": 2.0, "heading_rad": 1.57}
+        ]
+    }"#;
+
+    const ROUTES_JSON: &str = r#"{
+        "version": 1,
+        "map_id": "r2-lab-01",
+        "routes": [
+            {"id": "route-a", "name": "Route A", "aliases": ["route alpha"],
+             "waypoints": [
+                {"x_m": 1.0, "y_m": 0.0, "heading_rad": 0.0},
+                {"x_m": 2.0, "y_m": 1.0, "heading_rad": 0.7}
+             ]}
+        ]
+    }"#;
+
+    fn resolver() -> DestinationResolver {
+        DestinationResolver {
+            places: PlaceRegistry::from_json_str(PLACES_JSON).unwrap(),
+            routes: RouteRegistry::from_json_str(ROUTES_JSON).unwrap(),
+            object_policy: ObjectPolicy::default(),
+        }
+    }
+
+    fn no_targets() -> Vec<LabeledTarget> {
+        Vec::new()
+    }
+
+    fn view<'a>(targets: &'a [LabeledTarget], stamp: Option<u64>) -> TargetView<'a> {
+        TargetView {
+            targets,
+            stamp_ms: stamp,
+        }
+    }
+
+    fn ego_origin() -> EgoView {
+        EgoView {
+            x_m: 0.0,
+            y_m: 0.0,
+            heading_rad: 0.0,
+        }
+    }
+
+    fn target(label: &str, x: f64, y: f64, c: f32) -> LabeledTarget {
+        LabeledTarget {
+            label: label.into(),
+            x_m: x,
+            y_m: y,
+            confidence: c,
+        }
+    }
+
+    // ---- the one fail-closed parser ----------------------------------------
+
+    #[test]
+    fn parses_every_kind_and_returns_the_exact_slice() {
+        for (kind, expect) in [
+            ("named_place", "named_place"),
+            ("saved_route", "saved_route"),
+            ("tracked_object", "tracked_object"),
+            ("address", "address"),
+        ] {
+            let raw = format!(r#"{{"kind":"{kind}","query":"the kitchen"}}"#);
+            let (dref, slice) = DestinationRef::parse_json(&raw).expect(kind);
+            assert_eq!(dref.kind_str(), expect);
+            assert_eq!(dref.query(), "the kitchen");
+            assert_eq!(slice, raw, "the slice is the exact accepted object");
+        }
+    }
+
+    #[test]
+    fn tolerates_llm_framing_like_the_intent_parse() {
+        let (dref, _) = DestinationRef::parse_json(
+            "Sure — heading there:\n```json\n{\"kind\":\"named_place\",\"query\":\"kitchen\"}\n```",
+        )
+        .expect("framed reply parses");
+        assert_eq!(
+            dref,
+            DestinationRef::NamedPlace {
+                query: "kitchen".into()
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_coordinates_with_the_loud_code() {
+        // The core rule made mechanical: geometry in the language channel is a
+        // DISTINCT refusal, whatever key spells it.
+        for smuggle in [
+            r#"{"kind":"named_place","query":"kitchen","x_m":3.0}"#,
+            r#"{"kind":"named_place","query":"kitchen","y_m":1.0}"#,
+            r#"{"kind":"address","query":"125 Main St","lat":37.0}"#,
+            r#"{"kind":"address","query":"125 Main St","longitude":-122.0}"#,
+            r#"{"kind":"saved_route","query":"route a","waypoints":[]}"#,
+            r#"{"kind":"tracked_object","query":"cup","pose":{"x_m":1.0}}"#,
+        ] {
+            assert_eq!(
+                DestinationRef::parse_json(smuggle).unwrap_err(),
+                "DEST_COORDINATES_FORBIDDEN",
+                "{smuggle}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_malformed_unknown_and_oversized() {
+        assert_eq!(
+            DestinationRef::parse_json("just drive somewhere").unwrap_err(),
+            "DEST_JSON_PARSE_ERROR"
+        );
+        assert_eq!(
+            DestinationRef::parse_json(r#"{"kind":"teleport","query":"moon"}"#).unwrap_err(),
+            "DEST_UNKNOWN_KIND"
+        );
+        assert_eq!(
+            DestinationRef::parse_json(r#"{"kind":"named_place","query":"  "}"#).unwrap_err(),
+            "DEST_EMPTY_QUERY"
+        );
+        let long = "x".repeat(MAX_QUERY_CHARS + 1);
+        assert_eq!(
+            DestinationRef::parse_json(&format!(r#"{{"kind":"named_place","query":"{long}"}}"#))
+                .unwrap_err(),
+            "DEST_QUERY_TOO_LONG"
+        );
+        // An unknown extra field (not a coordinate) is still a strict parse error.
+        assert_eq!(
+            DestinationRef::parse_json(r#"{"kind":"named_place","query":"kitchen","speed":9}"#)
+                .unwrap_err(),
+            "DEST_JSON_PARSE_ERROR"
+        );
+    }
+
+    // ---- registries: fail-closed loads -------------------------------------
+
+    #[test]
+    fn place_registry_loads_and_looks_up_by_id_name_and_alias() {
+        let reg = PlaceRegistry::from_json_str(PLACES_JSON).unwrap();
+        assert_eq!(reg.map_id(), "r2-lab-01");
+        for q in ["kitchen", "Kitchen", "the kitchen", "THE KITCHEN!"] {
+            let p = reg.lookup(q).unwrap_or_else(|| panic!("{q}"));
+            assert_eq!(p.id, "kitchen");
+        }
+        assert_eq!(reg.lookup("charger").unwrap().id, "charging-dock");
+        assert!(reg.lookup("garage").is_none());
+        assert_eq!(reg.names(), vec!["Kitchen", "Charging Dock"]);
+    }
+
+    #[test]
+    fn registries_refuse_every_defect() {
+        // Wrong version.
+        let e = PlaceRegistry::from_json_str(r#"{"version": 2, "map_id": "m", "places": []}"#)
+            .unwrap_err();
+        assert!(e.contains("version"), "{e}");
+        // Missing map_id content.
+        let e = PlaceRegistry::from_json_str(r#"{"version": 1, "map_id": "  ", "places": []}"#)
+            .unwrap_err();
+        assert!(e.contains("map_id"), "{e}");
+        // An overflowing coordinate (1e999) is refused — serde_json rejects
+        // it at parse ("number out of range") before the belt-and-suspenders
+        // finiteness check even runs. Either way: fail-closed, never inf.
+        let e = PlaceRegistry::from_json_str(
+            r#"{"version": 1, "map_id": "m", "places":
+               [{"id":"a","name":"A","x_m":1e999,"y_m":0.0}]}"#,
+        )
+        .unwrap_err();
+        assert!(
+            e.contains("out of range") || e.contains("non-finite"),
+            "{e}"
+        );
+        // Duplicate key across entries (name of one == alias of another).
+        let e = PlaceRegistry::from_json_str(
+            r#"{"version": 1, "map_id": "m", "places": [
+                {"id":"a","name":"Dock","x_m":1.0,"y_m":0.0},
+                {"id":"b","name":"B","aliases":["dock"],"x_m":2.0,"y_m":0.0}
+            ]}"#,
+        )
+        .unwrap_err();
+        assert!(e.contains("collides"), "{e}");
+        // Unknown field — a typo'd registry must not half-load.
+        let e = PlaceRegistry::from_json_str(
+            r#"{"version": 1, "map_id": "m", "places":
+               [{"id":"a","name":"A","x_m":1.0,"y_m":0.0,"z_m":1.0}]}"#,
+        )
+        .unwrap_err();
+        assert!(e.contains("z_m") || e.contains("unknown"), "{e}");
+        // Route with no waypoints.
+        let e = RouteRegistry::from_json_str(
+            r#"{"version": 1, "map_id": "m", "routes":
+               [{"id":"r","name":"R","waypoints":[]}]}"#,
+        )
+        .unwrap_err();
+        assert!(e.contains("waypoints"), "{e}");
+    }
+
+    // ---- resolver outcomes -------------------------------------------------
+
+    #[test]
+    fn named_place_resolves_to_the_registry_pose() {
+        let r = resolver();
+        let out = r.resolve(
+            &DestinationRef::NamedPlace {
+                query: "the kitchen".into(),
+            },
+            &view(&no_targets(), None),
+            ego_origin(),
+            5_000,
+        );
+        let ResolveOutcome::Resolved(g) = out else {
+            panic!("must resolve, got {out:?}")
+        };
+        assert_eq!(g.destination_id, "kitchen");
+        assert_eq!(g.map_id.as_deref(), Some("r2-lab-01"));
+        assert_eq!(g.source, DestinationSource::PlaceRegistry);
+        assert_eq!(g.resolved_at_ms, 5_000);
+        assert!((g.goal_pose.x_m - 3.2).abs() < 1e-12);
+        assert!((g.goal_pose.y_m - (-1.4)).abs() < 1e-12);
+        assert!(g.route_waypoints.is_empty());
+    }
+
+    #[test]
+    fn saved_route_resolves_first_waypoint_plus_the_full_list() {
+        let r = resolver();
+        let out = r.resolve(
+            &DestinationRef::SavedRoute {
+                query: "route alpha".into(),
+            },
+            &view(&no_targets(), None),
+            ego_origin(),
+            7_000,
+        );
+        let ResolveOutcome::Resolved(g) = out else {
+            panic!("must resolve, got {out:?}")
+        };
+        assert_eq!(g.destination_id, "route-a");
+        assert_eq!(g.source, DestinationSource::RouteRegistry);
+        assert_eq!(g.route_waypoints.len(), 2);
+        assert!(
+            (g.goal_pose.x_m - 1.0).abs() < 1e-12,
+            "first waypoint is the goal"
+        );
+    }
+
+    #[test]
+    fn unknown_and_unregistered_fail_closed_with_distinct_codes() {
+        let r = resolver();
+        let miss = r.resolve(
+            &DestinationRef::NamedPlace {
+                query: "garage".into(),
+            },
+            &view(&no_targets(), None),
+            ego_origin(),
+            0,
+        );
+        assert_eq!(miss.code(), "DEST_NOT_FOUND");
+        assert!(!miss.sentence("the garage").is_empty());
+
+        let empty = DestinationResolver::default();
+        let none = empty.resolve(
+            &DestinationRef::NamedPlace {
+                query: "kitchen".into(),
+            },
+            &view(&no_targets(), None),
+            ego_origin(),
+            0,
+        );
+        assert_eq!(none.code(), "DEST_NO_REGISTRY");
+    }
+
+    #[test]
+    fn address_is_a_typed_unsupported_seam_never_a_fake_coordinate() {
+        let r = resolver();
+        let out = r.resolve(
+            &DestinationRef::Address {
+                query: "125 Main Street".into(),
+            },
+            &view(&no_targets(), None),
+            ego_origin(),
+            0,
+        );
+        assert_eq!(
+            out,
+            ResolveOutcome::Unsupported {
+                code: "DEST_UNSUPPORTED_ADDRESS"
+            }
+        );
+        assert_eq!(out.code(), "DEST_UNSUPPORTED_ADDRESS");
+        assert!(out.sentence("125 Main Street").contains("addresses"));
+    }
+
+    #[test]
+    fn tracked_object_resolves_with_a_standoff_short_of_the_object() {
+        let r = resolver();
+        let targets = [target("red cup", 4.0, 0.0, 0.9)];
+        let out = r.resolve(
+            &DestinationRef::TrackedObject {
+                query: "red cup".into(),
+            },
+            &view(&targets, Some(1_000)),
+            ego_origin(),
+            1_000,
+        );
+        let ResolveOutcome::Resolved(g) = out else {
+            panic!("must resolve, got {out:?}")
+        };
+        assert_eq!(g.source, DestinationSource::ObjectTrack);
+        assert_eq!(g.map_id, None, "a live sighting has no map identity");
+        // 4.0 m ahead, 0.75 m standoff → goal 3.25 m ahead, facing the cup.
+        assert!((g.goal_pose.x_m - 3.25).abs() < 1e-9, "{}", g.goal_pose.x_m);
+        assert!(g.goal_pose.y_m.abs() < 1e-9);
+        assert!(g.goal_pose.heading_rad.abs() < 1e-9);
+    }
+
+    #[test]
+    fn tracked_object_within_the_standoff_grounds_at_the_ego() {
+        let r = resolver();
+        let targets = [target("cup", 0.5, 0.0, 0.9)];
+        let out = r.resolve(
+            &DestinationRef::TrackedObject {
+                query: "cup".into(),
+            },
+            &view(&targets, Some(1_000)),
+            EgoView {
+                x_m: 10.0,
+                y_m: 5.0,
+                heading_rad: 0.0,
+            },
+            1_000,
+        );
+        let ResolveOutcome::Resolved(g) = out else {
+            panic!("{out:?}")
+        };
+        assert!((g.goal_pose.x_m - 10.0).abs() < 1e-9 && (g.goal_pose.y_m - 5.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn tracked_object_grounds_through_the_ego_pose_into_the_world_frame() {
+        // Ego at (10, 5) facing +90°: a cup 2 m ahead is 2 m north; a 0.75 m
+        // standoff puts the goal at (10, 6.25), heading north.
+        let r = resolver();
+        let targets = [target("cup", 2.0, 0.0, 0.9)];
+        let out = r.resolve(
+            &DestinationRef::TrackedObject {
+                query: "cup".into(),
+            },
+            &view(&targets, Some(1_000)),
+            EgoView {
+                x_m: 10.0,
+                y_m: 5.0,
+                heading_rad: std::f64::consts::FRAC_PI_2,
+            },
+            1_000,
+        );
+        let ResolveOutcome::Resolved(g) = out else {
+            panic!("{out:?}")
+        };
+        assert!((g.goal_pose.x_m - 10.0).abs() < 1e-9, "{}", g.goal_pose.x_m);
+        assert!((g.goal_pose.y_m - 6.25).abs() < 1e-9, "{}", g.goal_pose.y_m);
+        assert!((g.goal_pose.heading_rad - std::f64::consts::FRAC_PI_2).abs() < 1e-9);
+    }
+
+    #[test]
+    fn tracked_object_refusals_map_to_the_explicit_outcomes() {
+        let r = resolver();
+        let ego = ego_origin();
+        // Stale: no frame at all.
+        let targets = [target("cup", 2.0, 0.0, 0.9)];
+        assert_eq!(
+            r.resolve(
+                &DestinationRef::TrackedObject {
+                    query: "cup".into()
+                },
+                &view(&targets, None),
+                ego,
+                1_000
+            ),
+            ResolveOutcome::Stale
+        );
+        // Stale: frame older than the 2 s policy budget.
+        assert_eq!(
+            r.resolve(
+                &DestinationRef::TrackedObject {
+                    query: "cup".into()
+                },
+                &view(&targets, Some(1_000)),
+                ego,
+                4_000
+            ),
+            ResolveOutcome::Stale
+        );
+        // Fresh at exactly the policy edge still resolves (2 s inclusive).
+        assert!(matches!(
+            r.resolve(
+                &DestinationRef::TrackedObject {
+                    query: "cup".into()
+                },
+                &view(&targets, Some(1_000)),
+                ego,
+                3_000
+            ),
+            ResolveOutcome::Resolved(_)
+        ));
+        // Not seen.
+        let chairs = [target("chair", 2.0, 0.0, 0.9)];
+        assert_eq!(
+            r.resolve(
+                &DestinationRef::TrackedObject {
+                    query: "cup".into()
+                },
+                &view(&chairs, Some(1_000)),
+                ego,
+                1_000
+            ),
+            ResolveOutcome::NotFound {
+                code: "DEST_NOT_SEEN"
+            }
+        );
+        // Low confidence: 0.5 clears the object_goal channel default (0.40)
+        // but NOT this policy's 0.70 floor — the destination policy binds.
+        let dim = [target("cup", 2.0, 0.0, 0.5)];
+        assert_eq!(
+            r.resolve(
+                &DestinationRef::TrackedObject {
+                    query: "cup".into()
+                },
+                &view(&dim, Some(1_000)),
+                ego,
+                1_000
+            ),
+            ResolveOutcome::NotFound {
+                code: "DEST_LOW_CONFIDENCE"
+            }
+        );
+        // Ambiguous tie.
+        let two = [target("cup", 2.0, 0.0, 0.9), target("cup", 2.05, 0.1, 0.9)];
+        assert!(matches!(
+            r.resolve(
+                &DestinationRef::TrackedObject {
+                    query: "cup".into()
+                },
+                &view(&two, Some(1_000)),
+                ego,
+                1_000
+            ),
+            ResolveOutcome::Ambiguous { .. }
+        ));
+        // Behind the ego.
+        let behind = [target("cup", -2.0, 0.0, 0.9)];
+        assert_eq!(
+            r.resolve(
+                &DestinationRef::TrackedObject {
+                    query: "cup".into()
+                },
+                &view(&behind, Some(1_000)),
+                ego,
+                1_000
+            ),
+            ResolveOutcome::NotFound {
+                code: "DEST_BEHIND_EGO"
+            }
+        );
+    }
+
+    #[test]
+    fn object_policy_is_bounds_checked() {
+        assert!(ObjectPolicy::validated(2_000, 0.7, 0.75).is_ok());
+        assert!(ObjectPolicy::validated(0, 0.7, 0.75).is_err());
+        assert!(ObjectPolicy::validated(2_000, 1.5, 0.75).is_err());
+        assert!(ObjectPolicy::validated(2_000, f32::NAN, 0.75).is_err());
+        assert!(ObjectPolicy::validated(2_000, 0.7, -0.1).is_err());
+        assert!(ObjectPolicy::validated(2_000, 0.7, 9.0).is_err());
+        assert!(ObjectPolicy::validated(2_000, 0.7, f64::INFINITY).is_err());
+    }
+
+    // ---- outcome codes + narration -----------------------------------------
+
+    #[test]
+    fn every_refusal_outcome_has_a_stable_code_and_a_sentence() {
+        let outcomes = [
+            ResolveOutcome::Ambiguous { candidates: vec![] },
+            ResolveOutcome::Ambiguous {
+                candidates: vec!["kitchen".into(), "kitchenette".into()],
+            },
+            ResolveOutcome::NotFound {
+                code: "DEST_NOT_FOUND",
+            },
+            ResolveOutcome::NotFound {
+                code: "DEST_NO_REGISTRY",
+            },
+            ResolveOutcome::NotFound {
+                code: "DEST_NOT_SEEN",
+            },
+            ResolveOutcome::NotFound {
+                code: "DEST_LOW_CONFIDENCE",
+            },
+            ResolveOutcome::NotFound {
+                code: "DEST_BEHIND_EGO",
+            },
+            ResolveOutcome::NotFound {
+                code: "DEST_NON_FINITE",
+            },
+            ResolveOutcome::Stale,
+            ResolveOutcome::Unsupported {
+                code: "DEST_UNSUPPORTED_ADDRESS",
+            },
+        ];
+        for o in &outcomes {
+            assert!(o.code().starts_with("DEST_"), "{o:?}");
+            let s = o.sentence("the kitchen");
+            assert!(!s.is_empty() && s.ends_with(['.', '?']), "{o:?} -> {s:?}");
+        }
+    }
+
+    // ---- the LLM seam: schema + prompt -------------------------------------
+
+    /// The lockstep pin: every kind the schema constrains the model to must be
+    /// one the fail-closed parser accepts, and the schema must carry NO
+    /// numeric property — the structural "no coordinates" guarantee.
+    #[test]
+    fn destination_schema_kinds_match_the_parser_and_carry_no_numbers() {
+        let s = destination_schema();
+        assert_eq!(s["required"], serde_json::json!(["kind", "query"]));
+        assert_eq!(s["additionalProperties"], serde_json::json!(false));
+        let kinds: Vec<String> = s["properties"]["kind"]["enum"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap().to_string())
+            .collect();
+        assert_eq!(
+            kinds,
+            ["named_place", "saved_route", "tracked_object", "address"]
+        );
+        for kind in &kinds {
+            let raw = format!(r#"{{"kind":"{kind}","query":"somewhere"}}"#);
+            assert!(
+                DestinationRef::parse_json(&raw).is_ok(),
+                "parser must accept schema kind {kind}"
+            );
+        }
+        // No property admits a number — the model cannot emit a coordinate.
+        for (name, prop) in s["properties"].as_object().unwrap() {
+            assert_eq!(
+                prop["type"], "string",
+                "property {name} must be a string — no numeric channel"
+            );
+        }
+    }
+
+    #[test]
+    fn destination_prompt_carries_names_but_never_coordinates() {
+        let r = resolver();
+        let p = build_destination_prompt(
+            "take me to the kitchen",
+            &r.places.names(),
+            &r.routes.names(),
+        );
+        assert!(p.contains("Kitchen") && p.contains("Route A"));
+        assert!(p.contains("take me to the kitchen"));
+        assert!(
+            p.contains("never invent"),
+            "the no-coordinates rule is stated"
+        );
+        // The registry coordinates must not leak into the prompt.
+        for leak in ["3.2", "-1.4", "1.57", "x_m", "y_m"] {
+            assert!(!p.contains(leak), "coordinate leak {leak:?} in prompt");
+        }
+    }
+}

--- a/crates/kirra-sidecars/src/destination.rs
+++ b/crates/kirra-sidecars/src/destination.rs
@@ -1125,6 +1125,16 @@ mod tests {
         )
         .unwrap_err();
         assert!(e.contains("collides"), "{e}");
+        // Two DISTINCT entries sharing the same id collide (uniqueness is by
+        // entry position — the parity the Python CLI mirrors).
+        let e = PlaceRegistry::from_json_str(
+            r#"{"version": 1, "map_id": "m", "places": [
+                {"id":"kitchen","name":"Kitchen","x_m":1.0,"y_m":0.0},
+                {"id":"kitchen","name":"Kitchen Two","x_m":2.0,"y_m":0.0}
+            ]}"#,
+        )
+        .unwrap_err();
+        assert!(e.contains("collides"), "{e}");
         // Unknown field — a typo'd registry must not half-load.
         let e = PlaceRegistry::from_json_str(
             r#"{"version": 1, "map_id": "m", "places":

--- a/crates/kirra-sidecars/src/lib.rs
+++ b/crates/kirra-sidecars/src/lib.rs
@@ -23,6 +23,7 @@
 
 pub mod capabilities;
 pub mod chat;
+pub mod destination;
 pub mod http;
 pub mod mick;
 pub mod mick_fence;

--- a/crates/kirra-sidecars/src/planner.rs
+++ b/crates/kirra-sidecars/src/planner.rs
@@ -23,6 +23,9 @@
 //! * rate limiting and the loopback bind policy live in the binary
 //!   (`net::RateLimiter` / `net::enforce_bind_policy`).
 
+use crate::destination::{
+    DestinationRef, DestinationResolver, EgoView, GroundedDestination, ResolveOutcome, TargetView,
+};
 use kirra_core::frame_integrity::FrameTrust;
 use kirra_planner::{
     behavior::{
@@ -205,6 +208,17 @@ pub struct PlanRequest {
     /// behavior, byte-identical).
     #[serde(default)]
     pub intent: Option<serde_json::Value>,
+    /// **Typed destination** (OPT-IN) — a [`DestinationRef`] JSON object
+    /// (`{"kind":"named_place","query":"kitchen"}`) or that object as a JSON
+    /// string. Parsed by the ONE fail-closed destination parse and grounded
+    /// by the TRUSTED [`DestinationResolver`] (registries + live targets) —
+    /// language chooses the destination type; the resolver chooses the
+    /// coordinates. Any non-Resolved outcome → 422 + NO MOTION, carrying the
+    /// outcome's stable `DEST_*` code. Supplying this alongside `intent` or
+    /// `object_goal` is a rejected ambiguity (two goal sources), never a
+    /// silent precedence rule. Absent → byte-identical prior behaviour.
+    #[serde(default)]
+    pub destination: Option<serde_json::Value>,
     /// **Object goal** (OPT-IN) — the operator's requested thing, e.g. `"red cup"`.
     /// Resolved against `targets` into a plain `GoTo`, so it is a DESTINATION and
     /// asserts nothing about drivability (`kirra_taj::object_goal`). Absent →
@@ -304,6 +318,50 @@ pub struct PlanResponse {
     /// #893 narration: the operator sentence for the refusal, else null.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
+    /// Typed-destination echo: WHICH trusted grounding produced the goal,
+    /// when the request carried a `destination`. Observability only — the
+    /// grounded goal already shaped the planned trajectory above.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub destination: Option<DestinationWire>,
+}
+
+/// The grounded-destination echo on the wire — identity + provenance, plus
+/// the full waypoint list for a saved route (sequencing past the first
+/// waypoint is the mission layer's job).
+#[derive(Debug, Serialize)]
+pub struct DestinationWire {
+    pub destination_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub map_id: Option<String>,
+    pub source: String,
+    pub resolved_at_ms: u64,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub route_waypoints: Vec<WaypointWire>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct WaypointWire {
+    pub x: f64,
+    pub y: f64,
+    pub heading: f64,
+}
+
+fn destination_wire(g: &GroundedDestination) -> DestinationWire {
+    DestinationWire {
+        destination_id: g.destination_id.clone(),
+        map_id: g.map_id.clone(),
+        source: g.source.as_str().to_string(),
+        resolved_at_ms: g.resolved_at_ms,
+        route_waypoints: g
+            .route_waypoints
+            .iter()
+            .map(|w| WaypointWire {
+                x: w.x_m,
+                y: w.y_m,
+                heading: w.heading_rad,
+            })
+            .collect(),
+    }
 }
 
 /// A seam rejection: the request never reached the planner. Fail-closed to NO
@@ -953,6 +1011,81 @@ fn object_goal_intent(req: &PlanRequest, label: &str) -> Result<MickIntent, Seam
     Ok(MickIntent::GoTo { x_m, y_m })
 }
 
+/// Resolve a typed `destination` request into a grounded plain `GoTo`.
+///
+/// 🔴 Language chose only the destination TYPE + the operator's words; the
+/// coordinates come from the TRUSTED resolver (registries / live targets) —
+/// never from the request's language channel, whose parse rejects any
+/// coordinate-shaped key outright (`DEST_COORDINATES_FORBIDDEN`). Like the
+/// `object_goal` channel, the grounded point is a DESTINATION ONLY: it makes
+/// no drivability claim, and emitting an ordinary `GoTo` keeps everything
+/// downstream (Occy, the checker) unable to tell where the goal came from.
+///
+/// Every non-Resolved outcome is fail-closed → [`SeamRejection`] → NO MOTION,
+/// carrying the outcome's stable `DEST_*` code plus the operator sentence.
+fn destination_intent(
+    req: &PlanRequest,
+    resolver: &DestinationResolver,
+    value: &serde_json::Value,
+) -> Result<(MickIntent, GroundedDestination), SeamRejection> {
+    if req.intent.is_some() || req.object_goal.is_some() {
+        return Err(SeamRejection {
+            code: "PLAN_AMBIGUOUS_GOAL_SOURCE",
+            detail: "`destination` was supplied alongside `intent` or `object_goal` — \
+                     refusing rather than silently preferring one; NO MOTION"
+                .to_string(),
+        });
+    }
+    // Accept the object form or that object embedded as a JSON string —
+    // both land in the ONE fail-closed destination parse.
+    let raw = match value.as_str() {
+        Some(s) => s.to_string(),
+        None => value.to_string(),
+    };
+    let (dref, _slice) = DestinationRef::parse_json(&raw).map_err(|code| SeamRejection {
+        code,
+        detail: "typed destination failed the fail-closed parse; NO MOTION".to_string(),
+    })?;
+    let targets: Vec<LabeledTarget> = req
+        .targets
+        .iter()
+        .map(|t| LabeledTarget {
+            label: t.label.clone(),
+            x_m: t.x,
+            y_m: t.y,
+            confidence: t.confidence,
+        })
+        .collect();
+    // Stateless freshness, same convention as the object-goal channel.
+    let now = req.now_ms.or(req.targets_stamp_ms).unwrap_or(0);
+    let outcome = resolver.resolve(
+        &dref,
+        &TargetView {
+            targets: &targets,
+            stamp_ms: req.targets_stamp_ms,
+        },
+        EgoView {
+            x_m: req.ego.x,
+            y_m: req.ego.y,
+            heading_rad: req.ego.heading,
+        },
+        now,
+    );
+    match outcome {
+        ResolveOutcome::Resolved(grounded) => Ok((
+            MickIntent::GoTo {
+                x_m: grounded.goal_pose.x_m,
+                y_m: grounded.goal_pose.y_m,
+            },
+            grounded,
+        )),
+        refused => Err(SeamRejection {
+            code: refused.code(),
+            detail: refused.sentence(dref.query()),
+        }),
+    }
+}
+
 fn effective_intent(req: &PlanRequest) -> Result<MickIntent, SeamRejection> {
     if let Some(label) = req.object_goal.as_deref() {
         return object_goal_intent(req, label);
@@ -978,13 +1111,32 @@ fn effective_intent(req: &PlanRequest) -> Result<MickIntent, SeamRejection> {
     }
 }
 
-/// Handle one plan request: seam validation → Occy grounds the intent →
-/// the KIRRA slow-loop checker bounds it and narrates a refusal.
+/// Handle one plan request with NO destination context configured — the
+/// pre-destination behaviour, byte-identical for every request that carries
+/// no `destination`. A request that DOES carry one refuses fail-closed
+/// against the empty default resolver (`DEST_NO_REGISTRY` / policy defaults)
+/// rather than being silently ignored.
 pub fn handle_plan(req: &PlanRequest) -> Result<PlanResponse, SeamRejection> {
+    handle_plan_with_destinations(req, &DestinationResolver::default())
+}
+
+/// Handle one plan request: seam validation → (optional) trusted destination
+/// resolution → Occy grounds the intent → the KIRRA slow-loop checker bounds
+/// it and narrates a refusal.
+pub fn handle_plan_with_destinations(
+    req: &PlanRequest,
+    resolver: &DestinationResolver,
+) -> Result<PlanResponse, SeamRejection> {
     validate_finite(req)?;
     validate_predicted_vrus(req)?;
     validate_perception_frame_id(req)?;
-    let intent = effective_intent(req)?;
+    let (intent, grounded) = match &req.destination {
+        Some(value) => {
+            let (intent, grounded) = destination_intent(req, resolver, value)?;
+            (intent, Some(grounded))
+        }
+        None => (effective_intent(req)?, None),
+    };
     let target = intent_target(&intent).unwrap_or((req.goal.x, req.goal.y));
     validate_in_map(req, target)?;
 
@@ -1252,6 +1404,7 @@ pub fn handle_plan(req: &PlanRequest) -> Result<PlanResponse, SeamRejection> {
         },
         reason_code: reason.map(|r| r.code().to_string()),
         reason: reason.map(|r| r.explain().to_string()),
+        destination: grounded.as_ref().map(destination_wire),
     })
 }
 
@@ -1281,9 +1434,10 @@ mod tests {
             predicted_vrus: vec![],
             vehicle: None,
             intent: None,
-            // Object-goal channel off by default, so every pre-existing
-            // assertion still describes the plain-goal path.
+            // Object-goal + destination channels off by default, so every
+            // pre-existing assertion still describes the plain-goal path.
             object_goal: None,
+            destination: None,
             targets: vec![],
             targets_stamp_ms: None,
             now_ms: None,
@@ -1464,6 +1618,221 @@ mod tests {
         let req = base_request();
         assert!(req.object_goal.is_none() && req.targets.is_empty());
         handle_plan(&req).expect("the plain-goal path still plans");
+    }
+
+    // ---- typed destination: "drive to the kitchen" -------------------------
+
+    use crate::destination::{DestinationResolver, PlaceRegistry, RouteRegistry};
+
+    fn lab_resolver() -> DestinationResolver {
+        DestinationResolver {
+            places: PlaceRegistry::from_json_str(
+                r#"{"version": 1, "map_id": "r2-lab-01", "places": [
+                    {"id": "kitchen", "name": "Kitchen", "aliases": ["the kitchen"],
+                     "x_m": 40.0, "y_m": 0.0, "heading_rad": 0.0}
+                ]}"#,
+            )
+            .unwrap(),
+            routes: RouteRegistry::from_json_str(
+                r#"{"version": 1, "map_id": "r2-lab-01", "routes": [
+                    {"id": "route-a", "name": "Route A",
+                     "waypoints": [
+                        {"x_m": 20.0, "y_m": 0.0, "heading_rad": 0.0},
+                        {"x_m": 40.0, "y_m": 2.0, "heading_rad": 0.0}
+                     ]}
+                ]}"#,
+            )
+            .unwrap(),
+            object_policy: Default::default(),
+        }
+    }
+
+    /// The end-to-end shape of "drive to the kitchen": the language channel
+    /// carries only a kind + the operator's words; the TRUSTED registry
+    /// supplies the coordinates; the plan grounds as an ordinary `GoTo` and
+    /// is planned + checked like any other goal, with provenance echoed.
+    #[test]
+    fn named_place_destination_grounds_through_the_registry() {
+        let mut req = base_request();
+        req.destination = Some(serde_json::json!({"kind":"named_place","query":"the kitchen"}));
+        let resp =
+            handle_plan_with_destinations(&req, &lab_resolver()).expect("a registered place plans");
+        assert!(!resp.trajectory.is_empty());
+        let echo = resp.destination.expect("provenance is echoed");
+        assert_eq!(echo.destination_id, "kitchen");
+        assert_eq!(echo.map_id.as_deref(), Some("r2-lab-01"));
+        assert_eq!(echo.source, "place_registry");
+
+        // The string-embedded form (a relay shape) parses identically.
+        let mut req = base_request();
+        req.destination = Some(serde_json::json!(
+            r#"{"kind":"named_place","query":"kitchen"}"#
+        ));
+        handle_plan_with_destinations(&req, &lab_resolver())
+            .expect("string-embedded destination plans");
+    }
+
+    #[test]
+    fn saved_route_destination_grounds_to_its_first_waypoint_with_the_full_list() {
+        let mut req = base_request();
+        req.destination = Some(serde_json::json!({"kind":"saved_route","query":"route a"}));
+        let resp =
+            handle_plan_with_destinations(&req, &lab_resolver()).expect("a saved route plans");
+        let echo = resp.destination.expect("provenance is echoed");
+        assert_eq!(echo.destination_id, "route-a");
+        assert_eq!(echo.source, "route_registry");
+        assert_eq!(
+            echo.route_waypoints.len(),
+            2,
+            "the mission layer gets the whole route"
+        );
+    }
+
+    #[test]
+    fn tracked_object_destination_grounds_with_the_standoff() {
+        let mut req = base_request();
+        req.destination = Some(serde_json::json!({"kind":"tracked_object","query":"red cup"}));
+        req.targets = vec![target("red cup", 30.0, 0.0)];
+        req.targets_stamp_ms = Some(1_000);
+        req.now_ms = Some(1_000);
+        let resp =
+            handle_plan_with_destinations(&req, &lab_resolver()).expect("a seen, fresh cup plans");
+        let echo = resp.destination.expect("provenance is echoed");
+        assert_eq!(echo.source, "object_track");
+        assert!(
+            echo.map_id.is_none(),
+            "a live sighting carries no map identity"
+        );
+    }
+
+    /// Every non-Resolved outcome is fail-closed at the seam: 422 + NO
+    /// MOTION carrying the stable `DEST_*` code — never a silent fallback to
+    /// the request goal.
+    #[test]
+    fn destination_refusals_fail_closed_to_no_motion() {
+        // Unknown place.
+        let mut req = base_request();
+        req.destination = Some(serde_json::json!({"kind":"named_place","query":"garage"}));
+        let rej = handle_plan_with_destinations(&req, &lab_resolver())
+            .expect_err("an unknown place must refuse");
+        assert_eq!(rej.code, "DEST_NOT_FOUND");
+        let wire: serde_json::Value = serde_json::from_str(&rej.to_json()).unwrap();
+        assert_eq!(wire["kind"], "SafeStop");
+        assert_eq!(wire["trajectory"].as_array().map(Vec::len), Some(0));
+
+        // Address: typed, honest, unsupported — never a fabricated lat/long.
+        let mut req = base_request();
+        req.destination = Some(serde_json::json!({"kind":"address","query":"125 Main Street"}));
+        assert_eq!(
+            handle_plan_with_destinations(&req, &lab_resolver())
+                .expect_err("an address must refuse")
+                .code,
+            "DEST_UNSUPPORTED_ADDRESS"
+        );
+
+        // Stale object sighting.
+        let mut req = base_request();
+        req.destination = Some(serde_json::json!({"kind":"tracked_object","query":"red cup"}));
+        req.targets = vec![target("red cup", 30.0, 0.0)];
+        req.targets_stamp_ms = Some(1_000);
+        req.now_ms = Some(60_000);
+        assert_eq!(
+            handle_plan_with_destinations(&req, &lab_resolver())
+                .expect_err("a stale sighting must refuse")
+                .code,
+            "DEST_STALE"
+        );
+
+        // No context configured (the plain handle_plan wrapper): a
+        // destination request refuses rather than being ignored.
+        let mut req = base_request();
+        req.destination = Some(serde_json::json!({"kind":"named_place","query":"kitchen"}));
+        assert_eq!(
+            handle_plan(&req).expect_err("no registry must refuse").code,
+            "DEST_NO_REGISTRY"
+        );
+    }
+
+    /// The core rule made mechanical at the seam: coordinates in the
+    /// language channel are a LOUD, distinct refusal.
+    #[test]
+    fn destination_with_smuggled_coordinates_is_refused_loudly() {
+        let mut req = base_request();
+        req.destination = Some(serde_json::json!(
+            {"kind":"named_place","query":"kitchen","x_m": 40.0, "y_m": 0.0}
+        ));
+        assert_eq!(
+            handle_plan_with_destinations(&req, &lab_resolver())
+                .expect_err("smuggled coordinates must refuse")
+                .code,
+            "DEST_COORDINATES_FORBIDDEN"
+        );
+    }
+
+    /// Three goal channels, one request → refused ambiguity, same rule as
+    /// `intent` + `object_goal`.
+    #[test]
+    fn destination_plus_another_goal_source_is_a_refused_ambiguity() {
+        let mut req = base_request();
+        req.destination = Some(serde_json::json!({"kind":"named_place","query":"kitchen"}));
+        req.intent = Some(serde_json::json!({"intent":"go_to","x_m":40.0,"y_m":0.0}));
+        assert_eq!(
+            handle_plan_with_destinations(&req, &lab_resolver())
+                .expect_err("destination + intent must refuse")
+                .code,
+            "PLAN_AMBIGUOUS_GOAL_SOURCE"
+        );
+
+        let mut req = base_request();
+        req.destination = Some(serde_json::json!({"kind":"named_place","query":"kitchen"}));
+        req.object_goal = Some("red cup".into());
+        assert_eq!(
+            handle_plan_with_destinations(&req, &lab_resolver())
+                .expect_err("destination + object_goal must refuse")
+                .code,
+            "PLAN_AMBIGUOUS_GOAL_SOURCE"
+        );
+    }
+
+    /// A registered place OUTSIDE the supplied corridor (+margin) is refused
+    /// by the in-map bound exactly like any other goal — a trusted registry
+    /// does not bypass the seam's hallucination bound.
+    #[test]
+    fn a_grounded_destination_is_still_bounded_by_the_in_map_check() {
+        let far = DestinationResolver {
+            places: PlaceRegistry::from_json_str(
+                r#"{"version": 1, "map_id": "r2-lab-01", "places": [
+                    {"id": "warehouse", "name": "Warehouse",
+                     "x_m": 9000.0, "y_m": 0.0, "heading_rad": 0.0}
+                ]}"#,
+            )
+            .unwrap(),
+            routes: RouteRegistry::empty(),
+            object_policy: Default::default(),
+        };
+        let mut req = base_request();
+        req.destination = Some(serde_json::json!({"kind":"named_place","query":"warehouse"}));
+        assert_eq!(
+            handle_plan_with_destinations(&req, &far)
+                .expect_err("an out-of-map registry pose must refuse")
+                .code,
+            "INTENT_GOAL_OUT_OF_MAP"
+        );
+    }
+
+    /// Absent `destination` leaves the endpoint byte-identical to its prior
+    /// form, whatever context is configured.
+    #[test]
+    fn no_destination_is_unchanged_behaviour() {
+        let req = base_request();
+        assert!(req.destination.is_none());
+        let a = handle_plan(&req).expect("plain path plans");
+        let b = handle_plan_with_destinations(&req, &lab_resolver()).expect("same");
+        assert_eq!(a.proposal_digest, b.proposal_digest);
+        assert!(
+            b.destination.is_none(),
+            "no echo without a destination request"
+        );
     }
 
     #[test]

--- a/crates/kirra-sidecars/src/planner.rs
+++ b/crates/kirra-sidecars/src/planner.rs
@@ -1113,9 +1113,14 @@ fn effective_intent(req: &PlanRequest) -> Result<MickIntent, SeamRejection> {
 
 /// Handle one plan request with NO destination context configured — the
 /// pre-destination behaviour, byte-identical for every request that carries
-/// no `destination`. A request that DOES carry one refuses fail-closed
-/// against the empty default resolver (`DEST_NO_REGISTRY` / policy defaults)
-/// rather than being silently ignored.
+/// no `destination`. A request that DOES carry one runs against the empty
+/// default resolver rather than being silently ignored: `named_place` /
+/// `saved_route` refuse fail-closed (`DEST_NO_REGISTRY` — no registries are
+/// loaded), `address` refuses as always (`DEST_UNSUPPORTED_ADDRESS`), and
+/// `tracked_object` still resolves from the request's own `targets` under
+/// the DEFAULT object policy (it needs no registry). Callers wanting
+/// registry-backed kinds or a tuned policy use
+/// [`handle_plan_with_destinations`].
 pub fn handle_plan(req: &PlanRequest) -> Result<PlanResponse, SeamRejection> {
     handle_plan_with_destinations(req, &DestinationResolver::default())
 }

--- a/crates/kirra-sidecars/tests/cold_start_evidence_binding.rs
+++ b/crates/kirra-sidecars/tests/cold_start_evidence_binding.rs
@@ -79,6 +79,7 @@ fn plan_request_from(response: &PerceptionResponse) -> PlanRequest {
         vehicle: None,
         intent: None,
         object_goal: None,
+        destination: None,
         targets: vec![],
         targets_stamp_ms: None,
         now_ms: None,

--- a/docs/hardware/R2_DESTINATIONS.md
+++ b/docs/hardware/R2_DESTINATIONS.md
@@ -1,0 +1,186 @@
+# R2 Typed Destination Resolution
+
+**The rule this system enforces: language chooses the destination TYPE; a
+trusted resolver chooses the actual coordinates. The LLM never invents map
+coordinates, object poses, addresses, or routes.**
+
+Before this system, a spoken "drive to the kitchen" reached Mick's LLM, which
+could only answer with a `go_to`/`route_to` intent — i.e. with coordinates it
+made up. The typed destination layer replaces that with a typed, fail-closed
+pipeline:
+
+```
+voice/text ──▶ typed DestinationRef            (LANGUAGE: kind + the operator's words)
+                  {"kind":"named_place","query":"kitchen"}
+              ──▶ DestinationResolver          (TRUST: registries / live tracks)
+              ──▶ GroundedDestination          (goal pose + provenance)   ─┐
+                                                                           ▼
+              ──▶ ordinary MickIntent::GoTo ──▶ Occy plans ──▶ KIRRA checker bounds
+                                                (the EXISTING governed path, unchanged)
+```
+
+Everything lives in `crates/kirra-sidecars/src/destination.rs` — deliberately
+inside the crate fenced by `ci/check_mick_actuation_fence.py`, so "the
+resolver has no dependency route to the release-token mint, the serial seam,
+or any ROS/DDS transport" is a standing CI invariant.
+
+## The four destination kinds
+
+| kind             | example utterance          | trusted source                          | outcome                    |
+|------------------|----------------------------|-----------------------------------------|----------------------------|
+| `named_place`    | "drive to the kitchen"     | place registry JSON (operator-calibrated) | registry pose            |
+| `saved_route`    | "run route A"              | route registry JSON (operator-calibrated) | first waypoint + full list |
+| `tracked_object` | "drive to the red cup"     | live camera targets (`kirra_taj::object_goal`) | standoff pose        |
+| `address`        | "drive to 125 Main Street" | **none** — no geocoder exists           | `Unsupported` (refusal)    |
+
+`address` is a *typed seam*, present so an address request fails CLOSED with
+an honest reason (`DEST_UNSUPPORTED_ADDRESS`, "I can't navigate to street
+addresses yet") instead of being mis-bucketed into another kind or answered
+with a fabricated lat/long. Wiring a real geocoding source behind it is
+future work and a deliberate trust decision.
+
+## The explicit outcome enum
+
+`DestinationResolver::resolve` returns a `ResolveOutcome` — never an
+`Option`:
+
+* `Resolved(GroundedDestination)` — destination id, `map_id` (None for a live
+  object sighting), goal pose, route waypoints, source, `resolved_at_ms`.
+* `Ambiguous { candidates }` — more than one equally good match; refuse and
+  ask, never silently pick. (`DEST_AMBIGUOUS`)
+* `NotFound { code }` — with the specific reason: `DEST_NOT_FOUND`,
+  `DEST_NO_REGISTRY`, `DEST_NOT_SEEN`, `DEST_LOW_CONFIDENCE`,
+  `DEST_BEHIND_EGO`, `DEST_NON_FINITE`.
+* `Stale` — the object evidence is too old (or absent) to drive on.
+* `Unsupported { code }` — no trusted source for this kind.
+
+Every non-Resolved arm carries a stable machine code plus an operator
+sentence (`ResolveOutcome::sentence`) so the conversational layer SPEAKS the
+refusal instead of silently holding.
+
+## How coordinates are kept out of the language channel
+
+1. **The parser** — `DestinationRef::parse_json` is the ONE fail-closed
+   parser for destination JSON (`{"kind":..., "query":...}`, strict fields,
+   bounded query). Any coordinate-shaped key (`x_m`, `y`, `lat`,
+   `longitude`, `pose`, `waypoints`, …) is refused with the distinct
+   `DEST_COORDINATES_FORBIDDEN` code.
+2. **The LLM schema** — `destination_schema()` (the constrained-decode form
+   for an Ollama-style backend) has exactly two STRING properties and
+   `additionalProperties: false`: the model structurally cannot emit a
+   number at all.
+3. **The prompt** — `build_destination_prompt` renders known place/route
+   NAMES only; a registry coordinate never enters a prompt (pinned by test).
+4. **The seam** — the planner request's `destination` channel is mutually
+   exclusive with `intent` and `object_goal` (`PLAN_AMBIGUOUS_GOAL_SOURCE`),
+   and a grounded goal still passes the in-map bound (`INTENT_GOAL_OUT_OF_MAP`)
+   like any other goal.
+
+A grounded destination asserts **nothing about drivability**: it grounds as
+an ordinary `MickIntent::GoTo`, Occy plans inside the lidar corridor, and the
+KIRRA checker bounds the trajectory. A registered place behind an obstacle
+produces a robot that stops short — never one that drives at the registry
+entry. The governed enforcement chain (Mick → Occy → checker → release token
+→ verifying consumer) is untouched.
+
+## Registry files
+
+One registry file = one map frame (`map_id`). Loads are **fail-closed**: any
+defect refuses the whole file (and aborts `planner_service` startup) — wrong
+`version`, empty/duplicate keys, non-finite coordinates, unknown fields,
+empty waypoint lists. Ids, names, and aliases share ONE normalized key space
+per file, so a lookup can never be ambiguous by construction.
+
+`robot/testdata/places.example.json`:
+
+```json
+{
+  "version": 1,
+  "map_id": "example-uncalibrated",
+  "places": [
+    { "id": "kitchen", "name": "Kitchen", "aliases": ["the kitchen"],
+      "x_m": 0.0, "y_m": 0.0, "heading_rad": 0.0 }
+  ]
+}
+```
+
+`robot/testdata/routes.example.json` is the same header plus
+`"routes": [{ "id", "name", "aliases", "waypoints": [{x_m, y_m, heading_rad}, …] }]`
+(1..1024 waypoints, all finite).
+
+**Calibration is deliberate.** The shipped examples carry
+`map_id: "example-uncalibrated"` and all-zero poses; they are templates to
+copy, not defaults to install. Nothing in the repo's installers writes a
+registry file — creating one means measuring the real pose (e.g. from the
+consumer's `/odom` at the spot), editing the JSON by hand, and re-running
+`validate`. The CLI below is read-only on purpose.
+
+## Tracked-object policy
+
+Object resolution delegates to the proven `kirra_taj::object_goal` resolver
+(every-token label match, nearest-wins, tie → ambiguous, behind-ego refusal),
+under the destination policy:
+
+| knob | env (planner_service) | default |
+|------|------------------------|---------|
+| freshness budget | `KIRRA_DEST_OBJECT_MAX_AGE_MS` | `2000` ms |
+| min confidence | `KIRRA_DEST_OBJECT_MIN_CONFIDENCE` | `0.70` |
+| standoff | `KIRRA_DEST_OBJECT_STANDOFF_M` | `0.75` m |
+
+The grounded goal stops `standoff_m` SHORT of the object along the
+ego→object ray, facing it — the robot approaches a thing, it does not park
+on top of it. A sighting older than the budget is `Stale` ("my view is
+stale, so I won't drive on it"); a stale position is never driven to.
+Malformed knob values ABORT startup (`ObjectPolicy::validated`), never
+silently default.
+
+## planner_service wiring
+
+`POST /plan` accepts an opt-in `destination` field (the `DestinationRef`
+object, or that object as a JSON string). Configuration (boot-validated,
+fail-closed):
+
+```
+KIRRA_DEST_PLACES_PATH=/etc/kirra/places.json     # absent → named_place refuses DEST_NO_REGISTRY
+KIRRA_DEST_ROUTES_PATH=/etc/kirra/routes.json     # absent → saved_route refuses DEST_NO_REGISTRY
+KIRRA_DEST_OBJECT_MAX_AGE_MS=2000
+KIRRA_DEST_OBJECT_MIN_CONFIDENCE=0.70
+KIRRA_DEST_OBJECT_STANDOFF_M=0.75
+```
+
+A resolved plan echoes provenance in the response
+(`destination: { destination_id, map_id, source, resolved_at_ms,
+route_waypoints }`); a refusal is a 422 seam rejection carrying the `DEST_*`
+code + operator sentence and an EMPTY trajectory (NO MOTION). A saved route
+grounds to its FIRST waypoint; the full list rides the echo — sequencing the
+rest is the mission layer's job.
+
+**Frames**: registry poses are in the registry's `map_id` frame. The plan
+request must be expressed in that same frame (i.e. the caller is localized
+against that map). Live object sightings are ego-frame targets lifted through
+the request's ego pose; their `map_id` is `null`.
+
+## Operator CLI
+
+```
+python3 robot/location_registry.py list     --places places.json --routes routes.json
+python3 robot/location_registry.py validate --places places.json --routes routes.json   # exit 1 on defect
+python3 robot/location_registry.py lookup "the dock" --places places.json
+```
+
+Read-only; validation mirrors the resolver's rules (the Rust resolver
+remains authoritative — it re-validates at load).
+
+## Deferred (documented, not wired in this slice)
+
+* **Live voice-loop rewiring** — the R2 voice router still sends
+  destination-shaped motion text to `POST /intent` (where the model answers
+  with a typed intent). Routing "go to X" through `destination_schema()` +
+  `DestinationRef` into the planner's `destination` channel needs the
+  mick-service endpoint + occy_doer bridge changes, done as its own slice.
+* **Waypoint sequencing** for saved routes (mission layer receding-horizon
+  advance past the first waypoint).
+* **Map identity plumbing** — the plan request carries no map id today; the
+  grounded `map_id` is echoed so a localized caller can check it.
+* **Address resolution** — requires a trusted geocoding source + map
+  anchoring; the typed seam already refuses honestly.

--- a/robot/location_registry.py
+++ b/robot/location_registry.py
@@ -70,7 +70,15 @@ def _check_header(doc: dict, what: str, errors: list[str]) -> None:
         errors.append(f"{what}: map_id is required and must be non-empty")
 
 
-def _check_keys(entry: dict, keys: dict[str, str], what: str, errors: list[str]) -> None:
+def _check_keys(entry: dict, idx: int, keys: dict[str, tuple[int, str]],
+                what: str, errors: list[str]) -> None:
+    """Index one entry's id/name/aliases into the shared key space.
+
+    Uniqueness is tracked by ENTRY POSITION (`idx`), not by id string — two
+    distinct entries that share an id must collide, exactly as in the Rust
+    resolver's `index_entry_keys` (review: Copilot on #1293). Within one
+    entry, repeating its own key (name == id) is fine.
+    """
     entry_id = entry.get("id", "?")
     aliases = entry.get("aliases", [])
     if not isinstance(aliases, list) or not all(isinstance(a, str) for a in aliases):
@@ -83,13 +91,13 @@ def _check_keys(entry: dict, keys: dict[str, str], what: str, errors: list[str])
         key = normalize(raw)
         if not key:
             errors.append(f"{what} {entry_id!r}: key {raw!r} is empty after normalization")
-        elif key in keys and keys[key] != str(entry_id):
+        elif key in keys and keys[key][0] != idx:
             errors.append(
-                f"{what} {entry_id!r}: key {raw!r} collides with entry {keys[key]!r} — "
+                f"{what} {entry_id!r}: key {raw!r} collides with entry {keys[key][1]!r} — "
                 "ids, names and aliases must be unique across the registry"
             )
         else:
-            keys[key] = str(entry_id)
+            keys[key] = (idx, str(entry_id))
 
 
 def validate_places(doc: dict) -> list[str]:
@@ -100,12 +108,12 @@ def validate_places(doc: dict) -> list[str]:
     if not isinstance(places, list):
         errors.append("place registry: places must be a list")
         return errors
-    keys: dict[str, str] = {}
-    for e in places:
+    keys: dict[str, tuple[int, str]] = {}
+    for idx, e in enumerate(places):
         if not isinstance(e, dict):
             errors.append("place registry: every place must be an object")
             continue
-        _check_keys(e, keys, "place", errors)
+        _check_keys(e, idx, keys, "place", errors)
         for field in ("x_m", "y_m"):
             if not _is_finite_number(e.get(field)):
                 errors.append(f"place {e.get('id', '?')!r}: {field} must be a finite number")
@@ -122,12 +130,12 @@ def validate_routes(doc: dict) -> list[str]:
     if not isinstance(routes, list):
         errors.append("route registry: routes must be a list")
         return errors
-    keys: dict[str, str] = {}
-    for e in routes:
+    keys: dict[str, tuple[int, str]] = {}
+    for idx, e in enumerate(routes):
         if not isinstance(e, dict):
             errors.append("route registry: every route must be an object")
             continue
-        _check_keys(e, keys, "route", errors)
+        _check_keys(e, idx, keys, "route", errors)
         waypoints = e.get("waypoints")
         if not isinstance(waypoints, list) or not waypoints:
             errors.append(f"route {e.get('id', '?')!r}: waypoints must be a non-empty list")

--- a/robot/location_registry.py
+++ b/robot/location_registry.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""location_registry.py — READ-ONLY operator CLI for the typed-destination
+registries (named places + saved routes).
+
+The registries are the TRUSTED coordinate sources behind "drive to the
+kitchen" / "run route A": operator-calibrated JSON files consumed fail-closed
+by the Rust resolver (`kirra-sidecars/src/destination.rs`, loaded by
+`planner_service` via KIRRA_DEST_PLACES_PATH / KIRRA_DEST_ROUTES_PATH). This
+CLI lets the operator LIST what is registered, VALIDATE a file against the
+same rules the resolver enforces, and LOOK UP what a spoken query would
+resolve to — without starting any service.
+
+🔴 READ-ONLY by design: this tool never writes, edits, or creates a registry
+file. Calibrated coordinates are authored deliberately (measure the pose,
+edit the JSON, re-run `validate`) — there is no "add place" convenience that
+could install an invented coordinate. It holds no safety authority either
+way: the Rust resolver re-validates everything it loads.
+
+Validation mirrors the resolver's rules (the resolver remains authoritative):
+  * version == 1;  map_id present and non-empty;
+  * every id / name / alias non-empty after normalization and UNIQUE across
+    the whole file (one shared key space, so lookups are never ambiguous);
+  * every coordinate finite; every route has >= 1 waypoint.
+
+Usage:
+  location_registry.py list     [--places P] [--routes R]
+  location_registry.py validate [--places P] [--routes R]     (exit 1 on defect)
+  location_registry.py lookup QUERY [--places P] [--routes R]
+
+Runs standalone with the stdlib only; pure helpers are host-tested in
+location_registry_test.py.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+
+REGISTRY_VERSION = 1
+
+
+def normalize(text: str) -> str:
+    """ASCII-lowercase, non-alphanumerics collapse to single spaces, trimmed.
+    Mirrors the Rust resolver's `normalize_query` (and voice_route.normalize)
+    so this CLI answers lookups the way the resolver would."""
+    out: list[str] = []
+    pending = False
+    for c in text:
+        if c.isascii() and c.isalnum():
+            if pending and out:
+                out.append(" ")
+            pending = False
+            out.append(c.lower())
+        else:
+            pending = True
+    return "".join(out)
+
+
+def _is_finite_number(v) -> bool:
+    return isinstance(v, (int, float)) and not isinstance(v, bool) and math.isfinite(v)
+
+
+def _check_header(doc: dict, what: str, errors: list[str]) -> None:
+    if doc.get("version") != REGISTRY_VERSION:
+        errors.append(f"{what}: version must be {REGISTRY_VERSION}, got {doc.get('version')!r}")
+    map_id = doc.get("map_id")
+    if not isinstance(map_id, str) or not normalize(map_id):
+        errors.append(f"{what}: map_id is required and must be non-empty")
+
+
+def _check_keys(entry: dict, keys: dict[str, str], what: str, errors: list[str]) -> None:
+    entry_id = entry.get("id", "?")
+    aliases = entry.get("aliases", [])
+    if not isinstance(aliases, list) or not all(isinstance(a, str) for a in aliases):
+        errors.append(f"{what} {entry_id!r}: aliases must be a list of strings")
+        aliases = []
+    for raw in [entry.get("id"), entry.get("name"), *aliases]:
+        if not isinstance(raw, str):
+            errors.append(f"{what} {entry_id!r}: id/name must be strings")
+            continue
+        key = normalize(raw)
+        if not key:
+            errors.append(f"{what} {entry_id!r}: key {raw!r} is empty after normalization")
+        elif key in keys and keys[key] != str(entry_id):
+            errors.append(
+                f"{what} {entry_id!r}: key {raw!r} collides with entry {keys[key]!r} — "
+                "ids, names and aliases must be unique across the registry"
+            )
+        else:
+            keys[key] = str(entry_id)
+
+
+def validate_places(doc: dict) -> list[str]:
+    """All defects in a place-registry document (empty list = valid)."""
+    errors: list[str] = []
+    _check_header(doc, "place registry", errors)
+    places = doc.get("places")
+    if not isinstance(places, list):
+        errors.append("place registry: places must be a list")
+        return errors
+    keys: dict[str, str] = {}
+    for e in places:
+        if not isinstance(e, dict):
+            errors.append("place registry: every place must be an object")
+            continue
+        _check_keys(e, keys, "place", errors)
+        for field in ("x_m", "y_m"):
+            if not _is_finite_number(e.get(field)):
+                errors.append(f"place {e.get('id', '?')!r}: {field} must be a finite number")
+        if "heading_rad" in e and not _is_finite_number(e["heading_rad"]):
+            errors.append(f"place {e.get('id', '?')!r}: heading_rad must be a finite number")
+    return errors
+
+
+def validate_routes(doc: dict) -> list[str]:
+    """All defects in a route-registry document (empty list = valid)."""
+    errors: list[str] = []
+    _check_header(doc, "route registry", errors)
+    routes = doc.get("routes")
+    if not isinstance(routes, list):
+        errors.append("route registry: routes must be a list")
+        return errors
+    keys: dict[str, str] = {}
+    for e in routes:
+        if not isinstance(e, dict):
+            errors.append("route registry: every route must be an object")
+            continue
+        _check_keys(e, keys, "route", errors)
+        waypoints = e.get("waypoints")
+        if not isinstance(waypoints, list) or not waypoints:
+            errors.append(f"route {e.get('id', '?')!r}: waypoints must be a non-empty list")
+            continue
+        for i, w in enumerate(waypoints):
+            if not isinstance(w, dict):
+                errors.append(f"route {e.get('id', '?')!r}: waypoint {i} must be an object")
+                continue
+            for field in ("x_m", "y_m"):
+                if not _is_finite_number(w.get(field)):
+                    errors.append(
+                        f"route {e.get('id', '?')!r}: waypoint {i} {field} must be a finite number"
+                    )
+            if "heading_rad" in w and not _is_finite_number(w["heading_rad"]):
+                errors.append(
+                    f"route {e.get('id', '?')!r}: waypoint {i} heading_rad must be finite"
+                )
+    return errors
+
+
+def lookup(query: str, places_doc: dict | None, routes_doc: dict | None):
+    """What the normalized query resolves to: ("place"|"route", entry) or None.
+    Exact key match only, like the resolver — no fuzzy matching."""
+    key = normalize(query)
+    if not key:
+        return None
+    for kind, doc, field in (("place", places_doc, "places"), ("route", routes_doc, "routes")):
+        if not doc:
+            continue
+        for e in doc.get(field, []):
+            candidates = [e.get("id", ""), e.get("name", ""), *e.get("aliases", [])]
+            if any(normalize(c) == key for c in candidates if isinstance(c, str)):
+                return kind, e
+    return None
+
+
+def _load(path: str | None, what: str) -> dict | None:
+    if not path:
+        return None
+    p = Path(path)
+    try:
+        return json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"error: {what} {path}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("command", choices=("list", "validate", "lookup"))
+    ap.add_argument("query", nargs="?", default=None)
+    ap.add_argument("--places", default=None, help="place registry JSON path")
+    ap.add_argument("--routes", default=None, help="route registry JSON path")
+    args = ap.parse_args(argv)
+
+    places = _load(args.places, "places registry")
+    routes = _load(args.routes, "routes registry")
+    if places is None and routes is None:
+        print("error: pass --places and/or --routes", file=sys.stderr)
+        return 2
+
+    if args.command == "validate":
+        errors: list[str] = []
+        if places is not None:
+            errors += validate_places(places)
+        if routes is not None:
+            errors += validate_routes(routes)
+        for e in errors:
+            print(f"DEFECT: {e}")
+        print("INVALID" if errors else "OK")
+        return 1 if errors else 0
+
+    if args.command == "list":
+        if places is not None:
+            print(f"places (map_id={places.get('map_id')!r}):")
+            for e in places.get("places", []):
+                aliases = ", ".join(e.get("aliases", []))
+                print(f"  {e.get('id')}: {e.get('name')!r}"
+                      f" ({e.get('x_m')}, {e.get('y_m')})"
+                      + (f"  aka: {aliases}" if aliases else ""))
+        if routes is not None:
+            print(f"routes (map_id={routes.get('map_id')!r}):")
+            for e in routes.get("routes", []):
+                print(f"  {e.get('id')}: {e.get('name')!r}"
+                      f"  {len(e.get('waypoints', []))} waypoint(s)")
+        return 0
+
+    # lookup
+    if not args.query:
+        print("error: lookup needs a QUERY", file=sys.stderr)
+        return 2
+    hit = lookup(args.query, places, routes)
+    if hit is None:
+        print(f"NOT FOUND: {args.query!r} (normalized: {normalize(args.query)!r})")
+        return 1
+    kind, e = hit
+    print(f"{kind}: {e.get('id')} ({e.get('name')!r})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/robot/location_registry_test.py
+++ b/robot/location_registry_test.py
@@ -81,6 +81,21 @@ def test_validation_catches_each_defect_class():
     d["places"][1]["aliases"] = ["kitchen"]  # collides with entry 0's id
     check(any("collides" in e for e in validate_places(d)), "duplicate key")
 
+    # Two DISTINCT entries sharing the same id must collide — uniqueness is
+    # tracked by entry position, not id-string equality, so a copy-pasted
+    # entry cannot pass the CLI while the Rust resolver refuses it
+    # (review: Copilot on #1293).
+    d = places_doc()
+    d["places"][1]["id"] = "kitchen"
+    check(any("collides" in e for e in validate_places(d)),
+          "duplicate id across distinct entries")
+
+    # Within ONE entry, name == id is legitimately the same key, not a defect.
+    d = places_doc()
+    d["places"][0]["name"] = "kitchen"
+    check(not any("collides" in e for e in validate_places(d)),
+          "an entry may repeat its own key")
+
     d = places_doc()
     d["places"][0]["x_m"] = float("nan")
     check(any("finite" in e for e in validate_places(d)), "NaN coordinate")

--- a/robot/location_registry_test.py
+++ b/robot/location_registry_test.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Host tests for location_registry — the read-only registry CLI helpers.
+
+Pins: normalization mirrors the Rust resolver, validation catches every
+defect class the resolver refuses (version, map_id, duplicate keys across
+ids/names/aliases, non-finite coordinates, empty waypoint lists), lookup is
+exact-key-only, and the example registry files shipped in testdata/ are
+valid.
+
+Runs standalone (`python3 robot/location_registry_test.py`, exit 1 on
+failure); importable under pytest.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from location_registry import (  # noqa: E402
+    lookup, normalize, validate_places, validate_routes,
+)
+
+TESTDATA = Path(__file__).resolve().parent / "testdata"
+
+_F: list[str] = []
+
+
+def check(cond, msg):
+    if not cond:
+        _F.append(msg)
+        print(f"  FAIL: {msg}", file=sys.stderr)
+
+
+def places_doc():
+    return {
+        "version": 1,
+        "map_id": "r2-lab-01",
+        "places": [
+            {"id": "kitchen", "name": "Kitchen", "aliases": ["the kitchen"],
+             "x_m": 3.2, "y_m": -1.4, "heading_rad": 0.0},
+            {"id": "charging-dock", "name": "Charging Dock",
+             "aliases": ["the dock", "charger"], "x_m": 0.5, "y_m": 2.0},
+        ],
+    }
+
+
+def routes_doc():
+    return {
+        "version": 1,
+        "map_id": "r2-lab-01",
+        "routes": [
+            {"id": "route-a", "name": "Route A", "aliases": ["route alpha"],
+             "waypoints": [{"x_m": 1.0, "y_m": 0.0, "heading_rad": 0.0},
+                           {"x_m": 2.0, "y_m": 1.0}]},
+        ],
+    }
+
+
+def test_normalize_mirrors_the_resolver():
+    check(normalize("The Kitchen!") == "the kitchen", "basic normalize")
+    check(normalize("  ROUTE--A  ") == "route a", "punctuation collapses")
+    check(normalize("???") == "", "no alphanumerics -> empty")
+
+
+def test_valid_documents_have_no_defects():
+    check(validate_places(places_doc()) == [], "places doc valid")
+    check(validate_routes(routes_doc()) == [], "routes doc valid")
+
+
+def test_validation_catches_each_defect_class():
+    d = places_doc()
+    d["version"] = 2
+    check(any("version" in e for e in validate_places(d)), "wrong version")
+
+    d = places_doc()
+    d["map_id"] = "  "
+    check(any("map_id" in e for e in validate_places(d)), "empty map_id")
+
+    d = places_doc()
+    d["places"][1]["aliases"] = ["kitchen"]  # collides with entry 0's id
+    check(any("collides" in e for e in validate_places(d)), "duplicate key")
+
+    d = places_doc()
+    d["places"][0]["x_m"] = float("nan")
+    check(any("finite" in e for e in validate_places(d)), "NaN coordinate")
+
+    d = places_doc()
+    d["places"][0]["x_m"] = "3.2"
+    check(any("finite" in e for e in validate_places(d)), "string coordinate")
+
+    d = places_doc()
+    d["places"][0]["x_m"] = True  # bool is not a coordinate
+    check(any("finite" in e for e in validate_places(d)), "bool coordinate")
+
+    r = routes_doc()
+    r["routes"][0]["waypoints"] = []
+    check(any("waypoints" in e for e in validate_routes(r)), "empty waypoints")
+
+    r = routes_doc()
+    r["routes"][0]["waypoints"][1]["y_m"] = float("inf")
+    check(any("finite" in e for e in validate_routes(r)), "inf waypoint")
+
+
+def test_lookup_is_exact_key_only():
+    hit = lookup("the kitchen", places_doc(), routes_doc())
+    check(hit is not None and hit[0] == "place" and hit[1]["id"] == "kitchen",
+          "alias lookup hits the place")
+    hit = lookup("Route Alpha!", places_doc(), routes_doc())
+    check(hit is not None and hit[0] == "route" and hit[1]["id"] == "route-a",
+          "normalized alias lookup hits the route")
+    check(lookup("kitch", places_doc(), routes_doc()) is None,
+          "no prefix/fuzzy matching — exact keys only")
+    check(lookup("   ", places_doc(), routes_doc()) is None, "empty query misses")
+
+
+def test_shipped_example_registries_are_valid():
+    places = json.loads((TESTDATA / "places.example.json").read_text())
+    routes = json.loads((TESTDATA / "routes.example.json").read_text())
+    check(validate_places(places) == [], "places.example.json is valid")
+    check(validate_routes(routes) == [], "routes.example.json is valid")
+    # The examples are templates, not calibration: their map_id says so, so
+    # copying one into service unedited is loud in every list/echo/log line.
+    check("example" in places["map_id"] and "example" in routes["map_id"],
+          "example registries self-identify as uncalibrated")
+
+
+# --- standalone runner (house pattern) ----------------------------------------
+
+def main() -> int:
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            fn()
+            print(f"  ok  {name}")
+    if _F:
+        print(f"location_registry_test: {len(_F)} FAILURE(S)")
+        return 1
+    print("location_registry_test: ALL OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/robot/testdata/places.example.json
+++ b/robot/testdata/places.example.json
@@ -1,0 +1,22 @@
+{
+  "version": 1,
+  "map_id": "example-uncalibrated",
+  "places": [
+    {
+      "id": "kitchen",
+      "name": "Kitchen",
+      "aliases": ["the kitchen"],
+      "x_m": 0.0,
+      "y_m": 0.0,
+      "heading_rad": 0.0
+    },
+    {
+      "id": "charging-dock",
+      "name": "Charging Dock",
+      "aliases": ["the dock", "charger", "charging station"],
+      "x_m": 0.0,
+      "y_m": 0.0,
+      "heading_rad": 0.0
+    }
+  ]
+}

--- a/robot/testdata/routes.example.json
+++ b/robot/testdata/routes.example.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "map_id": "example-uncalibrated",
+  "routes": [
+    {
+      "id": "route-a",
+      "name": "Route A",
+      "aliases": ["route alpha"],
+      "waypoints": [
+        { "x_m": 0.0, "y_m": 0.0, "heading_rad": 0.0 },
+        { "x_m": 0.0, "y_m": 0.0, "heading_rad": 0.0 }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## What

A typed destination system so voice commands like **"drive to the kitchen"**, **"run route A"**, **"drive to the red cup"**, and **"drive to 125 Main Street"** resolve safely, under one rule:

> **Language chooses the destination type. A trusted resolver chooses the actual coordinates. The LLM must never invent map coordinates, object poses, addresses, or routes.**

```
voice/text ─▶ DestinationRef {"kind":"named_place","query":"kitchen"}   (LANGUAGE)
           ─▶ DestinationResolver (registries / live tracks)            (TRUST)
           ─▶ GroundedDestination ─▶ ordinary MickIntent::GoTo
           ─▶ existing governed path: Occy plans ─▶ KIRRA checker bounds (UNCHANGED)
```

## The typed model (`crates/kirra-sidecars/src/destination.rs`)

| kind | trusted source | outcome |
|---|---|---|
| `named_place` | operator-calibrated `PlaceRegistry` JSON | registry pose |
| `saved_route` | operator-calibrated `RouteRegistry` JSON | first waypoint + full list |
| `tracked_object` | live camera targets via `kirra_taj::object_goal` | standoff pose (0.75 m short, facing the object) |
| `address` | **none — no geocoder exists** | `Unsupported` refusal, never a faked lat/long |

- **Explicit `ResolveOutcome`** — `Resolved / Ambiguous / NotFound{code} / Stale / Unsupported{code}`, never an `Option`; every refusal carries a stable `DEST_*` code + an operator sentence the conversational layer can speak.
- **One fail-closed parser** (`DestinationRef::parse_json`): strict fields, bounded query, tolerant of LLM framing via the same shared extractor as the intent parse, and a **distinct `DEST_COORDINATES_FORBIDDEN`** refusal if any coordinate-shaped key (`x_m`, `lat`, `pose`, `waypoints`, …) rides the language channel.
- **`destination_schema()`** for constrained decoding: two *string* properties, `additionalProperties:false` — the model structurally cannot emit a number. `build_destination_prompt` renders known place/route **names only** (pinned by test: no coordinate leaks).
- **Registries fail-closed**: version pin, required `map_id`, ONE unique normalized key space across ids/names/aliases (lookups structurally unambiguous), finite coordinates, bounded sizes; any defect refuses the whole file and aborts service startup.
- **Object policy** (boot-validated env): `KIRRA_DEST_OBJECT_MAX_AGE_MS=2000`, `KIRRA_DEST_OBJECT_MIN_CONFIDENCE=0.70`, `KIRRA_DEST_OBJECT_STANDOFF_M=0.75`. Stale sightings refuse (`DEST_STALE`) — a moved object is never chased on an old position.

## Seam wiring (planner)

`PlanRequest.destination` (opt-in) → resolved by the trusted resolver → grounds as an **ordinary `GoTo`** (the same design the `object_goal` channel documents: nothing downstream can tell where a goal came from, so no new authority exists). Mutually exclusive with `intent` / `object_goal` (`PLAN_AMBIGUOUS_GOAL_SOURCE`). Refusals are 422 + **NO MOTION** (empty trajectory). Responses echo grounded provenance (`destination_id`, `map_id`, `source`, `resolved_at_ms`, `route_waypoints`). A grounded goal still passes the in-map hallucination bound.

`MickIntent`, its parser, and the enforcement chain (Mick → Occy → checker → release token → verifying consumer) are **untouched** (the only `kirra-planner` change makes `extract_first_json_object` `pub`).

## Fence proof

The resolver lives inside `kirra-sidecars`, which `ci/check_mick_actuation_fence.py` already fences: no dependency route to the release-token mint, serial consumer, or ROS/DDS transport can compile in. Fence run: **INTACT**.

## Robot side

- `robot/location_registry.py` — **read-only** CLI (`list` / `validate` / `lookup`) mirroring the resolver's rules; deliberately has no write path, so no convenience exists that could install an invented coordinate.
- `robot/testdata/{places,routes}.example.json` — templates that **self-identify as uncalibrated** (`map_id: "example-uncalibrated"`, zero poses). No installer stages them; calibration is a deliberate manual act (measure → edit → `validate`).

## Tests

- `destination.rs` (30+ assertions): parser fail-closed incl. coordinate-smuggling per key, registry defect classes, every resolver outcome (place/route/object/address, stale edge inclusive, confidence floor binding over the channel default, ambiguity tie, behind-ego, world-frame standoff transform), schema↔parser lockstep + no-numeric-property pin, prompt coordinate-leak pin.
- Planner seam: grounding for all three kinds, every refusal → NO MOTION, coordinate smuggling at the seam, three-way ambiguity, in-map bound on registry poses, byte-identical no-destination behaviour.
- `robot/location_registry_test.py` (added to the CI robot lane): normalization parity, defect classes, exact-key lookup, example-registry validity + uncalibrated self-identification.
- Full runs: `kirra-sidecars` 219 lib tests + integration, `kirra-planner` all suites, clippy clean, rustfmt clean, actuation fence INTACT, re-export shim ratchet clean.

## Deferred (documented in `docs/hardware/R2_DESTINATIONS.md`)

Live voice-loop rewiring (mick-service destination endpoint + occy_doer bridge), saved-route waypoint sequencing past the first waypoint, map-identity plumbing on the plan request, and real address resolution behind the typed seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_