### PR TITLE
feat(voice): live voice-to-destination resolution and admission (not navigation)

### DIFF
--- a/crates/kirra-sidecars/src/bin/mick_service.rs
+++ b/crates/kirra-sidecars/src/bin/mick_service.rs
@@ -18,6 +18,17 @@
 //!     → 422 {"ok":false,"error":"MICK_JSON_PARSE_ERROR"}   (fail-closed: no intent latched)
 //!     → 429 {"ok":false,"error":"MICK_RATE_LIMITED"}
 //!   GET  /intent/last     → {"intent":{...},"seq":n,"at_ms":t} | {"intent":null}
+//!   POST /destination     {"destination":{"kind":"named_place","query":"kitchen"},
+//!                          "targets"?:[..], "targets_stamp_ms"?, "ego"?}
+//!     → 200 {"ok":true,"seq":n,"outcome":"resolved",..}  ADMISSION ONLY — no pose
+//!     → 422 {"ok":false,"error":"DEST_NOT_FOUND"|"DEST_AMBIGUOUS"|"DEST_STALE"|
+//!            "DEST_UNSUPPORTED_ADDRESS"|…,"detail":"<operator sentence>"}
+//!            (fail-closed: NOTHING latched, seq unchanged)
+//!     → 429 {"ok":false,"error":"DEST_RATE_LIMITED"}
+//!   GET  /destination/last → {"destination":{..,"frame":"map"|"ego",..},"seq":n}
+//!                            | {"destination":null}. FRAME-EXPLICIT and its own
+//!                            channel: a map-frame registry pose published on
+//!                            /intent/last would be misread as ego-relative.
 //!   GET  /narration/last  → relay of the verifier's #893 GET /system/verdicts/last
 //!                           (AUDITOR tier — never the admin token); 503 if unconfigured
 //!   GET  /health          → {"status":"ok"}
@@ -27,7 +38,10 @@
 //! OllamaClient pair); `KIRRA_MICK_PERSONA` = `chauffeur` (default) |
 //! `courier`; `KIRRA_VERIFIER_URL` + `KIRRA_MICK_AUDITOR_TOKEN` (both or
 //! neither — half-configured aborts startup);
-//! `KIRRA_SIDECAR_ALLOW_NONLOCAL=1` to permit a routable bind.
+//! `KIRRA_SIDECAR_ALLOW_NONLOCAL=1` to permit a routable bind. The typed
+//! destination registries/policy come from the SAME `KIRRA_DEST_*` vars
+//! `planner_service` reads (`destination::resolver_from_env`) — one config
+//! path, so two processes cannot disagree about what "the kitchen" means.
 //!
 //! Fail-closed by construction: no Ollama / a hallucinated reply / a
 //! non-finite goal → 422 and NO latched intent — the doer sees nothing new,
@@ -37,6 +51,8 @@ use std::net::{TcpListener, TcpStream};
 
 use kirra_mick::OllamaClient;
 use kirra_planner::LlmBrain;
+use kirra_sidecars::destination::resolver_from_env;
+use kirra_sidecars::destination_service::{DestinationRequest, DestinationService};
 use kirra_sidecars::http::{read_request, respond, respond_error};
 use kirra_sidecars::mick::{IntentOutcome, IntentRequest, IntentService};
 use kirra_sidecars::narrator::{fetch_last_verdict, NarratorConfig};
