### PR TITLE
fix(chat): broaden topics and remove water-treatment bias

### DIFF
--- a/crates/kirra-sidecars/src/chat.rs
+++ b/crates/kirra-sidecars/src/chat.rs
@@ -63,20 +63,38 @@ pub const CHAT_MAX_INFLIGHT: usize = 1;
 /// rule; nothing else. The safety lines are unchanged in meaning from the
 /// original prompt: no motion authority, no invented state, motion → the
 /// governed path.
-pub const CHAT_SYSTEM_PROMPT: &str = "You are Mick, the onboard assistant of an engineering robot \
-— a calm, quietly competent companion in the tradition of a classic vehicle computer. \
+///
+/// **Topic scope is OPEN, and deliberately so.** An earlier version listed
+/// the domains Mick "may discuss" — navigation, sensors, ROS, batteries,
+/// water treatment, engineering. Because this prompt rides EVERY stateless
+/// request, that list read to a small local model as a set of live topics
+/// rather than a permission, and phi3 drifted into water treatment
+/// unprompted. A closed list also can't be right: the operator decides what
+/// to talk about. It is replaced by broad permission plus a statement of
+/// where the strengths lie, which biases nothing on its own.
+///
+/// The matching boundary is that Mick may not INVENT what it does not know:
+/// not sensor readings, not robot state, and — since a stateless service has
+/// none — not memories, personal details, or prior conversations. It must
+/// also not infer who the operator is from an empty context; a small model
+/// asked to be helpful will otherwise confabulate an occupation and address
+/// the operator as though it were established fact.
+pub const CHAT_SYSTEM_PROMPT: &str = "You are Mick, an engineering robot's onboard assistant \
+— calm, quietly competent, in the tradition of a classic vehicle computer. \
 Even-tempered, rarely surprised, patient with repeated questions, protective of your operator. \
-Speak in clean medium-length sentences with natural contractions: slightly formal, still conversational. \
-No filler, no slang, no exclamation points, no eager assistant phrases like 'I'd be happy to'. \
+Speak in medium-length sentences with natural contractions: slightly formal, never stiff. \
+No filler, no slang, no exclamation points, no eager assistant phrases. \
 Lead with a concise answer; give detail only when asked. Dry humor is welcome, sparingly. \
+Discuss any lawful, non-harmful subject the operator raises; be broadly knowledgeable, \
+strongest in engineering, robotics, science, and troubleshooting. \
+Don't infer the operator's occupation, interests, identity, history, or prior conversations \
+unless stated here. \
 Be truthful. If you can't answer, say you don't have enough information to answer accurately. \
-Never invent sensor readings or robot state. \
-Never claim access to live state unless it is provided in the request; \
-otherwise say you don't currently have access to that sensor. \
-You may discuss navigation, sensors, ROS, perception, batteries, cameras, water treatment, and engineering. \
+Never invent sensor readings or robot state, memories, or personal details. \
+Never claim access to live state unless provided; otherwise say you don't currently have access to that sensor. \
 You cannot move or control the robot, and never imply you drove it. \
 Motion requests must use the governed motion path. \
-If a request sounds unsafe, don't recommend it — say what should be verified first. \
+If a request sounds unsafe, say what should be verified first. \
 If something is beyond you, say you don't currently have that capability.";
 
 /// Ceiling the prompt-length regression test enforces. Raised 400 → 1300
