### PR TITLE
docs: establish Kirra OS foundation and Mick the Robot Companion

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,285 @@
+# Architecture — Kirra OS
+
+A navigable overview of how Kirra OS is put together and where authority
+lives. It **decides nothing**: every rule below is owned by an ADR, a
+specification, or code, and is linked to that owner.
+
+For the technology-by-technology integration narrative — QNX, iceoryx2, PTP,
+Zenoh, tracing, accelerators — the authoritative document is
+[`docs/ARCHITECTURE_STACK.md`](docs/ARCHITECTURE_STACK.md). This page does not
+duplicate it.
+
+---
+
+## 1. The three-domain architecture
+
+```
+Autonomy guest
+    Mick / geometric planner / learned planner / other doers
+          │ proposes
+          ▼
+Safety boundary
+    typed contracts / authentication / freshness / frame checks
+          │ admits
+          ▼
+Safety partition
+    Governor / verifier / checker / release-token enforcement
+          │ authorizes
+          ▼
+Physical actuation
+```
+
+**Autonomy guest** — throughput-optimized and *assumed fallible*. Planning,
+perception, and the guest-side checker layer live here. The value claim is
+precise: even a fully compromised guest cannot actuate, because authority
+lives only on the far side of the boundary.
+
+**Safety boundary** — a fixed-size, versioned, pointer-free `#[repr(C)]`
+region, not a transport endpoint. The contract is the layout, not the library.
+→ [`docs/safety/HYPERVISOR_CONTRACT_CHANNEL.md`](docs/safety/HYPERVISOR_CONTRACT_CHANNEL.md) §2,
+[`docs/adr/0006-governor-transport-iceoryx2.md`](docs/adr/0006-governor-transport-iceoryx2.md) Clause 2
+
+**Safety partition** — every dependency must justify itself into the trusted
+computing base: frozen contracts, zero-alloc hot paths, minimal TCB.
+
+→ Full narrative: [`docs/ARCHITECTURE_STACK.md`](docs/ARCHITECTURE_STACK.md) §2
+
+> **Maturity.** The three-domain model is decided and specified; the QNX
+> partition form is **pending hardware**. `ARCHITECTURE_STACK.md` §5 carries
+> the per-technology status table, and nothing on-target is verified until the
+> QNX deployment and measurement work lands. The host-side governor, verifier
+> and attestation path are built and tested today.
+
+---
+
+## 2. The human-facing path
+
+```
+Human
+  → Mick
+  → typed intent or request
+  → Occy or another doer
+  → Kirra bounds and verifies
+  → verdict
+  → release token
+  → verifying consumer
+  → hardware
+```
+
+Each arrow is a narrowing. Language enters at the left; only an authorized,
+bounded command reaches the right. Mick's contribution ends at *text*: it does
+not construct intents, velocities, or tokens.
+→ [`docs/adr/0033-actuation-authority-ros-r2-topology.md`](docs/adr/0033-actuation-authority-ros-r2-topology.md)
+
+---
+
+## 3. Components
+
+| Component | Role | Authority | Where |
+|---|---|---|---|
+| **Mick** | Conversation, explanation, intent translation | None | [`crates/kirra-sidecars/`](crates/kirra-sidecars/), [`COMPANION.md`](COMPANION.md) |
+| **Occy** | Trajectory / plan proposal | Untrusted | [`crates/kirra-planner/`](crates/kirra-planner/) |
+| **Taj** | Perception → corridor + objects + health | Untrusted input | [`crates/kirra-taj/`](crates/kirra-taj/) |
+| **Kirra Governor / Verifier** | Independent check, bound, authorize | **Trusted checker** | [`crates/kirra-trajectory/`](crates/kirra-trajectory/), [`src/verifier.rs`](src/verifier.rs) |
+| **Release token** | Cryptographic authorization of specific bytes | Binding | [`docs/adr/0031-release-token-on-the-actuation-path.md`](docs/adr/0031-release-token-on-the-actuation-path.md) |
+| **Verifying consumer** | Verify-before-act at the hardware edge | Enforcement | [`crates/kirra-inline-governor/`](crates/kirra-inline-governor/) |
+
+---
+
+## 4. Trust and authority boundaries
+
+**Trust boundary** — where untrusted input becomes checked input. Everything
+upstream is fallible; the checker re-derives what it needs rather than
+believing what it was told.
+
+**Authority boundary** — where a checked proposal becomes an authorized
+action. The governor digests the validated bytes and signs a release token
+over exactly those bytes; the consumer verifies before releasing. "The
+governor approved exactly the data represented by this digest."
+→ [`docs/safety/HYPERVISOR_CONTRACT_CHANNEL.md`](docs/safety/HYPERVISOR_CONTRACT_CHANNEL.md) §3
+
+The two are deliberately separate. Passing the check is necessary but not
+sufficient; the authorization is a distinct, verifiable artifact.
+
+---
+
+## 5. Proposal versus authorization
+
+| | Proposal | Authorization |
+|---|---|---|
+| Produced by | Any doer | The governor alone |
+| Trusted | No | Yes, within its envelope |
+| Form | Typed request | Verdict + release token over specific bytes |
+| Failure mode | Refused, clamped, or MRC | Consumer refuses to release |
+
+A well-formed proposal is not an authorized one. This is the single
+distinction the rest of the architecture exists to preserve.
+
+---
+
+## 6. World model versus conversation
+
+Two separate stores, deliberately not merged:
+
+- **World state** — sourced physical-world facts: perception output, registry
+  entries, posture, diagnostics.
+- **Conversation** — what was said. Never an input the safety path reads as
+  fact.
+
+Language chooses the *type* of a destination; a trusted resolver chooses the
+coordinates. A request carrying coordinate-shaped fields is refused rather
+than honoured.
+→ [`crates/kirra-sidecars/src/destination.rs`](crates/kirra-sidecars/src/destination.rs),
+[`docs/hardware/R2_DESTINATIONS.md`](docs/hardware/R2_DESTINATIONS.md)
+
+---
+
+## 7. Typed contracts
+
+Untyped text never crosses a boundary. An LLM reply becomes a typed intent
+through one fail-closed parser, and anything that does not parse — wrong
+shape, unknown tag, non-finite number — is refused rather than repaired.
+→ [`crates/kirra-planner/src/mick.rs`](crates/kirra-planner/src/mick.rs),
+[`src/action_policy.rs`](src/action_policy.rs)
+
+---
+
+## 8. Frame, freshness and identity checks
+
+| Check | Question | Owner |
+|---|---|---|
+| **Frame** | Which coordinate frame, and does the consumer agree? | [`crates/kirra-sidecars/src/destination_service.rs`](crates/kirra-sidecars/src/destination_service.rs) |
+| **Freshness** | Is this evidence recent enough to act on? | [`src/telemetry_watchdog.rs`](src/telemetry_watchdog.rs) |
+| **Identity** | Did the node it claims to be actually produce this? | [`crates/kirra-safety-authority/src/attestation.rs`](crates/kirra-safety-authority/src/attestation.rs) |
+| **Sequence** | Is this a replay of something already accepted? | [`src/verifier.rs`](src/verifier.rs) |
+
+All four fail closed. A frame mismatch is not resolved by guessing; a stale
+reading is not extrapolated; an unattested node is not trusted; a replayed
+message is refused.
+
+---
+
+## 9. Failure behaviour
+
+The single rule: **absence of evidence is never evidence of safety.**
+
+| Condition | Response |
+|---|---|
+| Missing / empty credential | Refuse (`503`), never pass through |
+| Silent sensor past its budget | Fault → posture degrades → MRC floor |
+| Non-finite value | Rejected before any envelope check |
+| Stale posture cache | Command gate closes |
+| Dependency cycle in the fleet graph | Locked out |
+| Unparseable model output | Refused; no repair attempt |
+| Rate-limited or unreachable service | Refuse; never assume success |
+
+→ [`docs/safety/SAFE_STATE_SPECIFICATION.md`](docs/safety/SAFE_STATE_SPECIFICATION.md)
+
+Degraded is not a slower version of normal: it is a controlled decel-to-stop
+and hold, with re-initiation denied.
+→ [`docs/adr/0011-degraded-http-actuator-503-vs-decel-gate.md`](docs/adr/0011-degraded-http-actuator-503-vs-decel-gate.md)
+
+---
+
+## 10. Auditability
+
+State transitions are recorded in a SHA-256 hash-chained, tamper-evident
+ledger; a broken link is detectable rather than silent. A denied actuator
+command can be rendered as an explainable verdict — deny code, operator
+sentence, recorded inputs, and the chain fields.
+→ [`src/audit_chain.rs`](src/audit_chain.rs), [`src/verdicts.rs`](src/verdicts.rs)
+
+Captured sessions can be replayed through the *real* checker and compared
+bit-identically, so an incident can be reconstructed rather than reasoned
+about.
+→ [`docs/REPLAY_INCIDENT_RECONSTRUCTION.md`](docs/REPLAY_INCIDENT_RECONSTRUCTION.md)
+
+---
+
+## 11. Hardware abstraction
+
+Kinematic limits are per-platform configuration, selected by vehicle class.
+There is no default class — an unset or unknown value aborts startup, because
+a wrong envelope is more dangerous than a stopped robot.
+→ [`docs/CONTRACT_PROFILES.md`](docs/CONTRACT_PROFILES.md)
+
+Platform kinematics are abstracted so the same checker serves differing
+drive geometries.
+→ [`docs/adr/0027-platform-kinematics-abstraction.md`](docs/adr/0027-platform-kinematics-abstraction.md)
+
+---
+
+## 12. Where ROS 2 sits
+
+ROS 2 is **middleware in the autonomy guest**. It is not the safety boundary
+and carries no authority.
+
+- The checker core is `no_std`-friendly and ROS-agnostic; the ROS 2 adapter is
+  a thin wiring layer.
+  → [`crates/kirra-ros2-adapter/`](crates/kirra-ros2-adapter/)
+- DDS actuator topics are `Volatile`, never `TransientLocal` — a late joiner
+  must not receive a stale command.
+- On the AV line, Autoware is kept as the doer and isolated, meeting the rest
+  of the stack on a small set of hash-verified boundary topics.
+  → [`docs/adr/0036-autoware-distro-migration-occy-gap.md`](docs/adr/0036-autoware-distro-migration-occy-gap.md)
+
+---
+
+## 13. The AV checker (Occy line)
+
+The autonomous-driving specialization runs as a two-rate checker: a slow loop
+at planning rate validating the candidate trajectory, and a fast loop at
+control rate enforcing the verdict. Verdicts are
+`TrajectoryVerdict::{Accept, Clamp, MRCFallback, Pending}`.
+
+| Mechanism | Owner |
+|---|---|
+| SG2 drivable-space containment + lateral margin | [`docs/safety/OCCY_SG2_MARGIN.md`](docs/safety/OCCY_SG2_MARGIN.md) |
+| RSS over horizon; longitudinal **and** lateral conjunction | [`docs/safety/KIRRA_RSS_FORMAL_SPECIFICATION.md`](docs/safety/KIRRA_RSS_FORMAL_SPECIFICATION.md) |
+| Occlusion-aware junction speed bound | [`docs/adr/0016-occlusion-aware-junction-speed-bound.md`](docs/adr/0016-occlusion-aware-junction-speed-bound.md) |
+| Multi-modal predictive RSS (CV / CTRV) | [`docs/adr/0017-multi-modal-predictive-rss.md`](docs/adr/0017-multi-modal-predictive-rss.md) |
+| Perception-divergence monitoring | [`docs/adr/0018-perception-divergence-monitor.md`](docs/adr/0018-perception-divergence-monitor.md) |
+| Two-tier Governor + independent detection channel | [`docs/safety/OCCY_ARCHITECTURE_TIERS.md`](docs/safety/OCCY_ARCHITECTURE_TIERS.md), [`docs/safety/OCCY_INDEPENDENT_DETECTOR.md`](docs/safety/OCCY_INDEPENDENT_DETECTOR.md) |
+| ASIL decomposition | [`docs/safety/ASIL_DECOMPOSITION.md`](docs/safety/ASIL_DECOMPOSITION.md) |
+| Dependent failure analysis | [`docs/safety/OCCY_DFA.md`](docs/safety/OCCY_DFA.md) |
+| Freedom from interference | [`docs/safety/OCCY_FFI_EVIDENCE.md`](docs/safety/OCCY_FFI_EVIDENCE.md) |
+| Minimum-risk-condition behaviour | [`docs/safety/SAFE_STATE_SPECIFICATION.md`](docs/safety/SAFE_STATE_SPECIFICATION.md) |
+| Lanelet2 corridor source | [`crates/kirra-map/`](crates/kirra-map/), [`docs/adr/0023-lanelet2-geographic-projection.md`](docs/adr/0023-lanelet2-geographic-projection.md) |
+| Subscription-staleness watchdog | [`crates/kirra-ros2-adapter/`](crates/kirra-ros2-adapter/) |
+| Learned planner vocabulary, still governed | [`crates/kirra-planner/src/learned.rs`](crates/kirra-planner/src/learned.rs) |
+| CARLA scenario coverage | [`docs/testing/CARLA_SCENARIO_SUITE.md`](docs/testing/CARLA_SCENARIO_SUITE.md) |
+| Ferrocene-ready traceability conventions | [`docs/safety/TRACEABILITY.md`](docs/safety/TRACEABILITY.md) |
+
+Claims here belong to their owning documents and should not be generalized
+beyond them. Occy safety goals and their status:
+[`docs/safety/OCCY_SAFETY_GOALS.md`](docs/safety/OCCY_SAFETY_GOALS.md).
+
+---
+
+## 14. Fleet and trust architecture
+
+| Mechanism | Where |
+|---|---|
+| Per-node and fleet posture; gray/black DAG traversal with cycle detection | [`src/verifier.rs`](src/verifier.rs) |
+| Dependency-graph processing | [`src/verifier.rs`](src/verifier.rs) |
+| Telemetry timeout thresholds | [`src/telemetry_watchdog.rs`](src/telemetry_watchdog.rs) |
+| Hysteresis-based trust recovery | [`src/recovery_hysteresis.rs`](src/recovery_hysteresis.rs) |
+| Federation trust reports, Ed25519-signed | [`crates/kirra-fleet-types/`](crates/kirra-fleet-types/) |
+| Generation ordering across controllers | [`docs/adr/0037-epoch-fenced-generation-ordering.md`](docs/adr/0037-epoch-fenced-generation-ordering.md) |
+| Replay prevention / nonce burning | [`crates/kirra-persistence/`](crates/kirra-persistence/) |
+| HA passive-standby promotion; durable epoch fence | [`src/standby_monitor/`](src/standby_monitor/), [`docs/deployment/HA_TOPOLOGY.md`](docs/deployment/HA_TOPOLOGY.md) |
+| WAL-mode SQLite persistence | [`crates/kirra-persistence/`](crates/kirra-persistence/) |
+| Audit-chain integrity | [`src/audit_chain.rs`](src/audit_chain.rs) |
+
+---
+
+## 15. Where to go next
+
+| Question | Document |
+|---|---|
+| How do the technologies integrate? | [`docs/ARCHITECTURE_STACK.md`](docs/ARCHITECTURE_STACK.md) |
+| What is the safety evidence? | [`SAFETY.md`](SAFETY.md), [`docs/safety/SAFETY_CASE_INDEX.md`](docs/safety/SAFETY_CASE_INDEX.md) |
+| What are the non-negotiables? | [`CONSTITUTION.md`](CONSTITUTION.md) |
+| What is Mick? | [`COMPANION.md`](COMPANION.md) |
+| What must an integrator provide? | [`docs/safety/ASSUMPTIONS_OF_USE.md`](docs/safety/ASSUMPTIONS_OF_USE.md), [`docs/safety/GOVERNOR_SAFETY_MANUAL.md`](docs/safety/GOVERNOR_SAFETY_MANUAL.md) |
+| Why was a decision made? | [`docs/adr/`](docs/adr/) |