@@ -45,6 +61,7 @@ use kirra_sidecars::net::{allow_nonlocal_from_env, enforce_bind_policy, now_ms};
 fn serve(
     mut stream: TcpStream,
     svc: &mut IntentService<OllamaClient>,
+    dest: &mut DestinationService,
     narrator: Option<&NarratorConfig>,
 ) {
     let req = match read_request(&mut stream) {
@@ -85,6 +102,35 @@ fn serve(
                 "400 Bad Request",
                 &serde_json::json!({"ok": false, "error": format!("{e}")}).to_string(),
             ),
+        },
+        // The TYPED DESTINATION door — "drive to the kitchen". The caller
+        // sends a kind + the operator's words; the TRUSTED resolver supplies
+        // the coordinates. Every non-resolved outcome is a 422 carrying the
+        // stable DEST_* code, with the latch and seq UNCHANGED: no grounded
+        // destination, no goal, no plan.
+        ("POST", "/destination") => match serde_json::from_slice::<DestinationRequest>(&req.body) {
+            Ok(r) => match dest.handle(&r, now_ms()) {
+                // Admission only — the success body carries NO pose.
+                Ok(accepted) => respond(&mut stream, "200 OK", &accepted.to_post_wire()),
+                Err(refusal) if refusal.code == "DEST_RATE_LIMITED" => {
+                    respond(&mut stream, "429 Too Many Requests", &refusal.to_json())
+                }
+                Err(refusal) => {
+                    respond(&mut stream, "422 Unprocessable Entity", &refusal.to_json())
+                }
+            },
+            Err(e) => respond(
+                &mut stream,
+                "400 Bad Request",
+                &serde_json::json!({"ok": false, "error": format!("{e}")}).to_string(),
+            ),
+        },
+        // The doer-facing grounded destination, FRAME-EXPLICIT. Deliberately
+        // its own channel: `/intent/last` is consumed as ego-frame, and a
+        // map-frame registry pose published there would be silently misread.
+        ("GET", "/destination/last") => match dest.last() {
+            Some(d) => respond(&mut stream, "200 OK", &d.to_wire()),
+            None => respond(&mut stream, "200 OK", "{\"destination\":null}"),
         },
         ("GET", "/intent/last") => match svc.last() {
             Some(a) => respond(&mut stream, "200 OK", &a.to_wire()),
@@ -152,17 +198,24 @@ fn main() {
             std::process::exit(1);
         }
     };
+    // The trusted destination resolver, from the SAME env config
+    // planner_service uses — one config path, so two processes can never
+    // disagree about what "the kitchen" means. Malformed → startup abort.
+    let mut dest = DestinationService::new(resolver_from_env().unwrap_or_else(|e| {
+        eprintln!("mick_service: destination config: {e}");
+        std::process::exit(1);
+    }));
     let listener = TcpListener::bind(&addr).unwrap_or_else(|e| {
         eprintln!("mick_service: bind {addr}: {e}");
         std::process::exit(1);
     });
     println!(
-        "Mick intent service on http://{addr}  (POST /intent, GET /intent/last, GET /narration/last, GET /health) — persona {persona_label}, narrator {}",
+        "Mick intent service on http://{addr}  (POST /intent, GET /intent/last, POST /destination, GET /destination/last, GET /narration/last, GET /health) — persona {persona_label}, narrator {}",
         if narrator.is_some() { "on" } else { "off" }
     );
     for stream in listener.incoming() {
         match stream {
-            Ok(s) => serve(s, &mut svc, narrator.as_ref()),
+            Ok(s) => serve(s, &mut svc, &mut dest, narrator.as_ref()),
             Err(e) => eprintln!("mick_service: accept error: {e}"),
         }
     }

--- a/crates/kirra-sidecars/src/bin/planner_service.rs
+++ b/crates/kirra-sidecars/src/bin/planner_service.rs
@@ -25,10 +25,7 @@
 
 use std::net::{TcpListener, TcpStream};
 
-use kirra_sidecars::destination::{
-    DestinationResolver, ObjectPolicy, PlaceRegistry, RouteRegistry, DEFAULT_OBJECT_MAX_AGE_MS,
-    DEFAULT_OBJECT_MIN_CONFIDENCE, DEFAULT_OBJECT_STANDOFF_M,
-};
+use kirra_sidecars::destination::{resolver_from_env, DestinationResolver};
 use kirra_sidecars::http::{read_request, respond, respond_error};
 use kirra_sidecars::net::{allow_nonlocal_from_env, enforce_bind_policy, now_ms, RateLimiter};
 use kirra_sidecars::planner::{handle_plan_with_destinations, PlanRequest};
@@ -37,67 +34,6 @@ use kirra_sidecars::planner::{handle_plan_with_destinations, PlanRequest};
 /// plan + slow-loop check; the doer bridge plans at ≤ 20 Hz.
 const PLAN_RATE_BURST: f64 = 40.0;
 const PLAN_RATE_PER_S: f64 = 20.0;
-
-/// Read one env var, parsed by `parse`, defaulting when absent/empty.
-/// Malformed → `Err` (the caller aborts startup) — never a silent default.
-fn env_parsed<T>(
-    key: &str,
-    default: T,
-    parse: impl FnOnce(&str) -> Option<T>,
-) -> Result<T, String> {
-    match std::env::var(key) {
-        Ok(raw) if !raw.trim().is_empty() => {
-            parse(raw.trim()).ok_or_else(|| format!("{key}: malformed value {raw:?}"))
-        }
-        _ => Ok(default),
-    }
-}
-
-/// Build the trusted destination resolver from env at boot. Fail-closed
-/// throughout: a configured registry path that is unreadable or fails
-/// validation, or a malformed policy knob, ABORTS startup — a planner with a
-/// half-loaded registry must not come up looking healthy.
-fn resolver_from_env() -> Result<DestinationResolver, String> {
-    let places = match std::env::var("KIRRA_DEST_PLACES_PATH") {
-        Ok(path) if !path.trim().is_empty() => {
-            let raw = std::fs::read_to_string(path.trim())
-                .map_err(|e| format!("KIRRA_DEST_PLACES_PATH {path:?}: {e}"))?;
-            PlaceRegistry::from_json_str(&raw)
-                .map_err(|e| format!("KIRRA_DEST_PLACES_PATH {path:?}: {e}"))?
-        }
-        _ => PlaceRegistry::empty(),
-    };
-    let routes = match std::env::var("KIRRA_DEST_ROUTES_PATH") {
-        Ok(path) if !path.trim().is_empty() => {
-            let raw = std::fs::read_to_string(path.trim())
-                .map_err(|e| format!("KIRRA_DEST_ROUTES_PATH {path:?}: {e}"))?;
-            RouteRegistry::from_json_str(&raw)
-                .map_err(|e| format!("KIRRA_DEST_ROUTES_PATH {path:?}: {e}"))?
-        }
-        _ => RouteRegistry::empty(),
-    };
-    let max_age_ms = env_parsed(
-        "KIRRA_DEST_OBJECT_MAX_AGE_MS",
-        DEFAULT_OBJECT_MAX_AGE_MS,
-        |s| s.parse::<u64>().ok(),
-    )?;
-    let min_confidence = env_parsed(
-        "KIRRA_DEST_OBJECT_MIN_CONFIDENCE",
-        DEFAULT_OBJECT_MIN_CONFIDENCE,
-        |s| s.parse::<f32>().ok(),
-    )?;
-    let standoff_m = env_parsed(
-        "KIRRA_DEST_OBJECT_STANDOFF_M",
-        DEFAULT_OBJECT_STANDOFF_M,
-        |s| s.parse::<f64>().ok(),
-    )?;
-    let object_policy = ObjectPolicy::validated(max_age_ms, min_confidence, standoff_m)?;
-    Ok(DestinationResolver {
-        places,
-        routes,
-        object_policy,
-    })
-}
 
 fn serve(mut stream: TcpStream, limiter: &mut RateLimiter, resolver: &DestinationResolver) {
     let req = match read_request(&mut stream) {

--- a/crates/kirra-sidecars/src/destination.rs
+++ b/crates/kirra-sidecars/src/destination.rs
@@ -124,6 +124,59 @@ const COORDINATE_KEYS: &[&str] = &[
     "waypoints",
 ];
 
+/// The tracked-object attribute keys. Admitted ONLY on `tracked_object`, and
+/// only in place of `query` — never alongside it (two spellings of the same
+/// field is an ambiguity, not a merge).
+const OBJECT_ATTRIBUTE_KEYS: &[&str] = &["class", "color"];
+
+/// Compose `{"class":"cup","color":"red"}` into the query `"red cup"`.
+///
+/// Returns `Ok(None)` when the object carries no attribute keys (the ordinary
+/// `query` form). Fail-closed on every misuse: attributes on a non-object
+/// kind, attributes alongside `query`, a missing/blank `class`, or a
+/// non-string attribute.
+fn compose_object_query(
+    obj: &serde_json::Map<String, serde_json::Value>,
+    kind: &str,
+) -> Result<Option<String>, &'static str> {
+    let has_attrs = OBJECT_ATTRIBUTE_KEYS.iter().any(|k| obj.contains_key(*k));
+    if !has_attrs {
+        return Ok(None);
+    }
+    if kind != "tracked_object" {
+        // A place/route/address does not have a class or a colour. Refusing
+        // keeps each kind's wire shape exactly one thing.
+        return Err("DEST_JSON_PARSE_ERROR");
+    }
+    if obj.contains_key("query") {
+        return Err("DEST_JSON_PARSE_ERROR");
+    }
+    // The attribute form bypasses serde's `deny_unknown_fields`, so it
+    // enforces the same closed key set itself — nothing may ride alongside.
+    if obj
+        .keys()
+        .any(|k| k != "kind" && !OBJECT_ATTRIBUTE_KEYS.contains(&k.as_str()))
+    {
+        return Err("DEST_JSON_PARSE_ERROR");
+    }
+    let attr = |key: &str| -> Result<Option<&str>, &'static str> {
+        match obj.get(key) {
+            None => Ok(None),
+            Some(serde_json::Value::String(s)) => Ok(Some(s.trim())),
+            Some(_) => Err("DEST_JSON_PARSE_ERROR"),
+        }
+    };
+    let class = attr("class")?.unwrap_or("");
+    if class.is_empty() {
+        // A colour alone ("the red one") names no thing to resolve.
+        return Err("DEST_EMPTY_QUERY");
+    }
+    Ok(Some(match attr("color")? {
+        Some(color) if !color.is_empty() => format!("{color} {class}"),
+        _ => class.to_string(),
+    }))
+}
+
 impl DestinationRef {
     /// Parse destination JSON — THE one fail-closed parser for the typed
     /// destination wire form. Tolerant of LLM framing (fences/preamble) via
@@ -141,8 +194,23 @@ impl DestinationRef {
         if obj.keys().any(|k| COORDINATE_KEYS.contains(&k.as_str())) {
             return Err("DEST_COORDINATES_FORBIDDEN");
         }
-        let parsed: DestinationJson =
-            serde_json::from_str(json).map_err(|_| "DEST_JSON_PARSE_ERROR")?;
+        // The tracked-object ATTRIBUTE form (`class` + optional `color`) is a
+        // second accepted spelling of the SAME typed request, for the voice
+        // router's deliberately small object grammar. It composes into the
+        // one `query` the resolver already matches — there is no second
+        // resolution path, and no other kind may carry these keys.
+        let kind = obj
+            .get("kind")
+            .and_then(|v| v.as_str())
+            .ok_or("DEST_JSON_PARSE_ERROR")?;
+        let composed = compose_object_query(obj, kind)?;
+        let parsed: DestinationJson = match composed {
+            Some(query) => DestinationJson {
+                kind: kind.to_string(),
+                query,
+            },
+            None => serde_json::from_str(json).map_err(|_| "DEST_JSON_PARSE_ERROR")?,
+        };
         let query = parsed.query.trim();
         if query.is_empty() {
             return Err("DEST_EMPTY_QUERY");
@@ -867,6 +935,81 @@ impl DestinationResolver {
 }
 
 // ---------------------------------------------------------------------------
+// Boot configuration — ONE config path, shared by every binary that resolves.
+// ---------------------------------------------------------------------------
+
+/// Read one env var, parsed by `parse`, defaulting when absent/empty.
+/// Malformed → `Err` (the caller aborts startup) — never a silent default.
+fn env_parsed<T>(
+    key: &str,
+    default: T,
+    parse: impl FnOnce(&str) -> Option<T>,
+) -> Result<T, String> {
+    match std::env::var(key) {
+        Ok(raw) if !raw.trim().is_empty() => {
+            parse(raw.trim()).ok_or_else(|| format!("{key}: malformed value {raw:?}"))
+        }
+        _ => Ok(default),
+    }
+}
+
+fn registry_from_env<T>(
+    key: &str,
+    empty: T,
+    parse: impl FnOnce(&str) -> Result<T, String>,
+) -> Result<T, String> {
+    match std::env::var(key) {
+        Ok(path) if !path.trim().is_empty() => {
+            let path = path.trim();
+            let raw = std::fs::read_to_string(path).map_err(|e| format!("{key} {path:?}: {e}"))?;
+            parse(&raw).map_err(|e| format!("{key} {path:?}: {e}"))
+        }
+        _ => Ok(empty),
+    }
+}
+
+/// Build the trusted destination resolver from the environment at boot.
+///
+/// Shared by EVERY binary that resolves destinations (`planner_service`,
+/// `mick_service`) so a fleet cannot end up with two processes disagreeing
+/// about what "the kitchen" means. Fail-closed throughout: a configured
+/// registry path that is unreadable or fails validation, or a malformed
+/// policy knob, is an `Err` the caller turns into a startup abort — a service
+/// with a half-loaded registry must not come up looking healthy.
+pub fn resolver_from_env() -> Result<DestinationResolver, String> {
+    let places = registry_from_env(
+        "KIRRA_DEST_PLACES_PATH",
+        PlaceRegistry::empty(),
+        PlaceRegistry::from_json_str,
+    )?;
+    let routes = registry_from_env(
+        "KIRRA_DEST_ROUTES_PATH",
+        RouteRegistry::empty(),
+        RouteRegistry::from_json_str,
+    )?;
+    let max_age_ms = env_parsed(
+        "KIRRA_DEST_OBJECT_MAX_AGE_MS",
+        DEFAULT_OBJECT_MAX_AGE_MS,
+        |s| s.parse::<u64>().ok(),
+    )?;
+    let min_confidence = env_parsed(
+        "KIRRA_DEST_OBJECT_MIN_CONFIDENCE",
+        DEFAULT_OBJECT_MIN_CONFIDENCE,
+        |s| s.parse::<f32>().ok(),
+    )?;
+    let standoff_m = env_parsed(
+        "KIRRA_DEST_OBJECT_STANDOFF_M",
+        DEFAULT_OBJECT_STANDOFF_M,
+        |s| s.parse::<f64>().ok(),
+    )?;
+    Ok(DestinationResolver {
+        places,
+        routes,
+        object_policy: ObjectPolicy::validated(max_age_ms, min_confidence, standoff_m)?,
+    })
+}
+
+// ---------------------------------------------------------------------------
 // The LLM seam — schema + prompt. The model can choose a KIND and repeat the
 // operator's words; it structurally cannot emit a coordinate.
 // ---------------------------------------------------------------------------
@@ -1049,6 +1192,70 @@ mod tests {
                 "{smuggle}"
             );
         }
+    }
+
+    /// The voice router's small object grammar sends attributes rather than a
+    /// free-text phrase; they compose into the ONE query the resolver already
+    /// matches, so there is no second resolution path.
+    #[test]
+    fn the_tracked_object_attribute_form_composes_one_query() {
+        let (dref, _) =
+            DestinationRef::parse_json(r#"{"kind":"tracked_object","class":"cup","color":"red"}"#)
+                .expect("attribute form parses");
+        assert_eq!(
+            dref,
+            DestinationRef::TrackedObject {
+                query: "red cup".into()
+            },
+            "colour + class compose in the order the detector labels them"
+        );
+        // Class alone is a generic request.
+        assert_eq!(
+            DestinationRef::from_json(r#"{"kind":"tracked_object","class":"person"}"#).unwrap(),
+            DestinationRef::TrackedObject {
+                query: "person".into()
+            }
+        );
+        // And it resolves exactly like the query form against real targets.
+        let r = resolver();
+        let targets = [target("red cup", 3.0, 0.0, 0.9)];
+        assert!(matches!(
+            r.resolve(&dref, &view(&targets, Some(1_000)), ego_origin(), 1_000),
+            ResolveOutcome::Resolved(_)
+        ));
+    }
+
+    #[test]
+    fn the_attribute_form_is_closed_and_object_only() {
+        // Attributes on a kind that has no class/colour.
+        for bad in [
+            r#"{"kind":"named_place","class":"cup"}"#,
+            r#"{"kind":"saved_route","color":"red"}"#,
+            r#"{"kind":"address","class":"cup"}"#,
+            // Two spellings of the same field is an ambiguity, not a merge.
+            r#"{"kind":"tracked_object","query":"cup","class":"cup"}"#,
+            // Nothing may ride alongside the attributes.
+            r#"{"kind":"tracked_object","class":"cup","bogus":1}"#,
+            // A non-string attribute.
+            r#"{"kind":"tracked_object","class":7}"#,
+        ] {
+            assert_eq!(
+                DestinationRef::parse_json(bad).unwrap_err(),
+                "DEST_JSON_PARSE_ERROR",
+                "{bad}"
+            );
+        }
+        // A colour with no class names no thing at all.
+        assert_eq!(
+            DestinationRef::parse_json(r#"{"kind":"tracked_object","color":"red"}"#).unwrap_err(),
+            "DEST_EMPTY_QUERY"
+        );
+        // A coordinate still outranks everything, even in the attribute form.
+        assert_eq!(
+            DestinationRef::parse_json(r#"{"kind":"tracked_object","class":"cup","x_m":1.0}"#)
+                .unwrap_err(),
+            "DEST_COORDINATES_FORBIDDEN"
+        );
     }
 
     #[test]

--- a/crates/kirra-sidecars/src/destination_service.rs
+++ b/crates/kirra-sidecars/src/destination_service.rs
@@ -1,0 +1,641 @@
+//! The Mick **typed-destination endpoint core** — typed destination in, a
+//! TRUSTED grounded target out, never a command and never a coordinate the
+//! caller supplied.
+//!
+//! This is the live half of the #1293 foundation: the voice router classifies
+//! a transcript deterministically, sends the typed [`DestinationRef`] here
+//! (kind + the operator's words, NEVER coordinates), and this service asks the
+//! trusted [`DestinationResolver`] — registries and live tracks — for the
+//! actual pose.
+//!
+//! ```text
+//!   voice → POST /destination {"kind":"named_place","query":"kitchen"}
+//!         → DestinationRef::parse_json      (the ONE fail-closed parse)
+//!         → DestinationResolver::resolve    (the ONLY source of coordinates)
+//!         → Resolved  → latched on GET /destination/last  (seq advances)
+//!         → anything else → 422 + a stable DEST_* code, latch UNCHANGED
+//! ```
+//!
+//! 🔴 **Refusals never move anything.** Ambiguous / NotFound / Stale /
+//! Unsupported all leave the latch and `seq` untouched, exactly like
+//! [`crate::mick::IntentService`]'s fail-closed arm: with no new grounded
+//! destination there is no goal, no plan, no proposal. There is no default
+//! destination and no "head roughly that way" arm anywhere on this path.
+//!
+//! 🔴 **The latch is FRAME-EXPLICIT, and deliberately its own channel.** A
+//! registry pose is in the registry's map frame; the existing
+//! `GET /intent/last` channel is consumed (by `occy_doer`) as EGO-frame at
+//! receipt. Publishing a map-frame pose there would be silently misread as
+//! ego-relative and aim the robot at the wrong place — so grounded
+//! destinations ride their own `GET /destination/last` channel carrying an
+//! explicit [`GroundedFrame`], and a consumer must understand the frame
+//! before it can use the pose. Wiring that consumption into the doer bridge
+//! is the remaining deferred step (see `docs/hardware/R2_DESTINATIONS.md`).
+//!
+//! 🔴 **No perception is invented here.** Tracked-object destinations resolve
+//! against the targets the CALLER supplies (a perception-aware bridge). The
+//! voice router has no perception and supplies none, so an object request
+//! from voice resolves [`ResolveOutcome::Stale`] — "the detector did not
+//! look" is never "it isn't there", the same rule the object-goal channel
+//! already holds.
+
+use crate::destination::{
+    DestinationRef, DestinationResolver, DestinationSource, EgoView, GroundedDestination,
+    ResolveOutcome, TargetView,
+};
+use crate::net::RateLimiter;
+use kirra_planner::{MickIntent, Pose};
+use kirra_taj::object_goal::LabeledTarget;
+use serde::Deserialize;
+
+/// Destination rate bound (burst / steady per second). A plumbing bound: a
+/// destination is one spoken request, so a runaway caller is shed cheaply.
+pub const DESTINATION_RATE_BURST: f64 = 3.0;
+pub const DESTINATION_RATE_PER_S: f64 = 1.0;
+
+/// One typed-destination request. `destination` is the typed
+/// [`DestinationRef`] wire object; everything else is OPTIONAL perception
+/// context that only a perception-aware caller supplies.
+#[derive(Deserialize, Default)]
+pub struct DestinationRequest {
+    /// The typed destination object (or that object as a JSON string).
+    pub destination: serde_json::Value,
+    /// Camera-detected labelled targets, ego frame — the tracked-object
+    /// resolver's evidence. Absent → no evidence (→ `Stale`).
+    #[serde(default)]
+    pub targets: Vec<TargetReq>,
+    /// Producer stamp of the frame `targets` came from. Absent while a
+    /// tracked object is requested → STALE, never "not seen".
+    #[serde(default)]
+    pub targets_stamp_ms: Option<u64>,
+    /// Consumer clock for the freshness check. Absent → the service clock.
+    #[serde(default)]
+    pub now_ms: Option<u64>,
+    /// Ego pose the object sighting is lifted through. Absent → the identity
+    /// pose, which makes an object result EGO-FRAME.
+    #[serde(default)]
+    pub ego: Option<EgoReq>,
+}
+
+/// One labelled camera target on the wire.
+#[derive(Deserialize)]
+pub struct TargetReq {
+    pub label: String,
+    pub x: f64,
+    pub y: f64,
+    #[serde(default = "default_confidence")]
+    pub confidence: f32,
+}
+fn default_confidence() -> f32 {
+    1.0
+}
+
+/// The caller's ego pose (world frame).
+#[derive(Deserialize, Clone, Copy)]
+pub struct EgoReq {
+    pub x: f64,
+    pub y: f64,
+    pub heading: f64,
+}
+
+/// Which frame a grounded pose is expressed in. Carried explicitly on the
+/// wire so a consumer can never mistake a map pose for an ego-relative one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GroundedFrame {
+    /// The registry's map frame — usable only by a consumer localized
+    /// against that same `map_id`.
+    Map(String),
+    /// The frame the request's `ego` was expressed in (the identity ego pose
+    /// → ego-relative: +X ahead, +Y left).
+    EgoRelative,
+}
+
+impl GroundedFrame {
+    /// The wire token.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        match self {
+            GroundedFrame::Map(_) => "map",
+            GroundedFrame::EgoRelative => "ego",
+        }
+    }
+}
+
+/// How completely a saved route was resolved. Phase 1 grounds ONLY the first
+/// waypoint; the marker rides the wire and the logs so nothing downstream (or
+/// spoken) can imply a whole route is under way.
+pub const ROUTE_RESOLUTION_FIRST_WAYPOINT_ONLY: &str = "first_waypoint_only";
+/// Not a route — no route-resolution claim applies.
+pub const ROUTE_RESOLUTION_NONE: &str = "none";
+
+/// An accepted, grounded destination, as latched for `GET /destination/last`.
+#[derive(Clone, Debug, PartialEq)]
+pub struct AcceptedDestination {
+    /// Monotonic per-process sequence — a consumer applies a destination at
+    /// most once by tracking the last seq it consumed (the same apply-once
+    /// discipline as the intent latch).
+    pub seq: u64,
+    pub at_ms: u64,
+    /// The registry id or matched detector label.
+    pub destination_id: String,
+    pub kind: &'static str,
+    pub source: DestinationSource,
+    pub frame: GroundedFrame,
+    pub goal_pose: Pose,
+    /// Full ordered waypoint list for a saved route (Phase 1: informational —
+    /// `goal_pose` is the first waypoint only).
+    pub route_waypoints: Vec<Pose>,
+    pub route_resolution: &'static str,
+}
+
+impl AcceptedDestination {
+    /// The `GET /destination/last` wire form.
+    #[must_use]
+    pub fn to_wire(&self) -> String {
+        let map_id = match &self.frame {
+            GroundedFrame::Map(id) => serde_json::Value::String(id.clone()),
+            GroundedFrame::EgoRelative => serde_json::Value::Null,
+        };
+        serde_json::json!({
+            "destination": {
+                "destination_id": self.destination_id,
+                "kind": self.kind,
+                "source": self.source.as_str(),
+                "frame": self.frame.as_str(),
+                "map_id": map_id,
+                "goal_pose": {
+                    "x_m": self.goal_pose.x_m,
+                    "y_m": self.goal_pose.y_m,
+                    "heading_rad": self.goal_pose.heading_rad,
+                },
+                "route_waypoints": self.route_waypoints.iter().map(|w| serde_json::json!({
+                    "x_m": w.x_m, "y_m": w.y_m, "heading_rad": w.heading_rad,
+                })).collect::<Vec<_>>(),
+                "route_resolution": self.route_resolution,
+            },
+            "seq": self.seq,
+            "at_ms": self.at_ms,
+        })
+        .to_string()
+    }
+
+    /// The `POST /destination` success wire form — **admission only**. It
+    /// deliberately carries NO pose: the caller (a voice frontend) has no use
+    /// for coordinates and must not be able to read them back out, speak
+    /// them, or log them. The grounded pose lives on the doer-facing latch.
+    #[must_use]
+    pub fn to_post_wire(&self) -> String {
+        serde_json::json!({
+            "ok": true,
+            "seq": self.seq,
+            "at_ms": self.at_ms,
+            "outcome": "resolved",
+            "kind": self.kind,
+            "source": self.source.as_str(),
+            "route_resolution": self.route_resolution,
+        })
+        .to_string()
+    }
+
+    /// The grounded destination as an ordinary governed [`MickIntent::GoTo`]
+    /// — the #1293 conversion, so a consumer grounds it exactly like any
+    /// other goal and nothing downstream can tell where it came from.
+    ///
+    /// The caller MUST have honoured [`Self::frame`] first: a `Map` pose is
+    /// only a valid `GoTo` for a consumer localized in that map.
+    #[must_use]
+    pub fn to_goto(&self) -> MickIntent {
+        MickIntent::GoTo {
+            x_m: self.goal_pose.x_m,
+            y_m: self.goal_pose.y_m,
+        }
+    }
+}
+
+/// A refusal: the stable machine code plus the operator sentence. Every
+/// refusal means NO grounded destination and NO planner request.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DestinationRefusal {
+    pub code: String,
+    pub sentence: String,
+}
+
+impl DestinationRefusal {
+    #[must_use]
+    pub fn to_json(&self) -> String {
+        serde_json::json!({
+            "ok": false,
+            "error": self.code,
+            "detail": self.sentence,
+        })
+        .to_string()
+    }
+}
+
+/// The service core: trusted resolver + rate limit + frame-explicit latch.
+/// Single-threaded, like the serve loop that drives it.
+pub struct DestinationService {
+    resolver: DestinationResolver,
+    limiter: RateLimiter,
+    last: Option<AcceptedDestination>,
+    seq: u64,
+}
+
+impl DestinationService {
+    #[must_use]
+    pub fn new(resolver: DestinationResolver) -> Self {
+        Self {
+            resolver,
+            limiter: RateLimiter::new(DESTINATION_RATE_BURST, DESTINATION_RATE_PER_S),
+            last: None,
+            seq: 0,
+        }
+    }
+
+    /// The last accepted destination, if any (the `GET /destination/last`
+    /// source).
+    #[must_use]
+    pub fn last(&self) -> Option<&AcceptedDestination> {
+        self.last.as_ref()
+    }
+
+    /// Handle one typed-destination request at `now_ms`.
+    ///
+    /// On a resolved destination the grounded target is latched and `seq`
+    /// advances. On ANY refusal the latch is untouched — fail-closed, so a
+    /// consumer polling by seq sees nothing new and grounds nothing.
+    pub fn handle(
+        &mut self,
+        req: &DestinationRequest,
+        now_ms: u64,
+    ) -> Result<AcceptedDestination, DestinationRefusal> {
+        if !self.limiter.admit(now_ms) {
+            return Err(DestinationRefusal {
+                code: "DEST_RATE_LIMITED".to_string(),
+                sentence: "Please wait a moment before asking for another destination.".to_string(),
+            });
+        }
+        // Accept the object form or that object embedded as a JSON string —
+        // both land in the ONE fail-closed destination parse.
+        let raw = match req.destination.as_str() {
+            Some(s) => s.to_string(),
+            None => req.destination.to_string(),
+        };
+        let dref = DestinationRef::from_json(&raw).map_err(|code| DestinationRefusal {
+            code: code.to_string(),
+            sentence: "I couldn't validate that destination.".to_string(),
+        })?;
+
+        let targets: Vec<LabeledTarget> = req
+            .targets
+            .iter()
+            .map(|t| LabeledTarget {
+                label: t.label.clone(),
+                x_m: t.x,
+                y_m: t.y,
+                confidence: t.confidence,
+            })
+            .collect();
+        // An absent ego pose is the IDENTITY pose, which makes an object
+        // result ego-relative — the honest frame for a caller that supplied
+        // no localization, and the one the frame tag then reports.
+        let ego = req.ego.unwrap_or(EgoReq {
+            x: 0.0,
+            y: 0.0,
+            heading: 0.0,
+        });
+        let now = req.now_ms.unwrap_or(now_ms);
+
+        let outcome = self.resolver.resolve(
+            &dref,
+            &TargetView {
+                targets: &targets,
+                stamp_ms: req.targets_stamp_ms,
+            },
+            EgoView {
+                x_m: ego.x,
+                y_m: ego.y,
+                heading_rad: ego.heading,
+            },
+            now,
+        );
+
+        let grounded = match outcome {
+            ResolveOutcome::Resolved(g) => g,
+            refused => {
+                // FAIL-CLOSED: nothing mutates. Not `last`, not `seq`. An
+                // unchanged seq is what stops a consumer re-reading the
+                // previous destination as newly requested.
+                return Err(DestinationRefusal {
+                    code: refused.code().to_string(),
+                    sentence: refused.sentence(dref.query()),
+                });
+            }
+        };
+
+        let accepted = self.latch(&dref, grounded, now_ms);
+        Ok(accepted)
+    }
+
+    fn latch(
+        &mut self,
+        dref: &DestinationRef,
+        grounded: GroundedDestination,
+        at_ms: u64,
+    ) -> AcceptedDestination {
+        // The frame comes from the RESOLUTION, not the request: a registry
+        // hit is in that registry's map frame; a live sighting was lifted
+        // through the supplied ego pose.
+        let frame = match &grounded.map_id {
+            Some(id) => GroundedFrame::Map(id.clone()),
+            None => GroundedFrame::EgoRelative,
+        };
+        let route_resolution = if grounded.route_waypoints.is_empty() {
+            ROUTE_RESOLUTION_NONE
+        } else {
+            // Phase 1: `goal_pose` is the FIRST waypoint. Nothing sequences
+            // the remainder yet, and the marker says so on every wire read.
+            ROUTE_RESOLUTION_FIRST_WAYPOINT_ONLY
+        };
+        self.seq += 1;
+        let accepted = AcceptedDestination {
+            seq: self.seq,
+            at_ms,
+            destination_id: grounded.destination_id,
+            kind: kind_token(dref),
+            source: grounded.source,
+            frame,
+            goal_pose: grounded.goal_pose,
+            route_waypoints: grounded.route_waypoints,
+            route_resolution,
+        };
+        self.last = Some(accepted.clone());
+        accepted
+    }
+}
+
+fn kind_token(dref: &DestinationRef) -> &'static str {
+    match dref {
+        DestinationRef::NamedPlace { .. } => "named_place",
+        DestinationRef::SavedRoute { .. } => "saved_route",
+        DestinationRef::TrackedObject { .. } => "tracked_object",
+        DestinationRef::Address { .. } => "address",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::destination::{ObjectPolicy, PlaceRegistry, RouteRegistry};
+
+    const PLACES: &str = r#"{
+        "version": 1, "map_id": "r2-lab-01",
+        "places": [
+            {"id":"kitchen","name":"Kitchen","aliases":["the kitchen"],
+             "x_m":3.2,"y_m":-1.4,"heading_rad":0.0},
+            {"id":"charging-dock","name":"Charging Dock","aliases":["the dock"],
+             "x_m":0.5,"y_m":2.0,"heading_rad":0.0}
+        ]}"#;
+    const ROUTES: &str = r#"{
+        "version": 1, "map_id": "r2-lab-01",
+        "routes": [
+            {"id":"route-a","name":"Route A","aliases":["route alpha"],
+             "waypoints":[{"x_m":1.0,"y_m":0.0},{"x_m":2.0,"y_m":1.0}]}
+        ]}"#;
+
+    fn service() -> DestinationService {
+        DestinationService::new(DestinationResolver {
+            places: PlaceRegistry::from_json_str(PLACES).unwrap(),
+            routes: RouteRegistry::from_json_str(ROUTES).unwrap(),
+            object_policy: ObjectPolicy::default(),
+        })
+    }
+
+    fn req(kind: &str, query: &str) -> DestinationRequest {
+        DestinationRequest {
+            destination: serde_json::json!({"kind": kind, "query": query}),
+            ..Default::default()
+        }
+    }
+
+    // ---- resolved destinations latch, frame-explicit ------------------------
+
+    #[test]
+    fn a_named_place_resolves_latches_and_advances_seq() {
+        let mut svc = service();
+        let a = svc
+            .handle(&req("named_place", "the kitchen"), 5_000)
+            .unwrap();
+        assert_eq!(a.destination_id, "kitchen");
+        assert_eq!(a.kind, "named_place");
+        assert_eq!(a.source, DestinationSource::PlaceRegistry);
+        assert_eq!(a.frame, GroundedFrame::Map("r2-lab-01".into()));
+        assert_eq!(a.route_resolution, ROUTE_RESOLUTION_NONE);
+        assert_eq!(a.seq, 1);
+        assert_eq!(svc.last(), Some(&a));
+        // The trusted registry pose — never anything the caller supplied.
+        assert!((a.goal_pose.x_m - 3.2).abs() < 1e-12);
+        // The #1293 conversion: an ordinary governed GoTo.
+        assert_eq!(
+            a.to_goto(),
+            MickIntent::GoTo {
+                x_m: 3.2,
+                y_m: -1.4
+            }
+        );
+    }
+
+    /// The POST body a voice frontend sees carries ADMISSION only — no pose,
+    /// no map id, nothing speakable about where the robot is going.
+    #[test]
+    fn the_post_wire_carries_no_coordinates_or_map_details() {
+        let mut svc = service();
+        let a = svc.handle(&req("named_place", "kitchen"), 1_000).unwrap();
+        let body = a.to_post_wire();
+        let v: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(v["ok"], true);
+        assert_eq!(v["outcome"], "resolved");
+        for leak in [
+            "3.2",
+            "-1.4",
+            "x_m",
+            "y_m",
+            "goal_pose",
+            "r2-lab-01",
+            "map_id",
+        ] {
+            assert!(!body.contains(leak), "POST wire leaked {leak:?}: {body}");
+        }
+    }
+
+    /// The doer-facing latch DOES carry the pose — with the frame named, so a
+    /// map pose can never be silently read as ego-relative.
+    #[test]
+    fn the_latch_wire_names_its_frame() {
+        let mut svc = service();
+        let a = svc.handle(&req("named_place", "kitchen"), 1_000).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&a.to_wire()).unwrap();
+        assert_eq!(v["destination"]["frame"], "map");
+        assert_eq!(v["destination"]["map_id"], "r2-lab-01");
+        assert_eq!(v["seq"], 1);
+        assert!((v["destination"]["goal_pose"]["x_m"].as_f64().unwrap() - 3.2).abs() < 1e-12);
+    }
+
+    #[test]
+    fn a_saved_route_is_marked_first_waypoint_only() {
+        let mut svc = service();
+        let a = svc
+            .handle(&req("saved_route", "route alpha"), 1_000)
+            .unwrap();
+        assert_eq!(a.destination_id, "route-a");
+        assert_eq!(a.route_resolution, ROUTE_RESOLUTION_FIRST_WAYPOINT_ONLY);
+        assert_eq!(a.route_waypoints.len(), 2);
+        assert!(
+            (a.goal_pose.x_m - 1.0).abs() < 1e-12,
+            "the goal is the FIRST waypoint"
+        );
+        // The marker rides the wire both ways, so nothing can imply the whole
+        // route is under way.
+        assert!(a
+            .to_post_wire()
+            .contains(ROUTE_RESOLUTION_FIRST_WAYPOINT_ONLY));
+        assert!(a.to_wire().contains(ROUTE_RESOLUTION_FIRST_WAYPOINT_ONLY));
+    }
+
+    /// A tracked object supplied by a perception-aware caller resolves, and
+    /// with no ego pose the result is honestly tagged EGO-relative.
+    #[test]
+    fn a_fresh_tracked_object_resolves_ego_relative_with_a_standoff() {
+        let mut svc = service();
+        let r = DestinationRequest {
+            destination: serde_json::json!({"kind": "tracked_object", "class": "cup", "color": "red"}),
+            targets: vec![TargetReq {
+                label: "red cup".into(),
+                x: 4.0,
+                y: 0.0,
+                confidence: 0.9,
+            }],
+            targets_stamp_ms: Some(1_000),
+            now_ms: Some(1_000),
+            ego: None,
+        };
+        let a = svc.handle(&r, 1_000).unwrap();
+        assert_eq!(a.kind, "tracked_object");
+        assert_eq!(a.frame, GroundedFrame::EgoRelative);
+        assert_eq!(a.source, DestinationSource::ObjectTrack);
+        // 4 m ahead, 0.75 m standoff → 3.25 m ahead: it approaches, never parks on it.
+        assert!((a.goal_pose.x_m - 3.25).abs() < 1e-9, "{}", a.goal_pose.x_m);
+    }
+
+    // ---- every refusal is fail-closed --------------------------------------
+
+    #[test]
+    fn every_refusal_leaves_the_latch_and_seq_untouched() {
+        let mut svc = service();
+        // Establish a good latch first, so "untouched" is a real assertion.
+        let good = svc.handle(&req("named_place", "kitchen"), 1_000).unwrap();
+        assert_eq!(good.seq, 1);
+
+        let cases: Vec<(DestinationRequest, &str)> = vec![
+            (req("named_place", "garage"), "DEST_NOT_FOUND"),
+            (req("saved_route", "route zulu"), "DEST_NOT_FOUND"),
+            (
+                req("address", "125 Main Street"),
+                "DEST_UNSUPPORTED_ADDRESS",
+            ),
+            // No camera frame supplied → STALE ("the detector did not look"),
+            // never "it isn't there".
+            (req("tracked_object", "red cup"), "DEST_STALE"),
+        ];
+        // Space the requests past the token-bucket burst so a refusal is
+        // charged to the resolver, not the rate limiter.
+        for (i, (r, code)) in cases.into_iter().enumerate() {
+            let t = 10_000 + i as u64 * 5_000;
+            let e = svc.handle(&r, t).expect_err("must refuse");
+            assert_eq!(e.code, code, "wrong code for case {i}");
+            assert!(!e.sentence.is_empty(), "a refusal must be speakable");
+            assert_eq!(svc.last(), Some(&good), "refusal {i} changed the latch");
+            assert_eq!(svc.last().unwrap().seq, 1, "refusal {i} advanced seq");
+        }
+    }
+
+    /// The core rule at the live seam: a caller cannot smuggle geometry
+    /// through the language channel, and the refusal is LOUD.
+    #[test]
+    fn smuggled_coordinates_are_refused_with_the_distinct_code() {
+        let mut svc = service();
+        let r = DestinationRequest {
+            destination: serde_json::json!({"kind":"named_place","query":"kitchen","x_m":9.0}),
+            ..Default::default()
+        };
+        let e = svc.handle(&r, 1_000).expect_err("must refuse");
+        assert_eq!(e.code, "DEST_COORDINATES_FORBIDDEN");
+        assert!(svc.last().is_none(), "a smuggled request must not latch");
+    }
+
+    #[test]
+    fn a_malformed_destination_object_fails_closed() {
+        let mut svc = service();
+        for bad in [
+            serde_json::json!("drive somewhere nice"),
+            serde_json::json!({"kind": "teleport", "query": "moon"}),
+            serde_json::json!({"kind": "named_place", "query": "  "}),
+            serde_json::json!({"kind": "tracked_object", "color": "red"}),
+        ] {
+            let r = DestinationRequest {
+                destination: bad.clone(),
+                ..Default::default()
+            };
+            let e = svc.handle(&r, 1_000).expect_err("must refuse");
+            assert!(e.code.starts_with("DEST_"), "{bad} → {}", e.code);
+            assert!(svc.last().is_none(), "{bad} latched");
+        }
+    }
+
+    #[test]
+    fn the_string_embedded_form_parses_identically() {
+        let mut svc = service();
+        let r = DestinationRequest {
+            destination: serde_json::json!(r#"{"kind":"named_place","query":"kitchen"}"#),
+            ..Default::default()
+        };
+        assert_eq!(svc.handle(&r, 1_000).unwrap().destination_id, "kitchen");
+    }
+
+    /// Two identical spoken requests produce two DISTINCT sequence numbers —
+    /// a consumer applies each at most once and never re-applies an old one.
+    #[test]
+    fn each_accepted_request_advances_the_sequence_exactly_once() {
+        let mut svc = service();
+        let a = svc.handle(&req("named_place", "kitchen"), 1_000).unwrap();
+        let b = svc.handle(&req("named_place", "the dock"), 10_000).unwrap();
+        assert_eq!((a.seq, b.seq), (1, 2));
+        assert_eq!(svc.last().unwrap().destination_id, "charging-dock");
+    }
+
+    #[test]
+    fn a_flood_is_shed_before_the_resolver() {
+        let mut svc = service();
+        let mut shed = 0;
+        for _ in 0..10 {
+            if svc
+                .handle(&req("named_place", "kitchen"), 10_000)
+                .err()
+                .is_some_and(|e| e.code == "DEST_RATE_LIMITED")
+            {
+                shed += 1;
+            }
+        }
+        assert!(shed >= 6, "the burst bound must shed a flood: {shed}");
+    }
+
+    #[test]
+    fn an_empty_resolver_refuses_registry_kinds_without_a_latch() {
+        let mut svc = DestinationService::new(DestinationResolver::default());
+        let e = svc
+            .handle(&req("named_place", "kitchen"), 1_000)
+            .expect_err("no registry must refuse");
+        assert_eq!(e.code, "DEST_NO_REGISTRY");
+        assert!(svc.last().is_none());
+    }
+}

