### PR TITLE
docs: land two fixes stranded by the #1302 / #1303 merges

### DIFF
--- a/docs/COMPETITIVE_ROADMAP.md
+++ b/docs/COMPETITIVE_ROADMAP.md
@@ -254,10 +254,15 @@ this process now puts Kirra 2-3 years ahead of a competitor who waits.
 | Multi-asset fleet governance | ❌ | ❌ | ✅ | ✅ | ✅ |
 
 > **Reading the two assessment rows.** They record whether an **independent
-> third party has assessed and certified the product** — not whether work
-> toward that has been done. **Kirra has no such assessment in any column**,
-> now or at any planned milestone; `assessment work planned` means the
-> activity is scheduled, not that an outcome exists. Kirra's actual position:
+> third party has assessed the product** — not whether work toward that has
+> been done. Assessment and certification are distinct: assessment is the
+> examination, certification is a certificate issued on its outcome, and a
+> product can have neither, the first, or both. These rows track the
+> **first**, because it is the gate — nothing is certified without it.
+> **Kirra has no independent assessment in any column**, now or at any
+> planned milestone, and therefore no certification either; `assessment work
+> planned` means the activity is scheduled, not that an outcome exists.
+> Kirra's actual position:
 > **Kirra is designed in alignment with ISO 26262 ASIL-D requirements and IEC 61508 SIL 3 requirements. Independent third-party assessment has not yet been performed.** The supporting evidence is indexed in
 > [`safety/SAFETY_CASE_INDEX.md`](safety/SAFETY_CASE_INDEX.md), and every
 > foundation document there is **Draft**.

