### PR TITLE
fix(chat): pace model smoketest to service rate limit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1458,6 +1458,15 @@ jobs:
           # number on a surface with no live robot state, and a claimed
           # external identity (including the spaced "chat gpt" spellings).
           python3 robot/mick_chat_contract_test.py
+          # The chat gate's PACING and failure classification. The chat service
+          # admits a short burst then ~1 request/second, so nine back-to-back
+          # turns took 429s that the gate reported as "this model does NOT
+          # honour the chat contract" — a false accusation against a model that
+          # was never asked. Sleep and HTTP are mocked, so this pins the exact
+          # interleaving (no sleep before the first request, one between every
+          # later pair) without waiting, and pins that a 429 is INFRASTRUCTURE
+          # and never pins a digest.
+          python3 robot/mick_chat_model_smoketest_test.py
           # Opt-in per-turn latency staging. Injected clock only — no sleeps, so
           # it cannot flake on a loaded runner. Pins that it is OFF by default and
           # inert when off, that the summary carries stage names + integers and

--- a/robot/mick_chat_model_smoketest.py
+++ b/robot/mick_chat_model_smoketest.py
@@ -4,21 +4,33 @@
 The sibling of `rabbit_model_smoketest.py`, for the surface that gate never
 covered. `KIRRA_RABBIT_MODEL` has had a smoketest and a digest pin for a while;
 `KIRRA_MICK_CHAT_MODEL` had neither, so the conversational sidecar — the thing
-an operator actually talks to — could be swapped with no vetting at all. That
-asymmetry is backwards relative to exposure, and this closes it.
+an operator actually talks to — could be swapped with no vetting at all.
 
-It matters more now than it used to: all three doer roles (chat, intent, Rabbit
-speech) default to ONE model, so a single stealth update to that tag lands on
-every one of them at once.
+It matters more now that all three doer roles (chat, intent, Rabbit speech)
+default to ONE model: a single stealth update to that tag lands on every one of
+them at once.
 
-WHAT IT DRIVES. The deployed sidecar at `KIRRA_MICK_CHAT_URL` (default
-:8103) — not Ollama directly. The contract being vetted is the SIDECAR'S: its
-deterministic fast routes, its motion-shape guard and its sentence-safe
-termination are part of what an operator experiences, so testing the model
-through anything else would be testing a fiction. `GET /health` names the model
-that actually resolved, which is also the only authoritative answer to "what is
-this thing running" — the unit's `Environment=` line is a default that
-`/etc/kirra/kirra.env` may override.
+WHAT IT DRIVES. The deployed sidecar at `--url` (default :8103) — not Ollama
+directly. The contract being vetted is the SIDECAR'S: its deterministic fast
+routes, its motion-shape guard and its sentence-safe termination are part of
+what an operator experiences, so testing the model through anything else would
+be testing a fiction. `GET /health` names the model that actually resolved,
+which is also the only authoritative answer to "what is this thing running" —
+the unit's `Environment=` line is a default that `/etc/kirra/kirra.env` may
+override.
+
+PACING (why `--delay-seconds` exists). The chat service is behind a rate
+limiter that admits a short burst and then settles to roughly one request per
+second. Nine back-to-back turns spend the burst on the first few cases and take
+`429` for the rest, which the earlier version of this script reported as a
+model-contract failure — a false accusation against a model that was never
+asked. The fix belongs HERE, not in the limiter: a bench tool must fit the
+production service, never the other way round. So every case is paced, and a
+`429` is classified as INFRASTRUCTURE, never as model quality.
+
+Waiting before launching the script does not help on its own — the burst
+allowance is consumed by the script's own first few requests, so the spacing
+has to be between cases.
 
 WHAT IT ASSERTS.
 
@@ -45,7 +57,8 @@ against canned replies). This file only supplies replies.
    conversation, never a command.
 
 NOT a CI test: it needs a live sidecar and a pulled model, so it runs at the