--- a/crates/kirra-sidecars/src/destination_service.rs
+++ b/crates/kirra-sidecars/src/destination_service.rs
@@ -66,11 +66,16 @@ pub struct DestinationRequest {
     pub targets: Vec<TargetReq>,
     /// Producer stamp of the frame `targets` came from. Absent while a
     /// tracked object is requested → STALE, never "not seen".
+    ///
+    /// 🔴 There is deliberately NO companion "now" field: freshness is always
+    /// judged against the SERVICE clock. A caller-supplied clock would let a
+    /// client make a stale (or future-stamped) sighting look fresh, which is
+    /// a fail-OPEN on the one gate that decides whether a sighting is a
+    /// present location (review: Copilot on #1294). The stateless
+    /// `/plan` seam can take a caller clock because it grounds nothing on its
+    /// own; this endpoint latches a target for a consumer to act on.
     #[serde(default)]
     pub targets_stamp_ms: Option<u64>,
-    /// Consumer clock for the freshness check. Absent → the service clock.
-    #[serde(default)]
-    pub now_ms: Option<u64>,
     /// Ego pose the object sighting is lifted through. Absent → the identity
     /// pose, which makes an object result EGO-FRAME.
     #[serde(default)]
@@ -83,11 +88,14 @@ pub struct TargetReq {
     pub label: String,
     pub x: f64,
     pub y: f64,
-    #[serde(default = "default_confidence")]
+    /// Detector confidence in `[0, 1]`.
+    ///
+    /// 🔴 Defaults to ZERO, not one: an omitted confidence is "the producer
+    /// told us nothing", and treating that as maximum confidence would let an
+    /// unlabelled target walk straight through the `min_confidence` gate. A
+    /// producer that means "certain" must say so (review: Copilot on #1294).
+    #[serde(default)]
     pub confidence: f32,
-}
-fn default_confidence() -> f32 {
-    1.0
 }
 
 /// The caller's ego pose (world frame).
@@ -304,7 +312,9 @@ impl DestinationService {
             y: 0.0,
             heading: 0.0,
         });
