### PR TITLE
docs: remove ambiguous and stale certification wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,8 @@ Kirra is designed in alignment with ISO 26262 ASIL-D requirements and IEC 61508 
 The **cert-target platform** decision and its prototype bring-up plan live under
 [`docs/adr/`](docs/adr/): `0032-governor-deployment-platform.md` (KIRRA
 governor on QNX Hypervisor 8.0 for Safety; the Autoware/ROS 2 doer as an isolated
-guest VM; a Ferrocene `no_std` verdict core as the certified artifact), with
+guest VM; a Ferrocene `no_std` verdict core as the artifact *intended* to carry
+the eventual certification claim — no such claim exists today), with
 companions `KIRRA_PLATFORM_DEPLOYMENT_STRATEGY.md`, `KIRRA_BRINGUP_RUNBOOK.md`,
 and `KIRRA_QNX_CROSSCOMPILE.md`. (That file's `ADR-0001` prefix is independent of
 the numbered ODD-cap ADRs in the table above — a known naming overlap.)
@@ -182,7 +183,8 @@ records the Occy-vs-Autoware gap analysis and the decision for the Ubuntu
 perception), **isolate it as the only component on Humble** in its own container,
 and move the rest of the stack (ros2 adapter, checker, Occy/Taj) to Jazzy now —
 meeting only on 5 curated, hash-verified boundary topics. The safety spine is
-`no_std`/ROS-agnostic, so this is a doer-side migration with no re-certification.
+`no_std`/ROS-agnostic, so this is a doer-side migration that leaves the safety
+argument and its evidence untouched.
 Isolation scaffold: [`deploy/autoware-isolation/`](deploy/autoware-isolation/).
 
 ### Governor transport / QNX partition lane (EPIC #270)