--- a/website/_src/pages/careers.mjs
+++ b/website/_src/pages/careers.mjs
@@ -30,9 +30,9 @@ ${pageHero({
           <div class="card" data-reveal>
             <h3>Evidence over assertion</h3>
             <p>“It works” means a test, a proof, a drill, or a measurement — with its scope stated. Draft artifacts
-            say Draft. Host benchmarks say host. The README's certification claim includes the sentence most
+            say Draft. Host benchmarks say host. The certification claim includes the sentence most
             companies leave out.</p>
-            ${evRow("README.md:117")}
+            ${evRow("SAFETY.md")}
           </div>
           <div class="card" data-reveal>
             <h3>Proofs where they pay</h3>

--- a/website/_src/pages/index.mjs
+++ b/website/_src/pages/index.mjs
@@ -327,7 +327,7 @@ export const body = `
             <h3>Never trusted for safety</h3>
             <p>An LLM can invent a 999&nbsp;m/s velocity or an action type that doesn't exist. Both die at the
             typed parse or the envelope — and the attempt is permanently recorded in the hash-chained audit ledger.</p>
-            ${evRow("README.md:40", "crates/kirra-planner/src/mick_llm.rs")}
+            ${evRow("docs/action_filter.md", "crates/kirra-planner/src/mick_llm.rs")}
           </div>
           <div class="card" data-reveal>
             <h3>One safety authority</h3>
@@ -658,7 +658,7 @@ export const body = `
         <div class="hero__ctas" style="justify-content:center" data-reveal>
           <a class="btn btn--ghost" href="certification.html">Read the certification posture <span class="arrow" aria-hidden="true">→</span></a>
         </div>
-        <p class="evidence-row" style="justify-content:center" data-reveal>${ev("README.md:117", "README — the claim, verbatim")}${ev("docs/safety/", "docs/safety — 65 artifacts")}</p>
+        <p class="evidence-row" style="justify-content:center" data-reveal>${ev("SAFETY.md", "SAFETY.md — the claim, verbatim")}${ev("docs/safety/", "docs/safety — 65 artifacts")}</p>
       </div>
     </section>
 

--- a/website/careers.html
+++ b/website/careers.html
@@ -116,9 +116,9 @@
           <div class="card" data-reveal>
             <h3>Evidence over assertion</h3>
             <p>“It works” means a test, a proof, a drill, or a measurement — with its scope stated. Draft artifacts
-            say Draft. Host benchmarks say host. The README's certification claim includes the sentence most
+            say Draft. Host benchmarks say host. The certification claim includes the sentence most
             companies leave out.</p>
-            <p class="evidence-row"><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/README.md#L117" target="_blank" rel="noopener">README.md:117</a></p>
+            <p class="evidence-row"><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/SAFETY.md" target="_blank" rel="noopener">SAFETY.md</a></p>
           </div>
           <div class="card" data-reveal>
             <h3>Proofs where they pay</h3>

--- a/website/index.html
+++ b/website/index.html
@@ -338,7 +338,7 @@
             <h3>Never trusted for safety</h3>
             <p>An LLM can invent a 999&nbsp;m/s velocity or an action type that doesn't exist. Both die at the
             typed parse or the envelope — and the attempt is permanently recorded in the hash-chained audit ledger.</p>
-            <p class="evidence-row"><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/README.md#L40" target="_blank" rel="noopener">README.md:40</a><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/crates/kirra-planner/src/mick_llm.rs" target="_blank" rel="noopener">crates/kirra-planner/src/mick_llm.rs</a></p>
+            <p class="evidence-row"><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/docs/action_filter.md" target="_blank" rel="noopener">docs/action_filter.md</a><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/crates/kirra-planner/src/mick_llm.rs" target="_blank" rel="noopener">crates/kirra-planner/src/mick_llm.rs</a></p>
           </div>
           <div class="card" data-reveal>
             <h3>One safety authority</h3>
@@ -703,7 +703,7 @@
         <div class="hero__ctas" style="justify-content:center" data-reveal>
           <a class="btn btn--ghost" href="certification.html">Read the certification posture <span class="arrow" aria-hidden="true">→</span></a>
         </div>
-        <p class="evidence-row" style="justify-content:center" data-reveal><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/README.md#L117" target="_blank" rel="noopener">README — the claim, verbatim</a><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/docs/safety/" target="_blank" rel="noopener">docs/safety — 65 artifacts</a></p>
+        <p class="evidence-row" style="justify-content:center" data-reveal><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/SAFETY.md" target="_blank" rel="noopener">SAFETY.md — the claim, verbatim</a><a class="evidence" href="https://github.com/kirra-systems/kirra-runtime-sdk/blob/main/docs/safety/" target="_blank" rel="noopener">docs/safety — 65 artifacts</a></p>
       </div>
     </section>
 


### PR DESCRIPTION
#1302 and #1303 both merged at heads that predate later commits on their branches, so two fixes never reached `main`. One of them is **live-broken on kirrasystems.com right now**.

| PR | Merged at | Later commit that didn't land |
|---|---|---|
| #1302 | `fbd97a12` | `38a40b1c` — website citation fix |
| #1303 | `d8c92651` | `8cacd361` — assessment/certification distinction |

Both cherry-picked here unchanged.

---

## 1. Website evidence links are broken on the live site ⚠️

#1302 moved the ISO 26262 qualification from `README.md` line 120 to **line 62**. The site cites README by **line number**, and those citations are still pointing at the old positions:

| Cited | Rendered | What it now shows on `main` |
|---|---|---|
| `README.md:117` — *"README — the claim, verbatim"* (homepage + careers) | `README.md#L117` | a row of the **Current maturity** table |
| `README.md:40` (homepage, Action Filter) | `README.md#L40` | blank line above **The product family** |

The homepage's most load-bearing citation — the certification claim, presented publicly as verbatim evidence — currently resolves to `| Independent assessment | **Not started** |`. Technically on-topic; not the sentence it promises.

**Fix:** repoint at the documents that own the claims, rather than line numbers that will move again:

- `README.md:117` → **`SAFETY.md`** — the document whose entire purpose is that sentence, where it sits at line 5. **This now resolves properly**, since #1302 landed `SAFETY.md`.
- `README.md:40` → **`docs/action_filter.md`** — the authoritative doc for that path, alongside the existing `mick_llm.rs` citation.

Careers prose changed from *"The README's certification claim…"* to *"The certification claim…"* so it stays true whichever document a reader opens.

Both `website/_src/pages/*.mjs` and the committed `website/*.html` are updated — `deploy-pages.yml` publishes `website/` as-is and does not rebuild from `_src`. Verified in sync by regenerating: no diff.

## 2. Assessment and certification conflated in the note

Copilot's finding on #1303, fixed after the merge took the earlier head. The rows are labelled "— independent assessment" while the note said a third party "assessed **and certified**" the product. Conflating the two, in the note whose purpose is to prevent that conflation, is the wrong slip to leave on `main`.

The note now states the distinction — assessment is the examination, certification is a certificate issued on its outcome, a product can have neither, the first, or both — and says why these rows track assessment: it is the gate, since nothing is certified without it. Kirra's position is now stated in both terms: no independent assessment in any column, and therefore no certification either.

## Validation

`git diff --check` clean · website HTML verified in sync with `_src` by regeneration · `SAFETY.md` and `docs/action_filter.md` both exist on `main` so the new citations resolve · mick actuation fence **INTACT** · 5 files, +17/−12.

## Follow-up not included here

**33 line-number citations remain across 8 other files** (`wcet_gate.rs:92`, `validation.rs:999`, `rss.rs:317`, `proofs_kinematics.rs:166`, …), all pointing at live source that changes regularly, all presented publicly as safety evidence, none with any mechanism to detect drift. This PR fixes only the three that #1302 broke. A CI check that resolves each citation and fails when the cited line no longer contains what the site claims would convert a silent-rot problem into a build failure — worth doing as its own change.

## No runtime change

Documentation and static site only. No source, configuration, threshold, API or actuation behaviour changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_