-        let now = req.now_ms.unwrap_or(now_ms);
+        // Freshness is judged against the SERVICE clock, never a caller's —
+        // see `DestinationRequest::targets_stamp_ms`.
+        let now = now_ms;
 
         let outcome = self.resolver.resolve(
             &dref,
@@ -516,7 +526,6 @@ mod tests {
                 confidence: 0.9,
             }],
             targets_stamp_ms: Some(1_000),
-            now_ms: Some(1_000),
             ego: None,
         };
         let a = svc.handle(&r, 1_000).unwrap();
@@ -627,6 +636,73 @@ mod tests {
             }
         }
         assert!(shed >= 6, "the burst bound must shed a flood: {shed}");
+    }
+
+    /// Freshness is judged on the SERVICE clock. A caller cannot supply a
+    /// "now" that makes an old sighting look present — the fail-open a
+    /// caller-controlled clock would have opened (review: Copilot on #1294).
+    #[test]
+    fn a_caller_cannot_make_a_stale_sighting_look_fresh() {
+        let object = |stamp: u64| DestinationRequest {
+            destination: serde_json::json!({"kind":"tracked_object","class":"cup"}),
+            targets: vec![TargetReq {
+                label: "cup".into(),
+                x: 3.0,
+                y: 0.0,
+                confidence: 0.9,
+            }],
+            targets_stamp_ms: Some(stamp),
+            ego: None,
+        };
+        // The sighting is 60 s old against the service clock → STALE, and no
+        // field on the request can change that verdict.
+        let mut svc = service();
+        assert_eq!(
+            svc.handle(&object(1_000), 61_000)
+                .expect_err("must refuse")
+                .code,
+            "DEST_STALE"
+        );
+        assert!(svc.last().is_none());
+        // Non-vacuity: the SAME sighting inside the budget resolves.
+        let mut svc = service();
+        assert!(svc.handle(&object(1_000), 1_500).is_ok());
+        // A FUTURE-stamped frame (a non-monotonic producer clock) is stale too.
+        let mut svc = service();
+        assert_eq!(
+            svc.handle(&object(90_000), 1_000)
+                .expect_err("must refuse")
+                .code,
+            "DEST_STALE"
+        );
+    }
+
+    /// An omitted confidence is not "certain". A target whose producer said
+    /// nothing must not clear the confidence floor.
+    #[test]
+    fn an_omitted_confidence_fails_closed_rather_than_counting_as_certain() {
+        let mut svc = service();
+        let req: DestinationRequest = serde_json::from_str(
+            r#"{"destination":{"kind":"tracked_object","class":"cup"},
+                "targets":[{"label":"cup","x":3.0,"y":0.0}],
+                "targets_stamp_ms":1000}"#,
+        )
+        .expect("the wire form parses without a confidence");
+        assert_eq!(req.targets[0].confidence, 0.0, "omitted confidence is ZERO");
+        assert_eq!(
+            svc.handle(&req, 1_500).expect_err("must refuse").code,
+            "DEST_LOW_CONFIDENCE"
+        );
+        assert!(svc.last().is_none());
+        // Non-vacuity: the same target WITH a stated confidence resolves.
+        let mut svc = service();
+        let req: DestinationRequest = serde_json::from_str(
+            r#"{"destination":{"kind":"tracked_object","class":"cup"},
+                "targets":[{"label":"cup","x":3.0,"y":0.0,"confidence":0.9}],
+                "targets_stamp_ms":1000}"#,
+        )
+        .unwrap();
+        assert!(svc.handle(&req, 1_500).is_ok());
     }
 
     #[test]

--- a/crates/kirra-sidecars/src/lib.rs
+++ b/crates/kirra-sidecars/src/lib.rs
@@ -24,6 +24,7 @@
 pub mod capabilities;
 pub mod chat;
 pub mod destination;
+pub mod destination_service;
 pub mod http;
 pub mod mick;
 pub mod mick_fence;

--- a/crates/kirra-sidecars/src/planner.rs
+++ b/crates/kirra-sidecars/src/planner.rs
@@ -249,11 +249,16 @@ pub struct TargetReq {
     pub label: String,
     pub x: f64,
     pub y: f64,
-    #[serde(default = "default_target_confidence")]
+    /// Detector confidence in `[0, 1]`.
+    ///
+    /// 🔴 Defaults to ZERO, not one: an omitted confidence means the producer
+    /// told us nothing, and treating that as maximum confidence would let an
+    /// unlabelled target walk straight through the `min_confidence` gate. A
+    /// producer that means "certain" must say so. (Review: Copilot on #1294
+    /// raised this on the destination endpoint's identical field; the same
+    /// fail-open lived here, feeding the same gate.)
+    #[serde(default)]
     pub confidence: f32,
-}
-fn default_target_confidence() -> f32 {
-    1.0
 }
 fn default_cruise() -> f64 {
     10.0

--- a/crates/kirra-sidecars/tests/voice_destination_governed_path.rs
+++ b/crates/kirra-sidecars/tests/voice_destination_governed_path.rs
@@ -1,0 +1,319 @@
+//! **The live voice-to-destination path, end to end through the governed
+//! seam** — the integration proof for the typed-destination integration.
+//!
+//! What this pins, in ONE chain and without touching actuation:
+//!
+//! ```text
+//!   typed DestinationRef  (what the voice router is allowed to say)
+//!     → DestinationService  (the trusted resolver + the frame-explicit latch)
+//!     → MickIntent::GoTo    (the ordinary governed intent — the #1293 conversion)
+//!     → handle_plan_with_destinations  (Occy + the KIRRA slow-loop checker)
+//! ```
+//!
+//! The load-bearing negatives are here too: an unresolved / ambiguous / stale
+//! / unsupported destination produces NO grounded target, and a plan request
+//! carrying that same unresolved destination produces NO MOTION — an empty
+//! trajectory behind a stable `DEST_*` code, never a fallback goal.
+//!
+//! Nothing in this file (or its crate) can reach a motor: `kirra-sidecars` is
+//! fenced by `ci/check_mick_actuation_fence.py`.
+
+use kirra_planner::MickIntent;
+use kirra_sidecars::destination::{
+    DestinationResolver, ObjectPolicy, PlaceRegistry, RouteRegistry,
+};
+use kirra_sidecars::destination_service::{
+    DestinationRequest, DestinationService, GroundedFrame, TargetReq,
+    ROUTE_RESOLUTION_FIRST_WAYPOINT_ONLY,
+};
+use kirra_sidecars::planner::{
+    handle_plan_with_destinations, EgoReq, PerceptionFrameIdReq, PlanRequest, Xy,
+};
+
+/// A calibrated lab: one place well inside the corridor the plan request
+/// supplies, and one saved route.
+const PLACES: &str = r#"{
+    "version": 1, "map_id": "r2-lab-01",
+    "places": [
+        {"id":"kitchen","name":"Kitchen","aliases":["the kitchen"],
+         "x_m":40.0,"y_m":0.0,"heading_rad":0.0}
+    ]}"#;
+const ROUTES: &str = r#"{
+    "version": 1, "map_id": "r2-lab-01",
+    "routes": [
+        {"id":"route-a","name":"Route A","aliases":["route alpha"],
+         "waypoints":[{"x_m":20.0,"y_m":0.0},{"x_m":40.0,"y_m":1.0}]}
+    ]}"#;
+
+fn resolver() -> DestinationResolver {
+    DestinationResolver {
+        places: PlaceRegistry::from_json_str(PLACES).expect("places"),
+        routes: RouteRegistry::from_json_str(ROUTES).expect("routes"),
+        object_policy: ObjectPolicy::default(),
+    }
+}
+
+/// The typed request a voice router would send — kind + the operator's words.
+fn voice_says(kind: &str, query: &str) -> DestinationRequest {
+    DestinationRequest {
+        destination: serde_json::json!({"kind": kind, "query": query}),
+        ..Default::default()
+    }
+}
+
+fn plan_request(destination: Option<serde_json::Value>) -> PlanRequest {
+    PlanRequest {
+        perception_frame_id: Some(PerceptionFrameIdReq {
+            scan_sequence: 7,
+            camera_sequence: Some(11),
+            tracker_generation: 3,
+            profile_digest: "a".repeat(64),
+            evidence_digest: "b".repeat(64),
+        }),
+        ego: EgoReq {
+            x: 2.0,
+            y: 0.0,
+            heading: 0.0,
+            speed: 1.0,
+        },
+        goal: Xy { x: 40.0, y: 0.0 },
+        cruise: 3.0,
+        left: vec![[-5.0, 5.0], [100.0, 5.0]],
+        right: vec![[-5.0, -5.0], [100.0, -5.0]],
+        objects: vec![],
+        pedestrians: vec![],
+        predicted_vrus: vec![],
+        vehicle: None,
+        intent: None,
+        object_goal: None,
+        destination,
+        targets: vec![],
+        targets_stamp_ms: None,
+        now_ms: None,
+    }
+}
+
+/// THE headline chain: "drive to the kitchen" resolves to a trusted registry
+/// pose, becomes an ordinary governed `GoTo`, and the SAME typed destination
+/// plans + passes the checker at the planner seam.
+#[test]
+fn a_spoken_named_place_grounds_through_the_resolver_and_plans() {
+    let mut svc = DestinationService::new(resolver());
+
+    // 1. The voice layer's whole contribution: a kind and a name.
+    let accepted = svc
+        .handle(&voice_says("named_place", "the kitchen"), 1_000)
+        .expect("a calibrated place resolves");
+
+    // 2. The TRUSTED resolver — not the caller — supplied the coordinates,
+    //    and the frame is named so nothing downstream can misread them.
+    assert_eq!(accepted.destination_id, "kitchen");
+    assert_eq!(accepted.frame, GroundedFrame::Map("r2-lab-01".into()));
+    assert_eq!(
+        accepted.to_goto(),
+        MickIntent::GoTo {
+            x_m: 40.0,
+            y_m: 0.0
+        },
+        "the #1293 conversion: an ordinary governed GoTo"
+    );
+
+    // 3. The same typed destination at the planner seam: Occy grounds it and
+    //    the KIRRA slow-loop checker bounds it. A drivable corridor admits it.
+    let resp = handle_plan_with_destinations(
+        &plan_request(Some(
+            serde_json::json!({"kind":"named_place","query":"the kitchen"}),
+        )),
+        &resolver(),
+    )
+    .expect("the grounded destination plans");
+    assert!(
+        resp.admitted && !resp.trajectory.is_empty(),
+        "an admitted plan carries its trajectory: {} / {}",
+        resp.verdict,
+        resp.trajectory.len()
+    );
+    let echo = resp.destination.expect("provenance is echoed");
+    assert_eq!(echo.destination_id, "kitchen");
+    assert_eq!(echo.source, "place_registry");
+    // The proposal is ADVISORY — authority stays with the release-token
+    // chokepoint and the verifying consumer, in other processes.
+    assert!(resp.advisory);
+}
+
+/// A saved route grounds to its FIRST waypoint only, and says so at every
+/// layer — the latch, the admission body, and the planner echo.
+#[test]
+fn a_spoken_saved_route_is_marked_first_waypoint_only_everywhere() {
+    let mut svc = DestinationService::new(resolver());
+    let accepted = svc
+        .handle(&voice_says("saved_route", "route alpha"), 1_000)
+        .expect("a calibrated route resolves");
+    assert_eq!(
+        accepted.route_resolution,
+        ROUTE_RESOLUTION_FIRST_WAYPOINT_ONLY
+    );
+    assert_eq!(
+        accepted.goal_pose.x_m, 20.0,
+        "the FIRST waypoint is the goal"
+    );
+    assert!(accepted
+        .to_post_wire()
+        .contains(ROUTE_RESOLUTION_FIRST_WAYPOINT_ONLY));
+
+    let resp = handle_plan_with_destinations(
+        &plan_request(Some(
+            serde_json::json!({"kind":"saved_route","query":"route alpha"}),
+        )),
+        &resolver(),
+    )
+    .expect("the route's first waypoint plans");
+    let echo = resp.destination.expect("provenance is echoed");
+    assert_eq!(
+        echo.route_waypoints.len(),
+        2,
+        "the whole route rides the echo"
+    );
+    assert_eq!(echo.source, "route_registry");
+}
+
+/// A tracked object supplied by a PERCEPTION-AWARE caller resolves to a
+/// standoff goal. The voice router supplies no targets, which is why the
+/// voice path gets `Stale` (proved below) rather than a guess.
+#[test]
+fn a_tracked_object_from_a_perception_aware_caller_grounds_with_a_standoff() {
+    let mut svc = DestinationService::new(resolver());
+    let req = DestinationRequest {
+        destination: serde_json::json!({"kind":"tracked_object","class":"cup","color":"red"}),
+        targets: vec![TargetReq {
+            label: "red cup".into(),
+            x: 4.0,
+            y: 0.0,
+            confidence: 0.9,
+        }],
+        targets_stamp_ms: Some(1_000),
+        now_ms: Some(1_000),
+        ego: None,
+    };
+    let accepted = svc.handle(&req, 1_000).expect("a fresh sighting resolves");
+    assert_eq!(accepted.frame, GroundedFrame::EgoRelative);
+    assert!(
+        (accepted.goal_pose.x_m - 3.25).abs() < 1e-9,
+        "0.75 m standoff short of a 4 m cup: {}",
+        accepted.goal_pose.x_m
+    );
+}
+
+/// EVERY refusal produces no grounded target AND no motion at the planner
+/// seam — the fail-closed half of the live path, in one table.
+#[test]
+fn every_unresolved_destination_yields_no_target_and_no_motion() {
+    let mut svc = DestinationService::new(resolver());
+    let cases: [(serde_json::Value, &str); 4] = [
+        (
+            serde_json::json!({"kind":"named_place","query":"garage"}),
+            "DEST_NOT_FOUND",
+        ),
+        (
+            serde_json::json!({"kind":"saved_route","query":"route zulu"}),
+            "DEST_NOT_FOUND",
+        ),
+        (
+            serde_json::json!({"kind":"address","query":"125 Main Street"}),
+            "DEST_UNSUPPORTED_ADDRESS",
+        ),
+        (
+            // No camera frame → STALE. "The detector did not look" is never
+            // "it isn't there" — this is the voice path's object outcome.
+            serde_json::json!({"kind":"tracked_object","class":"cup","color":"red"}),
+            "DEST_STALE",
+        ),
+    ];
+
+    for (i, (dest, code)) in cases.iter().enumerate() {
+        // (a) the resolver seam: a refusal, and NOTHING latched.
+        let refusal = svc
+            .handle(
+                &DestinationRequest {
+                    destination: dest.clone(),
+                    ..Default::default()
+                },
+                10_000 + i as u64 * 5_000,
+            )
+            .expect_err("must refuse");
+        assert_eq!(&refusal.code, code, "case {i}");
+        assert!(
+            !refusal.sentence.is_empty(),
+            "case {i}: a refusal must be speakable"
+        );
+        assert!(svc.last().is_none(), "case {i}: a refusal must not latch");
+
+        // (b) the planner seam: the SAME destination is refused to NO MOTION,
+        //     never a fallback to the request's own goal.
+        let rej = handle_plan_with_destinations(&plan_request(Some(dest.clone())), &resolver())
+            .expect_err("case {i}: must refuse at the planner seam");
+        assert_eq!(rej.code, *code, "case {i}");
+        let wire: serde_json::Value = serde_json::from_str(&rej.to_json()).unwrap();
+        assert_eq!(wire["kind"], "SafeStop", "case {i}");
+        assert_eq!(
+            wire["trajectory"].as_array().map(Vec::len),
+            Some(0),
+            "case {i}: no motion may ride an unresolved destination"
+        );
+    }
+}
+
+/// The core rule at the live seam: geometry offered through the language
+/// channel is refused LOUDLY, at both the resolver and the planner.
+#[test]
+fn smuggled_coordinates_are_refused_at_every_door() {
+    let smuggled = serde_json::json!({"kind":"named_place","query":"kitchen","x_m":9.0,"y_m":9.0});
+    let mut svc = DestinationService::new(resolver());
+    assert_eq!(
+        svc.handle(
+            &DestinationRequest {
+                destination: smuggled.clone(),
+                ..Default::default()
+            },
+            1_000
+        )
+        .expect_err("resolver must refuse")
+        .code,
+        "DEST_COORDINATES_FORBIDDEN"
+    );
+    assert!(svc.last().is_none());
+    assert_eq!(
+        handle_plan_with_destinations(&plan_request(Some(smuggled)), &resolver())
+            .expect_err("planner seam must refuse")
+            .code,
+        "DEST_COORDINATES_FORBIDDEN"
+    );
+}
+
+/// Apply-once: each accepted destination advances the sequence exactly once,
+/// so a consumer polling the latch can never re-apply an old target — and a
+/// refusal in between does not move the sequence at all.
+#[test]
+fn the_latch_sequence_advances_once_per_accepted_destination() {
+    let mut svc = DestinationService::new(resolver());
+    let first = svc
+        .handle(&voice_says("named_place", "kitchen"), 1_000)
+        .expect("resolves");
+    assert_eq!(first.seq, 1);
+
+    // A refusal between two acceptances must not advance anything.
+    assert!(svc
+        .handle(&voice_says("named_place", "garage"), 10_000)
+        .is_err());
+    assert_eq!(
+        svc.last().unwrap().seq,
+        1,
+        "a refusal advanced the sequence"
+    );
+
+    let second = svc
+        .handle(&voice_says("saved_route", "route alpha"), 20_000)
+        .expect("resolves");
+    assert_eq!(second.seq, 2);
+    assert_eq!(svc.last().unwrap().destination_id, "route-a");
+}

