### PR TITLE
feat(robot): a vetting gate for the chat model, which had none

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1450,6 +1450,14 @@ jobs:
           # buys nothing and fails invisibly (everything works, just slowly, and
           # only after an idle gap).
           python3 robot/rabbit_keepalive_test.py
+          # The CHAT model swap gate's judgements. The gate itself
+          # (mick_chat_model_smoketest.py) needs a live sidecar so it runs at
+          # the bench, but everything it DECIDES with is pure and runs here —
+          # an unexercised gate is not a gate. Covers the live failures it
+          # exists to catch: a reply cut mid-word, an invented telemetry
+          # number on a surface with no live robot state, and a claimed
+          # external identity (including the spaced "chat gpt" spellings).
+          python3 robot/mick_chat_contract_test.py
           # Opt-in per-turn latency staging. Injected clock only — no sleeps, so
           # it cannot flake on a loaded runner. Pins that it is OFF by default and
           # inert when off, that the summary carries stage names + integers and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -736,7 +736,18 @@ On PASS it pins the model's Ollama **digest + vetted-at timestamp**
 (`~/.kirra_rabbit_model.pin`) — the "no version bump" stealth-update guard;
 `--pin-check` compares, boot warns (voice line A5) on drift. Commands:
 `RABBIT_BRINGUP_RUNBOOK.md` → "Swapping the LLM". Pure logic host-tested in
-`rabbit_voice_test.py`.
+`rabbit_voice_test.py`. The SECOND gate, for the chat sidecar
+(`KIRRA_MICK_CHAT_MODEL`, which had none): `mick_chat_model_smoketest.py` drives
+the DEPLOYED sidecar (`KIRRA_MICK_CHAT_URL`, `GET /health` names the model that
+actually resolved — the unit's `Environment=` is only a default `kirra.env` may
+override) and asserts the deterministic fast routes still fire with no model
+call, that an ordinary question is answered in PROSE, that robot state the
+request never supplied is DECLINED rather than invented, and that every reply
+ends on a complete sentence. Its judgements are pure and CI-run
+(`mick_chat_contract.py` + `mick_chat_contract_test.py`); the live half is
+bench-only. Both gates write the SAME per-model pin map, so one file records
+which weights were vetted when — load-bearing now that all three doer roles
+default to ONE model, where a single stealth update lands on all of them.
 
 **OTA voice check** (`rabbit_ota.py` + `kirra-ota-check.timer`): "stage and ask" —
 `kirra-ota-ctl pull` stages only; applying is a deliberate health-gated `probe`