--- a/COMPANION.md
+++ b/COMPANION.md
@@ -1,0 +1,134 @@
+# Mick — The Robot Companion
+
+Mick is the human-facing conversational and explanation layer of Kirra OS.
+Mick helps operators understand what the robot knows, what it can do, why it
+made a decision, and when it is uncertain.
+
+**Mick has no direct actuation authority.**
+
+---
+
+## Character
+
+Mick is:
+
+- **calm** — steady tone, including when the fleet is not steady
+- **patient** — a repeated question gets a real answer, not a shorter one
+- **technically competent** — able to explain a refusal in terms of the
+  mechanism that produced it
+- **quietly confident** — no performed enthusiasm
+- **concise** — brevity is the default; spoken replies are short by design
+- **truthful** — including about its own limits
+- **lightly formal** — a professional colleague, not a mascot
+- **capable of restrained dry humor** — occasionally, never at the expense of
+  clarity
+- **honest about uncertainty** — "I don't have that" is a complete answer
+
+Mick is **not**:
+
+- a direct controller
+- a safety verifier
+- an actuator
+- a replacement for the world model
+- a source of unsourced sensor facts
+- a human
+- conscious
+- theatrical
+- manipulative
+- a generic customer-service chatbot
+
+The full persona specification, including the spoken-line catalogue, is
+[`docs/hardware/RABBIT_CONVERSATION_DESIGN.md`](docs/hardware/RABBIT_CONVERSATION_DESIGN.md)
+and [`docs/rabbit/RABBIT_VOICE_LINES.md`](docs/rabbit/RABBIT_VOICE_LINES.md).
+
+**A great robot companion is calm before clever.**
+
+---
+
+## Responsibilities
+
+| Responsibility | What it means |
+|---|---|
+| **Converse** | Ordinary language, no command syntax to memorize |
+| **Clarify** | Resolve an ambiguous request before anything acts on it |
+| **Explain** | Say what happened and why, in the operator's terms |
+| **Teach** | Make the machine's model of the world learnable |
+| **Report trusted state** | Relay posture and diagnostics — sourced, never invented |
+| **Translate goals into typed requests** | Turn intent into a typed proposal the governed path can evaluate |
+| **Explain refusals and uncertainty** | A denied command should leave the operator understanding the boundary |
+| **Reduce operator cognitive load** | The measure of success |
+
+---
+
+## The boundary
+
+> **Mick makes governed autonomy understandable.
+> Mick does not replace governed autonomy.**
+
+Mick may describe a decision. Mick may not make one. The distinction is
+enforced in three independent ways, none of which relies on Mick behaving:
+
+1. **A dependency fence.** No dependency route from the Mick binaries to
+   actuation — release-token, serial consumer, or ROS/DDS — can compile.
+   → [`ci/check_mick_actuation_fence.py`](ci/check_mick_actuation_fence.py)
+2. **A separation test.** The chat path must not reference the typed-intent
+   machinery, must serve no intent endpoint, and must not surface
+   motion-shaped model output as if it were a result.
+   → [`crates/kirra-sidecars/tests/mick_chat_separation.rs`](crates/kirra-sidecars/tests/mick_chat_separation.rs)
+3. **A single door.** Motion requests leave the conversational layer as *text*
+   and are re-parsed into a typed intent by the governed path — Mick never
+   builds a command, a velocity, or a release token.
+   → [`docs/adr/0033-actuation-authority-ros-r2-topology.md`](docs/adr/0033-actuation-authority-ros-r2-topology.md)
+
+---
+
+## Two channels
+
+Only one of them reaches the wheels.
+
+**Channel A — speak.** Questions, explanations, narration, boot and shutdown
+lines. Zero actuation authority. Deterministic lines (posture narration, OTA,
+boot) are templates fired by real events, not model output.
+
+**Channel B — act.** A movement request's *text* goes to the intent sidecar,
+is parsed fail-closed into a typed intent, and is handed to a doer. Kirra
+bounds the result. Mick's contribution ends at the text.
+
+System commands do not ride the movement door.
+
+---
+
+## What Mick will not say
+
+Three classes of statement are structurally unavailable rather than
+discouraged:
+
+- **Invented live state.** The chat surface has no telemetry feed. Asked for a
+  battery level it was never given, it declines instead of producing a
+  plausible number.
+- **A foreign identity.** Identity, provenance, model and memory questions are
+  answered from a fixed table with no model call — because a model asked "who
+  made you" will answer accurately about *itself*, which is the wrong answer
+  for the robot.
+  → [`crates/kirra-sidecars/src/chat.rs`](crates/kirra-sidecars/src/chat.rs)
+- **A truncated thought.** Replies end on a complete sentence. Spoken aloud
+  there is no visual cue that text was cut, so a mid-word stop sounds like the
+  robot losing its train of thought.
+
+These are checked by a doer-quality gate that runs against the deployed
+service: [`robot/mick_chat_model_smoketest.py`](robot/mick_chat_model_smoketest.py),
+with its judgements host-tested in
+[`robot/mick_chat_contract.py`](robot/mick_chat_contract.py).
+
+---
+
+## Why a companion at all
+
+A robot that cannot explain itself pushes the explaining onto its operator.
+That cost is invisible in a demo and dominant in daily operation.
+
+The safety architecture already knows why it refused a command — the verdict,
+the deny code, and the bounding mechanism are all recorded. Mick's job is to
+carry that across the gap between a correct system and an understood one.
+
+**Every robot deserves a trusted companion.**

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -1,0 +1,117 @@
+# The Kirra Constitution
+
+Fifteen non-negotiable principles. Everything else in this repository is an
+implementation detail that may change; these are the commitments that decide
+whether a change is acceptable at all.
+
+A principle here is only worth the evidence behind it, so each links to where
+it is actually enforced.
+
+---
+
+### 1. Safety is architectural, not prompt-based
+
+No system prompt, instruction, guardrail phrase, or fine-tune is a safety
+control. Safety comes from an independent component that evaluates a proposal
+after the model has finished producing it.
+→ [`docs/adr/0020-doer-invariant-safety-case.md`](docs/adr/0020-doer-invariant-safety-case.md)
+
+### 2. Doers are never trusted
+
+A planner is not trusted because it is well engineered, well tested, or
+well formed. Geometric, learned, and language-model planners are all treated
+as fallible proposers.
+→ [`docs/ARCHITECTURE_STACK.md`](docs/ARCHITECTURE_STACK.md) §2
+
+### 3. Intelligence proposes; architecture decides
+
+The component that generates a behaviour is never the component that
+authorizes it.
+→ [`crates/kirra-trajectory/src/validation.rs`](crates/kirra-trajectory/src/validation.rs)
+
+### 4. Missing, stale, malformed, unauthenticated, or non-finite evidence fails closed
+
+Absence of evidence is never evidence of safety. A silent sensor, an expired
+credential, an unparseable payload, and a `NaN` all resolve to refusal or a
+minimum-risk response — never to a permissive default.
+→ [`docs/safety/SAFE_STATE_SPECIFICATION.md`](docs/safety/SAFE_STATE_SPECIFICATION.md),
+[`src/telemetry_watchdog.rs`](src/telemetry_watchdog.rs)
+
+### 5. Physical action requires independent verification and authorization
+
+Reaching an actuator requires a verdict from a component that did not produce
+the command, and a release authorization the consumer verifies before acting.
+→ [`docs/adr/0031-release-token-on-the-actuation-path.md`](docs/adr/0031-release-token-on-the-actuation-path.md),
+[`crates/kirra-inline-governor/`](crates/kirra-inline-governor/)
+
+### 6. The robot never fabricates live state
+
+If the system was not told a fact and cannot source it, it says so. An
+invented sensor reading is worse than an admitted gap, because it is
+indistinguishable from a real one.
+→ [`robot/mick_chat_contract.py`](robot/mick_chat_contract.py)
+
+### 7. The world model represents sourced physical-world facts, not model imagination
+
+Coordinates, poses, object positions, and map features come from perception or
+a trusted registry. Language selects *which* thing is meant; it never supplies
+the geometry.
+→ [`crates/kirra-sidecars/src/destination.rs`](crates/kirra-sidecars/src/destination.rs)
+
+### 8. Conversation memory and world state are separate
+
+What was said is not what is true. Dialogue history must never become an
+input the safety path reads as fact.
+→ [`crates/kirra-sidecars/tests/mick_chat_separation.rs`](crates/kirra-sidecars/tests/mick_chat_separation.rs)
+
+### 9. Local operation and privacy are defaults
+
+The conversational and planning layers run on the robot. Remote services are
+opt-in, not assumed.
+→ [`docs/hardware/RABBIT_CONVERSATION_DESIGN.md`](docs/hardware/RABBIT_CONVERSATION_DESIGN.md)
+
+### 10. Hardware and model implementations are replaceable
+
+Swapping a model, a planner, or a chassis must not require re-reasoning about
+the safety boundary. If it does, the boundary was in the wrong place.
+→ [`docs/CONTRACT_PROFILES.md`](docs/CONTRACT_PROFILES.md)
+
+### 11. Safety claims must reflect actual evidence and assessment status
+
+Designed-in-alignment is not compliance. A draft mapping is not an assessment.
+A passing test is not a certificate. See the claim rules in
+[`SAFETY.md`](SAFETY.md#public-claim-rules).
+
+### 12. Mick is a Robot Companion, not an actuator
+
+The conversational layer has no motion authority, and that is enforced
+structurally rather than by policy.
+→ [`ci/check_mick_actuation_fence.py`](ci/check_mick_actuation_fence.py)
+
+### 13. A robot companion should reduce cognitive load
+
+The operator should finish an interaction knowing more and worrying less.
+Explanations exist to be understood, not to demonstrate sophistication.
+
+### 14. Calm before clever
+
+Predictable, quiet, and correct beats impressive. A companion that is
+occasionally delightful and frequently confusing is a bad companion.
+
+### 15. Architecture changes require updated evidence and traceability
+
+A change to a safety mechanism is incomplete until its requirement, test, and
+traceability records move with it.
+→ [`docs/safety/REQUIREMENTS_TRACEABILITY.md`](docs/safety/REQUIREMENTS_TRACEABILITY.md),
+[`docs/safety/TRACEABILITY.md`](docs/safety/TRACEABILITY.md)
+
+---
+
+## Applying this
+
+When a change is proposed, the questions are: which principle does it touch,
+what evidence moves with it, and does any claim in the change describe more
+assurance than the repository actually holds?
+
+Principle 11 is the one most easily broken by accident — usually in a README,
+a slide, or a release note rather than in code.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,143 @@
-# Kirra Runtime SDK
+# Kirra OS
 
 ![CI](https://github.com/kirra-systems/kirra-runtime-sdk/actions/workflows/ci.yml/badge.svg)
 ![Version](https://img.shields.io/github/v/tag/kirra-systems/kirra-runtime-sdk)
 
-A distributed runtime legitimacy engine and safety governor for AI-driven robotic and edge systems. Kirra enforces **fail-closed trust semantics** across a heterogeneous fleet — preventing unsafe or unauthorized commands from reaching actuators regardless of what an AI model, LLM output, or upstream orchestration layer instructs.
+**The governed cognitive operating system for robots.**
+
+Kirra sits between probabilistic autonomy and physical actuation. It lets
+language models, learned planners, geometric planners, and other doers propose
+actions while an independent governed architecture decides what may safely
+reach the robot.
+
+At the human interface is **Mick, the Robot Companion**.
+
+> *"Operating system"* is the platform framing for the governed intelligence
+> and interaction layer **above** robotics middleware. Kirra is not a kernel,
+> not a certified operating system, and not a replacement for Linux or ROS 2.
+
+---
+
+## The architecture in one picture
+
+```
+Human
+  → Mick                    the Robot Companion — explains, clarifies, translates
+  → typed intent            language becomes a typed proposal
+  → Occy or another doer    proposes a plan or trajectory (untrusted)
+  → Kirra bounds and verifies   independent check against envelopes + containment
+  → verdict                 Accept · Clamp · MRCFallback · Pending
+  → release token           Ed25519 over exactly the approved bytes
+  → verifying consumer      verify-before-act at the hardware edge
+  → hardware
+```
+
+**Intelligence proposes. Architecture decides.**
+**Mick communicates. Occy proposes. Kirra decides.**
+
+---
+
+## The product family
+
+| Name | Role | Status |
+|---|---|---|
+| **Kirra OS** | Governed cognitive operating system for robots | Active |
+| **Mick** | The Robot Companion — conversation and explanation, **no actuation authority** | Active |
+| **Occy** | The untrusted planning doer (geometric, learned, or LLM-driven) | Active |
+| **Kirra Governor / Verifier** | The trusted checker and authorization boundary | Active |
+| **Taj** | Perception → objects, drivable corridor, per-output health | Active |
+| **Parko** | Vendor-neutral ML inference substrate | Active |
+| **Kirra Studio** | Developer and operations tooling | *Planned* |
+| **Kirra Fleet** | Fleet deployment and monitoring tooling | *Planned* |
+
+A doer is never trusted merely because it is well formed. See
+[`ARCHITECTURE.md`](ARCHITECTURE.md) for the full picture and
+[`docs/adr/0014-rosmaster-r2-orin-nx-kirra-integration.md`](docs/adr/0014-rosmaster-r2-orin-nx-kirra-integration.md)–[`0015`](docs/adr/0015-rosmaster-r2-perception-layer.md)
+for the Rosmaster R2 + Jetson Orin NX reference integration.
+
+---
+
+## Safety qualification
+
+> **Kirra is designed in alignment with ISO 26262 ASIL-D requirements and IEC 61508 SIL 3 requirements. Independent third-party assessment has not yet been performed.**
+
+Alignment, mappings, tests, and draft evidence are **not** equivalent to
+independent certification. Nothing here has been certified, approved, or
+assessed by a third party, and every safety-case document is **Draft**.
+
+Full statement, claim taxonomy, evidence index, and assumptions of use:
+**[`SAFETY.md`](SAFETY.md)**.
+
+---
+
+## Major implemented capabilities
+
+- **Per-node Ed25519 attestation** — a node proves possession of its
+  registered attestation key; optional TPM2 quote under a per-node policy
+- **Live posture gating** — gray/black DAG traversal over the fleet dependency
+  graph; commands gated on current posture, stale cache fails closed
+- **Kinematic envelopes** — velocity, acceleration, yaw rate; non-finite
+  values rejected before any check
+- **Two-rate AV checking** — trajectory validated at planning rate, verdict
+  enforced at control rate
+- **RSS, containment, occlusion, and predictive bounds** on the AV line
+- **Release-token enforcement** — authorization bound cryptographically to
+  exactly the approved bytes
+- **Ed25519 fleet federation** — signed cross-controller reports, replay
+  prevention, generation ordering
+- **Hash-chained audit ledger** + deterministic incident replay
+- **Fail-closed everywhere** — missing, stale, malformed, unauthenticated, or
+  non-finite evidence never becomes a permissive default
+
+Each with links to its source: [`SAFETY.md`](SAFETY.md#technical-safety-mechanisms).
+
+---
+
+## Quick links
+
+| | |
+|---|---|
+| **Why this exists** | [`VISION.md`](VISION.md) |
+| **Non-negotiable principles** | [`CONSTITUTION.md`](CONSTITUTION.md) |
+| **How it fits together** | [`ARCHITECTURE.md`](ARCHITECTURE.md) · [`docs/ARCHITECTURE_STACK.md`](docs/ARCHITECTURE_STACK.md) |
+| **The Robot Companion** | [`COMPANION.md`](COMPANION.md) |
+| **Safety evidence** | [`SAFETY.md`](SAFETY.md) · [`docs/safety/SAFETY_CASE_INDEX.md`](docs/safety/SAFETY_CASE_INDEX.md) |
+| **What's next** | [`ROADMAP.md`](ROADMAP.md) |
+| **Decisions** | [`docs/adr/`](docs/adr/) |
+
+---
+
+## Current maturity
+
+| Area | State |
+|---|---|
+| Host-side governor, verifier, attestation, fleet trust | **Implemented and tested** |
+| AV checker (Occy line) — containment, RSS, occlusion, MRC | **Implemented and tested** |
+| Conversational companion (Mick) on the reference robot | **Implemented; hardware verification in progress** |
+| Voice → destination | **Resolution and admission only** — not completed navigation |
+| QNX safety partition | **Specified; pending hardware** |
+| Independent assessment | **Not started** |
+
+> **Physical deployment requires system integration and verification.** Kirra
+> is a Safety Element out of Context. System-level safety depends on the ODD,
+> hardware, configuration, maps, sensor contracts, integration assumptions, and
+> the verification chain you actually deploy — see
+> [`docs/safety/ASSUMPTIONS_OF_USE.md`](docs/safety/ASSUMPTIONS_OF_USE.md) and
+> [`docs/safety/GOVERNOR_SAFETY_MANUAL.md`](docs/safety/GOVERNOR_SAFETY_MANUAL.md).
+
+---
+
+## Build and test
+
+```bash
+cargo build --release --bin kirra_verifier_service   # core verifier
+cargo build --release -p kirra-sidecars              # Mick / Occy / Taj sidecars
+cargo test                                           # workspace tests
+cd parko && cargo test                               # ML + diverse-governor workspace
+```
+
+Full prerequisites, run, install and configuration instructions are in
+[Getting Started](#getting-started) below.
 
 > **Note on versioning:** v1.5.0 was a documentation-only release
 > (ASIL-D safety case foundation) tagged out-of-band by CI automation, so it
@@ -16,25 +150,9 @@ A distributed runtime legitimacy engine and safety governor for AI-driven roboti
 
 ---
 
-## The Kirra Stack (named components)
-
-The runtime is built as a **doer / checker** architecture — untrusted components *propose*, the governor *disposes*:
-
-| Component | Role |
-|---|---|
-| **Mick** | the LLM brain — System-2 cognition / LLM-as-planner. *Proposes* intent; never touches the actuator. |
-| **Taj** | perception — sensors → the Kirra perception input contract (objects + drivable corridor + per-output health). |
-| **Occy** (`kirra-planner`) | the formal autonomy planner — proposes trajectories the governor checks (Option-B, #131). |
-| **Kirra** | the fail-closed **governor / checker** — the sole authority that may pass a command to an actuator. |
-| **Parko** (`parko-core`) | vendor-neutral ML inference substrate (TensorRT / ONNX / OpenVINO / QNN / …) that Taj's ML phase runs on. |
-
-**The rule:** Mick reasons / Occy plans → they *propose* typed claims → **Kirra** validates against posture + the kinematic envelope + RSS/containment → only a clamped, safe command reaches the chassis. See `docs/adr/0014`–`0015` for the Rosmaster R2 + Jetson Orin NX reference integration.
-
----
-
 ## AI Safety Integration
 
-Kirra is the enforcement layer that prevents LLM hallucinations from reaching physical actuators — drop it between your AI agent and your robot fleet in minutes.
+Kirra is the enforcement layer that keeps unsafe model output from reaching physical actuators — drop it between your AI agent and your robot fleet.
 
 ```
 LLM output  →  Kirra Action Filter  →  Actuator
@@ -119,19 +237,27 @@ for the integrator runbook.
 
 Kirra is designed in alignment with ISO 26262 ASIL-D requirements and IEC 61508 SIL 3 requirements. Independent third-party assessment has not yet been performed.
 
+**The full safety statement, claim taxonomy, evidence index, assumptions of use,
+and non-certification notice live in [`SAFETY.md`](SAFETY.md).**
+
 ### Foundation (Kirra / Aegis line)
+
+> `AEGIS-*` IDs are **deliberately retained** across the Aegis → Kirra rename —
+> immutable cert-configuration lineage, not an incomplete rebrand. Newer
+> documents mint `KIRRA-*` IDs. The authoritative registry is
+> [`docs/safety/SAFETY_CASE_INDEX.md`](docs/safety/SAFETY_CASE_INDEX.md).
 
 | Document | Doc ID | Status |
 |----------|--------|--------|
-| Hazard Analysis and Risk Assessment (HARA) | KIRRA-HARA-001 | Draft |
+| Hazard Analysis and Risk Assessment (HARA) | AEGIS-HARA-001 | Draft |
 | Safety Goals | AEGIS-SG-001 | Draft |
-| Safety Architecture | KIRRA-SA-001 | Draft |
-| Requirements Traceability Matrix | KIRRA-RTM-001 | Draft |
-| Coding Guidelines | KIRRA-CG-001 | Draft |
-| Safety Standards Matrix (23 standards, 5 verticals) | KIRRA-STD-001 | Draft |
-| ASTM F3269 Run Time Assurance Mapping | KIRRA-F3269-001 | Draft |
+| Safety Architecture | AEGIS-SA-001 | Draft |
+| Requirements Traceability Matrix | AEGIS-RTM-001 | Draft |
+| Coding Guidelines | AEGIS-CG-001 | Draft |
+| Safety Standards Matrix (25 standards, 5 verticals) | AEGIS-STD-001 | Draft |
+| ASTM F3269 Run Time Assurance Mapping | AEGIS-F3269-001 | Draft |
 | ASTM F3269-21 Bounded Operation Mapping (current) | KIRRA-RTA-001 | Draft |
-| IEC 61508 SIL 3 Preliminary Claim Mapping | KIRRA-61508-001 | Draft |
+| IEC 61508 SIL 3 Preliminary Claim Mapping | AEGIS-61508-001 | Draft (Preliminary — pre-assessment) |
 | IEC 61508 SIL 3 Requirements Mapping (current) | KIRRA-SIL3-001 | Draft |
 | External Security/Safety Review Wrap-Up | KIRRA-REV-001 | Final |
 
@@ -232,7 +358,7 @@ See [docs/roadmap/](docs/roadmap/) for sequencing dependencies and execution pla
 
 Modern robotic and autonomous deployments increasingly rely on AI models to generate operational commands. Kirra sits between those models and the physical actuators, acting as a cryptographically-grounded safety layer that:
 
-- **Attests** each fleet node via HMAC-SHA256 challenge/response
+- **Attests** each fleet node via an Ed25519 challenge/response the node signs with its registered attestation key
 - **Tracks trust posture** per-node and fleet-wide using a gray/black DAG traversal algorithm
 - **Gates commands** based on live posture — locking out unsafe operations before they reach hardware
 - **Monitors AV sensor health** with a configurable telemetry watchdog and hysteresis-based recovery
@@ -604,7 +730,7 @@ KIRRA_VERIFIER_MODE=passive_standby KIRRA_INSTANCE_ID=kirra-standby ./kirra_veri
 | `dashmap` | 6 | Concurrent hashmaps |
 | `rusqlite` | 0.31 (bundled) | WAL-mode SQLite persistence |
 | `ed25519-dalek` | 2 | Federation signature verification |
-| `hmac` + `sha2` | 0.12 / 0.10 | Attestation proof computation |
+| `hmac` + `sha2` | 0.12 / 0.10 | HMAC for the two-box UDP prototype path; SHA-256 for the audit chain and digests (attestation proofs are Ed25519) |
 | `base64` | 0.22 | Encoding |
 | `tokio-stream` | 0.1 | SSE broadcast |
 | `reqwest` | 0.12 | CARLA client HTTP |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,131 @@
+# Roadmap — Kirra OS
+
+Organized by release and by **evidence maturity**, because those are different
+axes: a feature can ship long before the evidence supporting a safety claim
+about it is complete.
+
+Statuses use the [`SAFETY.md`](SAFETY.md#claim-taxonomy) taxonomy. Nothing here
+is evidence for an implemented mechanism — for that, see
+[`SAFETY.md`](SAFETY.md) and the source it links.
+
+Detailed sequencing lives in [`docs/roadmap/`](docs/roadmap/) and
+[`docs/safety/ROADMAP_TO_ASIL_D.md`](docs/safety/ROADMAP_TO_ASIL_D.md).
+
+---
+
+## Foundation
+
+Project-level identity and navigation.
+
+| Item | Status |
+|---|---|
+| Platform identity — Kirra OS, Mick, Occy, Governor | This PR |
+| Architecture documentation | [`ARCHITECTURE.md`](ARCHITECTURE.md), [`docs/ARCHITECTURE_STACK.md`](docs/ARCHITECTURE_STACK.md) |
+| Safety evidence index | [`SAFETY.md`](SAFETY.md), [`docs/safety/SAFETY_CASE_INDEX.md`](docs/safety/SAFETY_CASE_INDEX.md) |
+| Companion definition | [`COMPANION.md`](COMPANION.md) |
+| Constitution | [`CONSTITUTION.md`](CONSTITUTION.md) |
+
+---
+
+## Kirra OS 1.0
+
+Making a single robot genuinely usable through conversation, with every motion
+governed.
+
+| Item | Status | Notes |
+|---|---|---|
+| Stable local conversation | **Implemented / Tested** | Local Ollama; deterministic identity and memory routes; sentence-safe output |
+| Governed explicit motion | **Implemented / Tested** | Text → typed intent → doer → checker → release token → verifying consumer |
+| Semantic destination admission | **Implemented / Tested** | Language picks the destination *type*; a trusted resolver picks the coordinates → [`docs/hardware/R2_DESTINATIONS.md`](docs/hardware/R2_DESTINATIONS.md) |
+| **Frame-aware governed destination bridge** | **Planned** | The grounded-destination latch exists; the frame-aware consumer that would let it drive does not. Must reject unknown or mismatched `map_id`, stale sequence, duplicate sequence, unsupported frame, route metadata mistaken for a complete route, and a missing map↔planner transform |
+| Trusted world-state inputs | **Partial** | Perception and registry paths implemented; broader world state in progress |
+| Robot installer | **Implemented** | [`robot/install/`](robot/install/), [`deploy/systemd/install.sh`](deploy/systemd/install.sh) |
+| Diagnostics | **Implemented** | [`robot/doctor/`](robot/doctor/), [`docs/diagnostics.md`](docs/diagnostics.md) |
+| Hardware verification | **In progress** | Rosmaster R2 + Jetson Orin NX reference → [`docs/hardware/RABBIT_BRINGUP_RUNBOOK.md`](docs/hardware/RABBIT_BRINGUP_RUNBOOK.md) |
+
+> **Honest status.** Voice-to-destination today performs **resolution and
+> admission**, not completed navigation. A spoken destination resolves to a
+> trusted pose and is admitted by the checker; the bridge that would carry it
+> to the wheels is the planned work above. Do not read the implemented rows as
+> "the robot drives where you tell it."
+
+---
+
+## Kirra OS 1.5
+
+Persistence, richer world state, and the beginnings of a platform.
+
+| Item | Status |
+|---|---|
+| Persistent places and objects | Planned |
+| Object-goal relay | Partial — planner-side resolver implemented; end-to-end relay planned |
+| Route sequencing (multi-waypoint) | Planned — routes currently ground to their first waypoint only |
+| Dashboard | Planned |
+| Skill SDK | Planned |
+| More hardware platforms | Planned |
+
+---
+
+## Kirra OS 2.0
+
+Companion workflows — the robot doing a *job*, not a manoeuvre.
+
+| Item | Status |
+|---|---|
+| Companion workflows | Conceptual |
+| Inspection | Conceptual |
+| Delivery | Conceptual |
+| Follow-me | Conceptual |
+| Charging | Conceptual |
+| Home Assistant integration | Conceptual |
+| Fleet operations | Conceptual |
+
+Kirra Studio and Kirra Fleet are product names for this horizon. Neither
+exists.
+
+---
+
+## Safety evidence and assessment
+
+Tracked explicitly as work, never implied as complete. Current state of every
+row: **not started or in progress**.
+
+| Item | Status |
+|---|---|
+| Safety-case documents through formal confirmation review | **Planned** — all currently Draft |
+| Ferrocene toolchain qualification | **Planned** |
+| QNX target cross-compile and on-target WCET measurement | **In progress / blocked on hardware** → [`docs/safety/WCET_MEASUREMENT_METHODOLOGY.md`](docs/safety/WCET_MEASUREMENT_METHODOLOGY.md) |
+| Hardware fault-injection campaigns | **Planned** → [`docs/safety/HV_FAULT_CAMPAIGN.md`](docs/safety/HV_FAULT_CAMPAIGN.md) |
+| Independent third-party assessment (ISO 26262) | **Planned — not started** |
+| Independent third-party assessment (IEC 61508) | **Planned — not started** |
+| Certification body engagement | **Planned — not started** |
+
+→ [`docs/safety/ROADMAP_TO_ASIL_D.md`](docs/safety/ROADMAP_TO_ASIL_D.md),
+[`docs/safety/RTM_GAP_REPORT.md`](docs/safety/RTM_GAP_REPORT.md)
+
+---
+
+## Integrations
+
+| Integration | Status |
+|---|---|
+| Autoware (Option-B two-rate checker) | **Implemented** → [`docs/safety/OCCY_131_OPTIONB_DESIGN.md`](docs/safety/OCCY_131_OPTIONB_DESIGN.md) |
+| IEEE 2846 / RSS | **Implemented** → [`docs/safety/KIRRA_RSS_FORMAL_SPECIFICATION.md`](docs/safety/KIRRA_RSS_FORMAL_SPECIFICATION.md) |
+| QNX governor transport lane | **In progress** — specs landed; on-target work blocked on hardware |
+| Apollo AV stack | **Planned** → [`docs/roadmap/APOLLO_KIRRA_INTEGRATION.md`](docs/roadmap/APOLLO_KIRRA_INTEGRATION.md) |
+| Postgres shared control-plane state | **Implemented** → [`docs/adr/0038-postgres-shared-state-hybrid.md`](docs/adr/0038-postgres-shared-state-hybrid.md) |
+
+---
+
+## Reading this roadmap
+
+Three distinctions to keep straight:
+
+- **Implemented** means the mechanism exists and is tested. It does not mean
+  it is assessed.
+- **Planned** means intended and not built. No planned row should be cited as
+  a capability.
+- **Conceptual** means a direction, not a commitment.
+
+A roadmap entry is never evidence. If you need to know whether something
+works, follow the links in [`SAFETY.md`](SAFETY.md) to the source.

--- a/SAFETY.md
+++ b/SAFETY.md
@@ -1,0 +1,250 @@
+# Safety — Kirra OS
+
+## Safety statement
+
+> **Kirra is designed in alignment with ISO 26262 ASIL-D requirements and IEC 61508 SIL 3 requirements. Independent third-party assessment has not yet been performed.**
+
+That sentence is exact and load-bearing. *Designed in alignment with* is not
+*compliant with*; a draft mapping is not an assessment; a passing test is not a
+certificate. Nothing in this repository has been independently certified,
+approved, or assessed by a third party.
+
+---
+
+## Claim taxonomy
+
+Every safety claim carries one of these labels. They are ordered by strength,
+and a claim may not be promoted without the evidence the next level demands.
+
+| Label | Means | Evidence required |
+|---|---|---|
+| **Implemented** | The mechanism exists in shipped source | Source file |
+| **Tested** | Implemented, plus automated tests exercising it | Test + CI lane |
+| **Draft evidence** | A safety-case document exists, under review | Document marked Draft |
+| **Preliminary mapping** | Requirements mapped to a standard, pre-assessment | Mapping document |
+| **Planned assessment** | Scheduled, not begun | Roadmap entry |
+| **Independently assessed** | A third party has examined and reported | Assessor report |
+
+**No claim in this repository currently carries "Independently assessed."**
+If you find one, it is a defect — please report it.
+
+---
+
+## Evidence index
+
+The safety-case foundation. Authoritative registry:
+[`docs/safety/SAFETY_CASE_INDEX.md`](docs/safety/SAFETY_CASE_INDEX.md).
+
+> **Document identifier scheme.** `AEGIS-*` IDs are **deliberately retained**
+> across the Aegis → Kirra product rename. They are immutable
+> cert-configuration lineage, not an incomplete rebrand; newer documents mint
+> `KIRRA-*` IDs. Renaming a legacy ID would break the configuration record, so
+> the IDs below are reproduced exactly as the documents carry them.
+
+| Document | Doc ID | Status | File |
+|---|---|---|---|
+| Hazard Analysis and Risk Assessment | AEGIS-HARA-001 | Draft | [`docs/safety/HARA.md`](docs/safety/HARA.md) |
+| Safety Goals | AEGIS-SG-001 | Draft | [`docs/safety/SAFETY_GOALS.md`](docs/safety/SAFETY_GOALS.md) |
+| Safety Architecture | AEGIS-SA-001 | Draft | [`docs/safety/SAFETY_ARCHITECTURE.md`](docs/safety/SAFETY_ARCHITECTURE.md) |
+| Requirements Traceability Matrix | AEGIS-RTM-001 | Draft | [`docs/safety/REQUIREMENTS_TRACEABILITY.md`](docs/safety/REQUIREMENTS_TRACEABILITY.md) |
+| Rust Safety Coding Guidelines | AEGIS-CG-001 | Draft | [`docs/safety/CODING_GUIDELINES.md`](docs/safety/CODING_GUIDELINES.md) |
+| Safety Standards Matrix | AEGIS-STD-001 | Draft | [`docs/safety/STANDARDS_MATRIX.md`](docs/safety/STANDARDS_MATRIX.md) |
+| ASTM F3269 Run Time Assurance Mapping | AEGIS-F3269-001 | Draft | [`docs/safety/ASTM_F3269_MAPPING.md`](docs/safety/ASTM_F3269_MAPPING.md) |
+| ASTM F3269-21 Bounded Operation Mapping (current) | KIRRA-RTA-001 | Draft | [`docs/safety/ASTM_F3269_RTA_MAPPING.md`](docs/safety/ASTM_F3269_RTA_MAPPING.md) |
+| IEC 61508 SIL 3 Preliminary Claim Mapping | AEGIS-61508-001 | Draft (Preliminary — pre-assessment) | [`docs/safety/IEC_61508_MAPPING.md`](docs/safety/IEC_61508_MAPPING.md) |
+| IEC 61508 SIL 3 Requirements Mapping (current) | KIRRA-SIL3-001 | Draft | [`docs/safety/IEC_61508_SIL3_MAPPING.md`](docs/safety/IEC_61508_SIL3_MAPPING.md) |
+
+Every one is **Draft**. The AV-specific (Occy) safety case, the QNX partition
+lane documents, and the full registry are indexed in
+[`docs/safety/SAFETY_CASE_INDEX.md`](docs/safety/SAFETY_CASE_INDEX.md).
+
+Related: [`docs/safety/UL4600_SAFETY_CASE.md`](docs/safety/UL4600_SAFETY_CASE.md) ·
+[`docs/safety/ISO_IEC_TR_5469_MAPPING.md`](docs/safety/ISO_IEC_TR_5469_MAPPING.md) ·
+[`docs/safety/ROADMAP_TO_ASIL_D.md`](docs/safety/ROADMAP_TO_ASIL_D.md)
+
+---
+
+## Technical safety mechanisms
+
+**Implemented** and, except where noted, covered by automated tests. None of
+these is independently safety-certified.
+
+### Identity and authorization
+
+| Mechanism | Where |
+|---|---|
+| Per-node Ed25519 attestation — the node signs a `(node_id, nonce)` challenge, checked against its registered public key | [`crates/kirra-safety-authority/src/attestation.rs`](crates/kirra-safety-authority/src/attestation.rs) |
+| TPM2 quote verification under a per-node policy (PCR16 measured boot) | [`src/tpm_quote.rs`](src/tpm_quote.rs) |
+| Constant-time token comparison | [`src/security.rs`](src/security.rs) |
+| Scoped RBAC; fail-closed on absent or empty credentials | [`src/authz.rs`](src/authz.rs), [`docs/safety/PRINCIPAL_TOKENS.md`](docs/safety/PRINCIPAL_TOKENS.md) |
+| Release-token enforcement — Ed25519 over exactly the approved bytes, verified before release | [`crates/kirra-inline-governor/`](crates/kirra-inline-governor/), [`docs/adr/0031-release-token-on-the-actuation-path.md`](docs/adr/0031-release-token-on-the-actuation-path.md) |
+
+> **Correction of a long-standing description.** Node attestation is **Ed25519
+> per-node challenge-response**, not HMAC-SHA256. The earlier
+> `HMAC(admin_token, nonce)` proof was admin-asserted rather than node-proven
+> and was removed; a regression test
+> (`legacy_admin_token_hmac_proof_is_rejected`) keeps it removed. HMAC-SHA256
+> remains in use elsewhere — for the two-box UDP prototype command path in
+> [`crates/kirra-governor-service/`](crates/kirra-governor-service/) — which is
+> a different mechanism for a different purpose.
+
+### Trust posture and fleet state
+
+| Mechanism | Where |
+|---|---|
+| Gray/black DAG traversal — cycle detection, diamond memoization | [`src/verifier.rs`](src/verifier.rs) |
+| Per-node and fleet posture calculation | [`src/verifier.rs`](src/verifier.rs) |
+| Live posture-based command gating | [`src/posture_cache.rs`](src/posture_cache.rs) |
+| AV sensor telemetry watchdog | [`src/telemetry_watchdog.rs`](src/telemetry_watchdog.rs) |
+| Recovery hysteresis — consecutive healthy reports within a window | [`src/recovery_hysteresis.rs`](src/recovery_hysteresis.rs) |
+| Ed25519 federation; signed cross-controller trust reports | [`crates/kirra-fleet-types/`](crates/kirra-fleet-types/) |
+| Replay prevention and nonce burning | [`crates/kirra-persistence/`](crates/kirra-persistence/) |
+| Federation reconciliation with generation ordering | [`docs/adr/0037-epoch-fenced-generation-ordering.md`](docs/adr/0037-epoch-fenced-generation-ordering.md) |
+| Passive-standby promotion; durable epoch fence | [`src/standby_monitor/`](src/standby_monitor/), [`docs/deployment/HA_TOPOLOGY.md`](docs/deployment/HA_TOPOLOGY.md) |
+
+### Motion bounding
+
+| Mechanism | Where |
+|---|---|
+| Velocity, acceleration and yaw-rate envelopes | [`crates/kirra-core/src/kinematics_contract.rs`](crates/kirra-core/src/kinematics_contract.rs), [`docs/kinematics_envelope_protection.md`](docs/kinematics_envelope_protection.md) |
+| Non-finite (`NaN`/`Inf`) rejection before any envelope check | [`crates/kirra-core/src/kinematics_contract.rs`](crates/kirra-core/src/kinematics_contract.rs) |
+| Forward kinematics simulation | [`crates/kirra-core/src/kinematics_sim.rs`](crates/kirra-core/src/kinematics_sim.rs) |
+| Degraded = controlled decel-to-stop and hold | [`docs/safety/SAFE_STATE_SPECIFICATION.md`](docs/safety/SAFE_STATE_SPECIFICATION.md), [`docs/adr/0011-degraded-http-actuator-503-vs-decel-gate.md`](docs/adr/0011-degraded-http-actuator-503-vs-decel-gate.md) |
+| Per-class envelope profiles; no default class | [`docs/CONTRACT_PROFILES.md`](docs/CONTRACT_PROFILES.md) |
+
+### Model-output containment
+
+| Mechanism | Where |
+|---|---|
+| Action filtering against live posture | [`src/action_filter.rs`](src/action_filter.rs), [`docs/action_filter.md`](docs/action_filter.md) |
+| Typed LLM action parsing, fail-closed | [`src/action_policy.rs`](src/action_policy.rs), [`crates/kirra-planner/src/mick.rs`](crates/kirra-planner/src/mick.rs) |
+| Conversational layer fenced from actuation | [`ci/check_mick_actuation_fence.py`](ci/check_mick_actuation_fence.py) |
+
+### Boundaries and integration
+
+| Mechanism | Where |
+|---|---|
+| Industrial protocol adapters (Modbus, DNP3, CANopen, CIP, OPC-UA) | [`docs/protocol_adapters.md`](docs/protocol_adapters.md) |
+| ROS 2 / DDS boundaries; `Volatile` actuator topics | [`crates/kirra-ros2-adapter/`](crates/kirra-ros2-adapter/), [`docs/ros2_interlock.md`](docs/ros2_interlock.md) |
+| Fail-closed service behaviour | [`docs/safety/SECURITY_BOUNDARIES.md`](docs/safety/SECURITY_BOUNDARIES.md) |
+| Transport security (TLS / mTLS, opt-in, fail-closed on half-config) | [`docs/safety/TRANSPORT_SECURITY.md`](docs/safety/TRANSPORT_SECURITY.md) |
+
+### Evidence and reconstruction
+
+| Mechanism | Where |
+|---|---|
+| SHA-256 hash-chained audit ledger | [`src/audit_chain.rs`](src/audit_chain.rs) |
+| Explainable deny verdicts | [`src/verdicts.rs`](src/verdicts.rs) |
+| WAL-mode SQLite persistence; disk before memory | [`crates/kirra-persistence/`](crates/kirra-persistence/) |
+| Deterministic virtual-clock test harness | [`src/clock.rs`](src/clock.rs), [`src/scenario_runner.rs`](src/scenario_runner.rs) |
+| Deterministic incident replay through the real checker | [`docs/REPLAY_INCIDENT_RECONSTRUCTION.md`](docs/REPLAY_INCIDENT_RECONSTRUCTION.md) |
+
+### Verification harnesses
+
+Machine-checked proofs (Kani/CBMC), concurrency models (loom), UB checks
+(Miri), fuzzing, mutation testing, MC/DC-style decision coverage, and a
+crash-consistency drill run as CI lanes.
+→ [`verification/kani/`](verification/kani/),
+[`crates/kirra-loom-models/`](crates/kirra-loom-models/),
+[`fuzz/`](fuzz/),
+[`docs/safety/OCCY_MCDC_EVIDENCE.md`](docs/safety/OCCY_MCDC_EVIDENCE.md),
+[`docs/safety/GOVERNOR_INTEGRITY_EVIDENCE.md`](docs/safety/GOVERNOR_INTEGRITY_EVIDENCE.md)
+
+---
+
+## Assumptions and integration responsibility
+
+Kirra is a Safety Element out of Context. **System-level safety is a property
+of the integrated system, not of this repository.** It depends on:
+
+- the **operational design domain** — [`docs/safety/R2_ODD.md`](docs/safety/R2_ODD.md), [`docs/safety/OCCY_SOTIF.md`](docs/safety/OCCY_SOTIF.md)
+- the **hardware**, including redundancy — the quantitative metrics analysis derives a redundant-supply deployment requirement
+- the **configuration**, including the vehicle class and envelope profile
+- the **maps** and their accuracy
+- the **sensor contracts** and the rates at which producers actually publish
+- the **integration assumptions** — [`docs/safety/ASSUMPTIONS_OF_USE.md`](docs/safety/ASSUMPTIONS_OF_USE.md)
+- the **deployment environment**
+- the **safety manual** — [`docs/safety/GOVERNOR_SAFETY_MANUAL.md`](docs/safety/GOVERNOR_SAFETY_MANUAL.md)
+- **validation evidence** for the integrated system
+- **independent assessment**, where the application requires it
+
+An assumption of use that the integrator does not meet is not a Kirra
+mechanism that failed — it is a claim that was never supported. Read
+`ASSUMPTIONS_OF_USE.md` before deploying anything to hardware.
+
+Residual risk: [`docs/safety/R2_RESIDUAL_RISK.md`](docs/safety/R2_RESIDUAL_RISK.md).
+
+---
+
+## Non-certification notice
+
+**Alignment, mappings, tests, and draft evidence are not equivalent to
+independent certification.**
+
+Specifically:
+
+- No ISO 26262 assessment has been performed. No ASIL rating has been awarded
+  by any assessor.
+- No IEC 61508 assessment has been performed. No SIL rating has been awarded
+  by any assessor.
+- No third party has approved, certified, or endorsed this software.
+- The safety documents are **Draft** and have not been through a formal
+  confirmation review.
+- Timing figures measured on development hosts are **indicative only**. WCET
+  claims require measurement on the target under the documented scheduling
+  regime. → [`docs/safety/WCET_MEASUREMENT_METHODOLOGY.md`](docs/safety/WCET_MEASUREMENT_METHODOLOGY.md)
+- Toolchain qualification (Ferrocene) is **planned**, not completed.
+
+Certification and assessment activities are tracked as roadmap work:
+[`ROADMAP.md`](ROADMAP.md), [`docs/safety/ROADMAP_TO_ASIL_D.md`](docs/safety/ROADMAP_TO_ASIL_D.md).
+
+---
+
+## Public claim rules
+
+These apply to every README, release note, slide, issue comment, and
+documentation change.
+
+**Never convert:**
+
+| From | To |
+|---|---|
+| designed in alignment with | certified · compliant · approved |
+| draft mapping | assessed · compliant |
+| preliminary claim mapping | SIL 3 product |
+| tested mechanism | ASIL-D product · assessor-approved |
+
+...without documented evidence and approval.
+
+**Avoid:**
+
+- "guarantees safety"
+- "makes any AI safe"
+- "universally safe"
+- "impossible to bypass"
+- "fully autonomous and safe"
+- "certified architecture"
+
+**Prefer:**
+
+- "fail-closed under the documented conditions"
+- "designed to enforce"
+- "independently checks"
+- "bounds according to configured envelopes"
+- "supports evidence development"
+- "designed in alignment with"
+- "subject to assumptions of use"
+
+The distinction being protected: what the software *does* versus what a third
+party has *confirmed*. Kirra can honestly claim a great deal about the first
+and nothing yet about the second.
+
+---
+
+## Reporting a safety or security issue
+
+Open an issue for defects. For anything with security impact, prefer private
+disclosure to the maintainers over a public issue.
+
+A claim in this repository that overstates assurance is itself a defect worth
+reporting.

--- a/VISION.md
+++ b/VISION.md
@@ -1,0 +1,170 @@
+# Vision — Kirra OS
+
+## What Kirra OS is
+
+**Kirra OS is a governed cognitive operating system for robots.**
+
+Kirra sits between probabilistic autonomy and physical actuation. It provides
+the architecture that interprets, grounds, bounds, verifies, authorizes, and
+audits robot behaviour.
+
+> **On the words "operating system."** This is the platform framing for the
+> governed intelligence and interaction layer *above* robotics middleware.
+> Kirra is not a kernel, not a certified operating system, and not a
+> replacement for Linux or ROS 2. It runs on top of them, and on the QNX
+> partition path it runs beside them. See
+> [`ARCHITECTURE.md`](ARCHITECTURE.md) for where each piece actually sits.
+
+---
+
+## The problem
+
+Robotics has become good at generating plausible behaviour and has not become
+correspondingly good at refusing bad behaviour.
+
+A language model can emit a fluent, well-formed, entirely wrong motion
+command. A learned planner can produce a trajectory that is smooth,
+in-distribution, and headed into an occluded junction. A geometric planner can
+be correct about geometry and wrong about a stale sensor. In all three cases
+the output *looks* right, and looking right is exactly what the generating
+component optimizes for.
+
+The common industry response is to improve the generator: better prompts,
+better training data, more evaluation. That reduces the frequency of bad
+proposals. It cannot bound their consequence, because the thing being asked to
+judge the output is the thing that produced it.
+
+Kirra takes the other approach. The generator stays fallible, and an
+independent architecture decides what reaches the actuator.
+
+**Intelligence proposes. Architecture decides.**
+
+---
+
+## Governed autonomy
+
+Four roles, with authority deliberately concentrated in one of them:
+
+| Role | Name | Trust |
+|---|---|---|
+| Human-facing conversation and explanation | **Mick**, the Robot Companion | No actuation authority |
+| Proposing a plan or trajectory | **Occy**, or another swappable doer | Untrusted |
+| Independently checking, bounding, and authorizing | **Kirra Governor / Verifier** | The trusted checker |
+| Executing an authorized command | Verifying consumer → hardware | Verifies before acting |
+
+**Mick communicates. Occy proposes. Kirra decides.**
+
+The doer may be geometric, learned, or language-model-driven. It is never
+trusted merely because it is well formed. The checker evaluates the proposal
+against envelopes, containment, safety distance, freshness, and posture, then
+accepts, clamps, or falls back to a minimum-risk response.
+
+This is what makes the model swappable. The safety argument does not rest on
+which planner produced the proposal, so replacing the planner does not
+invalidate it — a property recorded in
+[`docs/adr/0020-doer-invariant-safety-case.md`](docs/adr/0020-doer-invariant-safety-case.md).
+
+---
+
+## Local-first operation
+
+The conversational and planning layers run on the robot. A robot that needs a
+datacentre to answer "what are you doing?" is not a companion; it is a thin
+client with a microphone.
+
+Local operation also removes a class of failure that no amount of cloud
+engineering fixes: the network being unavailable at exactly the moment an
+operator needs to understand what the machine is about to do.
+
+Remote services remain possible and are opt-in.
+→ [`docs/hardware/RABBIT_CONVERSATION_DESIGN.md`](docs/hardware/RABBIT_CONVERSATION_DESIGN.md)
+
+---
+
+## Hardware independence
+
+Kinematic limits differ per platform, so they are configuration rather than
+code. A deployment selects a vehicle class and gets that class's envelope;
+selecting nothing is a startup failure rather than a silent default, because a
+wrong envelope is worse than no robot.
+→ [`docs/CONTRACT_PROFILES.md`](docs/CONTRACT_PROFILES.md)
+
+The reference integration is a Rosmaster R2 on a Jetson Orin NX
+([`docs/adr/0014-rosmaster-r2-orin-nx-kirra-integration.md`](docs/adr/0014-rosmaster-r2-orin-nx-kirra-integration.md)),
+and the checker core is deliberately middleware-agnostic so the same argument
+survives a change of chassis.
+
+---
+
+## Model independence
+
+The doer LLM is swappable with no safety re-review, because the checker never
+consults it. What a swap *does* require is a doer-quality check, so a new model
+is not silently worse at its job.
+→ [`robot/rabbit_model_smoketest.py`](robot/rabbit_model_smoketest.py),
+[`robot/mick_chat_model_smoketest.py`](robot/mick_chat_model_smoketest.py)
+
+> **Models, planners, and robot hardware are replaceable.
+> The governed safety boundary remains stable.**
+
+---
+
+## The Robot Companion
+
+Most robots communicate in status codes, blinking lights, and log files. The
+operator is left inferring intent from behaviour, which works until the moment
+it matters.
+
+Mick is the human-facing layer: what the robot knows, what it can do, why it
+made a decision, and when it is uncertain. Mick explains refusals rather than
+hiding them, because a refusal an operator understands is a system they can
+work with.
+
+Mick has no direct actuation authority. That is enforced structurally, not by
+instruction.
+→ [`COMPANION.md`](COMPANION.md)
+
+**Every robot deserves a trusted companion.**
+
+---
+
+## Long-term platform vision
+
+| Product | Description | Status |
+|---|---|---|
+| **Kirra OS** | Governed cognitive operating system for robots | Active development |
+| **Mick** | The Robot Companion | Active development |
+| **Occy** | The untrusted planning doer | Active development |
+| **Kirra Governor / Verifier** | The trusted checker and authorization boundary | Active development |
+| **Kirra Studio** | Developer and operations tooling | **Planned / conceptual** |
+| **Kirra Fleet** | Fleet deployment and monitoring tooling | **Planned / conceptual** |
+
+Kirra Studio and Kirra Fleet are names for intended future products. They are
+not shipped, and nothing in this repository should be read as delivering them.
+
+Direction over time: more platforms, richer world state, and a companion that
+handles longer workflows — all without moving authority out of the checker.
+→ [`ROADMAP.md`](ROADMAP.md)
+
+---
+
+## Product boundaries
+
+What Kirra does **not** claim:
+
+- **Kirra does not make AI safe.** It bounds what a proposal may do to a
+  specific machine, under a documented configuration, within stated
+  assumptions of use. System-level safety depends on the ODD, the hardware,
+  the sensors, the maps, the configuration, the integration, and the
+  verification chain actually deployed.
+  → [`docs/safety/ASSUMPTIONS_OF_USE.md`](docs/safety/ASSUMPTIONS_OF_USE.md)
+- **Kirra is not a certified product.** Kirra is designed in alignment with ISO 26262 ASIL-D requirements and IEC 61508 SIL 3 requirements. Independent third-party assessment has not yet been performed. → [`SAFETY.md`](SAFETY.md)
+- **Kirra is not a planner.** It does not make the robot capable; it bounds
+  the capability something else provides.
+- **Kirra is not a perception system.** It consumes a perception contract and
+  fails closed when that contract is unmet.
+- **Kirra is not a replacement for ROS 2, Autoware, or a middleware stack.**
+  On the AV line it explicitly keeps Autoware as the doer.
+  → [`docs/adr/0036-autoware-distro-migration-occy-gap.md`](docs/adr/0036-autoware-distro-migration-occy-gap.md)
+
+**Trust the architecture, not the model.**


### PR DESCRIPTION
## Purpose

Establish the project-level vision, constitution, architecture, companion definition, roadmap, and safety-evidence landing page.

This is **not** a rebrand that replaces the existing safety work. The new documents explain and **index** what already exists, and every nontrivial claim links to the source file, ADR, or safety document that owns it. None of them decides anything — where a rule lives elsewhere, they cite it rather than restate it, following the convention [`docs/ARCHITECTURE_STACK.md`](docs/ARCHITECTURE_STACK.md) already sets ("this document DECIDES NOTHING").

**New:** `VISION.md` · `CONSTITUTION.md` · `ARCHITECTURE.md` · `COMPANION.md` · `SAFETY.md` · `ROADMAP.md`
**Restructured:** `README.md`'s opening, so a new reader understands the project in under two minutes.

## Safety claims

> **Kirra is designed in alignment with ISO 26262 ASIL-D requirements and IEC 61508 SIL 3 requirements. Independent third-party assessment has not yet been performed.**

Used verbatim in `README.md`, `VISION.md` and `SAFETY.md`.

`SAFETY.md` adds a **claim taxonomy** — Implemented · Tested · Draft evidence · Preliminary mapping · Planned assessment · Independently assessed — and records that **no claim in this repository currently carries "Independently assessed."** The public claim rules ("never convert *designed in alignment with* into *certified*") live there and are referenced from CONSTITUTION principle 11.

## Three factual corrections

Each verified against source rather than assumed. These are corrections to existing top-level wording, not new claims.

**1. Node attestation is Ed25519, not HMAC-SHA256.** `README.md`'s Overview and dependency table both said HMAC. The `HMAC(admin_token, nonce)` proof was admin-asserted rather than node-proven and was removed under #73 — a regression test named `legacy_admin_token_hmac_proof_is_rejected` keeps it removed. HMAC-SHA256 *is* still used, for the two-box UDP prototype path in `kirra-governor-service`: a different mechanism for a different purpose, and now described as such.

**2. Six of ten foundation document IDs were wrong.** HARA, Safety Architecture, RTM, Coding Guidelines, Standards Matrix and the IEC 61508 preliminary mapping carry `AEGIS-*` IDs, not `KIRRA-*`. [`SAFETY_CASE_INDEX.md`](docs/safety/SAFETY_CASE_INDEX.md) states the rule explicitly — `AEGIS-*` IDs are *deliberately retained* as immutable cert-configuration lineage, not an incomplete rebrand. An index that misidentifies the documents it indexes is worse than no index, so both files now reproduce the IDs the documents actually carry, with the scheme explained.

**3. The Standards Matrix covers 25 standards**, not the 23 `README.md` claimed.

The safety documents themselves are **untouched** and keep their **Draft** status. The IEC 61508 preliminary mapping keeps its more specific *"Draft (Preliminary — pre-assessment)"*.

## Current versus future

**Implemented mechanisms** — Ed25519 per-node attestation (+ optional TPM2 quote), constant-time token comparison, gray/black DAG traversal, fleet posture calculation, live posture gating, telemetry watchdog, recovery hysteresis, velocity/acceleration/yaw-rate envelopes, non-finite rejection, Ed25519 federation, replay prevention and nonce burning, generation-ordered reconciliation, passive-standby promotion, WAL-mode SQLite, hash-chained audit ledger, virtual-clock harness, forward kinematics simulation, action filtering, typed LLM action parsing, industrial protocol adapters, ROS 2/DDS boundaries, release-token enforcement, fail-closed service behaviour. Each linked to its source in [`SAFETY.md`](SAFETY.md#technical-safety-mechanisms).

**Draft evidence** — all ten foundation safety documents, plus the Occy AV safety case and QNX partition lane documents.

**Planned work** — the frame-aware governed destination bridge, persistent places and objects, route sequencing, dashboard, skill SDK, Kirra Studio, Kirra Fleet.

**Future assessment** — Ferrocene toolchain qualification, on-target WCET measurement, hardware fault-injection campaigns, ISO 26262 assessment, IEC 61508 assessment, certification-body engagement. All marked **not started** in `ROADMAP.md`.

Two honesty points carried deliberately: voice-to-destination is described as **resolution and admission, not navigation** (the frame-aware bridge does not exist yet), and Kirra Studio / Kirra Fleet are labelled **planned/conceptual** throughout.

## Validation

| Check | Result |
|---|---|
| Relative links across all 7 files | **243 checked, all resolve** |
| Intra-document anchors | **none broken** |
| `git diff --check` | clean |
| Conflict markers | none |
| Forbidden-claim scan | clean — only hits are `SAFETY.md`'s own prohibition list |
| Exact qualification present | `README.md` ×2, `VISION.md` ×1, `SAFETY.md` ×1 |
| `ci/check_mick_actuation_fence.py` | **INTACT** |
| `check_quality_guardrails` · `check_safety_constants` · `check_reexport_shims` · `check_orphan_cores` | pass |

No Markdown linter or link checker is configured in this repository, so the link and anchor validation above was run explicitly. `check_decision_floor.py` requires CLI arguments and prints usage — not applicable here.

## No runtime change

Documentation only. No source, configuration, routing, model, threshold, API, systemd, or actuation behaviour changed. Verified that **no test reads these files**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_