--- a/crates/kirra-sidecars/tests/voice_destination_governed_path.rs
+++ b/crates/kirra-sidecars/tests/voice_destination_governed_path.rs
@@ -192,7 +192,6 @@ fn a_tracked_object_from_a_perception_aware_caller_grounds_with_a_standoff() {
             confidence: 0.9,
         }],
         targets_stamp_ms: Some(1_000),
-        now_ms: Some(1_000),
         ego: None,
     };
     let accepted = svc.handle(&req, 1_000).expect("a fresh sighting resolves");

--- a/docs/hardware/R2_DESTINATIONS.md
+++ b/docs/hardware/R2_DESTINATIONS.md
@@ -4,6 +4,84 @@
 trusted resolver chooses the actual coordinates. The LLM never invents map
 coordinates, object poses, addresses, or routes.**
 
+## The live voice path
+
+Destination-shaped speech no longer goes to the ordinary `/intent` door (where
+a model would have had to invent a goal point). It routes to the typed
+destination door:
+
+```
+wake phrase → bounded capture → STT
+  → voice_route.classify_transcript      (PURE, deterministic — no LLM)
+      ├─ conversation      → POST /chat/stream
+      ├─ explicit motion   → POST /intent            (unchanged)
+      ├─ semantic destination
+      │     → typed DestinationRef {"kind":…, "query":…}
+      │     → POST /destination  (mick_service)
+      │        → DestinationRef::parse_json   (the ONE fail-closed parse)
+      │        → DestinationResolver          (the ONLY source of coordinates)
+      │        → grounded target latched on GET /destination/last
+      │        → ordinary MickIntent::GoTo → Occy → KIRRA checker → release
+      │                                       → verifying consumer
+      └─ ambiguous         → a fixed local clarification, NO endpoint
+```
+
+**One transcript reaches at most one endpoint.** A destination that does not
+resolve produces **no planner request at all** — there is no fallback to
+`/intent`, no fallback to chat, and no retry (a retry could duplicate an
+accepted grounded target).
+
+The voice router has **zero motion authority and never creates a coordinate**:
+it sends a kind plus the operator's own words, and the success body it gets
+back carries no pose — so there is nothing for it to speak, log, or leak. The
+grounded pose lives only on the doer-facing latch.
+
+### Spoken outcomes
+
+| resolver outcome | spoken line |
+|---|---|
+| resolved | "Destination accepted for governed navigation." |
+| resolved (saved route) | "Destination accepted for governed navigation, first waypoint only." |
+| `DEST_NOT_FOUND` / `DEST_NO_REGISTRY` / `DEST_NOT_SEEN` | "I don't have a configured location matching that request." |
+| `DEST_AMBIGUOUS` | "That destination is ambiguous. Please be more specific." |
+| `DEST_STALE` / `DEST_LOW_CONFIDENCE` | "I no longer have a fresh position for that object." |
+| `DEST_UNSUPPORTED_ADDRESS` | "Address routing isn't configured on this robot." |
+| unreachable service | "The destination service is unavailable." |
+| malformed / unknown code | "I couldn't validate that destination." |
+
+Acceptance is **admission, not execution**: the ack never claims the robot
+moved or arrived. Every line is spoken through the existing `PlaybackGuard`,
+so the robot cannot hear its own acknowledgement and start another turn.
+
+### The phrase grammar (deliberately small, pure, no LLM)
+
+| said | typed request |
+|---|---|
+| "drive to the kitchen", "go to the charging dock", "take me to the workshop", "navigate to the front door", "head to the garage" | `{"kind":"named_place","query":"kitchen"}` |
+| "run route A", "follow route A", "take route A", "start patrol route", "follow the perimeter route" | `{"kind":"saved_route","query":"route a"}` |
+| "drive to the red cup", "go to the blue chair", "move near the person", "navigate to the box" | `{"kind":"tracked_object","class":"cup","color":"red"}` |
+| "drive to 125 Main Street" | `{"kind":"address","query":"125 Main Street"}` |
+
+Wake phrases, courtesy prefixes and articles are stripped; meaningful
+destination words are not. The object vocabulary is a **closed** list of
+classes and colours — free-form scene description is out of scope, and an
+unrecognised thing falls through to `named_place` where the registry refuses
+it. An address needs a leading house number **and** a street suffix.
+
+These never become destinations: "what is the kitchen used for", "tell me
+about Route 66", "where is the red cup", "what do you see near the chair",
+"explain how address routing works", "tell me about the kitchen", "what is
+route planning", "describe a red cup" (all conversation), and "go there",
+"take me there", "drive to it", "run it", "follow that" (all **ambiguous** —
+a pronoun names nothing, so the robot asks rather than guesses). "Drive
+forward one meter", "turn left", "stop" and "pull over" remain ordinary
+motion on `/intent`.
+
+**Reclassification note.** "go to the loading dock" / "take me to the dock"
+were `MOTION` before this integration and are now `DESTINATION`. That is the
+point: they name a place, and a place must be grounded by the trusted
+resolver rather than by a model guessing a goal point.
+
 Before this system, a spoken "drive to the kitchen" reached Mick's LLM, which
 could only answer with a `go_to`/`route_to` intent — i.e. with coordinates it
 made up. The typed destination layer replaces that with a typed, fail-closed
@@ -134,6 +212,40 @@ stale, so I won't drive on it"); a stale position is never driven to.
 Malformed knob values ABORT startup (`ObjectPolicy::validated`), never
 silently default.
 
+## mick_service wiring (the voice-facing door)
+
+```
+POST /destination  {"destination":{"kind":"named_place","query":"kitchen"},
+                    "targets"?:[…], "targets_stamp_ms"?, "ego"?}
+  → 200 {"ok":true,"seq":n,"outcome":"resolved","kind":…,"route_resolution":…}
+        ADMISSION ONLY — no pose, no map id
+  → 422 {"ok":false,"error":"DEST_…","detail":"<operator sentence>"}
+        fail-closed: NOTHING latched, seq unchanged
+  → 429 {"ok":false,"error":"DEST_RATE_LIMITED"}
+
+GET /destination/last → {"destination":{…,"frame":"map"|"ego",…},"seq":n}
+```
+
+`mick_service` reads the **same** `KIRRA_DEST_*` registry/policy vars as
+`planner_service` (`destination::resolver_from_env`) — one config path, so two
+processes can never disagree about what "the kitchen" means. A malformed value
+or an invalid registry aborts startup.
+
+**The latch is frame-explicit, and deliberately its own channel.** A registry
+pose is in the registry's map frame; `GET /intent/last` is consumed by
+`occy_doer` as **ego-frame at receipt**. Publishing a map pose there would be
+silently misread as ego-relative and aim the robot at the wrong place — so
+grounded destinations ride `GET /destination/last` with an explicit `frame`
+(`map` + `map_id`, or `ego`), and a consumer must understand the frame before
+it can use the pose.
+
+**Tracked objects need a perception-aware caller.** `mick_service` has no
+perception (it is inside the actuation fence — no ROS, no camera). Object
+resolution runs against the `targets` the *caller* supplies. The voice router
+supplies none, so an object destination spoken today resolves `DEST_STALE` —
+"the detector did not look" is never "it isn't there". Relaying live targets
+is the deferred doer-bridge step below.
+
 ## planner_service wiring
 
 `POST /plan` accepts an opt-in `destination` field (the `DestinationRef`
@@ -171,15 +283,34 @@ python3 robot/location_registry.py lookup "the dock" --places places.json
 Read-only; validation mirrors the resolver's rules (the Rust resolver
 remains authoritative — it re-validates at load).
 
+## Verification discipline
+
+**Keep the planner parked for initial verification.** With
+`kirra-planner.service` stopped, every step below exercises voice → typed
+destination → trusted resolver → refusal-or-admission and the robot cannot
+move. That is deliberate: the resolver round trip is what this integration
+adds, and it is verifiable without motion.
+
+Do **not** claim voice-to-destination navigation works on hardware until a
+real calibrated destination resolves *and* the full governed chain (Occy →
+checker → release token → verifying consumer) has been observed end to end.
+
 ## Deferred (documented, not wired in this slice)
 
-* **Live voice-loop rewiring** — the R2 voice router still sends
-  destination-shaped motion text to `POST /intent` (where the model answers
-  with a typed intent). Routing "go to X" through `destination_schema()` +
-  `DestinationRef` into the planner's `destination` channel needs the
-  mick-service endpoint + occy_doer bridge changes, done as its own slice.
+* **Doer-bridge consumption of the grounded latch** — `occy_doer` polls
+  `GET /intent/last` (ego-frame) and does not yet read
+  `GET /destination/last`. Consuming it requires honouring the explicit
+  `frame`: a `map` pose is usable only by a consumer localized against that
+  `map_id`. Until then a grounded destination is resolved, latched and
+  auditable, but is not yet picked up by the ROS doer.
+* **Live target relay for object destinations** — the voice path supplies no
+  `targets`, so spoken object destinations resolve `DEST_STALE`. A
+  perception-aware caller (the doer bridge) supplying `targets` +
+  `targets_stamp_ms` gets full standoff resolution today.
 * **Waypoint sequencing** for saved routes (mission layer receding-horizon
-  advance past the first waypoint).
+  advance past the first waypoint). Phase 1 grounds the FIRST waypoint only
+  and marks it `route_resolution=first_waypoint_only` on every wire read, in
+  the logs, and in the spoken acknowledgement.
 * **Map identity plumbing** — the plan request carries no map id today; the
   grounded `map_id` is echoed so a localized caller can check it.
 * **Address resolution** — requires a trusted geocoding source + map

--- a/robot/voice_route.py
+++ b/robot/voice_route.py
@@ -36,13 +36,42 @@ from enum import Enum
 class RouteKind(Enum):
     CONVERSATION = "conversation"
     MOTION = "motion"
+    DESTINATION = "destination"
     AMBIGUOUS = "ambiguous"
+
+
+@dataclass(frozen=True)
+class DestinationRequest:
+    """A TYPED destination request — a kind plus the operator's words.
+
+    🔴 There is no coordinate field, and there is no code path in this module
+    that could produce one: naming a destination is all language is allowed to
+    do. The trusted resolver (`kirra-sidecars/src/destination.rs`, behind
+    `POST /destination`) is the ONLY thing that turns a name into a pose.
+
+    `class_`/`color` are set ONLY for `tracked_object`, from a deliberately
+    small closed vocabulary; every other kind carries `query` alone.
+    """
+    kind: str                      # named_place | saved_route | tracked_object | address
+    query: str | None = None
+    class_: str | None = None
+    color: str | None = None
+
+    def to_wire(self) -> dict:
+        """The exact `destination` object POSTed to the resolver."""
+        if self.kind == "tracked_object" and self.class_:
+            wire = {"kind": self.kind, "class": self.class_}
+            if self.color:
+                wire["color"] = self.color
+            return wire
+        return {"kind": self.kind, "query": self.query or ""}
 
 
 @dataclass(frozen=True)
 class RouteDecision:
     kind: RouteKind
     reason: str
+    destination: DestinationRequest | None = None
 
 
 # Wake phrases (mirrors wake_word.py's set) plus bare honorifics. Stripped
@@ -84,6 +113,45 @@ _PRONOUN_DESTS = frozenset({"there", "here", "it", "that", "them", "away"})
 
 _WS = re.compile(r"\s+")
 _PUNCT = re.compile(r"[^a-z0-9 ]+")
+# The same punctuation strip WITHOUT lowercasing, so a destination query can
+# keep the operator's capitalization ("125 Main Street") while every routing
+# decision is still made on the lowercase form. Token counts match exactly.
+_PUNCT_CASED = re.compile(r"[^a-zA-Z0-9 ]+")
+
+# --- typed destination grammar (deliberately small and closed) ---------------
+#
+# 🔴 This grammar chooses a destination KIND and repeats the operator's words.
+# It never produces a coordinate — see DestinationRequest. Anything it does
+# not recognise stays conversation or fails closed as ambiguous; the resolver
+# then refuses anything it cannot ground.
+
+# Verbs that can carry a destination complement.
+_DEST_VERBS = frozenset({"drive", "go", "head", "navigate", "move", "proceed"})
+# Prepositions that introduce the destination itself.
+_DEST_PREPOSITIONS = frozenset({"to", "near", "toward", "towards"})
+# Verbs that can start a SAVED ROUTE request ("run route A").
+_ROUTE_VERBS = frozenset({"run", "follow", "start", "take", "resume"})
+_ARTICLES = frozenset({"the", "a", "an", "my", "our"})
+
+# The closed tracked-object vocabulary. Small on purpose: a bigger list would
+# start swallowing named places ("front door", "garage"), and free-form scene
+# description is explicitly out of scope — an unrecognised thing simply routes
+# as a named place and the registry refuses it.
+_OBJECT_CLASSES = frozenset({
+    "cup", "chair", "person", "box", "bottle", "ball", "bag", "book", "cone",
+    "mug", "can",
+})
+_OBJECT_COLORS = frozenset({
+    "red", "blue", "green", "yellow", "black", "white", "orange", "purple",
+    "grey", "gray", "brown", "pink",
+})
+
+# Street suffixes that, together with a leading house number, mark an address.
+_STREET_SUFFIXES = frozenset({
+    "street", "st", "avenue", "ave", "road", "rd", "lane", "ln", "drive",
+    "boulevard", "blvd", "way", "court", "ct", "place", "pl", "terrace",
+    "circle", "crescent", "parade", "highway", "hwy",
+})
 
 # Bounded distance expressions — the ONLY complement (besides a direction or
 # destination) that makes a bare "drive" an explicit motion order. Narrow on
@@ -133,6 +201,88 @@ def strip_wake_prefixes(norm: str) -> str:
     return norm
 
 