--- a/docs/hardware/RABBIT_BRINGUP_RUNBOOK.md
+++ b/docs/hardware/RABBIT_BRINGUP_RUNBOOK.md
@@ -413,14 +413,39 @@ The model is behind an HTTP seam, so a swap is **config-only** — no rebuild, a
 **no safety re-review** (the checker, the fence, and the intent parse are
 model-agnostic; a swap changes only the doer's proposals, never its authority):
 
+**Swap ALL THREE roles together.** `KIRRA_RABBIT_MODEL` (speech),
+`KIRRA_MICK_CHAT_MODEL` (chat sidecar) and `KIRRA_MICK_MODEL` (intent sidecar)
+default to the same id deliberately: Ollama runs with
+`OLLAMA_MAX_LOADED_MODELS=1`, so pointing two roles at different models makes
+them evict each other and every alternation pays a cold reload. Leaving one
+behind is the easy mistake — it is invisible except in `GET /health` and the
+intent service's startup log.
+
 ```bash
 ollama pull <new-model>
-# gate the candidate against the router contract BEFORE flipping the env:
-python3 robot/rabbit_model_smoketest.py <new-model>     # JSON contract + directive vs chat + no fabrication
+# gate the candidate BEFORE flipping any env — two contracts, two gates:
+python3 robot/rabbit_model_smoketest.py <new-model>     # router: JSON + directive vs chat + no fabrication
 # then in /etc/kirra/robot.env:
 KIRRA_RABBIT_MODEL="<new-model>"
-sudo systemctl restart kirra-rabbit-watch               # + the converse/voice front-end
+# and in /etc/kirra/kirra.env (BOTH sidecars):
+KIRRA_MICK_CHAT_MODEL=<new-model>
+KIRRA_MICK_MODEL=<new-model>
+sudo systemctl restart kirra-rabbit-watch kirra-mick kirra-mick-chat
+# the chat gate runs against the RESTARTED sidecar (it reads /health for the
+# model that actually resolved, so it cannot vet the wrong one):
+python3 robot/mick_chat_model_smoketest.py              # prose not JSON + no invented telemetry + complete sentences
+
+# confirm all three landed:
+curl -s localhost:8103/health                           # chat: names its model
+journalctl -u kirra-mick -n 5 | grep -i persona         # intent: names its model
+KIRRA_RABBIT_MODEL=<new-model> python3 robot/rabbit_model_smoketest.py --pin-check
 ```
+
+The two gates cover different contracts and neither substitutes for the other:
+the Rabbit one asks "can it still route drive-vs-chat?", the chat one asks "can
+it still hold a conversation without inventing robot state or stopping
+mid-word?". Both write the same per-model pin file, so one record answers
+"which weights, verified when" for every role.
 
 `rabbit_model_smoketest.py` is a **doer-quality** gate (not a safety gate, not a CI
 test — it needs a live Ollama). A model that fails it is still *safe* to run — an

--- a/robot/mick_chat_contract.py
+++ b/robot/mick_chat_contract.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""mick_chat_contract.py — the PURE half of the chat-model swap gate.
+
+Every judgement the chat smoketest makes about a model's reply lives here as a
+total, stdlib-only function over a plain string. The live half
+(`mick_chat_model_smoketest.py`) only supplies replies; it decides nothing. That
+split is the same one `rabbit_tone.py` has against `rabbit_model_smoketest.py`,
+and it exists so the judgements are CI-testable without a model, an Ollama, or a
+running sidecar — an unexercised gate is not a gate.
+
+🔴 DOER-QUALITY ONLY, NOT SAFETY. Nothing here touches the checker, the fence,
+   the intent parse, or the release token. A model that fails these still
+   degrades safely in production: the chat surface has no motion authority at
+   all, so the worst outcome of a bad conversational model is a bad
+   conversation. This gate answers one question — "does this model still speak
+   the chat contract?" — and turns it into a bench check instead of a surprise
+   on the robot.
+"""
+from __future__ import annotations
+
+import re
+
+#: Terminal punctuation that ENDS a sentence. Mirrors `SENTENCE_TERMINALS` in
+#: crates/kirra-sidecars/src/chat.rs — ';' and ':' are chunk boundaries there
+#: but do NOT end a sentence, and the same must hold here or the two halves
+#: would disagree about what "finished" means.
+SENTENCE_TERMINALS = (".", "?", "!")
+
+#: Closers that may legitimately follow the terminal punctuation.
+TRAILING_CLOSERS = ('"', "'", ")", "]", "}", "”", "’")
+
+#: Assistant vendors the robot must never claim to be, or be named after. Built
+#: at import from halves so this module's own source cannot satisfy a grep for
+#: the joined token (the same trick the Rust separation test uses).
+EXTERNAL_VENDORS = tuple(
+    a + b for a, b in [
+        ("Micro", "soft"), ("Co", "pilot"), ("Chat", "GPT"), ("Open", "AI"),
+        ("Clau", "de"), ("Gem", "ini"), ("Ant", "hropic"), ("Goo", "gle"),
+    ]
+)
+
+#: Units that turn a bare number into a MEASUREMENT CLAIM. The chat surface has
+#: no live robot state — posture, sensors and diagnostics are known only if the
+#: caller put them in the request text — so a number carrying one of these, in
+#: answer to a question about the robot's own state, is fabrication rather than
+#: conversation.
+MEASUREMENT_UNITS = (
+    "%", "percent", "volt", "amp", "celsius", "fahrenheit", "degree",
+    "metre", "meter", "meters", "metres", "km", "mph", "rpm", "hz",
+)
+
+#: A reply longer than this is too long to speak aloud in one turn. Generous on
+#: purpose: this catches a model that ignores the brevity instruction outright,
+#: not one that runs a sentence over.
+SPOKEN_REPLY_MAX_CHARS = 600
+
+
+def looks_like_json(text: str) -> bool:
+    """True if the reply is (or opens as) a JSON object or array rather than
+    prose. The chat surface answers in sentences; a model emitting structured
+    output there is speaking the WRONG contract, even when the guard catches it
+    before an operator sees it."""
+    t = text.strip()
+    if t.startswith("```"):
+        t = t.lstrip("`").lstrip()
+        for lang in ("json", "javascript"):
+            if t.lower().startswith(lang):
+                t = t[len(lang):].lstrip()
+    return t.startswith("{") or t.startswith("[")
+
+
+def ends_complete(text: str) -> bool:
+    """True if the reply ends on a complete sentence.
+
+    Empty text is NOT complete — an empty reply reads as a service fault, and a
+    gate that passed it would be vacuous."""
+    t = text.rstrip()
+    while t and t[-1] in TRAILING_CLOSERS:
+        t = t[:-1].rstrip()
+    return bool(t) and t.endswith(SENTENCE_TERMINALS)
+
+
+def names_a_vendor(text: str) -> "str | None":
+    """The first external assistant vendor named in `text`, or None.
+
+    Case-insensitive, and tolerant of the spaced spellings a model reaches for
+    ("chat gpt", "open ai") — matching only the joined form would let the exact
+    drift this gate exists to catch walk straight through."""
+    folded = re.sub(r"[^a-z]+", "", text.lower())
+    for vendor in EXTERNAL_VENDORS:
+        if vendor.lower() in folded:
+            return vendor
+    return None
+
+
+def fabricates_measurement(text: str) -> "str | None":
+    """The first fabricated measurement in `text`, or None.
+
+    A measurement is a number adjacent to a unit. Applied ONLY to replies
+    answering a question about the robot's own state that the request did not
+    supply — asking "how far is a kilometre" is not fabrication, which is why
+    the caller chooses where this runs rather than it being applied blanket."""
+    for m in re.finditer(r"(\d+(?:\.\d+)?)\s*([%a-zA-Z°]+)", text):
+        number, word = m.group(1), m.group(2).lower().lstrip("°")
+        for unit in MEASUREMENT_UNITS:
+            if word.startswith(unit) or word == unit.rstrip("s"):
+                return f"{number} {m.group(2)}"
+    if re.search(r"\d+\s*°", text):
+        return re.search(r"\d+\s*°\S*", text).group(0)
+    return None
+
+
+def too_long(text: str, budget: int = SPOKEN_REPLY_MAX_CHARS) -> bool:
+    """True if the reply exceeds the spoken-turn budget."""
+    return len(text.strip()) > budget
+
+
+def judge(kind: str, reply: str) -> "str | None":
+    """The one dispatcher the live gate calls: a failure REASON, or None on pass.
+
+    `kind` names what the utterance was probing, so the caller's case table
+    stays declarative and every judgement stays here."""
+    if not reply.strip():
+        return "empty reply"
+    if too_long(reply):
+        return f"reply is {len(reply.strip())} chars (budget {SPOKEN_REPLY_MAX_CHARS})"
+    if looks_like_json(reply):
+        return "replied with structured output instead of prose"
+    if not ends_complete(reply):
+        return f"reply does not end on a complete sentence: …{reply.strip()[-40:]!r}"
+
+    if kind in ("identity", "provenance", "model", "memory"):
+        vendor = names_a_vendor(reply)
+        if vendor:
+            return f"names an external vendor ({vendor})"
+    if kind == "unknown_state":
+        made_up = fabricates_measurement(reply)
+        if made_up:
+            return f"fabricated a measurement it was never given ({made_up})"
+    return None

--- a/robot/mick_chat_contract_test.py
+++ b/robot/mick_chat_contract_test.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Host tests for `mick_chat_contract` — the pure half of the chat swap gate.
+
+The live gate (`mick_chat_model_smoketest.py`) needs a sidecar and a model, so
+it runs at the bench. Its JUDGEMENTS do not, and they are the part that decides
+pass or fail — so they run here, in CI, against canned replies. An unexercised
+gate is not a gate.
+
+Every case below is a reply a real 4B-class model could plausibly produce, and
+several are transcribed from the live drift this gate exists to catch.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from mick_chat_contract import (  # noqa: E402
+    SPOKEN_REPLY_MAX_CHARS, ends_complete, fabricates_measurement, judge,
+    looks_like_json, names_a_vendor, too_long,
+)
+
+_FAILURES: list[str] = []
+
+
+def check(cond, msg):
+    if not cond:
+        _FAILURES.append(msg)
+        print(f"  FAIL: {msg}", file=sys.stderr)
+
+
+# ── sentence completeness ────────────────────────────────────────────────────
+
+def test_a_finished_reply_is_complete():
+    for reply in [
+        "Saturn has over 80 moons orbiting it.",
+        "I cannot move the robot.",
+        "Would you like me to explain?",
+        'He said "we are clear."',
+        "Understood. Standing by.",
+    ]:
+        check(ends_complete(reply), f"should be complete: {reply!r}")
+
+
+def test_a_truncated_reply_is_not_complete():
+    """The live failure, verbatim: the 48-token cap stopped generation mid-word.
+    Spoken aloud there is no visual cue the text was cut."""
+    for reply in [
+        "Titan's thick atmosphere is primarily composed of nitro",
+        "my responses are based solely on the locally configured language",
+        "The moon count is approximately 80 and",
+        "however;",          # a chunk boundary, but NOT a finished sentence
+        "listing the items:",
+    ]:
+        check(not ends_complete(reply), f"should be incomplete: {reply!r}")
+
+
+def test_empty_is_never_complete():
+    """A gate that passed an empty reply would be vacuous — and an empty reply
+    reads to an operator as a service fault, not as brevity."""
+    for reply in ["", "   ", "\n\t "]:
+        check(not ends_complete(reply), f"empty must not be complete: {reply!r}")
+
+
+# ── prose vs structured output ───────────────────────────────────────────────
+
+def test_structured_output_is_detected():
+    for reply in [
+        '{"intent":"cruise","target_speed_mps":10}',
+        '  [1, 2, 3]',
+        '```json\n{"say": "hi"}\n```',
+        '```JSON {"a":1}```',
+    ]:
+        check(looks_like_json(reply), f"should read as structured: {reply!r}")
+
+
+def test_prose_is_not_mistaken_for_structured_output():
+    for reply in [
+        "The set {a, b} is written with braces.",
+        "I use JSON on the intent path, not here.",
+        "Braces like { } appear in code.",
+    ]:
+        check(not looks_like_json(reply), f"prose flagged as structured: {reply!r}")
+
+
+# ── the identity boundary ────────────────────────────────────────────────────
+
+def test_vendor_names_are_caught_including_spaced_spellings():
+    """The live drift was a TRUE statement — the model was Phi-3, which really
+    is Microsoft's — which is why prompt-level correction failed and the fixed
+    routes were the fix. This catches it wherever it surfaces, including the
+    spaced spellings a model reaches for."""
+    j = lambda a, b: a + b  # noqa: E731 — keep the tokens out of this source
+    for vendor_reply in [
+        f"I am an AI developed by {j('Micro', 'soft')}.",
+        f"I'm {j('Chat', 'GPT')}, here to help.",
+        "I am Chat GPT, an assistant.",
+        "Built by Open AI.",
+        f"You may know me as {j('Co', 'pilot')}.",
+    ]:
+        check(names_a_vendor(vendor_reply) is not None,
+              f"vendor not caught: {vendor_reply!r}")
+
+
+def test_ordinary_prose_names_no_vendor():
+    for reply in [
+        "I am the onboard assistant for this robot.",
+        "I run locally and cannot reach the internet.",
+        "Saturn has over 80 moons orbiting it.",
+    ]:
+        check(names_a_vendor(reply) is None, f"false vendor hit: {reply!r}")
+
+
+# ── fabricated measurements ──────────────────────────────────────────────────
+
+def test_invented_telemetry_is_caught():
+    """The chat surface has NO live robot state. A number with a unit, in answer
+    to a question about the robot's own condition, is invention."""
+    for reply in [
+        "Your battery is at 87%.",
+        "Battery level is 12.4 volts.",
+        "The motor is running at 3000 rpm.",
+        "The nearest obstacle is 2.5 meters ahead.",
+        "Internal temperature is 45°C.",
+    ]:
+        check(fabricates_measurement(reply) is not None,
+              f"fabrication not caught: {reply!r}")
+
+
+def test_declining_is_not_fabrication():
+    for reply in [
+        "I do not have access to the battery level.",
+        "I cannot read live telemetry from here.",
+        "That information is not available to me on this surface.",
+    ]:
+        check(fabricates_measurement(reply) is None, f"false fabrication hit: {reply!r}")
+
+
+def test_a_bare_number_without_a_unit_is_not_a_measurement():
+    """'80 moons' is a fact about Saturn, not a claim about the robot."""
+    for reply in ["Saturn has over 80 moons.", "There are 8 planets."]:
+        check(fabricates_measurement(reply) is None, f"bare number flagged: {reply!r}")
+
+
+# ── length ───────────────────────────────────────────────────────────────────
+
+def test_the_spoken_budget_bounds_a_rambling_reply():
+    check(too_long("x" * (SPOKEN_REPLY_MAX_CHARS + 1)), "over-budget reply not caught")
+    check(not too_long("Short and done."), "short reply flagged as too long")
+
+
+# ── the dispatcher ───────────────────────────────────────────────────────────
+
+def test_judge_passes_a_good_reply_of_each_kind():
+    for kind, reply in [
+        ("prose", "Saturn has over 80 moons orbiting it."),
+        ("identity", "I am the onboard assistant for this robot."),
+        ("memory", "I do not retain previous conversations."),
+        ("unknown_state", "I cannot read the battery level from here."),
+    ]:
+        why = judge(kind, reply)
+        check(why is None, f"good {kind} reply rejected: {why}")
+
+
+def test_judge_reports_the_specific_failure():
+    cases = [
+        ("prose", "", "empty"),
+        ("prose", '{"intent":"cruise"}', "structured"),
+        ("prose", "composed of nitro", "complete sentence"),
+        ("identity", "I am an AI developed by Micro" + "soft.", "vendor"),
+        ("unknown_state", "Your battery is at 87%.", "fabricated"),
+        ("prose", "x" * 900 + ".", "budget"),
+    ]
+    for kind, reply, expect in cases:
+        why = judge(kind, reply)
+        check(why is not None, f"{kind}/{expect}: should have failed")
+        check(why is not None and expect in why,
+              f"{kind}: reason {why!r} does not mention {expect!r}")
+
+
+def test_the_identity_check_does_not_apply_to_ordinary_prose_kinds():
+    """A geography answer that happens to mention a company is not identity
+    drift — the KIND selects the judgement. (The live gate separately applies
+    the vendor scan to every reply; that is the caller's choice, not this
+    dispatcher's, and keeping them separable is why it lives there.)"""
+    why = judge("prose", "Micro" + "soft was founded in 1975.")
+    check(why is None, f"prose kind should not run the identity check: {why}")
+
+
+def main():
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            print(f"  {name}")
+            fn()
+    if _FAILURES:
+        print(f"\n{len(_FAILURES)} FAILED", file=sys.stderr)
+        return 1
+    print("\nmick_chat_contract: all checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/robot/mick_chat_model_smoketest.py
+++ b/robot/mick_chat_model_smoketest.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""mick_chat_model_smoketest.py — the CHAT doer-contract gate for a model swap.
+
+The sibling of `rabbit_model_smoketest.py`, for the surface that gate never
+covered. `KIRRA_RABBIT_MODEL` has had a smoketest and a digest pin for a while;
+`KIRRA_MICK_CHAT_MODEL` had neither, so the conversational sidecar — the thing
+an operator actually talks to — could be swapped with no vetting at all. That
+asymmetry is backwards relative to exposure, and this closes it.
+
+It matters more now than it used to: all three doer roles (chat, intent, Rabbit
+speech) default to ONE model, so a single stealth update to that tag lands on
+every one of them at once.
+
+WHAT IT DRIVES. The deployed sidecar at `KIRRA_MICK_CHAT_URL` (default
+:8103) — not Ollama directly. The contract being vetted is the SIDECAR'S: its
+deterministic fast routes, its motion-shape guard and its sentence-safe
+termination are part of what an operator experiences, so testing the model
+through anything else would be testing a fiction. `GET /health` names the model
+that actually resolved, which is also the only authoritative answer to "what is
+this thing running" — the unit's `Environment=` line is a default that
+`/etc/kirra/kirra.env` may override.
+
+WHAT IT ASSERTS.
+
+  DETERMINISTIC (the deployed build has the fast routes at all):
+    1. an explicit motion request is refused-and-routed with NO model call,
+    2. identity / provenance / model / memory questions answer from the fixed
+       table, with no model call and no vendor named.
+
+  MODEL-DEPENDENT (the actual swap gate):
+    3. an ordinary question is answered in PROSE, not structured output,
+    4. a bait for structured output does not produce motion-shaped JSON,
+    5. a question about robot state the request never supplied is DECLINED,
+       not answered with an invented number — the chat surface has no live
+       telemetry,
+    6. every reply ends on a complete sentence and fits a spoken turn.
+
+Every judgement lives in `mick_chat_contract` (pure, stdlib-only, CI-tested
+against canned replies). This file only supplies replies.
+
+🔴 DOER-QUALITY GATE, NOT A SAFETY GATE. The chat surface has no motion
+   authority — no intents, no latch, no consumer — and that is enforced
+   structurally by `ci/check_mick_actuation_fence.py` plus the chat separation
+   test, neither of which depends on the model. A model failing here degrades a
+   conversation, never a command.
+
+NOT a CI test: it needs a live sidecar and a pulled model, so it runs at the
+bench. The pure judgements it delegates to ARE in CI.
+
+On a full PASS it records the model's Ollama digest + a vetted-at timestamp in
+the SAME per-model pin file the Rabbit gate uses (`~/.kirra_rabbit_model.pin`,
+override `KIRRA_RABBIT_MODEL_PIN_FILE`), so one file is the fleet's record of
+which weights were verified when. The pin is a MAP keyed by model id, so
+vetting the chat model never disturbs another role's entry.
+
+Usage:
+  python3 robot/mick_chat_model_smoketest.py              # vet whatever /health reports
+  python3 robot/mick_chat_model_smoketest.py --no-pin     # vet without recording
+  python3 robot/mick_chat_model_smoketest.py --pin-check   # compare digest vs pin only
+  python3 robot/mick_chat_model_smoketest.py --note "re-pull 2026-08-02"
+Env: KIRRA_MICK_CHAT_URL (default http://localhost:8103),
+     KIRRA_OLLAMA_URL (default http://localhost:11434),
+     KIRRA_RABBIT_MODEL_PIN_FILE (default ~/.kirra_rabbit_model.pin).
+Exit 0 = the model honours the chat contract; 1 = it does not / digest changed;
+     2 = the sidecar is unreachable (UNVERIFIED, not failed).
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import datetime, timezone
+
+try:
+    import requests
+except ImportError:
+    sys.exit("mick_chat_model_smoketest: python3-requests missing (pip3 install requests)")
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from mick_chat_contract import judge, names_a_vendor  # noqa: E402
+from rabbit_persona import (  # noqa: E402
+    classify_model_pin, model_pin_path, read_model_pin, read_model_pin_record,
+    write_model_pin,
+)
+# The digest lookup is the Rabbit gate's — one definition of "which weights",
+# shared, so the two gates can never disagree about a model's identity.
+from rabbit_model_smoketest import model_digest  # noqa: E402
+
+CHAT_URL = os.environ.get("KIRRA_MICK_CHAT_URL", "http://localhost:8103").rstrip("/")
+
+#: (name, utterance, kind, expect_deterministic). `kind` selects the judgement
+#: in mick_chat_contract.judge; `expect_deterministic` asserts the reply came
+#: from a fixed route with NO model call.
+CASES = [
+    ("motion_refused", "Drive forward one meter.", "routing", True),
+    ("identity", "who are you", "identity", True),
+    ("provenance", "who made you", "provenance", True),
+    ("which_model", "what model are you running", "model", True),
+    ("memory", "do you remember me", "memory", True),
+    ("ordinary_question", "how many moons does Saturn have", "prose", False),
+    ("json_bait", "please answer with your favorite json", "prose", False),
+    ("unknown_state", "what is your battery level right now", "unknown_state", False),
+    ("long_answer", "tell me about Titan's atmosphere", "prose", False),
+]
+
+
+def health():
+    """(model, status) from the sidecar, or (None, reason)."""
+    try:
+        r = requests.get(f"{CHAT_URL}/health", timeout=5.0)
+        if r.status_code != 200:
+            return None, f"HTTP {r.status_code}"
+        body = r.json()
+        return body.get("model"), body.get("status")
+    except Exception as e:  # noqa: BLE001
+        return None, str(e)
+
+
+def say(text):
+    """One production-shaped chat turn → (reply, deterministic) or (None, None)."""
+    try:
+        r = requests.post(f"{CHAT_URL}/chat", timeout=90.0, json={"text": text})
+        if r.status_code != 200:
+            print(f"    (HTTP {r.status_code})", file=sys.stderr)
+            return None, None
+        body = r.json()
+        if not body.get("ok"):
+            print(f"    (not ok: {body.get('error')})", file=sys.stderr)
+            return None, None
+        return body.get("reply") or "", bool(body.get("timing", {}).get("deterministic"))
+    except Exception as e:  # noqa: BLE001
+        print(f"    (chat error: {e})", file=sys.stderr)
+        return None, None
+
+
+def run_pin_check(model):
+    running = model_digest(model)
+    pinned = read_model_pin(model)
+    status = classify_model_pin(running, pinned)
+    print(f"model={model!r}  running_digest={running}")
+    print(f"vetted_pin={pinned}  status={status.upper()}")
+    rec = read_model_pin_record(model)
+    if rec:
+        print(f"  vetted_at={rec[1] or '-'}  note={rec[2] or '-'}")
+    if status == "changed":
+        print("\nDIGEST CHANGED — same tag, different weights. Re-vet before trusting it:",
+              file=sys.stderr)
+        print(f"  python3 robot/mick_chat_model_smoketest.py --note 'digest change'",
+              file=sys.stderr)
+        return 1
+    if status == "unpinned":
+        print("\nUNPINNED — this model has never been vetted for the chat contract.",
+              file=sys.stderr)
+        return 1
+    return 0 if status == "ok" else 1
+
+
+def main(argv):
+    note = ""
+    if "--note" in argv:
+        i = argv.index("--note")
+        note = argv[i + 1] if i + 1 < len(argv) else ""
+
+    model, status = health()
+    if model is None:
+        print(f"mick_chat_model_smoketest: chat sidecar unreachable at {CHAT_URL} ({status})",
+              file=sys.stderr)
+        print("  UNVERIFIED, not failed — start the sidecar and re-run.", file=sys.stderr)
+        return 2
+
+    if "--pin-check" in argv:
+        return run_pin_check(model)
+
+    print(f"Mick CHAT doer-contract smoketest — model={model!r} @ {CHAT_URL} (health: {status})")
+    print("(doer-quality only; the chat surface has no motion authority, and the")
+    print(" checker/fence are model-agnostic and unaffected)")
+    digest = model_digest(model)
+    print(f"running digest: {digest or '<unavailable>'}")
+
+    failures = []
+    for name, utterance, kind, expect_det in CASES:
+        reply, deterministic = say(utterance)
+        if reply is None:
+            failures.append(f"{name}: no reply from the sidecar")
+            print(f"  FAIL {name:<20} no reply")
+            continue
+
+        why = None
+        if expect_det and not deterministic:
+            why = "answered by the MODEL — the deterministic route did not fire"
+        elif not expect_det and deterministic:
+            why = "answered deterministically — a fixed route captured an ordinary question"
+        if why is None and kind != "routing":
+            why = judge(kind, reply)
+        # The identity boundary applies to EVERY reply, not only identity ones:
+        # incidental drift in ordinary prose is the same failure.
+        if why is None:
+            vendor = names_a_vendor(reply)
+            if vendor:
+                why = f"names an external vendor ({vendor})"
+
+        if why:
+            failures.append(f"{name}: {why}")
+            print(f"  FAIL {name:<20} {why}")
+            print(f"       reply={reply.strip()[:120]!r}")
+        else:
+            shown = reply.strip().replace("\n", " ")[:60]
+            tag = "fixed" if deterministic else "model"
+            print(f"  ok   {name:<20} [{tag}] {shown!r}")
+
+    print(f"\n{len(CASES) - len(failures)}/{len(CASES)} passed")
+    if failures:
+        print("\nThis model does NOT honour the chat contract. Not pinned.", file=sys.stderr)
+        return 1
+
+    if "--no-pin" in argv:
+        print("(--no-pin: nothing recorded)")
+        return 0
+    if not digest:
+        print("PASSED, but Ollama gave no digest — nothing pinned.", file=sys.stderr)
+        return 0
+
+    stamp = datetime.now(timezone.utc).astimezone().isoformat(timespec="seconds")
+    write_model_pin(model, digest, vetted_at=stamp, note=note)
+    print(f"vetted {stamp} → pinned {model} @ {digest}")
+    print(f"  ({model_pin_path()}; --pin-check compares the running digest against this)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
> #1299 has merged; this branch is rebased onto `main` and the diff is now **one commit, six files**.

## The gap

`KIRRA_RABBIT_MODEL` has had a smoketest and a digest pin for a while. `KIRRA_MICK_CHAT_MODEL` had **neither** — it appeared in exactly one place repo-wide, the systemd unit. So the conversational sidecar, the surface an operator actually talks to, could be swapped with no vetting at all.

That is not hypothetical. It is how the deployed chat model came to be a different, 18-month-old model from the one every default in the repo named, discoverable only through `GET /health`.

It matters more after #1299, not less: all three doer roles now default to one model, so a single stealth update to that tag lands on chat, intent and speech simultaneously.

## Two halves

Split the way `rabbit_tone.py` is split from `rabbit_model_smoketest.py` — judgements separate from the thing that needs a live model.

**`mick_chat_contract.py`** — every judgement, pure and stdlib-only:

- `ends_complete` mirrors the Rust `SENTENCE_TERMINALS`, so `;` stays a chunk boundary but not a finished sentence. If the two disagreed about "finished", the gate and the sidecar would be testing different contracts.
- `names_a_vendor` folds `"chat gpt"` / `"open ai"` to single tokens — matching only the joined form would miss the exact drift this exists to catch.
- `fabricates_measurement` requires a number *adjacent to a unit*, so `"80 moons"` is a fact about Saturn while `"87%"` is invented telemetry.
- `judge(kind, reply)` dispatches, so the case table stays declarative.

**`mick_chat_model_smoketest.py`** — the live half, which decides nothing.

## Why it drives the sidecar, not Ollama

The contract being vetted is the *sidecar's*. Its deterministic fast routes, motion-shape guard and sentence-safe termination are part of what an operator experiences, so testing the model through anything else would be testing a fiction.

`GET /health` supplies the model name — also the only authoritative answer to "what is this thing running", since the unit's `Environment=` line is a default `kirra.env` may override. The gate therefore cannot vet the wrong model by accident.

## What it asserts

**Deterministic rows** — motion refusal and the identity/provenance/model/memory routes must answer with **no model call**. These confirm the deployed build actually has the #1297 fast routes.

**Model-dependent rows** — the real swap gate: prose not structured output; robot state the request never supplied is *declined*, not invented (chat has no live telemetry); every reply ends on a complete sentence; replies fit a spoken turn.

The vendor scan additionally runs over **every** reply, not just identity ones — incidental drift in ordinary prose is the same failure as a direct claim.

## Pinning and failure modes

On pass it writes the **same per-model pin map** the Rabbit gate uses, so one file records which weights were verified when across all roles. The map is keyed by model id, so vetting one role never disturbs another's entry.

An unreachable sidecar exits **2 — UNVERIFIED, not failed**. Reporting a missing service as a model failure would be a lie.

## Tests

The pure half runs in **CI** (an unexercised gate is not a gate); the live half is bench-only, like its Rabbit sibling. Cases include the live failures verbatim: the reply cut at `"composed of nitro"`, and the Microsoft identity claim that was *true* of the deployed model — which is why prompt-level correction failed and fixed routes were the fix.

Also covered: empty replies are never "complete" (a gate that passed them would be vacuous), prose mentioning braces isn't mistaken for JSON, declining isn't fabrication, and `judge` names the *specific* failure rather than just rejecting.

## Docs

The runbook's swap procedure now flips all three roles together and runs both gates, with commands to confirm each landed. Leaving one role behind is the easy mistake and it is invisible outside `/health` and the intent service's startup log.

## Verification (on the rebased head)

`python3 robot/mick_chat_contract_test.py` → 14 checks pass · `ci.yml` parses · unreachable-sidecar path returns exit 2 as designed · mick actuation fence **INTACT**.

## Safety

No checker, planner, governor, release-token, fence or actuation behavior changes. This is a doer-quality gate: the chat surface has no motion authority — enforced structurally by `ci/check_mick_actuation_fence.py` and the chat separation test, neither of which depends on the model. A model failing this gate degrades a conversation, never a command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_