-bench. The pure judgements it delegates to ARE in CI.
+bench. The pure judgements it delegates to ARE in CI, and so is this file's
+pacing/classification logic (`mick_chat_model_smoketest_test.py`).
 
 On a full PASS it records the model's Ollama digest + a vetted-at timestamp in
 the SAME per-model pin file the Rabbit gate uses (`~/.kirra_rabbit_model.pin`,
@@ -55,20 +68,27 @@ vetting the chat model never disturbs another role's entry.
 
 Usage:
   python3 robot/mick_chat_model_smoketest.py              # vet whatever /health reports
+  python3 robot/mick_chat_model_smoketest.py --delay-seconds 2.0
   python3 robot/mick_chat_model_smoketest.py --no-pin     # vet without recording
   python3 robot/mick_chat_model_smoketest.py --pin-check   # compare digest vs pin only
   python3 robot/mick_chat_model_smoketest.py --note "re-pull 2026-08-02"
-Env: KIRRA_MICK_CHAT_URL (default http://localhost:8103),
-     KIRRA_OLLAMA_URL (default http://localhost:11434),
-     KIRRA_RABBIT_MODEL_PIN_FILE (default ~/.kirra_rabbit_model.pin).
-Exit 0 = the model honours the chat contract; 1 = it does not / digest changed;
-     2 = the sidecar is unreachable (UNVERIFIED, not failed).
+
+Exit codes:
+  0  the model honours the chat contract (and was pinned, unless --no-pin)
+  1  MODEL-CONTRACT failure — the model was asked and answered badly
+  2  NO MODEL VERDICT was produced. Either the invocation was wrong (argparse
+     usage error) or the service could not be exercised: unreachable, rate
+     limited, or a transport/backend error. These are deliberately the same
+     code because they mean the same thing to a caller — nothing was learned
+     about the model. They are never conflated in the OUTPUT, which always
+     says which one happened.
 """
 from __future__ import annotations
 
-import json
+import argparse
 import os
 import sys
+import time
 from datetime import datetime, timezone
 
 try:
@@ -86,7 +106,34 @@ from rabbit_persona import (  # noqa: E402
 # shared, so the two gates can never disagree about a model's identity.
 from rabbit_model_smoketest import model_digest  # noqa: E402
 
-CHAT_URL = os.environ.get("KIRRA_MICK_CHAT_URL", "http://localhost:8103").rstrip("/")
+DEFAULT_URL = os.environ.get("KIRRA_MICK_CHAT_URL", "http://localhost:8103")
+
+#: Seconds between cases. The service admits a short burst then settles to
+#: ~1 request/second, so 1.0 is the floor and this leaves a small margin for
+#: clock jitter rather than sitting exactly on the boundary.
+DEFAULT_DELAY_SECONDS = 1.1
+MAX_DELAY_SECONDS = 10.0
+
+#: Per-request timeout. Generous: a cold model on an Orin can take tens of
+#: seconds for the first token, and a timeout misreported as a model failure
+#: is the same false accusation this script exists to avoid.
+DEFAULT_TIMEOUT_SECONDS = 90
+MIN_TIMEOUT_SECONDS = 1
+MAX_TIMEOUT_SECONDS = 300
+
+# Transport outcomes. RATE_LIMITED is split out from TRANSPORT_ERROR because
+# it is the one an operator can FIX from the command line (--delay-seconds),
+# and saying so is more useful than a generic failure.
+OK = "ok"
+RATE_LIMITED = "rate_limited"
+TRANSPORT_ERROR = "transport_error"
+
+EXIT_OK = 0
+EXIT_MODEL_CONTRACT = 1
+EXIT_NO_VERDICT = 2
+
+#: Seam for tests — patched to record pacing without actually waiting.
+_sleep = time.sleep
 
 #: (name, utterance, kind, expect_deterministic). `kind` selects the judgement
 #: in mick_chat_contract.judge; `expect_deterministic` asserts the reply came
@@ -104,33 +151,202 @@ CASES = [
 ]
 
 
-def health():
-    """(model, status) from the sidecar, or (None, reason)."""
+# ── argument parsing ─────────────────────────────────────────────────────────
+
+def _delay_seconds(text):
+    """A pacing delay in [0, MAX_DELAY_SECONDS]. 0 is allowed deliberately: a
+    caller testing against a stub or a limiter-free build should be able to run
+    at full speed without editing the script."""
     try:
-        r = requests.get(f"{CHAT_URL}/health", timeout=5.0)
-        if r.status_code != 200:
-            return None, f"HTTP {r.status_code}"
-        body = r.json()
-        return body.get("model"), body.get("status")
-    except Exception as e:  # noqa: BLE001
-        return None, str(e)
+        value = float(text)
+    except (TypeError, ValueError):
+        raise argparse.ArgumentTypeError(f"not a number: {text!r}")
+    if value != value or value in (float("inf"), float("-inf")):
+        raise argparse.ArgumentTypeError(f"must be finite, got {text!r}")
+    if not 0.0 <= value <= MAX_DELAY_SECONDS:
+        raise argparse.ArgumentTypeError(
+            f"must be between 0.0 and {MAX_DELAY_SECONDS} seconds, got {value}")
+    return value
 
 
-def say(text):
-    """One production-shaped chat turn → (reply, deterministic) or (None, None)."""
+def _timeout_seconds(text):
     try:
-        r = requests.post(f"{CHAT_URL}/chat", timeout=90.0, json={"text": text})
-        if r.status_code != 200:
-            print(f"    (HTTP {r.status_code})", file=sys.stderr)
-            return None, None
-        body = r.json()
-        if not body.get("ok"):
-            print(f"    (not ok: {body.get('error')})", file=sys.stderr)
-            return None, None
-        return body.get("reply") or "", bool(body.get("timing", {}).get("deterministic"))
+        value = int(text)
+    except (TypeError, ValueError):
+        raise argparse.ArgumentTypeError(f"not an integer: {text!r}")
+    if not MIN_TIMEOUT_SECONDS <= value <= MAX_TIMEOUT_SECONDS:
+        raise argparse.ArgumentTypeError(
+            f"must be between {MIN_TIMEOUT_SECONDS} and {MAX_TIMEOUT_SECONDS} "
+            f"seconds, got {value}")
+    return value
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(
+        prog="mick_chat_model_smoketest.py",
+        description=(
+            "Vet the deployed chat sidecar's model against the chat doer "
+            "contract, then pin its Ollama digest. Doer-QUALITY only: the chat "
+            "surface has no motion authority, and the checker/fence are "
+            "model-agnostic and unaffected."),
+        epilog=(
+            "Pacing: the chat service admits a short burst then settles to "
+            "~1 request/second. The cases are spaced by --delay-seconds so a "
+            "429 never gets misreported as a model failure. A 429 is an "
+            "INFRASTRUCTURE result (exit 2), never a model-contract one.\n\n"
+            "Env: KIRRA_MICK_CHAT_URL (default for --url), "
+            "KIRRA_OLLAMA_URL, KIRRA_RABBIT_MODEL_PIN_FILE."),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--url", default=DEFAULT_URL, metavar="URL",
+        help="chat sidecar base URL (default: %(default)s)")
+    parser.add_argument(
+        "--delay-seconds", type=_delay_seconds, default=DEFAULT_DELAY_SECONDS,
+        metavar="S",
+        help=f"seconds to wait BETWEEN cases, never before the first "
+             f"(0.0-{MAX_DELAY_SECONDS}; default: %(default)s)")
+    parser.add_argument(
+        "--timeout-seconds", type=_timeout_seconds, default=DEFAULT_TIMEOUT_SECONDS,
+        metavar="S",
+        help=f"per-request timeout ({MIN_TIMEOUT_SECONDS}-{MAX_TIMEOUT_SECONDS}; "
+             f"default: %(default)s)")
+    parser.add_argument(
+        "--no-pin", action="store_true",
+        help="run the contract but record no pin")
+    parser.add_argument(
+        "--pin-check", action="store_true",
+        help="ONLY compare the running digest against the pin (no model calls)")
+    parser.add_argument(
+        "--note", default="", metavar="TEXT",
+        help="provenance note recorded alongside the pin")
+    return parser
+
+
+# ── transport ────────────────────────────────────────────────────────────────
+
+def _status_detail(resp):
+    """'HTTP 429 (Retry-After: 1)' — the status plus whatever the service told
+    us about when to come back."""
+    detail = f"HTTP {resp.status_code}"
+    retry = (getattr(resp, "headers", None) or {}).get("Retry-After")
+    return f"{detail} (Retry-After: {retry})" if retry else detail
+
+
+def health(url, timeout):
+    """(outcome, model, detail)."""
+    try:
+        resp = requests.get(f"{url}/health", timeout=timeout)
     except Exception as e:  # noqa: BLE001
-        print(f"    (chat error: {e})", file=sys.stderr)
-        return None, None
+        return TRANSPORT_ERROR, None, f"{type(e).__name__}: {e}"
+    if resp.status_code == 429:
+        return RATE_LIMITED, None, _status_detail(resp)
+    if resp.status_code != 200:
+        return TRANSPORT_ERROR, None, _status_detail(resp)
+    try:
+        body = resp.json()
+    except Exception as e:  # noqa: BLE001
+        return TRANSPORT_ERROR, None, f"unparseable /health body: {e}"
+    return OK, body.get("model"), body.get("status")
+
+
+def say(url, text, timeout):
+    """One production-shaped chat turn → (outcome, reply, deterministic, detail).
+
+    A non-200, a service-level `ok:false` (e.g. Ollama unreachable) and an
+    exception are all TRANSPORT results: the model either was not asked or its
+    answer never arrived, so none of them is evidence about model quality."""
+    try:
+        resp = requests.post(f"{url}/chat", timeout=timeout, json={"text": text})
+    except Exception as e:  # noqa: BLE001
+        return TRANSPORT_ERROR, None, None, f"{type(e).__name__}: {e}"
+    if resp.status_code == 429:
+        return RATE_LIMITED, None, None, _status_detail(resp)
+    if resp.status_code != 200:
+        return TRANSPORT_ERROR, None, None, _status_detail(resp)
+    try:
+        body = resp.json()
+    except Exception as e:  # noqa: BLE001
+        return TRANSPORT_ERROR, None, None, f"unparseable /chat body: {e}"
+    if not body.get("ok"):
+        return TRANSPORT_ERROR, None, None, f"service error: {body.get('error')}"
+    return (OK, body.get("reply") or "",
+            bool(body.get("timing", {}).get("deterministic")), None)
+
+
+# ── the contract run ─────────────────────────────────────────────────────────
+
+def evaluate(kind, reply, deterministic, expect_deterministic):
+    """The per-case verdict: a failure REASON, or None on pass. Pure."""
+    if expect_deterministic and not deterministic:
+        return "answered by the MODEL — the deterministic route did not fire"
+    if not expect_deterministic and deterministic:
+        return "answered deterministically — a fixed route captured an ordinary question"
+    if kind != "routing":
+        why = judge(kind, reply)
+        if why:
+            return why
+    # The identity boundary applies to EVERY reply, not only identity ones:
+    # incidental drift in ordinary prose is the same failure.
+    vendor = names_a_vendor(reply)
+    if vendor:
+        return f"names an external vendor ({vendor})"
+    return None
+
+
+def run_cases(url, delay_seconds, timeout_seconds):
+    """Drive every case, paced. → (failures, infrastructure).
+
+    `infrastructure` is (outcome, case_name, detail) or None. A transport
+    result ABORTS the run: once the service stops answering honestly the
+    remaining cases can only produce more of the same, and continuing would
+    print a wall of failures that reads like a bad model."""
+    failures = []
+    for index, (name, utterance, kind, expect_deterministic) in enumerate(CASES):
+        # Pace BETWEEN cases only. Sleeping before the first would delay every
+        # run for nothing — the burst allowance is spent by our own requests,
+        # not by whatever came before us.
+        if index:
+            _sleep(delay_seconds)
+
+        outcome, reply, deterministic, detail = say(url, utterance, timeout_seconds)
+        if outcome != OK:
+            print(f"  ---- {name:<20} {detail}")
+            return failures, (outcome, name, detail)
+
+        why = evaluate(kind, reply, deterministic, expect_deterministic)
+        if why:
+            failures.append(f"{name}: {why}")
+            print(f"  FAIL {name:<20} {why}")
+            print(f"       reply={reply.strip()[:120]!r}")
+        else:
+            shown = reply.strip().replace("\n", " ")[:60]
+            tag = "fixed" if deterministic else "model"
+            print(f"  ok   {name:<20} [{tag}] {shown!r}")
+    return failures, None
+
+
+def report_infrastructure(outcome, name, detail, delay_seconds):
+    """Say plainly that no model verdict was produced, and why."""
+    if outcome == RATE_LIMITED:
+        suggested = min(max(delay_seconds * 2, 2.0), MAX_DELAY_SECONDS)
+        print("\nINFRASTRUCTURE FAILURE: chat service rate limited the smoketest",
+              file=sys.stderr)
+        print(f"  case: {name}    status: {detail}", file=sys.stderr)
+        print("  This is NOT a model-contract failure — the model was never asked.",
+              file=sys.stderr)
+        print(f"  The service admits a short burst then ~1 request/second; this run",
+              file=sys.stderr)
+        print(f"  paced at {delay_seconds}s. Re-run with more room:", file=sys.stderr)
+        print(f"    python3 robot/mick_chat_model_smoketest.py --delay-seconds {suggested}",
+              file=sys.stderr)
+    else:
+        print("\nINFRASTRUCTURE FAILURE: chat service transport error",
+              file=sys.stderr)
+        print(f"  case: {name}    status: {detail}", file=sys.stderr)
+        print("  This is NOT a model-contract failure — no answer reached us.",
+              file=sys.stderr)
+    print("  Nothing pinned.", file=sys.stderr)
 
 
 def run_pin_check(model):
@@ -145,86 +361,64 @@ def run_pin_check(model):
     if status == "changed":
         print("\nDIGEST CHANGED — same tag, different weights. Re-vet before trusting it:",
               file=sys.stderr)
-        print(f"  python3 robot/mick_chat_model_smoketest.py --note 'digest change'",
+        print("  python3 robot/mick_chat_model_smoketest.py --note 'digest change'",
               file=sys.stderr)
-        return 1
+        return EXIT_MODEL_CONTRACT
     if status == "unpinned":
         print("\nUNPINNED — this model has never been vetted for the chat contract.",
               file=sys.stderr)
-        return 1
-    return 0 if status == "ok" else 1
+        return EXIT_MODEL_CONTRACT
+    return EXIT_OK if status == "ok" else EXIT_MODEL_CONTRACT
 
 
-def main(argv):
-    note = ""
-    if "--note" in argv:
-        i = argv.index("--note")
-        note = argv[i + 1] if i + 1 < len(argv) else ""
+def main(argv=None):
+    args = build_parser().parse_args(argv)
+    url = args.url.rstrip("/")
 
-    model, status = health()
-    if model is None:
-        print(f"mick_chat_model_smoketest: chat sidecar unreachable at {CHAT_URL} ({status})",
-              file=sys.stderr)
-        print("  UNVERIFIED, not failed — start the sidecar and re-run.", file=sys.stderr)
-        return 2
+    outcome, model, status = health(url, args.timeout_seconds)
+    if outcome != OK:
+        if outcome == RATE_LIMITED:
+            report_infrastructure(outcome, "health", status, args.delay_seconds)
+        else:
+            print(f"mick_chat_model_smoketest: chat sidecar unreachable at {url} "
+                  f"({status})", file=sys.stderr)
+            print("  UNVERIFIED, not failed — start the sidecar and re-run.",
+                  file=sys.stderr)
+        return EXIT_NO_VERDICT
 
-    if "--pin-check" in argv:
+    if args.pin_check:
         return run_pin_check(model)
 
-    print(f"Mick CHAT doer-contract smoketest — model={model!r} @ {CHAT_URL} (health: {status})")
+    print(f"Mick CHAT doer-contract smoketest — model={model!r} @ {url} (health: {status})")
     print("(doer-quality only; the chat surface has no motion authority, and the")
     print(" checker/fence are model-agnostic and unaffected)")
     digest = model_digest(model)
     print(f"running digest: {digest or '<unavailable>'}")
+    print(f"pacing: {args.delay_seconds}s between cases, {args.timeout_seconds}s timeout")
 
-    failures = []
-    for name, utterance, kind, expect_det in CASES:
-        reply, deterministic = say(utterance)
-        if reply is None:
-            failures.append(f"{name}: no reply from the sidecar")
-            print(f"  FAIL {name:<20} no reply")
-            continue
+    failures, infrastructure = run_cases(url, args.delay_seconds, args.timeout_seconds)
 
-        why = None
-        if expect_det and not deterministic:
-            why = "answered by the MODEL — the deterministic route did not fire"
-        elif not expect_det and deterministic:
-            why = "answered deterministically — a fixed route captured an ordinary question"
-        if why is None and kind != "routing":
-            why = judge(kind, reply)
-        # The identity boundary applies to EVERY reply, not only identity ones:
-        # incidental drift in ordinary prose is the same failure.
-        if why is None:
-            vendor = names_a_vendor(reply)
-            if vendor:
-                why = f"names an external vendor ({vendor})"
-
-        if why:
-            failures.append(f"{name}: {why}")
-            print(f"  FAIL {name:<20} {why}")
-            print(f"       reply={reply.strip()[:120]!r}")
-        else:
-            shown = reply.strip().replace("\n", " ")[:60]
-            tag = "fixed" if deterministic else "model"
-            print(f"  ok   {name:<20} [{tag}] {shown!r}")
+    if infrastructure:
+        report_infrastructure(*infrastructure, args.delay_seconds)
+        return EXIT_NO_VERDICT
 
     print(f"\n{len(CASES) - len(failures)}/{len(CASES)} passed")
     if failures:
         print("\nThis model does NOT honour the chat contract. Not pinned.", file=sys.stderr)
-        return 1
+        return EXIT_MODEL_CONTRACT
 
-    if "--no-pin" in argv:
+    if args.no_pin:
         print("(--no-pin: nothing recorded)")
-        return 0
+        return EXIT_OK
     if not digest:
         print("PASSED, but Ollama gave no digest — nothing pinned.", file=sys.stderr)
-        return 0
+        return EXIT_OK
 
     stamp = datetime.now(timezone.utc).astimezone().isoformat(timespec="seconds")
-    write_model_pin(model, digest, vetted_at=stamp, note=note)
+    write_model_pin(model, digest, vetted_at=stamp, note=args.note)
     print(f"vetted {stamp} → pinned {model} @ {digest}")
     print(f"  ({model_pin_path()}; --pin-check compares the running digest against this)")
-    return 0
+    return EXIT_OK
 
 
 if __name__ == "__main__":

--- a/robot/mick_chat_model_smoketest.py
+++ b/robot/mick_chat_model_smoketest.py
@@ -74,14 +74,20 @@ Usage:
   python3 robot/mick_chat_model_smoketest.py --note "re-pull 2026-08-02"
 
 Exit codes:
-  0  the model honours the chat contract (and was pinned, unless --no-pin)
-  1  MODEL-CONTRACT failure — the model was asked and answered badly
-  2  NO MODEL VERDICT was produced. Either the invocation was wrong (argparse
-     usage error) or the service could not be exercised: unreachable, rate
-     limited, or a transport/backend error. These are deliberately the same
-     code because they mean the same thing to a caller — nothing was learned
-     about the model. They are never conflated in the OUTPUT, which always
-     says which one happened.
+  0  PASS — the model honours the chat contract (and was pinned, unless
+     --no-pin), or under --pin-check its running digest matches the vetted one.
+  1  NEGATIVE VERDICT about this model. Either it was asked and answered badly
+     (a contract failure), or --pin-check found its weights CHANGED under the
+     same tag, or it is UNPINNED — never vetted. All three are answers about
+     the model's standing, and all three are fixed by a human deciding
+     something, not by retrying.
+  2  NO VERDICT was produced. The invocation was wrong (argparse usage error),
+     a dependency is missing, or the service could not be exercised:
+     unreachable, rate limited, a transport/backend error, or Ollama down so
+     no running digest exists. These share a code because they mean the same
+     thing to a caller — nothing was learned about the model, and a retry may
+     well succeed. They are never conflated in the OUTPUT, which always says
+     which one happened.
 """
 from __future__ import annotations
 
@@ -91,10 +97,21 @@ import sys
 import time
 from datetime import datetime, timezone
 
+EXIT_OK = 0
+EXIT_MODEL_CONTRACT = 1
+EXIT_NO_VERDICT = 2
+
 try:
     import requests
 except ImportError:
-    sys.exit("mick_chat_model_smoketest: python3-requests missing (pip3 install requests)")
+    # EXIT_NO_VERDICT, not the bare sys.exit(<string>) that would exit 1: a
+    # missing dependency means the model was never asked, which is the same
+    # thing to a caller as an unreachable service. Exiting 1 here would put a
+    # tooling problem in the same bucket as "this model answers badly" — the
+    # exact conflation this script exists to avoid (review: Copilot on #1301).
+    print("mick_chat_model_smoketest: python3-requests missing (pip3 install requests)",
+          file=sys.stderr)
+    sys.exit(EXIT_NO_VERDICT)
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from mick_chat_contract import judge, names_a_vendor  # noqa: E402
@@ -127,10 +144,6 @@ MAX_TIMEOUT_SECONDS = 300
 OK = "ok"
 RATE_LIMITED = "rate_limited"
 TRANSPORT_ERROR = "transport_error"
-
-EXIT_OK = 0
-EXIT_MODEL_CONTRACT = 1
-EXIT_NO_VERDICT = 2
 
 #: Seam for tests — patched to record pacing without actually waiting.
 _sleep = time.sleep
@@ -350,6 +363,15 @@ def report_infrastructure(outcome, name, detail, delay_seconds):
 
 
 def run_pin_check(model):
+    """Compare the running digest against the vetted pin.
+
+    `changed` and `unpinned` are NEGATIVE VERDICTS about the model (exit 1):
+    each is a real answer about its standing, resolved by a human re-vetting,
+    not by retrying. `unavailable` is NOT — it means Ollama gave no running
+    digest, so there was nothing to compare and nothing was learned. Returning
+    1 there would report an infrastructure outage as a judgement against the
+    model, which is the conflation this whole script exists to avoid
+    (review: Copilot on #1301)."""
     running = model_digest(model)
     pinned = read_model_pin(model)
     status = classify_model_pin(running, pinned)
@@ -358,6 +380,8 @@ def run_pin_check(model):
     rec = read_model_pin_record(model)
     if rec:
         print(f"  vetted_at={rec[1] or '-'}  note={rec[2] or '-'}")
+    if status == "ok":
+        return EXIT_OK
     if status == "changed":
         print("\nDIGEST CHANGED — same tag, different weights. Re-vet before trusting it:",
               file=sys.stderr)
@@ -368,7 +392,12 @@ def run_pin_check(model):
         print("\nUNPINNED — this model has never been vetted for the chat contract.",
               file=sys.stderr)
         return EXIT_MODEL_CONTRACT
-    return EXIT_OK if status == "ok" else EXIT_MODEL_CONTRACT
+    # 'unavailable' — no running digest to compare against.
+    print("\nNO RUNNING DIGEST — Ollama did not report one, so the pin could not be",
+          file=sys.stderr)
+    print("  checked. This is NOT a judgement about the model; nothing was compared.",
+          file=sys.stderr)
+    return EXIT_NO_VERDICT
 
 
 def main(argv=None):

--- a/robot/mick_chat_model_smoketest_test.py
+++ b/robot/mick_chat_model_smoketest_test.py
@@ -1,0 +1,459 @@
+#!/usr/bin/env python3
+"""Host tests for the chat smoketest's CLI, pacing and failure classification.
+
+The gate itself needs a live sidecar, but the two things that were BROKEN do
+not: how it paces itself against the service's rate limiter, and how it
+classifies what comes back. Both run here, with `time.sleep` and `requests`
+mocked, so the suite is instant and cannot flake on a loaded runner.
+
+The bug this pins: the chat service admits a short burst then settles to about
+one request per second. Nine back-to-back turns spent the burst on the first
+few cases and took `429` for the rest — which the script reported as *"This
+model does NOT honour the chat contract"*, a false accusation against a model
+that was never asked. Waiting before launching did not help, because the script
+consumed the allowance itself.
+
+Nothing here touches the rate limiter. A bench tool fits the production
+service, never the other way round.
+"""
+from __future__ import annotations
+
+import contextlib
+import io
+import sys
+import types
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+
+def _install_requests_stub() -> None:
+    """Same convention as rabbit_keepalive_test: stub `requests` when it is
+    absent (the CI robot lane) so this RUNS there rather than skipping. Every
+    entry point refuses loudly, so an unstubbed call is a test bug, not a real
+    network request."""
+    def _refuse(*_a, **_k):
+        raise AssertionError("the test made a REAL HTTP call — a seam is unstubbed")
+
+    stub = types.ModuleType("requests")
+    stub.get = _refuse
+    stub.post = _refuse
+    stub.RequestException = type("RequestException", (Exception,), {})
+    stub.exceptions = types.SimpleNamespace(RequestException=stub.RequestException)
+    sys.modules["requests"] = stub
+
+
+try:
+    import requests  # noqa: F401
+except ImportError:
+    _install_requests_stub()
+
+import mick_chat_model_smoketest as sm  # noqa: E402
+
+_FAILURES: list[str] = []
+
+
+def check(cond, msg):
+    if not cond:
+        _FAILURES.append(msg)
+        print(f"  FAIL: {msg}", file=sys.stderr)
+
+
+# ── fakes ────────────────────────────────────────────────────────────────────
+
+class FakeResponse:
+    def __init__(self, status=200, body=None, headers=None):
+        self.status_code = status
+        self._body = {} if body is None else body
+        self.headers = headers or {}
+
+    def json(self):
+        return self._body
+
+
+def ok_reply(text, deterministic):
+    return FakeResponse(200, {"ok": True, "reply": text,
+                              "timing": {"deterministic": deterministic}})
+
+
+#: A reply that PASSES for each case in order — the five fixed rows answered
+#: deterministically, the four model rows in clean prose.
+def good_replies():
+    return [
+        ok_reply("I cannot move the robot. That request goes to the motion path.", True),
+        ok_reply("I am the onboard assistant for this robot.", True),
+        ok_reply("I was built by the team that maintains this robot.", True),
+        ok_reply("I run on the locally configured language model.", True),
+        ok_reply("I do not retain previous conversations.", True),
+        ok_reply("Saturn has over 80 moons orbiting it.", False),
+        ok_reply("I answer in plain sentences rather than structured output.", False),
+        ok_reply("I cannot read the battery level from here.", False),
+        ok_reply("Titan has a thick atmosphere composed mostly of nitrogen.", False),
+    ]
+
+
+class FakeHttp:
+    """Records an interleaved event log so a test can assert not just THAT the
+    script slept but exactly WHERE — the ordering is the whole property."""
+
+    def __init__(self, events, replies, health_body=None, health_response=None):
+        self.events = events
+        self.replies = list(replies)
+        self.health_body = health_body or {"status": "ready", "model": "phi3:3.8b",
+                                           "warmup_ms": 287}
+        self.health_response = health_response
+        self.posted = []
+
+    def get(self, url, timeout=None, **_kw):
+        self.events.append(("get", url))
+        if self.health_response is not None:
+            return self.health_response
+        return FakeResponse(200, self.health_body)
+
+    def post(self, url, timeout=None, json=None, **_kw):
+        self.events.append(("post", (json or {}).get("text")))
+        self.posted.append(json)
+        if not self.replies:
+            raise AssertionError("more requests than the test provided replies for")
+        return self.replies.pop(0)
+
+
+class Harness:
+    """Patches every seam: HTTP, sleep, the digest lookup and the pin writer."""
+
+    def __init__(self, replies, health_response=None, digest="sha256:abc"):
+        self.events = []
+        self.http = FakeHttp(self.events, replies, health_response=health_response)
+        self.digest = digest
+        self.pins = []
+
+    def __enter__(self):
+        self._saved = (sm.requests, sm._sleep, sm.model_digest, sm.write_model_pin)
+        sm.requests = self.http
+        sm._sleep = lambda s: self.events.append(("sleep", s))
+        sm.model_digest = lambda _m: self.digest
+        sm.write_model_pin = lambda *a, **k: self.pins.append((a, k))
+        self.out, self.err = io.StringIO(), io.StringIO()
+        self._redirect = contextlib.ExitStack()
+        self._redirect.enter_context(contextlib.redirect_stdout(self.out))
+        self._redirect.enter_context(contextlib.redirect_stderr(self.err))
+        return self
+
+    def __exit__(self, *exc):
+        self._redirect.close()
+        sm.requests, sm._sleep, sm.model_digest, sm.write_model_pin = self._saved
+        return False
+
+    @property
+    def kinds(self):
+        return [kind for kind, _ in self.events]
+
+    @property
+    def sleeps(self):
+        return [value for kind, value in self.events if kind == "sleep"]
+
+    @property
+    def text(self):
+        return self.out.getvalue() + self.err.getvalue()
+
+
+def run(argv, replies=None, **kw):
+    """Run main() under the harness → (exit_code, harness)."""
+    harness = Harness(good_replies() if replies is None else replies, **kw)
+    with harness:
+        code = sm.main(argv)
+    return code, harness
+
+
+# ── 1. the CLI exists ────────────────────────────────────────────────────────
+
+def test_help_exits_zero_and_prints_usage():
+    """The reported symptom: `--help` ran the smoketest, because there was no
+    argument parser at all — flags were sniffed out of sys.argv by hand."""
+    out = io.StringIO()
+    try:
+        with contextlib.redirect_stdout(out):
+            sm.build_parser().parse_args(["--help"])
+    except SystemExit as e:
+        check(e.code == 0, f"--help must exit 0, got {e.code}")
+    else:
+        check(False, "--help must raise SystemExit")
+    text = out.getvalue()
+    check(text.startswith("usage:"), f"--help must print usage, got {text[:60]!r}")
+    for flag in ("--url", "--delay-seconds", "--timeout-seconds"):
+        check(flag in text, f"--help must document {flag}")
+
+
+def test_the_documented_defaults():
+    args = sm.build_parser().parse_args([])
+    check(args.delay_seconds == 1.1, f"default delay must be 1.1, got {args.delay_seconds}")
+    check(args.timeout_seconds == 90, f"default timeout must be 90, got {args.timeout_seconds}")
+    check(args.url == sm.DEFAULT_URL, f"default url must be {sm.DEFAULT_URL}")
+    check("localhost:8103" in sm.DEFAULT_URL, f"default url must be :8103, got {sm.DEFAULT_URL}")
+
+
+def test_custom_values_are_accepted():
+    args = sm.build_parser().parse_args(
+        ["--url", "http://r2:9999/", "--delay-seconds", "0.25", "--timeout-seconds", "5"])
+    check(args.delay_seconds == 0.25, f"custom delay not applied: {args.delay_seconds}")
+    check(args.timeout_seconds == 5, f"custom timeout not applied: {args.timeout_seconds}")
+    check(args.url == "http://r2:9999/", f"custom url not applied: {args.url}")
+
+
+def test_out_of_range_values_are_rejected():
+    """Bounds are a ratchet against the two ways this goes wrong: a delay so
+    large the run never finishes, and a timeout so short every case 'fails'."""
+    for bad in (["--delay-seconds", "20"], ["--delay-seconds", "-1"],
+                ["--delay-seconds", "nonsense"], ["--delay-seconds", "inf"],
+                ["--timeout-seconds", "0"], ["--timeout-seconds", "301"],
+                ["--timeout-seconds", "1.5"]):
+        try:
+            with contextlib.redirect_stderr(io.StringIO()):
+                sm.build_parser().parse_args(bad)
+        except SystemExit as e:
+            check(e.code == 2, f"{bad} must exit 2, got {e.code}")
+        else:
+            check(False, f"{bad} must be rejected")
+
+
+def test_the_boundaries_themselves_are_allowed():
+    for good, attr, want in (("--delay-seconds", "delay_seconds", 0.0),
+                             ("--delay-seconds", "delay_seconds", 10.0),
+                             ("--timeout-seconds", "timeout_seconds", 1),
+                             ("--timeout-seconds", "timeout_seconds", 300)):
+        args = sm.build_parser().parse_args([good, str(want)])
+        check(getattr(args, attr) == want, f"{good} {want} must be accepted")
+
+
+# ── 2. pacing ────────────────────────────────────────────────────────────────
+
+def test_no_sleep_before_the_first_request():
+    """Sleeping first would delay every run for nothing: the burst allowance is
+    spent by THIS script's own requests, not by whatever ran before it."""
+    code, h = run([])
+    check(code == 0, f"the good run must pass, got {code}: {h.text}")
+    check(h.kinds[0] == "get", f"the run must open with /health, got {h.kinds[:3]}")
+    check(h.kinds[1] == "post", f"a sleep preceded the first case: {h.kinds[:3]}")
+
+
+def test_a_sleep_falls_between_every_later_pair_of_requests():
+    """The exact shape, not just the count — 'it slept nine times' would pass
+    with all nine sleeps bunched at the end and every request still bursted."""
+    code, h = run([])
+    check(code == 0, f"the good run must pass, got {code}")
+    expected = ["get"] + ["post", "sleep"] * (len(sm.CASES) - 1) + ["post"]
+    check(h.kinds == expected, f"pacing shape wrong:\n  want {expected}\n  got  {h.kinds}")
+    check(len(h.sleeps) == len(sm.CASES) - 1,
+          f"expected {len(sm.CASES) - 1} sleeps, got {len(h.sleeps)}")
+
+
+def test_the_default_delay_reaches_the_sleep_calls():
+    code, h = run([])
+    check(code == 0, f"the good run must pass, got {code}")
+    check(all(s == 1.1 for s in h.sleeps), f"default delay not used: {set(h.sleeps)}")
+
+
+def test_a_custom_delay_reaches_the_sleep_calls():
+    code, h = run(["--delay-seconds", "0.25"])
+    check(code == 0, f"the good run must pass, got {code}")
+    check(all(s == 0.25 for s in h.sleeps), f"custom delay not used: {set(h.sleeps)}")
+
+
+def test_fixed_and_model_backed_cases_are_paced_alike():
+    """The deterministic rows return without a model call, but they are still
+    HTTP requests and still spend rate-limit budget. Skipping their pacing
+    would reintroduce exactly the burst that caused the bug."""
+    code, h = run([])
+    check(code == 0, f"the good run must pass, got {code}")
+    # Walk the log; every adjacent post pair must have a sleep between them,
+    # regardless of whether the reply was deterministic.
+    posts = [i for i, k in enumerate(h.kinds) if k == "post"]
+    for a, b in zip(posts, posts[1:]):
+        between = h.kinds[a + 1:b]
+        check(between == ["sleep"], f"posts {a}->{b} separated by {between}, not one sleep")
+
+
+def test_zero_delay_paces_nothing():
+    """0.0 is a legitimate choice against a stub or a limiter-free build. It
+    must still be honoured verbatim rather than silently floored."""
+    code, h = run(["--delay-seconds", "0"])
+    check(code == 0, f"the good run must pass, got {code}")
+    check(all(s == 0.0 for s in h.sleeps), f"zero delay not honoured: {set(h.sleeps)}")
+
+
+# ── 3. 429 is infrastructure, not model quality ──────────────────────────────
+
+def _rate_limited_at(index):
+    replies = good_replies()
+    replies[index] = FakeResponse(429, {}, headers={"Retry-After": "1"})
+    return replies
+
+
+def test_a_429_is_reported_as_infrastructure_not_a_bad_model():
+    """The false accusation this fixes: the model was never asked, so calling
+    it a contract failure is a lie about a model that did nothing wrong."""
+    code, h = run([], replies=_rate_limited_at(3))
+    check(code == 2, f"a rate-limited run must exit 2, got {code}")
+    check("INFRASTRUCTURE FAILURE" in h.text, f"must name the failure kind:\n{h.text}")
+    check("rate limited" in h.text, f"must say rate limited:\n{h.text}")
+    check("which_model" in h.text, f"must name the case that hit it:\n{h.text}")
+    check("429" in h.text, f"must report the status:\n{h.text}")
+    check("does NOT honour the chat contract" not in h.text,
+          f"a 429 must never be reported as a model-contract failure:\n{h.text}")
+
+
+def test_a_429_suggests_a_larger_delay():
+    _, h = run(["--delay-seconds", "1.1"], replies=_rate_limited_at(2))
+    check("--delay-seconds" in h.text, f"must suggest the fix:\n{h.text}")
+
+
+def test_a_429_never_pins():
+    code, h = run([], replies=_rate_limited_at(3))
+    check(code == 2, f"expected exit 2, got {code}")
+    check(h.pins == [], f"a rate-limited run must not pin: {h.pins}")
+    check("Nothing pinned" in h.text, f"must say nothing was pinned:\n{h.text}")
+
+
+def test_a_429_aborts_rather_than_hammering_the_limiter():
+    """Continuing would only collect more 429s and print a wall of failures
+    that reads like a broken model."""
+    code, h = run([], replies=_rate_limited_at(3))
+    check(code == 2, f"expected exit 2, got {code}")
+    check(len(h.http.posted) == 4, f"must stop at the 429, sent {len(h.http.posted)}")
+
+
+def test_a_rate_limited_health_probe_is_also_infrastructure():
+    code, h = run([], health_response=FakeResponse(429, {}))
+    check(code == 2, f"expected exit 2, got {code}")
+    check("INFRASTRUCTURE FAILURE" in h.text, f"must classify as infrastructure:\n{h.text}")
+    check(h.pins == [], "a rate-limited health probe must not pin")
+
+
+# ── 4. other transport errors are separated too ──────────────────────────────
+
+def test_a_transport_error_is_not_a_model_failure():
+    replies = good_replies()
+    replies[5] = FakeResponse(502, {"ok": False, "error": "MICK_CHAT_MODEL_ERROR"})
+    code, h = run([], replies=replies)
+    check(code == 2, f"a transport error must exit 2, got {code}")
+    check("INFRASTRUCTURE FAILURE" in h.text, f"must classify as infrastructure:\n{h.text}")
+    check("transport error" in h.text, f"must say transport error:\n{h.text}")
+    check("ordinary_question" in h.text, f"must name the case:\n{h.text}")
+    check("does NOT honour the chat contract" not in h.text,
+          f"must not blame the model:\n{h.text}")
+    check(h.pins == [], "a transport error must not pin")
+
+
+def test_a_service_level_not_ok_is_transport_not_model():
+    """A 200 carrying ok:false means the sidecar reached us but the BACKEND
+    failed (Ollama down). The model still never answered."""
+    replies = good_replies()
+    replies[1] = FakeResponse(200, {"ok": False, "error": "MICK_CHAT_MODEL_ERROR"})
+    code, h = run([], replies=replies)
+    check(code == 2, f"expected exit 2, got {code}")
+    check("INFRASTRUCTURE FAILURE" in h.text, f"must classify as infrastructure:\n{h.text}")
+    check(h.pins == [], "a backend error must not pin")
+
+
+def test_an_unreachable_sidecar_is_unverified_not_failed():
+    class Dead:
+        def get(self, *_a, **_k):
+            raise OSError("Connection refused")
+
+        def post(self, *_a, **_k):
+            raise AssertionError("must not reach /chat when /health is dead")
+
+    saved = sm.requests
+    sm.requests = Dead()
+    out, err = io.StringIO(), io.StringIO()
+    try:
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            code = sm.main([])
+    finally:
+        sm.requests = saved
+    check(code == 2, f"an unreachable sidecar must exit 2, got {code}")
+    check("UNVERIFIED" in err.getvalue(), f"must say UNVERIFIED:\n{err.getvalue()}")
+
+
+# ── 5. model-contract failures still report normally ─────────────────────────
+
+def test_a_truncated_reply_is_still_a_model_contract_failure():
+    """The 429 work must not blunt the gate: a model that really does answer
+    badly is still reported as a model failure, and still does not pin."""
+    replies = good_replies()
+    replies[8] = ok_reply("Titan's thick atmosphere is primarily composed of nitro", False)
+    code, h = run([], replies=replies)
+    check(code == 1, f"a bad reply must exit 1, got {code}")
+    check("does NOT honour the chat contract" in h.text,
+          f"must report a model-contract failure:\n{h.text}")
+    check("long_answer" in h.text, f"must name the failing case:\n{h.text}")
+    check("INFRASTRUCTURE" not in h.text, f"must not claim infrastructure:\n{h.text}")
+    check(h.pins == [], "a failing model must not pin")
+    check("8/9 passed" in h.text, f"must keep the tally format:\n{h.text}")
+
+
+def test_a_fixed_route_answered_by_the_model_is_a_failure():
+    replies = good_replies()
+    replies[1] = ok_reply("I am the onboard assistant for this robot.", False)
+    code, h = run([], replies=replies)
+    check(code == 1, f"expected exit 1, got {code}")
+    check("deterministic route did not fire" in h.text,
+          f"must name the specific failure:\n{h.text}")
+
+
+def test_a_vendor_claim_in_ordinary_prose_is_a_failure():
+    replies = good_replies()
+    replies[5] = ok_reply("I am an AI developed by Micro" + "soft.", False)
+    code, h = run([], replies=replies)
+    check(code == 1, f"expected exit 1, got {code}")
+    check("external vendor" in h.text, f"must catch drift in ordinary prose:\n{h.text}")
+
+
+# ── 6. the happy path still pins ─────────────────────────────────────────────
+
+def test_a_clean_nine_case_run_pins_the_digest():
+    code, h = run([])
+    check(code == 0, f"a clean run must exit 0, got {code}: {h.text}")
+    check("9/9 passed" in h.text, f"must report the full tally:\n{h.text}")
+    check(len(h.pins) == 1, f"a clean run must pin exactly once, got {h.pins}")
+    args, kwargs = h.pins[0]
+    check(args[0] == "phi3:3.8b", f"must pin the model /health named, got {args[0]!r}")
+    check(args[1] == "sha256:abc", f"must pin the running digest, got {args[1]!r}")
+    check(bool(kwargs.get("vetted_at")), "must record a vetted-at timestamp")
+
+
+def test_the_deterministic_rows_are_labelled_fixed():
+    _, h = run([])
+    check(h.text.count("[fixed]") == 5, f"expected 5 fixed rows:\n{h.text}")
+    check(h.text.count("[model]") == 4, f"expected 4 model rows:\n{h.text}")
+
+
+def test_no_pin_runs_the_contract_without_recording():
+    code, h = run(["--no-pin"])
+    check(code == 0, f"expected exit 0, got {code}")
+    check(h.pins == [], f"--no-pin must record nothing, got {h.pins}")
+    check("9/9 passed" in h.text, "the contract must still run")
+
+
+def test_a_custom_url_is_actually_used():
+    code, h = run(["--url", "http://r2.local:8103/"])
+    check(code == 0, f"expected exit 0, got {code}")
+    urls = [value for kind, value in h.events if kind == "get"]
+    check(urls == ["http://r2.local:8103/health"],
+          f"the trailing slash must be normalised away: {urls}")
+
+
+def main():
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            print(f"  {name}")
+            fn()
+    if _FAILURES:
+        print(f"\n{len(_FAILURES)} FAILED", file=sys.stderr)
+        return 1
+    print("\nmick_chat_model_smoketest: all checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/robot/mick_chat_model_smoketest_test.py
+++ b/robot/mick_chat_model_smoketest_test.py
@@ -443,6 +443,81 @@ def test_a_custom_url_is_actually_used():
           f"the trailing slash must be normalised away: {urls}")
 
 
+# ── 7. exit codes mean what the docstring says ───────────────────────────────
+
+def _pin_check(digest, pinned):
+    """Run --pin-check with the digest lookup and pin stubbed → (code, text)."""
+    saved = (sm.requests, sm.model_digest, sm.read_model_pin, sm.read_model_pin_record)
+    sm.requests = FakeHttp([], [])
+    sm.model_digest = lambda _m: digest
+    sm.read_model_pin = lambda _m, *a, **k: pinned
+    sm.read_model_pin_record = lambda _m, *a, **k: None
+    out, err = io.StringIO(), io.StringIO()
+    try:
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            code = sm.main(["--pin-check"])
+    finally:
+        (sm.requests, sm.model_digest, sm.read_model_pin,
+         sm.read_model_pin_record) = saved
+    return code, out.getvalue() + err.getvalue()
+
+
+def test_pin_check_ok_exits_zero():
+    code, _ = _pin_check("sha256:abc", "sha256:abc")
+    check(code == 0, f"a matching pin must exit 0, got {code}")
+
+
+def test_pin_check_changed_and_unpinned_are_negative_verdicts():
+    """Both are real answers about the model's standing, resolved by a human
+    re-vetting rather than by retrying — so exit 1, as the docstring says."""
+    code, text = _pin_check("sha256:new", "sha256:old")
+    check(code == 1, f"a changed digest must exit 1, got {code}")
+    check("DIGEST CHANGED" in text, f"must say what happened:\n{text}")
+
+    code, text = _pin_check("sha256:abc", None)
+    check(code == 1, f"an unpinned model must exit 1, got {code}")
+    check("UNPINNED" in text, f"must say what happened:\n{text}")
+
+
+def test_pin_check_with_no_running_digest_is_no_verdict_not_a_failure():
+    """Ollama down means nothing was COMPARED. Exiting 1 would report an
+    infrastructure outage as a judgement against the model — the same
+    conflation the 429 handling fixes (review: Copilot on #1301)."""
+    code, text = _pin_check(None, "sha256:abc")
+    check(code == 2, f"an unavailable digest must exit 2, got {code}")
+    check("NO RUNNING DIGEST" in text, f"must say nothing was compared:\n{text}")
+    check("UNPINNED" not in text, f"must not claim the model is unvetted:\n{text}")
+
+
+def test_a_missing_requests_dependency_exits_no_verdict():
+    """A missing dependency means the model was never asked — the same thing to
+    a caller as an unreachable service. The previous `sys.exit(<string>)` gave
+    exit 1, putting a tooling problem in the model-failure bucket."""
+    import subprocess
+    here = Path(__file__).resolve().parent
+    program = (
+        "import sys, importlib.abc\n"
+        "class Block(importlib.abc.MetaPathFinder):\n"
+        "    def find_spec(self, name, path, target=None):\n"
+        "        if name == 'requests':\n"
+        "            raise ImportError('blocked by the test')\n"
+        "sys.meta_path.insert(0, Block())\n"
+        f"sys.path.insert(0, {str(here)!r})\n"
+        "import mick_chat_model_smoketest\n"
+    )
+    proc = subprocess.run([sys.executable, "-c", program],
+                          capture_output=True, text=True)
+    check(proc.returncode == 2,
+          f"missing requests must exit 2, got {proc.returncode}: {proc.stderr[-300:]}")
+    check("python3-requests missing" in proc.stderr,
+          f"must say which dependency:\n{proc.stderr[-300:]}")
+
+
+def test_the_exit_code_constants_are_distinct():
+    codes = {sm.EXIT_OK, sm.EXIT_MODEL_CONTRACT, sm.EXIT_NO_VERDICT}
+    check(codes == {0, 1, 2}, f"exit codes must be 0/1/2, got {codes}")
+
+
 def main():
     for name, fn in sorted(globals().items()):
         if name.startswith("test_") and callable(fn):


### PR DESCRIPTION
## Root cause

The chat service admits a short burst and then settles to roughly one request per second. The smoketest fired all nine cases back-to-back, spending the burst on the first three:

```
ok   motion_refused
ok   identity
ok   provenance
HTTP 429 on which_model
HTTP 429 on memory
HTTP 429 on ordinary_question
...
```

Those `429`s were then reported as **"This model does NOT honour the chat contract"** — a false accusation against a model that was never asked. Waiting before launching the script didn't help, because the script consumed the burst allowance itself.

**The fix belongs in the bench tool, not the limiter.** A smoketest fits the production service, never the other way round. The rate limiter is untouched.

## Pacing

Cases are spaced by `--delay-seconds` (default **1.1** — 1.0 is the floor, with margin for jitter rather than sitting exactly on the boundary).

Two properties that are easy to get subtly wrong, so both are pinned by tests:

- **The sleep falls between cases, never before the first.** The burst is spent by *this script's own* requests, so a leading sleep would delay every run for nothing.
- **Deterministic cases are paced identically to model-backed ones.** They answer without a model call, but they are still HTTP requests that spend rate-limit budget. Skipping their pacing would reintroduce exactly the burst that caused the bug.

## CLI

There was no argument parser at all — flags were sniffed out of `sys.argv` by hand, which is why `--help` ran the smoketest instead of printing usage.

| Flag | Default | Validation |
|---|---|---|
| `--url` | `http://localhost:8103` | — |
| `--delay-seconds` | `1.1` | `0.0 ≤ d ≤ 10.0`, finite |
| `--timeout-seconds` | `90` | `1 ≤ t ≤ 300`, integer |

`--pin-check`, `--no-pin` and `--note` keep working. `0.0` delay is deliberately allowed for running against a stub.

## 429 classification

A `429` is **INFRASTRUCTURE**, reported with the case name and status, and never pins:

```
INFRASTRUCTURE FAILURE: chat service rate limited the smoketest
  case: which_model    status: HTTP 429 (Retry-After: 1)
  This is NOT a model-contract failure — the model was never asked.
  The service admits a short burst then ~1 request/second; this run
  paced at 1.1s. Re-run with more room:
    python3 robot/mick_chat_model_smoketest.py --delay-seconds 2.2
  Nothing pinned.
```

It **aborts** rather than continuing — more requests could only collect more 429s and print a wall of failures that reads like a broken model.

Other transport results are separated the same way: non-200, a service-level `ok:false` (Ollama down behind a 200), an unparseable body, and connection errors all mean the model never answered, so none of them is evidence about model quality.

**Exit codes**, now stated in the docstring: `0` pass · `1` model-contract failure · `2` no model verdict. `2` covers both an argparse usage error and an un-exercisable service deliberately — they mean the same thing to a caller (nothing was learned about the model), and the output always says which happened.

## Files changed

- `robot/mick_chat_model_smoketest.py`
- `robot/mick_chat_model_smoketest_test.py` *(new)*
- `.github/workflows/ci.yml` — one line, wiring the new test into the robot lane beside `mick_chat_contract_test.py`. Beyond the listed scope, but an unexercised gate is not a gate.

No Rust, systemd units, model configuration, rate limits, chat prompts or safety paths touched.

## Tests

**26 checks**, with `time.sleep` and `requests` mocked — instant, and cannot flake on a loaded runner.

The pacing assertion pins the exact event interleaving rather than a sleep count:

```python
expected = ["get"] + ["post", "sleep"] * 8 + ["post"]
```

"It slept eight times" would pass with all eight bunched at the end and every request still bursted. This won't.

Covering: `--help` exits 0 with usage · defaults (1.1 / 90 / :8103) · custom values · out-of-range and non-numeric rejection (exit 2) · boundaries accepted · no sleep before the first request · a sleep between every later pair · fixed and model rows paced alike · zero delay honoured · 429 → infrastructure, names the case, suggests a larger delay, never pins, aborts · rate-limited `/health` · transport error and `ok:false` separated from model quality · unreachable sidecar stays UNVERIFIED · truncated reply / fixed-route-answered-by-model / vendor drift still fail as model-contract · clean run pins once with the right model and digest · `--no-pin` records nothing · trailing slash normalised.

## Results

```
python3 robot/mick_chat_model_smoketest_test.py   → 26 checks, all passed
python3 -m py_compile <both files>                → OK
git diff --check                                  → clean
python3 robot/mick_chat_model_smoketest.py --help → exit 0, usage printed
python3 robot/mick_chat_model_smoketest.py --delay-seconds 20
                                                  → exit 2, "must be between 0.0 and 10.0"
```

Existing robot lane re-run, all pass: `mick_chat_contract_test.py`, `rabbit_voice_test.py`, `rabbit_keepalive_test.py`, `rabbit_tone_test.py`, `consumer_config_contract_test.py`. `ci.yml` parses. Mick actuation fence **INTACT**.

## Safety

Doer-quality tooling only. The chat surface has no motion authority — enforced structurally by `ci/check_mick_actuation_fence.py` and the chat separation test, neither of which depends on the model. No checker, planner, governor, release-token, fence or actuation behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_