+def _split_cased(text: str) -> list[str]:
+    """Tokens with case PRESERVED, through the same punctuation/whitespace
+    pipeline as `normalize` — so the two token lists align index-for-index."""
+    cased = _WS.sub(" ", _PUNCT_CASED.sub(" ", text)).strip()
+    return cased.split(" ") if cased else []
+
+
+def _strip_articles(lower: list[str], cased: list[str]) -> tuple[list[str], list[str]]:
+    """Drop leading articles from an aligned (lowercase, cased) token pair."""
+    i = 0
+    while i < len(lower) and lower[i] in _ARTICLES:
+        i += 1
+    return lower[i:], cased[i:]
+
+
+def _is_address(lower: list[str]) -> bool:
+    """A leading house number PLUS a street suffix. Both are required: "125"
+    alone is not an address, and "main street" without a number is more
+    plausibly a named place the operator registered."""
+    return (
+        len(lower) >= 2
+        and lower[0].isdigit()
+        and any(tok in _STREET_SUFFIXES for tok in lower[1:])
+    )
+
+
+def _as_object(lower: list[str]) -> DestinationRequest | None:
+    """`<class>` or `<color> <class>` from the closed vocabulary, else None."""
+    if len(lower) == 1 and lower[0] in _OBJECT_CLASSES:
+        return DestinationRequest(kind="tracked_object", class_=lower[0])
+    if (
+        len(lower) == 2
+        and lower[0] in _OBJECT_COLORS
+        and lower[1] in _OBJECT_CLASSES
+    ):
+        return DestinationRequest(
+            kind="tracked_object", class_=lower[1], color=lower[0]
+        )
+    return None
+
+
+def _destination_decision(lower: list[str], cased: list[str]) -> RouteDecision:
+    """Classify the tokens AFTER a destination preposition into a typed
+    request — or fail closed as ambiguous when they name nothing resolvable.
+
+    Order is deliberate: address (a house number is unmistakable) → tracked
+    object (closed vocabulary) → named place (everything else the operator
+    may have registered). A pronoun names nothing and never moves the robot.
+    """
+    lower, cased = _strip_articles(lower, cased)
+    if not lower:
+        return RouteDecision(RouteKind.AMBIGUOUS, "motion_without_destination")
+    if all(tok in _PRONOUN_DESTS for tok in lower):
+        return RouteDecision(RouteKind.AMBIGUOUS, "pronoun_destination")
+    if _is_address(lower):
+        return RouteDecision(
+            RouteKind.DESTINATION, "destination_address",
+            DestinationRequest(kind="address", query=" ".join(cased)))
+    obj = _as_object(lower)
+    if obj is not None:
+        return RouteDecision(RouteKind.DESTINATION, "destination_tracked_object", obj)
+    # A route named with a preposition ("go to route a") is still a route.
+    if "route" in lower:
+        return RouteDecision(
+            RouteKind.DESTINATION, "destination_saved_route",
+            DestinationRequest(kind="saved_route", query=" ".join(lower)))
+    return RouteDecision(
+        RouteKind.DESTINATION, "destination_named_place",
+        DestinationRequest(kind="named_place", query=" ".join(cased)))
+
+
+def _route_decision(lower: list[str]) -> RouteDecision:
+    """A saved-route request: `run route A`, `follow the perimeter route`."""
+    lower, _ = _strip_articles(lower, list(lower))
+    if not lower or all(tok in _PRONOUN_DESTS for tok in lower):
+        # "run it" / "follow that" name no route — never guess which one.
+        return RouteDecision(RouteKind.AMBIGUOUS, "pronoun_destination")
+    return RouteDecision(
+        RouteKind.DESTINATION, "destination_saved_route",
+        DestinationRequest(kind="saved_route", query=" ".join(lower)))
+
+
 def _dest_after_to(tokens: list[str], to_idx: int) -> str | None:
     """The destination tokens after a 'to', or None if absent/pronoun-only.
 
@@ -155,6 +305,11 @@ def classify_transcript(text: str) -> RouteDecision:
     if not norm:
         return RouteDecision(RouteKind.AMBIGUOUS, "empty_after_normalization")
     tokens = norm.split(" ")
+    # The case-preserving twin of `tokens`, aligned by dropping exactly the
+    # tokens wake/courtesy stripping removed — so a destination query can
+    # carry "125 Main Street" while routing stays lowercase.
+    all_cased = _split_cased(text)
+    cased = all_cased[len(all_cased) - len(tokens):] if len(all_cased) >= len(tokens) else tokens
 
     if norm in _HOLD_FORMS:
         return RouteDecision(RouteKind.MOTION, "explicit_hold")
@@ -175,21 +330,26 @@ def classify_transcript(text: str) -> RouteDecision:
         # duration/purpose/prose complement stay conversation.
         if rest[0] == "for" and _is_bounded_distance(rest[1:]):
             return RouteDecision(RouteKind.MOTION, "explicit_motion_verb")
-    if verb in ("drive", "move", "head") and rest:
+    # A DESTINATION verb plus a preposition names a PLACE, not a maneuver:
+    # it routes to the typed destination door, where a trusted resolver — not
+    # this process and not a model — supplies the coordinates. A direction
+    # word after the same verb is still ordinary motion and is checked first,
+    # so "drive forward" and "go straight" are unchanged.
+    if verb in _DEST_VERBS and rest:
         if rest[0] in _DIR_WORDS:
             return RouteDecision(RouteKind.MOTION, "explicit_motion_verb")
-        if rest[0] == "to":
-            if _dest_after_to(tokens, 1):
-                return RouteDecision(RouteKind.MOTION, "explicit_destination")
-            return RouteDecision(RouteKind.AMBIGUOUS, "motion_without_destination")
-    if verb == "go" and rest:
-        if rest[0] in _DIR_WORDS:
-            return RouteDecision(RouteKind.MOTION, "explicit_motion_verb")
-        if rest[0] == "to":
-            if _dest_after_to(tokens, 1):
-                return RouteDecision(RouteKind.MOTION, "explicit_destination")
-            return RouteDecision(RouteKind.AMBIGUOUS, "motion_without_destination")
+        if rest[0] in _DEST_PREPOSITIONS:
+            return _destination_decision(rest[1:], cased[2:])
+        # "go there", "head over" — a destination verb aimed at a pronoun
+        # names nothing. Fail closed rather than guess where "there" is.
+        if all(tok in _PRONOUN_DESTS for tok in rest):
+            return RouteDecision(RouteKind.AMBIGUOUS, "pronoun_destination")
         # "go over that again", "go on" … → conversation (default below)
+    if verb in _ROUTE_VERBS and rest and verb != "take":
+        if "route" in rest:
+            return _route_decision(rest)
+        if all(tok in _PRONOUN_DESTS for tok in rest):
+            return RouteDecision(RouteKind.AMBIGUOUS, "pronoun_destination")
     if verb == "turn" and rest and rest[0] in ("left", "right", "around"):
         return RouteDecision(RouteKind.MOTION, "explicit_motion_verb")
     if verb == "back" and rest and rest[0] == "up":
@@ -204,9 +364,13 @@ def classify_transcript(text: str) -> RouteDecision:
         return RouteDecision(RouteKind.MOTION, "explicit_motion_verb")
     if norm.startswith("lane change"):
         return RouteDecision(RouteKind.MOTION, "explicit_motion_verb")
-    if verb == "take" and rest and rest[0] == "me":
-        if len(rest) >= 2 and rest[1] == "to" and _dest_after_to(tokens, 2):
-            return RouteDecision(RouteKind.MOTION, "explicit_destination")
-        return RouteDecision(RouteKind.AMBIGUOUS, "motion_without_destination")
+    if verb == "take" and rest:
+        if rest[0] == "me":
+            if len(rest) >= 2 and rest[1] in _DEST_PREPOSITIONS:
+                return _destination_decision(rest[2:], cased[3:])
+            return RouteDecision(RouteKind.AMBIGUOUS, "motion_without_destination")
+        # "take route A" — a saved route, not a passenger request.
+        if "route" in rest:
+            return _route_decision(rest)
 
     return RouteDecision(RouteKind.CONVERSATION, "default_conversation")

--- a/robot/voice_route_test.py
+++ b/robot/voice_route_test.py
@@ -42,23 +42,51 @@ MOTION_REQUIRED = [
     "Drive forward one meter.",
     "Hey Parker, turn left.",
     "Rabbit, stop.",
-    "Please go to the loading dock.",
     "Back up slowly.",
     "Cruise at two meters per second.",
     "Pull over.",
     # extra coverage from the design examples
     "move forward",
-    "go to the loading dock",
     "turn right",
     "hold position",
     "change lanes",
     "reverse",
     "go straight",
-    "take me to the dock",
     "hey parker drive forward one meter",
     "hello rabbit turn left",
     "parker stop",
     "HALT",
+]
+
+# SEMANTIC destinations. These name a PLACE rather than a maneuver, so they
+# route to the typed destination door where a TRUSTED resolver supplies the
+# coordinates — they were MOTION before the typed-destination integration,
+# when the only door was /intent and an LLM had to invent the goal point.
+DESTINATION_REQUIRED = [
+    "Please go to the loading dock.",
+    "go to the loading dock",
+    "take me to the dock",
+    "drive to the kitchen",
+    "go to the charging dock",
+    "take me to the workshop",
+    "navigate to the front door",
+    "head to the garage",
+    "run route A",
+    "follow route A",
+    "take route A",
+    "start patrol route",
+    "follow the perimeter route",
+    "drive to the red cup",
+    "go to the blue chair",
+    "move near the person",
+    "navigate to the box",
+    "drive to 125 Main Street",
+    "take me to 10 Oak Avenue",
+    "navigate to 42 West Elm Road",
+    "hey parker, drive to the kitchen",
+    "please go to the charging dock",
+    "hello rabbit take me to the workshop",
+    "please run route A",
 ]
 
 CONVERSATION_REQUIRED = [
@@ -82,6 +110,16 @@ CONVERSATION_REQUIRED = [
     "how does a motor drive work",
     "turn the summary into bullet points",
     "tell me about the loading dock",
+    # Destination NOUNS in ordinary prose must never become navigation.
+    "what is the kitchen used for",
+    "tell me about Route 66",
+    "where is the red cup",
+    "what do you see near the chair",
+    "explain how address routing works",
+    "tell me about the kitchen",
+    "what is route planning",
+    "describe a red cup",
+    "describe the blue chair",
 ]
 
 AMBIGUOUS_REQUIRED = [
@@ -95,6 +133,11 @@ AMBIGUOUS_REQUIRED = [
     "let's go",
     "go",
     "move",
+    # A destination verb aimed at a PRONOUN names nothing resolvable.
+    "go there",
+    "drive to it",
+    "run it",
+    "follow that",
 ]
 
 
@@ -119,6 +162,84 @@ def test_required_ambiguous_phrases():
               f"must be AMBIGUOUS, got {d.kind.value} ({d.reason}): {t!r}")
         check(d.kind is not RouteKind.MOTION,
               f"ambiguous must NEVER become motion: {t!r}")
+
+
+def test_required_destination_phrases():
+    for t in DESTINATION_REQUIRED:
+        d = classify_transcript(t)
+        check(d.kind is RouteKind.DESTINATION,
+              f"must be DESTINATION, got {d.kind.value} ({d.reason}): {t!r}")
+        check(d.destination is not None,
+              f"a DESTINATION decision must carry a typed request: {t!r}")
+
+
+def test_typed_request_wire_shapes_are_exact():
+    cases = [
+        ("drive to the kitchen", {"kind": "named_place", "query": "kitchen"}),
+        ("go to the charging dock",
+         {"kind": "named_place", "query": "charging dock"}),
+        ("take me to the workshop",
+         {"kind": "named_place", "query": "workshop"}),
+        ("run route A", {"kind": "saved_route", "query": "route a"}),
+        ("follow the perimeter route",
+         {"kind": "saved_route", "query": "perimeter route"}),
+        ("drive to the red cup",
+         {"kind": "tracked_object", "class": "cup", "color": "red"}),
+        ("go to the blue chair",
+         {"kind": "tracked_object", "class": "chair", "color": "blue"}),
+        ("move near the person", {"kind": "tracked_object", "class": "person"}),
+        ("navigate to the box", {"kind": "tracked_object", "class": "box"}),
+        # An address keeps the operator's capitalization; routing itself is
+        # always decided on the lowercase form.
+        ("drive to 125 Main Street",
+         {"kind": "address", "query": "125 Main Street"}),
+        # Wake + courtesy prefixes must not reach the query.
+        ("hey parker, please drive to the kitchen",
+         {"kind": "named_place", "query": "kitchen"}),
+    ]
+    for text, wire in cases:
+        d = classify_transcript(text)
+        check(d.kind is RouteKind.DESTINATION, f"{text!r} must be DESTINATION")
+        got = d.destination.to_wire() if d.destination else None
+        check(got == wire, f"{text!r} → {got!r}, expected {wire!r}")
+
+
+def test_the_python_parser_can_never_produce_a_coordinate():
+    """The core rule, made structural on the language side: no code path in
+    the router's grammar emits a numeric field. Every wire object carries
+    only the kind and the operator's own words."""
+    allowed = {"kind", "query", "class", "color"}
+    for t in DESTINATION_REQUIRED:
+        d = classify_transcript(t)
+        wire = d.destination.to_wire()
+        check(set(wire) <= allowed,
+              f"{t!r} produced non-vocabulary keys: {sorted(set(wire) - allowed)}")
+        for k, v in wire.items():
+            check(isinstance(v, str),
+                  f"{t!r}: field {k} is {type(v).__name__}, must be a string")
+    # And the dataclass itself has no coordinate field to fill in.
+    import dataclasses
+    from voice_route import DestinationRequest
+    fields = {f.name for f in dataclasses.fields(DestinationRequest)}
+    for banned in ("x", "y", "x_m", "y_m", "lat", "lon", "pose", "heading_rad"):
+        check(banned not in fields,
+              f"DestinationRequest must have no {banned!r} field")
+
+
+def test_destination_grammar_stays_closed():
+    # An unrecognised "object" is NOT invented as a tracked object — it falls
+    # through to a named place, which the registry then refuses if unknown.
+    d = classify_transcript("drive to the flux capacitor")
+    check(d.destination.to_wire()["kind"] == "named_place",
+          "free-form scene description must not become a tracked object")
+    # A colour with no class names no thing at all.
+    d = classify_transcript("drive to the red")
+    check(d.destination is None or d.destination.to_wire()["kind"] == "named_place",
+          "a bare colour must not become a tracked object")
+    # A number without a street suffix is not an address.
+    d = classify_transcript("drive to bay 12")
+    check(d.destination.to_wire()["kind"] == "named_place",
+          "a bare number must not become an address")
 
 
 def test_wake_prefixes_do_not_change_classification():
@@ -221,18 +342,49 @@ def test_hold_forms_are_exact_not_prefix():
           "'stop moving' is the hold order")
 
 
+# The CLOSED set of reason tokens this module may emit. A reason names the
+# RULE that fired, never the transcript — so the leak check below can allow
+# exactly this vocabulary and nothing else.
+ALL_REASONS = {
+    "empty_after_normalization", "explicit_hold", "ambiguous_motion_phrase",
+    "explicit_motion_verb", "explicit_destination", "motion_without_destination",
+    "default_conversation", "pronoun_destination", "destination_named_place",
+    "destination_saved_route", "destination_tracked_object",
+    "destination_address",
+}
+REASON_VOCABULARY = {w for r in ALL_REASONS for w in r.split("_")}
+
+
 def test_reasons_are_stable_tokens_without_transcript():
-    for t in MOTION_REQUIRED + CONVERSATION_REQUIRED + AMBIGUOUS_REQUIRED:
+    for t in (MOTION_REQUIRED + CONVERSATION_REQUIRED + AMBIGUOUS_REQUIRED
+              + DESTINATION_REQUIRED):
         d = classify_transcript(t)
         check(" " not in d.reason and d.reason.replace("_", "").isalnum(),
               f"reason must be a bare token: {d.reason!r}")
+        check(d.reason in ALL_REASONS,
+              f"reason {d.reason!r} is outside the closed set")
         # No transcript word longer than 3 chars may leak into the reason —
         # except the fixed CATEGORY vocabulary the reason tokens are built
-        # from ("hold"/"motion"/"destination" name the rule, not the words).
+        # from ("hold"/"route"/"address" name the RULE, not the words).
         for w in normalize(t).split():