@@ -1056,10 +1074,79 @@ mod tests {
         // request style challenges politely rather than complying.
         assert!(CHAT_SYSTEM_PROMPT.contains("never imply you drove it"));
         assert!(CHAT_SYSTEM_PROMPT.contains("what should be verified first"));
-        // Domains it may discuss are engineering-real, not roleplay props.
-        for domain in ["navigation", "ROS", "batteries", "water treatment"] {
-            assert!(CHAT_SYSTEM_PROMPT.contains(domain), "{domain}");
+    }
+
+    /// THE regression: the prompt must not name a topic the operator did not.
+    ///
+    /// It used to list the domains Mick "may discuss", water treatment among
+    /// them. On every stateless request that list reached the model as a set
+    /// of live subjects, and phi3 drifted into water treatment unprompted.
+    /// Nothing here bans the SUBJECT — an operator who asks about water
+    /// treatment still gets an answer — it bans the standing suggestion.
+    #[test]
+    fn system_prompt_seeds_no_topic_of_its_own() {
+        let prompt = CHAT_SYSTEM_PROMPT.to_lowercase();
+        for seeded in ["water treatment", "watertreatment", "water"] {
+            assert!(
+                !prompt.contains(seeded),
+                "prompt seeds the topic {seeded:?} — it rides every request"
+            );
         }
+        // The canned deterministic replies must stay topic-free too.
+        for canned in [
+            MOTION_SHAPE_REFUSAL,
+            MOTION_ROUTE_REPLY,
+            fast_route("hello").unwrap(),
+            fast_route("thanks").unwrap(),
+            fast_route("bye").unwrap(),
+        ] {
+            assert!(
+                !canned.to_lowercase().contains("water"),
+                "canned reply seeds a topic: {canned}"
+            );
+        }
+    }
+
+    /// Topic scope is OPEN: broad permission plus where the strengths lie,
+    /// never a closed allowlist the model can read as an agenda.
+    #[test]
+    fn system_prompt_grants_broad_topic_scope_without_an_allowlist() {
+        assert!(CHAT_SYSTEM_PROMPT.contains("any lawful, non-harmful subject"));
+        assert!(CHAT_SYSTEM_PROMPT.contains("broadly knowledgeable"));
+        assert!(
+            CHAT_SYSTEM_PROMPT.contains("operator raises"),
+            "the operator, not the prompt, chooses the subject"
+        );
+        // The enumerating construction itself is gone — "may discuss <list>"
+        // is what turned a permission into a suggestion.
+        assert!(
+            !CHAT_SYSTEM_PROMPT.contains("may discuss"),
+            "a closed domain allowlist must not return"
+        );
+    }
+
+    /// A stateless service has no operator model, so the prompt forbids
+    /// inventing one. Without this, a small model asked to be helpful
+    /// confabulates an occupation and then speaks as if it were established.
+    #[test]
+    fn system_prompt_forbids_inferring_the_operator() {
+        assert!(CHAT_SYSTEM_PROMPT.contains("Don't infer"));
+        for inference in [
+            "occupation",
+            "interests",
+            "identity",
+            "history",
+            "prior conversations",
+        ] {
+            assert!(
+                CHAT_SYSTEM_PROMPT.contains(inference),
+                "prompt must forbid inferring {inference}"
+            );
+        }
+        // And the same boundary on the invention side: no fabricated
+        // memories or personal details to go with the fabricated persona.
+        assert!(CHAT_SYSTEM_PROMPT.contains("memories"));
+        assert!(CHAT_SYSTEM_PROMPT.contains("personal details"));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The permanent Mick system prompt explicitly listed water treatment as a discussion domain:

> You may discuss navigation, sensors, ROS, perception, batteries, cameras, water treatment, and engineering.

Because the prompt is included on every **stateless** chat request (`KIRRA_MICK_CHAT_HISTORY_TURNS=0`), the small local model could drift into that subject without the operator mentioning it. This was never personal-memory transfer — the bias was in the standing prompt itself. A closed allowlist also can't be right in principle: the operator chooses the subject, not the prompt.

## Fix

- remove the water-treatment reference;
- replace the narrow domain list with broad conversational coverage — *"Discuss any lawful, non-harmful subject the operator raises; be broadly knowledgeable, strongest in engineering, robotics, science, and troubleshooting"* (a statement of strengths biases nothing on its own);
- prohibit inferring the operator's occupation, interests, identity, history, or previous conversations unless stated in the current conversation;
- widen the no-invention boundary to match: *"Never invent sensor readings or robot state, memories, or personal details."*
- preserve all motion-isolation and live-state truthfulness boundaries.

Every substring the safety and persona tests pin is unchanged: `cannot move or control the robot`, `governed motion path`, `Never claim access to live state`, `never imply you drove it`, `Be truthful`, `don't have enough information to answer accurately`, `Never invent sensor readings or robot state`, `don't currently have access to that sensor`, `don't currently have that capability`, `what should be verified first`, plus the whole calm-companion tone contract.

## Safety

No routing, motion, planner, checker, voice, or actuation code changed. One file: `crates/kirra-sidecars/src/chat.rs` (prompt constant, its doc comment, and prompt-contract tests). `/chat` and `/chat/stream` wire behavior, model selection, history settings, token limits, streaming and the deterministic fast paths are untouched. Actuation fence: **INTACT**.

## Latency

Prompt size **1187 → 1279 chars** (cap `CHAT_SYSTEM_PROMPT_MAX_CHARS = 1300`, unchanged) and **184 → 188 words** — prefill cost is essentially flat, so TTFT should not move. Fitting the new content inside the existing budget cost three flourishes — `still conversational`, the `like 'I'd be happy to'` example, and `don't recommend it` — none pinned by a test and each redundant with a rule that remains (`slightly formal, never stiff`, `no eager assistant phrases`, and `say what should be verified first`).

## Tests

The closed-domain assertion (`for domain in [..., "water treatment"]`) is replaced by three contract tests:

- **`system_prompt_seeds_no_topic_of_its_own`** — the prompt *and* every canned reply are free of `water` / `water treatment` / `watertreatment` in any casing. This bans the standing suggestion, not the subject: an operator who asks about water treatment still gets an answer.
- **`system_prompt_grants_broad_topic_scope_without_an_allowlist`** — pins `any lawful, non-harmful subject`, `broadly knowledgeable`, `operator raises`, and asserts the enumerating construction `may discuss` cannot return.
- **`system_prompt_forbids_inferring_the_operator`** — pins `Don't infer` plus occupation / interests / identity / history / prior conversations, and the invention-side `memories` / `personal details`.

Existing motion-isolation, live-state, truthfulness, tone, budget and no-motion-wire-form tests are unchanged and green. No live-model test was added — prompt contracts are deterministic; model behavior is checked on hardware after deployment.

**Results:** `cargo test -p kirra-sidecars` 222 lib + all integration suites green (incl. `mick_chat_separation`) · `cargo fmt --all --check` clean · `cargo clippy -p kirra-sidecars --all-targets -D warnings` clean · `ci/check_mick_actuation_fence.py` INTACT · `git diff --check` clean.

## Residual drift this cannot fully eliminate

Prompt wording bounds a 3.8B model's tendencies; it does not guarantee them. Removing the seed removes the *cause* we identified, but a small model may still occasionally over-assume context or answer more confidently than its knowledge warrants. The structural guarantees are unchanged and do not depend on the model complying: no motion authority in this service at all, the governed motion path for anything that moves, and a stateless service that has no prior conversations to leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_