@@ -202,7 +204,9 @@ Test-evidence tooling: [`tools/qnx-rtm-harness/`](tools/qnx-rtm-harness/) — a 
 shim (driver) → Rust judge (checker) FDIT/RTM fault-injection harness, every row
 traced to the kernel RTM (#271 / #272); [`tools/iceoryx2-spike/`](tools/iceoryx2-spike/)
 — the host-side iceoryx2 feature-subset spike (#273). **Host timing is indicative
-only; certified WCET is measured on the QNX target under FIFO scheduling (#274).**
+only. A WCET figure usable as safety evidence must be measured on the QNX
+target under FIFO scheduling (#274); no such measurement has been taken, so no
+WCET claim is currently supported.**
 
 See [docs/safety/](docs/safety/) for the complete safety case foundation,
 [docs/safety/SAFETY_CASE_INDEX.md](docs/safety/SAFETY_CASE_INDEX.md) for the

--- a/docs/ARCHITECTURE_STACK.md
+++ b/docs/ARCHITECTURE_STACK.md
@@ -37,7 +37,7 @@ partition-transport decision (ADR-0006).
 ### Safety partition (QNX host)
 Every dependency must **justify itself into the trusted computing base**: frozen
 `#[repr(C)]` contracts, zero-alloc hot paths, read-only mappings, minimal TCB.
-**Members:** the kernel governor / gateway — with `src/gateway/kinematics_contract.rs`
+**Members:** the kernel governor / gateway — with `crates/kirra-core/src/kinematics_contract.rs`
 as the **frozen-ABI precedent** (the "talisman": layout stability *is* the safety
 claim, `HYPERVISOR_CONTRACT_CHANNEL.md` §2.4); the actuator-release authority
 (HVCHAN §3 steps 6–7); and the boundary consumer (HVCHAN §3 snapshot/validate).
@@ -83,7 +83,7 @@ this digest, and release is cryptographically bound to that approval." It is
 **layered**: a guest-side checker (the parko `SafetyGovernor` layer) plus the
 host-side final authority; the host authority is what the safety claim rests on.
 **Anchors:** `HYPERVISOR_CONTRACT_CHANNEL.md` §3 (the 7-step normative trust chain);
-`src/attestation.rs` (the existing Ed25519 `verify_strict` + single-use
+`crates/kirra-safety-authority/src/attestation.rs` (the existing Ed25519 `verify_strict` + single-use
 `consume_challenge` verify-then-consume pattern the release token reuses — no new
 crypto); the SG detection layer in `parko/crates/parko-kirra` (the guest-side
 checker).
@@ -169,7 +169,7 @@ distribution gate); **#300** (the Qualcomm/Ride vendor engagement).
 | Technology | Status | Anchors |
 |---|---|---|
 | QNX Hypervisor | **DECIDED-PENDING-HARDWARE** — requirements specced; on-target unverified | HVCHAN §5; #274, #278, #279, #36 |
-| KIRRA Governor | **DECIDED-AND-BUILT** (host judge + verifier/attestation); **boundary form PENDING-HARDWARE** | HVCHAN §3; `src/attestation.rs`; #271/#272 (harness), #278 |
+| KIRRA Governor | **DECIDED-AND-BUILT** (host judge + verifier/attestation); **boundary form PENDING-HARDWARE** | HVCHAN §3; `crates/kirra-safety-authority/src/attestation.rs`; #271/#272 (harness), #278 |
 | iceoryx2 | **DECIDED** (ADR-0006) + **host spike BUILT** (#273); QNX cross-compile **PENDING-HARDWARE** | ADR-0006; iceoryx2-spike README; #274 |
 | PTP / two clock domains | **DECIDED** (model + non-mixing rule); concrete clock primitive **PENDING-HARDWARE** | HVCHAN §5 R-HV-3; AOU-TIMESYNC-001; #274 |
 | Zenoh | **FILED-FUTURE** (not scheduled) | #296; ADR-0006 C2 |

--- a/docs/COMPETITIVE_ROADMAP.md
+++ b/docs/COMPETITIVE_ROADMAP.md
@@ -246,12 +246,26 @@ this process now puts Kirra 2-3 years ahead of a competitor who waits.
 | QNX deployment | ✅ | ❌ | 🔄 | ✅ | ✅ |
 | TensorRT backend | ✅ | ❌ | stub | ✅ | ✅ |
 | Multi-silicon | ❌ | ❌ | arch only | partial | ✅ |
-| ISO 26262 ASIL-D certified | ✅ | ✅ | docs only | docs only | in progress |
-| ISO 21434 certified | ✅ | ✅ | ❌ | ❌ | in progress |
+| ISO 26262 ASIL-D — independent assessment | ✅ | ✅ | none — draft evidence only | none — draft evidence only | assessment work planned |
+| ISO 21434 — independent assessment | ✅ | ✅ | none | none | assessment work planned |
 | Hardware demo | ✅ | ✅ | ❌ | ✅ | ✅ |
 | Open source | ❌ | ❌ | private | public | public |
 | Audit log (tamper-evident) | partial | ❌ | ✅ | ✅ | ✅ |
 | Multi-asset fleet governance | ❌ | ❌ | ✅ | ✅ | ✅ |
+
+> **Reading the two assessment rows.** They record whether an **independent
+> third party has assessed and certified the product** — not whether work
+> toward that has been done. **Kirra has no such assessment in any column**,
+> now or at any planned milestone; `assessment work planned` means the
+> activity is scheduled, not that an outcome exists. Kirra's actual position:
+> **Kirra is designed in alignment with ISO 26262 ASIL-D requirements and IEC 61508 SIL 3 requirements. Independent third-party assessment has not yet been performed.** The supporting evidence is indexed in
+> [`safety/SAFETY_CASE_INDEX.md`](safety/SAFETY_CASE_INDEX.md), and every
+> foundation document there is **Draft**.
+>
+> The competitor cells in this table are **unsourced** — they reflect vendor
+> marketing as understood at the time of writing and have not been verified
+> against certificates. Do not quote any cell in this table as a Kirra claim
+> or as a verified competitor claim.
 
 ---
 

--- a/docs/adr/0032-governor-deployment-platform.md
+++ b/docs/adr/0032-governor-deployment-platform.md
@@ -13,7 +13,7 @@
 
 The KIRRA governor runs as the **safety-domain payload directly on QNX Hypervisor 8.0 for Safety**. The Autoware / ROS 2 Jazzy / Occy planning stack (the *doer*) runs **unmodified as an isolated Ubuntu guest VM** on the same SoC. The certified virtual machine manager provides the ASIL-D freedom-from-interference boundary between them.
 
-The governor is implemented in **Rust** targeting QNX Neutrino — built with upstream `rustc` today and **Ferrocene-ready**; qualified-toolchain productization is tracked in **#132**. The **certified artifact is the minimal `no_std` verdict core** (the kinematic contract and its gates), not the full governor process.
+The governor is implemented in **Rust** targeting QNX Neutrino — built with upstream `rustc` today and **Ferrocene-ready**; qualified-toolchain productization is tracked in **#132**. The artifact **intended to carry the eventual certification claim is the minimal `no_std` verdict core** (the kinematic contract and its gates), not the full governor process. This is a scoping decision about what would be submitted; no certification has been obtained.
 
 PikeOS and INTEGRITY are **not** build targets. They remain roadmap-only, activated solely by a named customer whose platform is already certified on them (aerospace / defense / space / rail).
 

--- a/docs/adr/KIRRA_PLATFORM_DEPLOYMENT_STRATEGY.md
+++ b/docs/adr/KIRRA_PLATFORM_DEPLOYMENT_STRATEGY.md
@@ -8,7 +8,7 @@
 
 ## Executive summary
 
-The KIRRA governor will run as the safety-domain payload **directly on QNX Hypervisor 8.0 for Safety**, with the Autoware / ROS 2 Jazzy / Occy stack (the *doer*) running **unmodified as an isolated Ubuntu guest VM** on the same SoC. The certified VMM supplies the ASIL-D freedom-from-interference boundary that makes the runtime-assurance decomposition creditable. The governor is written in **Rust** — today built with upstream `rustc`, and **Ferrocene-ready** for the ASIL-D build (Ferrocene is qualified for QNX Neutrino; productization is tracked in #132) — and the **certified artifact is the minimal `no_std` verdict core**, not the whole process.
+The KIRRA governor will run as the safety-domain payload **directly on QNX Hypervisor 8.0 for Safety**, with the Autoware / ROS 2 Jazzy / Occy stack (the *doer*) running **unmodified as an isolated Ubuntu guest VM** on the same SoC. The certified VMM supplies the ASIL-D freedom-from-interference boundary that makes the runtime-assurance decomposition creditable. The governor is written in **Rust** — today built with upstream `rustc`, and **Ferrocene-ready** for the ASIL-D build (Ferrocene is qualified for QNX Neutrino; productization is tracked in #132) — and the artifact **intended to carry the eventual certification claim is the minimal `no_std` verdict core**, not the whole process. No certification exists today.
 
 QNX is chosen over PikeOS and INTEGRITY for one decisive reason on top of parity: it is the only one of the three with a qualified ASIL-D Rust toolchain target, so the governor stays in Rust without a bespoke toolchain qualification. PikeOS and INTEGRITY remain roadmap-only, activated by a named customer already certified on them.
 
@@ -36,6 +36,15 @@ This is a feature, not a compromise: the doer ports to the target platform "for 
 ## 3. Substrate comparison — QNX vs PikeOS vs INTEGRITY
 
 All three are credible certified separation kernels and all three are supported targets for Apex.Grace (the certified ROS 2 fork), per Apex.AI's own statements. The decision criteria that matter to KIRRA:
+
+> **These are THIRD-PARTY substrate certifications, not Kirra's.** Every
+> "certified" entry in the table below describes QNX, PikeOS, INTEGRITY or
+> their toolchains — products certified by their own vendors and assessors.
+> **Running on a certified substrate does not confer certification on the
+> software running atop it.** Kirra itself has no independent assessment:
+> **Kirra is designed in alignment with ISO 26262 ASIL-D requirements and IEC 61508 SIL 3 requirements. Independent third-party assessment has not yet been performed.** Evidence index:
+> [`../safety/SAFETY_CASE_INDEX.md`](../safety/SAFETY_CASE_INDEX.md). Do not
+> quote a cell from this table as a Kirra certification claim.
 
 | Criterion | QNX | PikeOS | INTEGRITY |
 |---|---|---|---|


### PR DESCRIPTION
The four issues deferred from #1302, kept separate so that PR stays a disciplined foundation change.

**This PR is independent of #1302** and can merge while #1302 waits on claim-language sign-off — it references only documents that exist today, deliberately avoiding a link to the not-yet-merged `SAFETY.md`.

---

## 1. Ambiguous comparison row

`docs/COMPETITIVE_ROADMAP.md` had:

```
| ISO 26262 ASIL-D certified | ✅ | ✅ | docs only | docs only | in progress |
```

Competitor ticks beside Kirra cells, inviting the read that Kirra is partway to a certification it does not have. Now:

```
| ISO 26262 ASIL-D — independent assessment | ✅ | ✅ | none — draft evidence only | none — draft evidence only | assessment work planned |
```

Plus a note giving the exact qualification and stating that *assessment work planned* means the activity is scheduled, not that an outcome exists.

The note also records that **the competitor cells are unsourced** vendor marketing. A table that is precise about us and vague about everyone else is still misleading, and this one is now explicitly not quotable as a verified claim in either direction.

## 2. Future-tense certification language

Three places asserted in the present tense that something certified exists:

| File | Was | Now |
|---|---|---|
| `README.md` | "a Ferrocene `no_std` verdict core as the certified artifact" | "…the artifact *intended* to carry the eventual certification claim — no such claim exists today" |
| `docs/adr/0032-governor-deployment-platform.md` | "The **certified artifact is** the minimal `no_std` verdict core" | "…the artifact **intended to carry the eventual certification claim is**… no certification has been obtained" |
| `docs/adr/KIRRA_PLATFORM_DEPLOYMENT_STRATEGY.md` | same phrase | same fix |

The scoping decision these record — that the submitted artifact would be the minimal `no_std` verdict core, not the whole process — is **unchanged**.

Also in `README.md`: "certified WCET is measured on the QNX target" now says a WCET figure usable as safety evidence **must** be measured there, that no such measurement has been taken, and that no WCET claim is currently supported. And "no re-certification" became "leaves the safety argument and its evidence untouched" — what was meant, without presuming a certification to redo.

## 3. Stale source paths

`docs/ARCHITECTURE_STACK.md` cited three files moved in v2.0.0:

- `src/gateway/kinematics_contract.rs` → `crates/kirra-core/src/kinematics_contract.rs`
- `src/attestation.rs` (×2) → `crates/kirra-safety-authority/src/attestation.rs`

That document's governing rule is that *every claim cites the artifact where the decision lives*. A citation pointing at nothing is a defect in its central mechanism, not a cosmetic slip.

## 4. QNX certification readable as Kirra's

`KIRRA_PLATFORM_DEPLOYMENT_STRATEGY.md` §3 lists "ISO 26262 ASIL-D certified kernel | Yes (TÜV Rheinland)" — true of **QNX**, quotable out of context as Kirra. A note now states these are third-party certifications, that **running on a certified substrate does not confer certification on the software above it**, and gives Kirra's actual position.

---

## The qualification, verbatim wherever it appears

> Kirra is designed in alignment with ISO 26262 ASIL-D requirements and IEC 61508 SIL 3 requirements. Independent third-party assessment has not yet been performed.

## Validation

`git diff --check` clean · no conflict markers · **29 relative links across the five touched files all resolve** · both corrected source paths exist · quality-guardrail, safety-constant, re-export-shim and orphan-core gates pass · mick actuation fence **INTACT**.

## No runtime change

Documentation only. No source, configuration, threshold, API or actuation behaviour changed. **No safety document's technical content or Draft status altered** — the changes are to a competitive roadmap, an architecture index, two platform ADRs, and the README.

## Merge ordering

Independent of #1302; either order works. Both touch `README.md` in non-overlapping regions (#1302 rewrites the opening, this one edits the QNX/ADR sections further down), so they should merge cleanly in either sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_