-            if len(w) > 3 and w not in ("motion", "hold", "destination"):
+            if len(w) > 3 and w not in REASON_VOCABULARY:
                 check(w not in d.reason,
                       f"transcript word {w!r} leaked into reason {d.reason!r}")
+
+
+def test_a_destination_query_carries_only_the_operators_words():
+    # The query is the operator's own naming of the place — never a coordinate
+    # and never router-invented text. Pin that it is a SUBSTRING of the
+    # normalized transcript (modulo case), so nothing can be added.
+    for t in DESTINATION_REQUIRED:
+        d = classify_transcript(t)
+        wire = d.destination.to_wire()
+        spoken = normalize(t)
+        for key in ("query", "class", "color"):
+            value = wire.get(key)
+            if value:
+                check(value.lower() in spoken,
+                      f"{t!r}: {key}={value!r} is not the operator's own words")
 
 
 def test_normalize_and_strip_helpers():
@@ -251,7 +403,8 @@ def test_every_kind_has_disjoint_membership():
     # One transcript, one classification — sanity that the three required
     # sets do not overlap under classification.
     seen = {}
-    for t in MOTION_REQUIRED + CONVERSATION_REQUIRED + AMBIGUOUS_REQUIRED:
+    for t in (MOTION_REQUIRED + CONVERSATION_REQUIRED + AMBIGUOUS_REQUIRED
+              + DESTINATION_REQUIRED):
         k = kind_of(t)
         n = normalize(t)
         check(seen.setdefault(n, k) is k, f"unstable classification: {t!r}")

--- a/robot/voice_turn_router.py
+++ b/robot/voice_turn_router.py
@@ -7,12 +7,22 @@ per stdin line → deterministic route → EXACTLY ONE endpoint (or none).
     motion       → POST /intent (mick_service) — TEXT ONLY; Mick's typed
                    parse, Occy, the checker, release and the consumer are
                    unchanged downstream
+    destination  → POST /destination (mick_service) — a TYPED DestinationRef
+                   (kind + the operator's words, NEVER coordinates); the
+                   trusted resolver grounds it against the calibrated
+                   registries / live tracks, or refuses
     ambiguous    → a FIXED local clarification; NO endpoint is contacted
 
 🔴 SEPARATION (all host-tested):
-  * this process knows exactly two HTTP endpoints — the chat sidecar and the
-    intent door. No planner, ROS, verifier, release-token, serial, or motor
-    API is imported or addressed, and the actuation-fence test pins that;
+  * this process knows exactly two HTTP HOSTS — the chat sidecar and the Mick
+    sidecar (its intent and destination doors). No planner, ROS, verifier,
+    release-token, serial, or motor API is imported or addressed, and the
+    actuation-fence test pins that;
+  * 🔴 THE ROUTER NEVER CREATES A COORDINATE. It names a destination; the
+    trusted resolver behind /destination is the only thing that turns a name
+    into a pose, and the acceptance body it returns carries none — so there
+    is nothing here to speak, log, or leak. A destination that does not
+    resolve produces NO planner request at all;
   * a transcript goes to AT MOST one endpoint, never both;
   * NO automatic retry anywhere on the motion path (a retry could duplicate
     an accepted intent); every failure is spoken and the turn ends;
@@ -63,6 +73,40 @@ LINE_INTENT_RATE = "Please wait a moment before giving another motion request."
 LINE_INTENT_DOWN = "The governed motion service is unavailable."
 LINE_ROUTE_DISAGREE = ("That didn't register as a motion request. "
                        "Please say exactly where or how you want me to move.")
+
+# --- typed destination lines --------------------------------------------------
+#
+# Admission only, and deliberately free of WHERE: the router never receives a
+# pose (the success body carries none), so it cannot speak, log, or leak one.
+LINE_DEST_ACCEPTED = "Destination accepted for governed navigation."
+# Phase 1 saved routes ground ONLY the first waypoint. The wording must never
+# imply the whole route is under way.
+LINE_DEST_ACCEPTED_FIRST_WAYPOINT = (
+    "Destination accepted for governed navigation, first waypoint only.")
+LINE_DEST_NOT_FOUND = "I don't have a configured location matching that request."
+LINE_DEST_AMBIGUOUS = "That destination is ambiguous. Please be more specific."
+LINE_DEST_STALE = "I no longer have a fresh position for that object."
+LINE_DEST_UNSUPPORTED = "Address routing isn't configured on this robot."
+LINE_DEST_DOWN = "The destination service is unavailable."
+LINE_DEST_INVALID = "I couldn't validate that destination."
+LINE_DEST_RATE = "Please wait a moment before asking for another destination."
+
+# Stable resolver code → fixed spoken line. An UNKNOWN code maps to the
+# validation line, never to a guess and never to a fallback route.
+DEST_LINES = {
+    "DEST_NOT_FOUND": LINE_DEST_NOT_FOUND,
+    "DEST_NO_REGISTRY": LINE_DEST_NOT_FOUND,
+    "DEST_NOT_SEEN": LINE_DEST_NOT_FOUND,
+    "DEST_LOW_CONFIDENCE": LINE_DEST_STALE,
+    "DEST_BEHIND_EGO": LINE_DEST_NOT_FOUND,
+    "DEST_NON_FINITE": LINE_DEST_INVALID,
+    "DEST_AMBIGUOUS": LINE_DEST_AMBIGUOUS,
+    "DEST_STALE": LINE_DEST_STALE,
+    "DEST_UNSUPPORTED_ADDRESS": LINE_DEST_UNSUPPORTED,
+    "DEST_RATE_LIMITED": LINE_DEST_RATE,
+}
+# The Phase-1 marker the resolver returns for a saved route.
+ROUTE_FIRST_WAYPOINT_ONLY = "first_waypoint_only"
 
 
 def _log_enabled() -> bool:
@@ -152,6 +196,60 @@ def post_intent(text: str, turn: int) -> tuple[str, float]:
     return LINE_INTENT_INVALID, ms
 
 
+def post_destination(dest, turn: int) -> tuple[str, float]:
+    """POST ONE typed destination to the trusted resolver door. ONE request,
+    NO retry, NO fallback to /intent or /chat on any outcome.
+
+    🔴 The body carries the typed request ONLY — a kind and the operator's
+    words. This process never sends, receives, or speaks a coordinate: the
+    success body is admission metadata, and the grounded pose stays on the
+    doer-facing latch inside the service.
+
+    Returns (spoken line, http_ms)."""
+    body = json.dumps({"destination": dest.to_wire()}).encode("utf-8")
+    req = urllib.request.Request(
+        intent_url() + "/destination", data=body,
+        headers={"Content-Type": "application/json"}, method="POST")
+    t0 = time.monotonic() * 1000.0
+    try:
+        with urllib.request.urlopen(req, timeout=timeout_s()) as resp:
+            raw = resp.read()
+    except urllib.error.HTTPError as e:
+        ms = time.monotonic() * 1000.0 - t0
+        # A refusal body carries the stable code; read it for the LINE only.
+        code = ""
+        try:
+            code = str(json.loads(e.read() or b"{}").get("error") or "")
+        except (json.JSONDecodeError, OSError, ValueError):
+            code = ""
+        if code in DEST_LINES:
+            log_event(turn, f"resolve_outcome={code.lower()}", ms)
+            return DEST_LINES[code], ms
+        log_event(turn, f"resolve_refused_{e.code}", ms)
+        return LINE_DEST_INVALID, ms
+    except (urllib.error.URLError, TimeoutError, OSError):
+        ms = time.monotonic() * 1000.0 - t0
+        log_event(turn, "resolve_unreachable", ms)
+        return LINE_DEST_DOWN, ms
+    ms = time.monotonic() * 1000.0 - t0
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        log_event(turn, "resolve_malformed_response", ms)
+        return LINE_DEST_INVALID, ms
+    if not (isinstance(payload, dict) and payload.get("ok")
+            and payload.get("outcome") == "resolved"):
+        # A 200 that does not clearly say "resolved" is not an acceptance.
+        log_event(turn, "resolve_malformed_response", ms)
+        return LINE_DEST_INVALID, ms
+    log_event(turn, "resolve_outcome=resolved", ms)
+    if payload.get("route_resolution") == ROUTE_FIRST_WAYPOINT_ONLY:
+        # Say the limitation out loud — never imply a whole route started.
+        log_event(turn, f"route_resolution={ROUTE_FIRST_WAYPOINT_ONLY}")
+        return LINE_DEST_ACCEPTED_FIRST_WAYPOINT, ms
+    return LINE_DEST_ACCEPTED, ms
+
+
 def handle_turn(text: str, turn: int, tts_cmd: str | None) -> None:
     t0 = time.monotonic() * 1000.0
     decision = classify_transcript(text)
@@ -168,6 +266,14 @@ def handle_turn(text: str, turn: int, tts_cmd: str | None) -> None:
     if decision.kind is RouteKind.MOTION:
         line, http_ms = post_intent(text, turn)
         log_event(turn, "intent_http_ms", http_ms)
+        speak_line(line, tts_cmd)
+        return
+    if decision.kind is RouteKind.DESTINATION and decision.destination is not None:
+        # The typed destination door — the ONLY endpoint this branch touches.
+        # A refusal is spoken and the turn ENDS: no /intent, no chat, no retry.
+        log_event(turn, f"destination_kind={decision.destination.kind}")
+        line, http_ms = post_destination(decision.destination, turn)
+        log_event(turn, "resolve_http_ms", http_ms)
         speak_line(line, tts_cmd)
         return
     # AMBIGUOUS — no endpoint is contacted at all; a fixed local reply.

--- a/robot/voice_turn_router_test.py
+++ b/robot/voice_turn_router_test.py
@@ -57,6 +57,11 @@ class StubState:
     intent_paths: list[str] = []
     intent_mode = "accept"
     intent_bodies: list[dict] = []
+    # The typed-destination door lives on the SAME sidecar as /intent, so the
+    # intent stub serves both paths and one list records every request — that
+    # is what makes "exactly one endpoint per transcript" checkable.
+    dest_mode = "resolved"
+    dest_bodies: list[dict] = []
 
 
 def _sse(handler, events):
@@ -84,12 +89,27 @@ class ChatStub(BaseHTTPRequestHandler):
         pass
 
 
+DEST_REFUSALS = {
+    "not_found": ("DEST_NOT_FOUND", 422),
+    "no_registry": ("DEST_NO_REGISTRY", 422),
+    "ambiguous": ("DEST_AMBIGUOUS", 422),
+    "stale": ("DEST_STALE", 422),
+    "unsupported": ("DEST_UNSUPPORTED_ADDRESS", 422),
+    "low_confidence": ("DEST_LOW_CONFIDENCE", 422),
+    "rate": ("DEST_RATE_LIMITED", 429),
+    "coords": ("DEST_COORDINATES_FORBIDDEN", 422),
+}
+
+
 class IntentStub(BaseHTTPRequestHandler):
     def do_POST(self):  # noqa: N802
         StubState.intent_paths.append(self.path)
         length = int(self.headers.get("Content-Length", 0))
-        StubState.intent_bodies.append(
-            json.loads(self.rfile.read(length) or b"{}"))
+        body = json.loads(self.rfile.read(length) or b"{}")
+        if self.path == "/destination":
+            StubState.dest_bodies.append(body)
+            return self._destination()
+        StubState.intent_bodies.append(body)
         mode = StubState.intent_mode
         if mode == "accept":
             body, code = {"ok": True, "seq": 12, "at_ms": 1,
@@ -107,6 +127,38 @@ class IntentStub(BaseHTTPRequestHandler):
             self.end_headers()
             self.wfile.write(payload)
             return
+        else:  # pragma: no cover
+            raise AssertionError(mode)
+        payload = json.dumps(body).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def _destination(self):
+        mode = StubState.dest_mode
+        if mode == "resolved":
+            body, code = {"ok": True, "seq": 4, "at_ms": 1, "outcome": "resolved",
+                          "kind": "named_place", "source": "place_registry",
+                          "route_resolution": "none"}, 200
+        elif mode == "resolved_route":
+            body, code = {"ok": True, "seq": 5, "at_ms": 1, "outcome": "resolved",
+                          "kind": "saved_route", "source": "route_registry",
+                          "route_resolution": "first_waypoint_only"}, 200
+        elif mode == "garbage":
+            payload = b"not json"
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+            return
+        elif mode == "ok_without_outcome":
+            # A 200 that never says "resolved" is NOT an acceptance.
+            body, code = {"ok": True, "seq": 9}, 200
+        elif mode in DEST_REFUSALS:
+            err, code = DEST_REFUSALS[mode]
+            body = {"ok": False, "error": err, "detail": "refused"}
         else:  # pragma: no cover
             raise AssertionError(mode)
         payload = json.dumps(body).encode()
@@ -136,6 +188,7 @@ class Turn:
         StubState.chat_paths.clear()
         StubState.intent_paths.clear()
         StubState.intent_bodies.clear()
+        StubState.dest_bodies.clear()
         out, err = io.StringIO(), io.StringIO()
         real_out, real_err = sys.stdout, sys.stderr
         sys.stdout, sys.stderr = out, err
@@ -147,7 +200,12 @@ class Turn:
                 os.environ.pop(k, None)
         self.out, self.err = out.getvalue(), err.getvalue()
         self.chat = list(StubState.chat_paths)
-        self.intent = list(StubState.intent_paths)
+        # Every request to the Mick sidecar, by path — so a test can assert
+        # BOTH which door was used and that no second door was touched.
+        self.mick = list(StubState.intent_paths)
+        self.intent = [p for p in StubState.intent_paths if p == "/intent"]
+        self.dest = [p for p in StubState.intent_paths if p == "/destination"]
+        self.dest_bodies = list(StubState.dest_bodies)
 
 
 # --- endpoint isolation -------------------------------------------------------
@@ -239,6 +297,227 @@ def test_one_transcript_one_request_and_no_replay():
         check(len(t1.intent) == 1 and len(t2.intent) == 1,
               "each spoken turn maps to exactly ONE request — the router "
               "itself never replays or retries")
+    finally:
+        cs.shutdown()
+        is_.shutdown()
+
+
+# --- typed destinations -------------------------------------------------------
+
+def test_destination_contacts_only_the_resolver_door():
+    cs, cu = serve(ChatStub)
+    is_, iu = serve(IntentStub)
+    try:
+        StubState.dest_mode = "resolved"
+        t = Turn(cu, iu, "drive to the kitchen")
+        check(t.dest == ["/destination"],
+              f"a destination must hit /destination exactly once: {t.mick}")
+        check(t.intent == [], f"a destination must NEVER touch /intent: {t.mick}")
+        check(t.chat == [], f"a destination must NEVER touch chat: {t.chat}")
+        check(t.dest_bodies == [{"destination": {"kind": "named_place",
+                                                 "query": "kitchen"}}],
+              f"the typed request is the ONLY payload: {t.dest_bodies}")
+        check(router.LINE_DEST_ACCEPTED in t.out,
+              f"the admission line is spoken: {t.out!r}")
+    finally:
+        cs.shutdown()
+        is_.shutdown()
+
+
+def test_the_admission_ack_claims_no_movement_and_speaks_no_geometry():
+    cs, cu = serve(ChatStub)
+    is_, iu = serve(IntentStub)
+    try:
+        StubState.dest_mode = "resolved"
+        t = Turn(cu, iu, "drive to the kitchen")
+        for banned in ("moving", "moved", "driving", "arrived", "arrival",
+                       "executing", "complete", "started", "x_m", "y_m",
+                       "metre", "meters", "coordinates", "map"):
+            check(banned not in t.out.lower(),
+                  f"the ack must be admission-only, found {banned!r}: {t.out!r}")
+    finally:
+        cs.shutdown()
+        is_.shutdown()
+
+
+def test_every_refusal_outcome_speaks_its_fixed_line_with_no_fallback():
+    cs, cu = serve(ChatStub)
+    is_, iu = serve(IntentStub)
+    try:
+        cases = [
+            ("not_found", "drive to the kitchen", router.LINE_DEST_NOT_FOUND),
+            ("no_registry", "drive to the kitchen", router.LINE_DEST_NOT_FOUND),
+            ("ambiguous", "drive to the red cup", router.LINE_DEST_AMBIGUOUS),
+            ("stale", "drive to the red cup", router.LINE_DEST_STALE),
+            ("low_confidence", "drive to the red cup", router.LINE_DEST_STALE),
+            ("unsupported", "drive to 125 Main Street",
+             router.LINE_DEST_UNSUPPORTED),
+            ("rate", "drive to the kitchen", router.LINE_DEST_RATE),
+            ("coords", "drive to the kitchen", router.LINE_DEST_INVALID),
+            ("garbage", "drive to the kitchen", router.LINE_DEST_INVALID),
+            ("ok_without_outcome", "drive to the kitchen",
+             router.LINE_DEST_INVALID),
+        ]
+        for mode, text, line in cases:
+            StubState.dest_mode = mode
+            t = Turn(cu, iu, text)
+            check(len(t.dest) == 1,
+                  f"{mode}: exactly one attempt, NO retry: {t.mick}")
+            check(t.intent == [],
+                  f"{mode}: a destination failure must NEVER fall back to /intent")
+            check(t.chat == [],
+                  f"{mode}: a destination failure must NEVER fall back to chat")
+            check(line in t.out, f"{mode}: must speak {line!r}, got {t.out!r}")
+        StubState.dest_mode = "resolved"
+    finally:
+        cs.shutdown()
+        is_.shutdown()
+
+
+def test_saved_route_admission_says_first_waypoint_only():
+    cs, cu = serve(ChatStub)
+    is_, iu = serve(IntentStub)
+    try:
+        StubState.dest_mode = "resolved_route"
+        t = Turn(cu, iu, "run route A")
+        check(t.dest_bodies == [{"destination": {"kind": "saved_route",
+                                                 "query": "route a"}}],
+              f"the typed route request: {t.dest_bodies}")
+        check(router.LINE_DEST_ACCEPTED_FIRST_WAYPOINT in t.out,
+              f"Phase 1 must be spoken, not implied: {t.out!r}")
+        # It must never sound like the whole route is under way.
+        for banned in ("route started", "following the route", "en route"):
+            check(banned not in t.out.lower(),
+                  f"must not imply full route execution ({banned!r}): {t.out!r}")
+        check("first_waypoint_only" in t.err,
+              "the Phase-1 marker must be in the stage log")
+        StubState.dest_mode = "resolved"
+    finally:
+        cs.shutdown()
+        is_.shutdown()
+
+
+def test_unreachable_resolver_fails_safe_without_any_fallback():
+    cs, cu = serve(ChatStub)
+    try:
+        t = Turn(cu, "http://127.0.0.1:1", "drive to the kitchen")
+        check(router.LINE_DEST_DOWN in t.out,
+              f"an unreachable resolver speaks the outage line: {t.out!r}")
+        check(t.chat == [], "a resolver outage must not reroute to chat")
+    finally:
+        cs.shutdown()
+
+
+def test_one_destination_transcript_makes_exactly_one_request():
+    cs, cu = serve(ChatStub)
+    is_, iu = serve(IntentStub)
+    try:
+        StubState.dest_mode = "resolved"
+        t1 = Turn(cu, iu, "drive to the kitchen", turn=1)
+        t2 = Turn(cu, iu, "drive to the kitchen", turn=2)
+        check(len(t1.dest) == 1 and len(t2.dest) == 1,
+              "each spoken turn maps to exactly ONE resolver request — the "
+              "router never replays or retries a grounded destination")
+        # A fresh process (the module is stateless) cannot replay either: the
+        # statelessness test pins that no transcript or request is persisted.
+    finally:
+        cs.shutdown()
+        is_.shutdown()
+
+
+def test_ambiguous_destination_contacts_nothing():
+    cs, cu = serve(ChatStub)
+    is_, iu = serve(IntentStub)
+    try:
+        for text in ("go there", "drive to it", "run it", "follow that"):
+            t = Turn(cu, iu, text)
+            check(t.mick == [] and t.chat == [],
+                  f"{text!r} must contact NOTHING: mick={t.mick} chat={t.chat}")
+    finally:
+        cs.shutdown()
+        is_.shutdown()
+
+
+def test_destination_prose_still_routes_to_chat_only():
+    cs, cu = serve(ChatStub)
+    is_, iu = serve(IntentStub)
+    try:
+        for text in ("tell me about the kitchen", "what is route planning",
+                     "where is the red cup"):
+            t = Turn(cu, iu, text)
+            check(t.chat == ["/chat/stream"] and t.mick == [],
+                  f"{text!r} must be chat-only: chat={t.chat} mick={t.mick}")
+    finally:
+        cs.shutdown()
+        is_.shutdown()
+
+
+def test_destination_content_never_appears_in_logs():
+    cs, cu = serve(ChatStub)
+    is_, iu = serve(IntentStub)
+    try:
+        StubState.dest_mode = "resolved"
+        # Distinctive markers in the place name, the address and the object.
+        for text in ("drive to the zebrawaffle",
+                     "drive to 125 Unicornfeather Street",
+                     "drive to the red cup"):
+            t = Turn(cu, iu, text)
+            for marker in ("zebrawaffle", "unicornfeather", "red cup",
+                           "Unicornfeather"):
+                check(marker not in t.err,
+                      f"destination content leaked to logs for {text!r}")
+        # The refusal DETAIL from the resolver is never echoed to logs either.
+        StubState.dest_mode = "not_found"
+        t = Turn(cu, iu, "drive to the zebrawaffle")
+        check("zebrawaffle" not in t.err and "refused" not in t.err,
+              f"a refusal must log the CODE only: {t.err!r}")
+        check("resolve_outcome=dest_not_found" in t.err,
+              f"the stable outcome token is logged: {t.err!r}")
+        StubState.dest_mode = "resolved"
+    finally:
+        cs.shutdown()
+        is_.shutdown()
+
+
+def test_destination_speech_holds_the_playback_lock():
+    # Every spoken destination line goes through speak_line, which holds the
+    # PlaybackGuard for the whole utterance — so the robot cannot hear its own
+    # acknowledgement and start another turn (the #1290 self-echo regression).
+    import inspect
+    import voice_playback
+    src = inspect.getsource(router.speak_line)
+    check("PlaybackGuard" in src, "speak_line must hold the playback guard")
+    body = inspect.getsource(router.handle_turn)
+    check(body.count("speak_line") >= 3,
+          "every non-chat branch (motion, destination, ambiguous) speaks "
+          "through the guarded path")
+    # And while the lock is held no trigger may be emitted at all — so a
+    # destination acknowledgement cannot self-trigger the next turn.
+    check(not voice_playback.should_emit_trigger(
+        playback=True, episode_followups=0, max_followups=3),
+        "no turn may be created while playback holds the lock")
+    # The episode cap is unchanged by this PR: a destination turn is one
+    # real user turn and adds no follow-up of its own.
+    check(voice_playback.should_emit_trigger(
+        playback=False, episode_followups=0, max_followups=3),
+        "a genuine wake-free follow-up under the cap is still allowed")
+    check(not voice_playback.should_emit_trigger(
+        playback=False, episode_followups=3, max_followups=3),
+        "the existing follow-up cap still binds")
+
+
+def test_destination_turn_creates_no_automatic_follow_up():
+    # A destination turn is ONE user turn: the router speaks once and returns.
+    # It never issues a second request, and it never enqueues another turn.
+    cs, cu = serve(ChatStub)
+    is_, iu = serve(IntentStub)
+    try:
+        for mode in ("resolved", "not_found", "unsupported"):
+            StubState.dest_mode = mode
+            t = Turn(cu, iu, "drive to the kitchen")
+            check(len(t.dest) == 1 and t.chat == [],
+                  f"{mode}: exactly one request, no follow-up turn")
+        StubState.dest_mode = "resolved"
     finally:
         cs.shutdown()
         is_.shutdown()
@@ -354,6 +633,45 @@ def test_router_sources_know_only_the_two_http_doors():
     code = _code_only((HERE / "mick_voice_chat.py").read_text())
     check(join("/int", "ent") not in code,
           "the shared chat client must stay motion-free")
+
+
+def test_voice_router_cannot_import_or_reference_actuation():
+    """The structural fence, stated as a property of the SOURCE: no module in
+    the voice-router layer may import or name any actuation machinery. Only
+    comments and docstrings (which explain what the layer is fenced FROM) are
+    exempt — `_code_only` strips them, so a breach must be real code."""
+    import ast
+    join = lambda a, b: a + b  # noqa: E731 — needles built by concat so this
+    #                            test cannot match its own source text
+    forbidden_tokens = [
+        join("rcl", "py"), join("ro", "s2"), join("ser", "ial"),
+        join("cmd", "_vel"), join("Twi", "st"), join("release", "_token"),
+        join("Release", "Token"), join("actu", "ator"), join("Motor", "Serial"),
+        join("kirra_", "ffi"), join("set_car", "_motion"), join("/pl", "an"),
+    ]
+    forbidden_imports = {join("rcl", "py"), join("ser", "ial"),
+                         join("kirra_", "ffi"), join("kirra_motor", "_consumer"),
+                         join("kirra_release", "_publisher")}
+    layer = ("voice_route.py", "voice_turn_router.py", "mick_voice_chat.py")
+    for name in layer:
+        src = (HERE / name).read_text()
+        code = _code_only(src)
+        for needle in forbidden_tokens:
+            check(needle.lower() not in code.lower(),
+                  f"{name} references actuation machinery {needle!r}")
+        # An import is checked structurally, not textually: a renamed or
+        # aliased import still shows up as a module name in the AST.
+        for node in ast.walk(ast.parse(src)):
+            mods = []
+            if isinstance(node, ast.Import):
+                mods = [a.name for a in node.names]
+            elif isinstance(node, ast.ImportFrom):
+                mods = [node.module or ""]
+            for m in mods:
+                root = m.split(".")[0]
+                check(root not in forbidden_imports,
+                      f"{name} imports {m!r} — the voice layer has no "
+                      "actuation dependency")
 
 
 def test_explicit_motion_cannot_reach_chat_under_normal_routing():


### PR DESCRIPTION
## Scope — read this first

This PR delivers **live voice-to-destination resolution and admission.** It is **not** completed voice-to-destination navigation.

R2 can now classify, resolve, latch and *acknowledge* a spoken destination. It **cannot yet physically navigate to one.** The grounded destination is latched on its own frame-explicit channel, and no consumer acts on it yet — deliberately, because map-frame poses cannot safely be published through the existing ego-frame `/intent/last` channel that `occy_doer` consumes. The governed bridge that closes that gap is the next PR (scoped at the bottom).

**Do not enable motion from the destination latch until that frame-aware bridge exists.**

## What

Connects the wake-driven voice router to the #1293 typed destination resolver, so these resolve end to end — without weakening any existing boundary:

- "drive to the kitchen" · "run route A" · "drive to the red cup" · "drive to 125 Main Street"

```
wake → bounded capture → STT → deterministic routing (PURE, no LLM)
  ├─ conversation          → POST /chat/stream        (unchanged)
  ├─ explicit motion       → POST /intent             (unchanged)
  ├─ semantic destination  → typed DestinationRef → POST /destination
  │      → trusted resolver → grounded target (frame-explicit latch)
  │      → [DEFERRED: frame-aware consumer] → Occy → checker → release → consumer
  └─ ambiguous             → fixed local clarification, NO endpoint
```

**One transcript reaches at most one endpoint.** A destination failure never falls back to `/intent`, never falls back to chat, and is never retried.

## Safety properties (all host-tested)

- **The router has zero motion authority and never creates a coordinate.** No numeric field exists on `DestinationRequest` and no code path could emit one (asserted structurally, including over the dataclass fields). The acceptance body carries **no pose** — nothing for the voice layer to speak, log, or leak.
- **Only the trusted resolver produces coordinates.** Unresolved / ambiguous / stale / unsupported produce **no planner request at all** — latch and `seq` unchanged, so a consumer polling by seq sees nothing new.
- **No planner/checker/release/consumer bypass; no ROS, `cmd_vel`, serial, or actuator access.** `kirra-sidecars` stays inside `ci/check_mick_actuation_fence.py` (INTACT), and a new AST-level test proves the Python voice layer neither imports nor names actuation machinery.

## Voice layer

Fourth deterministic `RouteKind.DESTINATION` carrying a typed request. The grammar is small and closed: destination verb + preposition, a fixed object vocabulary (class/colour), route verbs, and address = house number **and** street suffix.

| said | typed request |
|---|---|
| "drive to the kitchen" | `{"kind":"named_place","query":"kitchen"}` |
| "run route A" | `{"kind":"saved_route","query":"route a"}` |
| "drive to the red cup" | `{"kind":"tracked_object","class":"cup","color":"red"}` |
| "drive to 125 Main Street" | `{"kind":"address","query":"125 Main Street"}` |

Pronoun-only destinations ("go there", "drive to it", "run it", "follow that") fail closed as **ambiguous**; destination nouns in prose ("tell me about the kitchen", "what is route planning", "where is the red cup") stay conversation; "drive forward one meter" / "turn left" / "stop" / "pull over" stay ordinary motion.

**Reclassification:** "go to the loading dock" / "take me to the dock" were `MOTION` and are now `DESTINATION` — they name a place, which must be grounded by the trusted resolver rather than by a model guessing a goal point.

## Resolver seam

`POST /destination` + `GET /destination/last` on `mick_service`. Resolved → latched with a monotonic `seq` (apply-once); every other outcome → 422 with the stable `DEST_*` code plus the operator sentence. `resolver_from_env` is shared with `planner_service` — one config path, **no second resolver**.

Two load-bearing design calls:

1. **The latch is frame-explicit and is its own channel.** `/intent/last` is consumed by `occy_doer` as *ego-frame at receipt*; publishing a map-frame registry pose there would be silently misread and aim the robot at the wrong place.
2. **Tracked objects resolve against caller-supplied targets.** `mick_service` has no perception (it's inside the fence). The voice path supplies none, so a spoken object destination resolves `DEST_STALE` — "the detector did not look" is never "it isn't there".

## Saved-route limitation (preserved, and said out loud)

Phase 1 grounds the **first waypoint only**. The `route_resolution=first_waypoint_only` marker rides the latch wire, the admission body, the stage log, and the spoken line. Nothing implies a route started.

## Review fixes (Copilot, both real fail-opens)

- **Caller-controlled freshness clock removed.** `now_ms` is gone from the request; freshness is judged on the **service** clock only, so a client cannot make an old or future-stamped sighting look present.
- **Omitted target confidence now defaults to 0.0, not 1.0** — "the producer told us nothing" must not read as "certain" and clear the `min_confidence` floor. Fixed on the new endpoint **and** on the planner's identical `TargetReq` field, which fed the same gate with the same fail-open.

## Tests

Exact wire shapes per kind · structural no-coordinate proof · endpoint isolation including failure paths · every resolution outcome (found / unknown / ambiguous / route / first-waypoint / fresh / stale / low-confidence / unsupported address / malformed / timeout / connection refused / 422 / 429) · duplicate prevention · playback-lock coverage with the follow-up cap unchanged · marker-based logging privacy · AST-level actuation-import fence · governed-path integration test proving typed destination → resolver → grounded `GoTo` → planner seam with unresolved destinations yielding **NO MOTION**.

**Results:** all six required Python suites green · `kirra-sidecars` 235 lib + 6 integration green · `kirra-planner` 25 suites · `kirra-mick` · `spoken_governed_loop` · `mick_governed_loop` · fence INTACT · fmt / clippy `-D warnings` / py_compile / `bash -n` / shellcheck / `git diff --check` all clean.

## Hardware verification (planner stays STOPPED)

Confirm only that phrases route correctly, the expected `DEST_*` responses are spoken, and the grounded latch is auditable. **Do not enable motion from that latch.**

## Next PR — the missing governed bridge

```
grounded destination latch → frame-aware consumer → map identity validation
  → Occy goal → checker → release → consumer
```

It must reject: unknown or mismatched `map_id`; a stale destination sequence; a duplicate sequence; an unsupported frame; route metadata mistaken for a complete route; and a missing transform between map and planner frames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW