### PR TITLE
feat(wm2): make the Jetson drill record its own acceptance evidence

### DIFF
--- a/docs/hardware/JETSON_WM2_PERSISTENCE_DRILL.md
+++ b/docs/hardware/JETSON_WM2_PERSISTENCE_DRILL.md
@@ -351,6 +351,33 @@ On target, measure this on a store at realistic occupancy, and record it
 alongside the device and medium — a rewrite of the whole database has an I/O and
 power profile that does not transfer between eMMC, microSD and NVMe.
 
+### Capture the environment *before* the first VACUUM
+
+The harness records where SQLite resolved its temp directory and whether that
+directory is volatile, but it cannot record how much room there was or how much
+RAM was free at the time. Capture that first, into the run's evidence:
+
+```sh
+df -hT                              # free space, per mount, with fs types
+free -h                             # available RAM — see the tmpfs warning below
+printf 'TMPDIR=%q\n' "${TMPDIR:-}"  # empty is meaningful: SQLite falls back
+findmnt /tmp                        # is /tmp its own mount, and of what type
+ls -l /var/lib/kirra/wm2/           # database size going in
+```
+
+Read them against three `reclaim` fields:
+
+| Captured | Compare with | Because |
+|---|---|---|
+| `df -hT` free on the database mount | `transient_overhead_bytes` | reclamation *consumes* free space to release it. Too little free space and the `VACUUM` fails — the store cannot shrink precisely when it most needs to. |
+| `free -h` | `temp_fs_is_volatile` + database size | if the temp directory is `tmpfs`, the copy is built in **RAM**. An 8 GiB store against 4 GiB free is an OOM kill, not an `ENOSPC`. |
+| `findmnt /tmp`, `TMPDIR` | `temp_dir`, `temp_on_same_fs_as_db` | when the temp copy shares the database's mount, the reserve has to cover **both** at once. |
+
+An empty `TMPDIR` is not a non-result: it means SQLite falls through to
+`/var/tmp`, `/usr/tmp`, `/tmp` in that order, and on a Jetson those are
+frequently not the same medium as `/var/lib/kirra`. Record what it actually
+resolved to (`temp_dir` in the results), not what it was assumed to be.
+
 ---
 
 ## 7. Crash tiers A and B (automated)

--- a/docs/hardware/JETSON_WM2_PERSISTENCE_DRILL.md
+++ b/docs/hardware/JETSON_WM2_PERSISTENCE_DRILL.md
@@ -25,7 +25,7 @@ This drill produces those recordings. The instrument is
 | Measured Jetson prototype | ✅ | the whole run, if it reports `JETSON-TARGET-MEASURED` |
 | Replay benchmark (full + checkpointed) | ✅ | `replay` |
 | Query benchmark, one per §12 family | ✅ | `query` |
-| Corruption / restart experiment | ⚠️ **partly** | `crash` tiers A and B; **tier C is manual, §8** |
+| Corruption / restart experiment | ⚠️ **partly** | `crash` tiers A and B automatically; **tier C needs a power switch — `powercut arm`/`verify`, §8** |
 | Storage growth estimate | ✅ | `growth` |
 | Migration proof of concept | ✅ | `migrate` |
 | Compaction-with-citation (§11.3; not a numbered gate, but the retention policy the growth number makes urgent) | ✅ | `compact` |
@@ -389,41 +389,70 @@ caches are common on embedded storage, especially microSD. `SIGKILL` leaves the
 page cache intact, so tier A proves nothing about durability. The only
 instrument is a power switch.
 
-The harness always reports tier C as `NOT-RUN` with that reason. It cannot be
-made to report anything else, so a results file can never imply this happened.
+The harness cannot perform this tier. What it *can* do is record it, so the
+result is a machine-checked ledger rather than a recollection: `powercut arm`
+fsyncs a known prefix and states what must survive, and `powercut verify` — run
+after the reboot — checks what actually did and appends the verdict.
+
+With no trials recorded, tier C stays `NOT-RUN`, which is the default for every
+automated run and keeps the exit code meaningful.
 
 ### Procedure
 
+Run this **five times**, incrementing `--trial` each time. Use one database for
+the whole series; the trials ledger accumulates beside it.
+
 1. Boot the Orin normally, on the storage under test.
-2. Append a known, counted prefix at the durability setting you intend to ship:
+
+2. Arm the trial. This appends a prefix at `synchronous=FULL`, checkpoints it
+   into the main file, fsyncs a marker recording exactly what was made durable,
+   and then appends an un-checkpointed tail forever:
+
    ```sh
-   ./wm2-persistence-harness append \
-       --db /var/lib/kirra/wm2/power.sqlite \
-       --durability full --events 50000 --batch 1 --assert-target
+   ./wm2-persistence-harness powercut arm --db /var/lib/kirra/wm2/power.sqlite
    ```
-3. Record the committed count:
+
+   Wait for the `ARMED:` line. **Before it appears, nothing has been promised
+   and a cut proves nothing.**
+
+3. With the tail still running, cut power **at the source** — pull the barrel
+   jack or kill the bench supply. Do **not** use `poweroff`, `reboot`, or a
+   long-press: each of those flushes, which is the opposite of the experiment.
+
+4. Restore power, boot, and verify:
+
    ```sh
-   sqlite3 /var/lib/kirra/wm2/power.sqlite 'SELECT COUNT(*), MAX(generation) FROM world_events;'
-   ```
-4. Start a second append run and, **while it is running**, cut power at the
-   source — pull the barrel jack or kill the bench supply. Do **not** use
-   `poweroff`, `reboot`, or a long-press: each of those flushes.
-5. Restore power, boot, and re-verify:
-   ```sh
-   ./wm2-persistence-harness crash --db /var/lib/kirra/wm2/power.sqlite --assert-target
+   ./wm2-persistence-harness powercut verify \
+       --db /var/lib/kirra/wm2/power.sqlite --trial 1
    sqlite3 /var/lib/kirra/wm2/power.sqlite 'PRAGMA integrity_check;'
    ```
-6. **Pass** = the chain verifies intact, the count is ≥ the step-3 count, and
-   `integrity_check` reports `ok`. **Fail** = a broken chain, a count *below*
-   the committed prefix, or any corruption. A count below step 3 at
-   `synchronous=FULL` means the storage is lying about `fsync` — that is a
-   hardware finding, and it invalidates the durability half of every other
-   result on that medium.
-7. Repeat **at least five times**. One power cut that happens to land between
-   commits proves nothing.
-8. Record the outcome in the ADR conversation with the medium named
-   (`db_fs_source` from the results file). Durability is a property of *that
-   medium*, and it does not transfer to a different one.
+
+   `verify` exits non-zero until five clean trials are recorded, so a
+   half-finished series cannot be filed as a complete one.
+
+5. Repeat from step 2 with `--trial 2`, `3`, `4`, `5`.
+
+### Reading the verdict
+
+| Result | Meaning |
+|---|---|
+| `PASS` | Chain intact and the fsynced prefix survived. Losing the un-fsynced tail is **correct** — that is what tier B already establishes portably. |
+| `FAIL` — *DURABILITY VIOLATION* | Fewer events came back than were fsynced and acknowledged. **The storage device acknowledged writes it had not persisted.** This is the only failure tier C can detect that tiers A and B cannot, no `synchronous` setting compensates for it, and it invalidates the durability half of every other result on that medium. |
+| `FAIL` — broken chain / gap | A torn or forked write: worse than a lost tail. |
+| `INCONCLUSIVE` | No armed marker — the cut landed before `ARMED:`, so nothing stated what should have survived. Re-run that trial. |
+
+Five is a floor, not a ritual: device-cache loss is probabilistic and depends
+where in the erase-block cycle the cut lands, so a store that survives once can
+lose an acknowledged write on the next attempt. Below five the aggregate reports
+`INCONCLUSIVE` rather than a pass.
+
+> **Do not run `crash` against the power-cut database.** Tier A deletes and
+> recreates the store it is given. The trials ledger survives (it is a separate
+> file, and is read before tier A runs), but the database state the cuts
+> produced does not. Use `powercut verify`, which only reads.
+
+Record the medium (`db_fs_source`) alongside the result. Durability is a
+property of *that medium* and does not transfer to a different one.
 
 ---
 
@@ -458,14 +487,50 @@ produce.
 
 ## 10. Recording the result
 
-Attach the JSONL file to the ADR-0041 ratification conversation, with:
+Attach the JSONL file and the trials ledger
+(`<db>-tierc-trials.jsonl`) to the ADR-0041 ratification conversation. Every
+field below is stamped by the harness — the record should be a file, not a
+retyping of one.
 
-- the `evidence_status` line, quoted verbatim;
-- the device and medium (`device_model`, `db_fs_source`);
-- the tier C outcome and how many power cuts were performed, or an explicit
-  statement that tier C was not run;
-- the `standin_schema_digest`, so a later reader can tell whether the schema
-  measured is the schema ratified.
+**Provenance** — on every record:
+
+| Field | Why it is in the record |
+|---|---|
+| `evidence_status` | Quoted verbatim. Anything but `JETSON-TARGET-MEASURED` is not ratification evidence. |
+| `device_model`, `db_fs_type`, `db_fs_source` | Durability is a property of the medium; the number does not transfer off it. |
+| `build_profile`, `rustc_version`, `git_commit`, `source_digest` | Which binary said this. `git_commit` carries a `-dirty` suffix when the tree had uncommitted changes; `source_digest` is what was *actually* built, which is the pair that makes a figure reproducible later. |
+| `standin_schema_digest` | Whether the schema measured is the schema ratified. |
+| `sqlite_version` | |
+
+**Measurements** — the load-bearing rows:
+
+| Question | Records / fields |
+|---|---|
+| Bytes per event | `growth` → `bytes_per_event` |
+| Point vs graph latency | `query` → the `point_*` and `graph_*` families |
+| Replay / restart recovery | `replay` → cold rebuild vs checkpointed resume |
+| Corruption detection | `crash` tier A, plus `compact`'s tamper control |
+| Migration behaviour | `migrate` |
+| Logical compaction | `compact` → events removed, spans, `bytes_reclaimed_percent` |
+| VACUUM duration and reclaimed bytes | `reclaim` → `vacuum_ms`, `bytes_freed` |
+| **VACUUM system impact** | `reclaim` → `transient_overhead_bytes`, `transient_overhead_ratio`, `temp_dir_fs_type`, `temp_fs_is_volatile`, `max_append_stall_ms`, `concurrent_appends_blocked` |
+| Disk-pressure behaviour | `pressure` → the seven boolean checks |
+| Tier A / B | `crash` → `outcome` + `detail` |
+| Tier C | the trials ledger, plus `tier_c_trials_recorded` / `tier_c_trials_required` |
+
+Three of those deserve to be read rather than filed:
+
+- **`temp_fs_is_volatile`.** If SQLite's temp directory is `tmpfs`, `VACUUM`
+  builds its copy in **RAM**. On an 8 GiB store the failure mode is the OOM
+  killer, not `ENOSPC`. Point `TMPDIR` at durable storage before concluding
+  anything about reclamation cost.
+- **`transient_overhead_bytes`.** Reclamation *consumes* free space to release
+  it, so this — not `bytes_freed` — is what a minimum-free-space reserve is set
+  from. The overhead scales with what will remain, so the worst case is a store
+  with little to reclaim, and the conservative reserve is ~1× the database size.
+- **`max_append_stall_ms`.** `VACUUM` holds an exclusive lock for its whole
+  duration; the store cannot record events during it. This is the number the
+  "required robot state during reclamation" decision rests on.
 
 **Do not tick a box in ADR-0041 from a `HOST-INDICATIVE-NOT-TARGET` run**, and
 do not tick the corruption/restart box from tiers A and B alone. Say what was

--- a/tools/wm2-persistence-harness/README.md
+++ b/tools/wm2-persistence-harness/README.md
@@ -56,9 +56,21 @@ can emit while measuring none of the property being decided.
 **Tier C.** The crash experiment has three tiers. `SIGKILL` crash-consistency
 and WAL-loss prefix validity are automated. The actual power cut is not, because
 nothing in software distinguishes an honest `fsync` from a device cache that
-acknowledged and buffered it. That tier always reports `NOT-RUN` with the reason
-attached, so a results file can never imply a durability test that did not
-happen.
+acknowledged and buffered it.
+
+The harness cannot perform that tier, but it does *record* it. `powercut arm`
+fsyncs a known prefix and writes a durable marker stating what must survive;
+`powercut verify`, run after the reboot, checks what actually did and appends
+the verdict to a ledger beside the database. The judgement is pure and unit
+tested, so the distinction it turns on is not left to the operator: losing the
+un-fsynced tail is **correct**, while coming back with fewer events than were
+fsynced is a device that acknowledged writes it had not persisted — the one
+failure this tier can detect that A and B cannot.
+
+With no trials recorded, tier C reports `NOT-RUN` with the reason attached, so
+a results file can never imply a durability test that did not happen. Below the
+required five trials the aggregate is `INCONCLUSIVE`, not a pass: device-cache
+loss is probabilistic, so one survived cut is not evidence.
 
 ## Layout
 
@@ -68,6 +80,8 @@ happen.
 | `standin.rs` | The stand-in schema, hash chain, deterministic fold, migrations |
 | `gen.rs` | Seeded synthetic load (splitmix64, dependency-free) |
 | `bench.rs` | Append, replay, the four §12 query families, growth, migration |
-| `crash.rs` | Corruption / restart tiers A, B and the C refusal |
+| `crash.rs` | Corruption / restart tiers A, B, and tier C's arm/verify/ledger machinery |
+| `pressure.rs` | Disk-full behaviour, and what `VACUUM` costs the system while it runs |
 | `json.rs`, `sha256.rs` | Minimal writer and the local hash — see above |
+| `build.rs` | Build identity: rustc version, git commit (`-dirty` when it is), source digest |
 | `tests/crash_tier_a.rs` | Tier A end-to-end against the real binary (a unit test would exercise the spawn-failure path forever and look like coverage) |

--- a/tools/wm2-persistence-harness/build.rs
+++ b/tools/wm2-persistence-harness/build.rs
@@ -40,8 +40,13 @@ use sha256::hex;
 
 fn main() {
     // Re-run when any measured source changes, so the digest can never be
-    // stale relative to the binary it describes.
+    // stale relative to the binary it describes. These must cover EXACTLY what
+    // `source_digest` reads — a file inside the digest but outside this list
+    // can change without the digest being recomputed, which is worse than not
+    // digesting it at all: the value would still be reported, and would be
+    // wrong.
     println!("cargo:rerun-if-changed=src");
+    println!("cargo:rerun-if-changed=tests");
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=Cargo.toml");
 

--- a/tools/wm2-persistence-harness/build.rs
+++ b/tools/wm2-persistence-harness/build.rs
@@ -1,0 +1,140 @@
+//! Build-time capture of **which binary produced a number**.
+//!
+//! `build_profile` already answers "release or debug", which is the difference
+//! between measuring SQLite and measuring rustc. It does not answer *which*
+//! release build — and a figure that is going to sit in ADR-0041 for years
+//! needs that, because "459 B/event" is only reproducible if a later reader can
+//! rebuild the thing that said it.
+//!
+//! Three facts are captured, all from the environment, adding **no dependency**
+//! (the crate's one-dependency rule is load-bearing — see the manifest header):
+//!
+//! - `rustc -V` — the compiler, since optimisation output moves between
+//!   versions and this harness reports microsecond-scale query latencies.
+//! - the git commit, with an explicit `-dirty` suffix when the tree has
+//!   uncommitted changes. A dirty build is not disqualifying, but it must be
+//!   visible: it is the difference between a citable commit and a working copy
+//!   nobody else has.
+//! - a SHA-256 over the harness sources. The commit identifies what *should*
+//!   have been built; the digest identifies what *was*. They differ exactly
+//!   when someone edited a file to make a number come out better, which is the
+//!   failure mode worth being able to detect after the fact.
+//!
+//! None of this can prevent a fabricated result. It makes an honest result
+//! reconstructible, and a dishonest one leave a trace.
+
+use std::path::Path;
+use std::process::Command;
+
+// The harness's own SHA-256, included rather than imported: a build script is
+// a separate crate and cannot `use` the crate it builds. Keeping one
+// implementation means the source digest and the chain links are the same
+// function, so a change to one cannot silently diverge from the other.
+// Declared by path rather than `include!`d inline, so the file's own `//!`
+// header stays a module doc comment instead of trying to annotate the first
+// constant. Only `hex` is used here; the rest is unused by design.
+#[path = "src/sha256.rs"]
+#[allow(dead_code)]
+mod sha256;
+use sha256::hex;
+
+fn main() {
+    // Re-run when any measured source changes, so the digest can never be
+    // stale relative to the binary it describes.
+    println!("cargo:rerun-if-changed=src");
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=Cargo.toml");
+
+    println!("cargo:rustc-env=WM2_RUSTC_VERSION={}", rustc_version());
+    println!("cargo:rustc-env=WM2_GIT_COMMIT={}", git_commit());
+    println!("cargo:rustc-env=WM2_SOURCE_DIGEST={}", source_digest());
+}
+
+/// `rustc -V`, or `unknown` if it cannot be run. Never fails the build: a
+/// harness that will not compile because it could not describe itself is worse
+/// than one that reports `unknown` and says so in the artifact.
+fn rustc_version() -> String {
+    let rustc = std::env::var("RUSTC").unwrap_or_else(|_| "rustc".into());
+    Command::new(rustc)
+        .arg("-V")
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".into())
+}
+
+/// Short commit hash, suffixed `-dirty` when tracked files differ from HEAD.
+///
+/// `unknown` when git is absent or this is not a repository — a tarball build
+/// is legitimate and should not fail, it should be *labelled*.
+fn git_commit() -> String {
+    let head = Command::new("git")
+        .args(["rev-parse", "--short=12", "HEAD"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
+
+    let Some(head) = head else {
+        return "unknown".into();
+    };
+
+    // `--quiet` exits non-zero when there are differences. An error running it
+    // at all is reported as unknown-dirtiness rather than assumed clean.
+    let clean = Command::new("git")
+        .args(["diff", "--quiet", "HEAD"])
+        .status()
+        .ok()
+        .map(|s| s.success());
+
+    match clean {
+        Some(true) => head,
+        Some(false) => format!("{head}-dirty"),
+        None => format!("{head}-dirtiness-unknown"),
+    }
+}
+
+/// SHA-256 over `src/*.rs`, `tests/*.rs`, `build.rs` and `Cargo.toml`, in
+/// sorted order, each contribution length-prefixed by its path.
+///
+/// Sorted so the digest is stable across filesystems that enumerate
+/// differently; path-tagged so moving a file's contents to another name
+/// changes the digest rather than preserving it.
+fn source_digest() -> String {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let mut files: Vec<std::path::PathBuf> = Vec::new();
+
+    for dir in ["src", "tests"] {
+        if let Ok(entries) = std::fs::read_dir(root.join(dir)) {
+            for e in entries.flatten() {
+                let p = e.path();
+                if p.extension().is_some_and(|x| x == "rs") {
+                    files.push(p);
+                }
+            }
+        }
+    }
+    files.push(root.join("build.rs"));
+    files.push(root.join("Cargo.toml"));
+    files.sort();
+
+    let mut buf: Vec<u8> = Vec::new();
+    buf.extend_from_slice(b"wm2-harness-source-v1\x00");
+    for f in &files {
+        let rel = f.strip_prefix(root).unwrap_or(f);
+        // Normalised to `/` so a digest taken on Windows matches one taken on
+        // the Jetson; the point is comparing builds, not platforms.
+        let name = rel.to_string_lossy().replace('\\', "/");
+        let body = std::fs::read(f).unwrap_or_default();
+        buf.extend_from_slice(name.as_bytes());
+        buf.push(0x00);
+        buf.extend_from_slice(&(body.len() as u64).to_le_bytes());
+        buf.extend_from_slice(&body);
+    }
+    hex(&buf)
+}

--- a/tools/wm2-persistence-harness/src/crash.rs
+++ b/tools/wm2-persistence-harness/src/crash.rs
@@ -569,15 +569,26 @@ pub fn append_trial(db: &Path, rec: &TrialRecord) -> Result<(), String> {
         .str("detail", rec.outcome.detail())
         .render();
 
+    let path = trials_ledger_path(db);
     let mut f = std::fs::OpenOptions::new()
         .create(true)
         .append(true)
-        .open(trials_ledger_path(db))
+        .open(&path)
         .map_err(|e| e.to_string())?;
     writeln!(f, "{line}").map_err(|e| e.to_string())?;
     // The ledger records evidence about power loss and is itself written on a
     // machine that is about to lose power again. fsync it.
-    f.sync_all().map_err(|e| e.to_string())
+    f.sync_all().map_err(|e| e.to_string())?;
+    // And fsync the directory: on the trial that CREATES the ledger, syncing
+    // the file alone leaves the directory entry un-durable, so a cut can lose
+    // the whole file — and with it every trial recorded so far. Same reason
+    // `write_marker` does it.
+    if let Some(dir) = path.parent() {
+        if let Ok(d) = std::fs::File::open(dir) {
+            let _ = d.sync_all();
+        }
+    }
+    Ok(())
 }
 
 /// Arm a power-cut trial: fsync a known prefix, record it, then append forever.

--- a/tools/wm2-persistence-harness/src/crash.rs
+++ b/tools/wm2-persistence-harness/src/crash.rs
@@ -96,6 +96,10 @@ pub struct CrashResult {
     pub tier_a_sigkill: TierOutcome,
     pub tier_b_wal_loss: TierOutcome,
     pub tier_c_power_cut: TierOutcome,
+    /// How many manual power-cut trials were found recorded next to the
+    /// database. Reported alongside the outcome so a reader can tell a genuine
+    /// `NOT-RUN` from a drill that stopped short.
+    pub tier_c_trials: u64,
 }
 
 fn sidecar(path: &Path, suffix: &str) -> PathBuf {
@@ -287,14 +291,397 @@ pub fn tier_b_wal_loss(
 // Tier C
 // ---------------------------------------------------------------------------
 
+/// How many power cuts a tier C claim requires.
+///
+/// A single surviving cut proves nothing: device-cache loss is probabilistic,
+/// depends where in the erase-block cycle the cut lands, and a store that
+/// survives once can lose an acknowledged write on the next attempt. Five is
+/// the drill's stated floor — enough that a pass is not a coincidence, few
+/// enough to actually perform by hand.
+pub const MIN_TIER_C_TRIALS: u64 = 5;
+
+/// One recorded power-cut trial.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TrialRecord {
+    pub trial: u64,
+    pub outcome: TierOutcome,
+    /// Generation of the last event fsynced *before* the cut. Everything up to
+    /// here was acknowledged as durable and must survive.
+    pub durable_generation: u64,
+    /// Highest generation present after the reboot.
+    pub recovered_generation: u64,
+    pub chain: String,
+}
+
+/// What `powercut arm` fsyncs before the tail starts, so that after the reboot
+/// there is an independent statement of what *should* have survived.
+///
+/// Without this the trial is unfalsifiable: a store that came back with fewer
+/// events than it acknowledged would be indistinguishable from one that was
+/// simply cut earlier than the operator thought.
+pub struct ArmedMarker {
+    pub durable_generation: u64,
+    pub durable_head: String,
+}
+
+impl ArmedMarker {
+    fn render(&self) -> String {
+        format!("{}\n{}\n", self.durable_generation, self.durable_head)
+    }
+
+    fn parse(s: &str) -> Option<Self> {
+        let mut lines = s.lines();
+        let durable_generation = lines.next()?.trim().parse().ok()?;
+        let durable_head = lines.next()?.trim().to_string();
+        Some(Self {
+            durable_generation,
+            durable_head,
+        })
+    }
+}
+
+pub fn armed_marker_path(db: &Path) -> PathBuf {
+    sidecar(db, "-tierc-armed")
+}
+
+pub fn trials_ledger_path(db: &Path) -> PathBuf {
+    sidecar(db, "-tierc-trials.jsonl")
+}
+
+/// Judge one trial from what the marker promised and what came back.
+///
+/// Pure, so the three outcomes that matter can be tested without a power
+/// supply. The distinction that carries the whole tier:
+///
+/// - a **shorter** log than armed is a `FAIL` only if it is shorter than the
+///   *fsynced prefix*. Losing un-fsynced tail events is correct behaviour —
+///   that is what tier B already establishes portably.
+/// - a log shorter than the fsynced prefix means the device acknowledged a
+///   write it had not persisted. That is the device-cache lie, it is the only
+///   thing tier C can detect that tiers A and B cannot, and it is a `FAIL`.
+/// - a broken chain is a torn or forked write: also `FAIL`, and worse.
+pub fn judge_trial(
+    trial: u64,
+    marker: Option<&ArmedMarker>,
+    recovered: &Result<ChainStatus, String>,
+) -> TrialRecord {
+    let Some(marker) = marker else {
+        return TrialRecord {
+            trial,
+            outcome: TierOutcome::Inconclusive(
+                "no armed marker: `powercut arm` did not fsync a durable prefix before \
+                 the cut, so nothing states what should have survived"
+                    .into(),
+            ),
+            durable_generation: 0,
+            recovered_generation: 0,
+            chain: "unknown".into(),
+        };
+    };
+
+    let (chain_token, recovered_generation, verdict) = match recovered {
+        Ok(ChainStatus::Intact { entries, .. }) => {
+            let entries = *entries;
+            if entries >= marker.durable_generation {
+                (
+                    "intact",
+                    entries,
+                    TierOutcome::Pass(format!(
+                        "chain intact after power cut; fsynced prefix of {} event(s) survived \
+                         ({} present)",
+                        marker.durable_generation, entries
+                    )),
+                )
+            } else {
+                (
+                    "intact",
+                    entries,
+                    TierOutcome::Fail(format!(
+                        "DURABILITY VIOLATION: {} event(s) were fsynced and acknowledged before \
+                         the cut, but only {} came back. The storage device acknowledged writes \
+                         it had not persisted — this is the failure tier C exists to detect, and \
+                         no `synchronous` setting can compensate for it.",
+                        marker.durable_generation, entries
+                    )),
+                )
+            }
+        }
+        Ok(ChainStatus::Broken { at_generation }) => (
+            "broken",
+            *at_generation,
+            TierOutcome::Fail(format!(
+                "chain broken at generation {at_generation} after power cut: a torn or forked \
+                 write, not merely a lost tail"
+            )),
+        ),
+        Ok(ChainStatus::Gap { after_generation }) => (
+            "gap",
+            *after_generation,
+            TierOutcome::Fail(format!(
+                "generation gap after {after_generation}: the log came back missing an interior \
+                 run, which a valid prefix cannot contain"
+            )),
+        ),
+        Ok(ChainStatus::Empty) => (
+            "empty",
+            0,
+            TierOutcome::Fail(format!(
+                "store came back empty although {} event(s) were fsynced before the cut",
+                marker.durable_generation
+            )),
+        ),
+        Err(e) => (
+            "unreadable",
+            0,
+            TierOutcome::Fail(format!(
+                "store could not be reopened after the power cut: {e}"
+            )),
+        ),
+    };
+
+    TrialRecord {
+        trial,
+        outcome: verdict,
+        durable_generation: marker.durable_generation,
+        recovered_generation,
+        chain: chain_token.into(),
+    }
+}
+
+/// Aggregate recorded trials into the tier C outcome.
+///
+/// Zero trials stays `NOT-RUN` — the default for every automated run, so the
+/// exit code keeps its meaning. Between one and [`MIN_TIER_C_TRIALS`] is
+/// `INCONCLUSIVE` rather than a pass: partial evidence toward a durability
+/// claim is not a durability claim, and it fails the run so a half-finished
+/// drill cannot be filed as a complete one.
+pub fn tier_c_from_trials(trials: &[TrialRecord]) -> TierOutcome {
+    if trials.is_empty() {
+        return tier_c_not_run();
+    }
+
+    let failures: Vec<&TrialRecord> = trials
+        .iter()
+        .filter(|t| matches!(t.outcome, TierOutcome::Fail(_)))
+        .collect();
+    if let Some(first) = failures.first() {
+        return TierOutcome::Fail(format!(
+            "{} of {} power-cut trial(s) failed. First: trial {} — {}",
+            failures.len(),
+            trials.len(),
+            first.trial,
+            first.outcome.detail()
+        ));
+    }
+
+    let inconclusive = trials
+        .iter()
+        .filter(|t| matches!(t.outcome, TierOutcome::Inconclusive(_)))
+        .count();
+    if inconclusive > 0 {
+        return TierOutcome::Inconclusive(format!(
+            "{inconclusive} of {} trial(s) never established a durable prefix; re-run those cuts",
+            trials.len()
+        ));
+    }
+
+    let n = trials.len() as u64;
+    if n < MIN_TIER_C_TRIALS {
+        return TierOutcome::Inconclusive(format!(
+            "only {n} of the required {MIN_TIER_C_TRIALS} power-cut trial(s) recorded; a single \
+             survived cut is not evidence of durability, because device-cache loss is \
+             probabilistic"
+        ));
+    }
+
+    TierOutcome::Pass(format!(
+        "{n} power-cut trial(s) recorded, all preserving the fsynced prefix with an intact chain"
+    ))
+}
+
 pub fn tier_c_not_run() -> TierOutcome {
     TierOutcome::NotRun(
         "a real power cut cannot be performed from software: nothing in-process can \
          tell an honest fsync from a device cache that acknowledged and buffered it. \
          Manual procedure in docs/hardware/JETSON_WM2_PERSISTENCE_DRILL.md §8; until \
-         it is run and its result recorded, no durability claim is supported."
+         it is run and its result recorded, no durability claim is supported. Record \
+         trials with `powercut arm` / `powercut verify`."
             .to_string(),
     )
+}
+
+/// Read whatever trials have been recorded next to this database.
+///
+/// A malformed line is skipped rather than fatal: the ledger is appended to
+/// across reboots and power cuts, so a torn final line is an expected state,
+/// and losing the trials already recorded because of it would be perverse.
+pub fn read_trials(db: &Path) -> Vec<TrialRecord> {
+    let Ok(text) = std::fs::read_to_string(trials_ledger_path(db)) else {
+        return Vec::new();
+    };
+    text.lines().filter_map(parse_trial_line).collect()
+}
+
+/// Minimal field extraction from a ledger line.
+///
+/// The ledger is written by this harness in a fixed shape, so a full JSON
+/// parser would be a dependency bought for nothing.
+fn parse_trial_line(line: &str) -> Option<TrialRecord> {
+    let field = |key: &str| -> Option<String> {
+        let pat = format!("\"{key}\":");
+        let start = line.find(&pat)? + pat.len();
+        let rest = line[start..].trim_start();
+        if let Some(stripped) = rest.strip_prefix('"') {
+            let end = stripped.find('"')?;
+            Some(stripped[..end].to_string())
+        } else {
+            let end = rest.find([',', '}'])?;
+            Some(rest[..end].trim().to_string())
+        }
+    };
+
+    let trial = field("trial")?.parse().ok()?;
+    let token = field("outcome")?;
+    let detail = field("detail").unwrap_or_default();
+    let outcome = match token.as_str() {
+        "PASS" => TierOutcome::Pass(detail),
+        "FAIL" => TierOutcome::Fail(detail),
+        "INCONCLUSIVE" => TierOutcome::Inconclusive(detail),
+        _ => return None,
+    };
+    Some(TrialRecord {
+        trial,
+        outcome,
+        durable_generation: field("durable_generation")?.parse().ok()?,
+        recovered_generation: field("recovered_generation")?.parse().ok()?,
+        chain: field("chain").unwrap_or_default(),
+    })
+}
+
+pub fn append_trial(db: &Path, rec: &TrialRecord) -> Result<(), String> {
+    use std::io::Write;
+    let line = crate::json::Obj::new()
+        .int("trial", rec.trial)
+        .str("outcome", rec.outcome.token())
+        .int("durable_generation", rec.durable_generation)
+        .int("recovered_generation", rec.recovered_generation)
+        .str("chain", &rec.chain)
+        .str("detail", rec.outcome.detail())
+        .render();
+
+    let mut f = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(trials_ledger_path(db))
+        .map_err(|e| e.to_string())?;
+    writeln!(f, "{line}").map_err(|e| e.to_string())?;
+    // The ledger records evidence about power loss and is itself written on a
+    // machine that is about to lose power again. fsync it.
+    f.sync_all().map_err(|e| e.to_string())
+}
+
+/// Arm a power-cut trial: fsync a known prefix, record it, then append forever.
+///
+/// Never returns — the operator ends it with the power switch. That is the
+/// instrument, and it is why this cannot be a normal stage.
+pub fn powercut_arm(db: &Path, prefix_events: u64, entities: u64, seed: u64) -> ! {
+    let mut store = match Store::open(db, Durability::Full) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("powercut arm: cannot open store: {e}");
+            std::process::exit(2);
+        }
+    };
+
+    // The durable prefix, one transaction per event at synchronous=FULL, then
+    // an explicit checkpoint so the content is in the main file and not only
+    // in a WAL that the cut may take with it.
+    let events = gen::events(0, prefix_events, entities, seed);
+    for e in &events {
+        if let Err(err) = store.append_batch(std::slice::from_ref(e)) {
+            eprintln!("powercut arm: append failed: {err}");
+            std::process::exit(2);
+        }
+    }
+    if let Err(e) = store.durable_checkpoint() {
+        eprintln!("powercut arm: checkpoint failed: {e}");
+        std::process::exit(2);
+    }
+
+    let head = match store.verify_chain() {
+        Ok(ChainStatus::Intact { entries, head, .. }) => ArmedMarker {
+            durable_generation: entries,
+            durable_head: head,
+        },
+        other => {
+            eprintln!("powercut arm: prefix did not verify: {other:?}");
+            std::process::exit(2);
+        }
+    };
+
+    if let Err(e) = write_marker(db, &head) {
+        eprintln!("powercut arm: cannot record marker: {e}");
+        std::process::exit(2);
+    }
+
+    println!(
+        "ARMED: {} event(s) fsynced and recorded. Cut power NOW, at any time.\n\
+         After reboot, run: wm2-persistence-harness powercut verify --db {} --trial <n>",
+        head.durable_generation,
+        db.display()
+    );
+    // This function never returns, so nothing else will ever flush this. To a
+    // terminal it would appear anyway; to a pipe it would not, and an operator
+    // who cannot see "ARMED" does not know when it is safe to cut power.
+    let _ = std::io::Write::flush(&mut std::io::stdout());
+
+    // The tail: appended continuously and deliberately never checkpointed, so
+    // the cut always lands mid-write. Losing all of this is correct; losing any
+    // of the prefix above is not.
+    let mut n = prefix_events;
+    loop {
+        let batch = gen::events(n, 64, entities, seed);
+        if store.append_batch(&batch).is_err() {
+            // A write error here is expected as the device dies. Keep going;
+            // only the power switch ends this.
+            continue;
+        }
+        n += 64;
+    }
+}
+
+fn write_marker(db: &Path, marker: &ArmedMarker) -> Result<(), String> {
+    use std::io::Write;
+    let path = armed_marker_path(db);
+    let mut f = std::fs::File::create(&path).map_err(|e| e.to_string())?;
+    f.write_all(marker.render().as_bytes())
+        .map_err(|e| e.to_string())?;
+    // Must be durable before the tail starts, or the trial is unfalsifiable.
+    f.sync_all().map_err(|e| e.to_string())?;
+    // fsync the directory too, so the file's *existence* survives the cut.
+    if let Some(dir) = path.parent() {
+        if let Ok(d) = std::fs::File::open(dir) {
+            let _ = d.sync_all();
+        }
+    }
+    Ok(())
+}
+
+pub fn read_marker(db: &Path) -> Option<ArmedMarker> {
+    ArmedMarker::parse(&std::fs::read_to_string(armed_marker_path(db)).ok()?)
+}
+
+/// Verify one power-cut trial after the reboot and record it.
+pub fn powercut_verify(db: &Path, trial: u64) -> TrialRecord {
+    let marker = read_marker(db);
+    let recovered = Store::open(db, Durability::Full)
+        .map_err(|e| e.to_string())
+        .and_then(|s| s.verify_chain().map_err(|e| e.to_string()));
+    let rec = judge_trial(trial, marker.as_ref(), &recovered);
+    if let Err(e) = append_trial(db, &rec) {
+        eprintln!("warning: could not append to the trials ledger: {e}");
+    }
+    rec
 }
 
 pub fn run(
@@ -304,10 +691,15 @@ pub fn run(
     prefix_events: u64,
     tail_events: u64,
 ) -> CrashResult {
+    // Tier A and B rewrite the database, so the trials ledger is read first —
+    // it is evidence about earlier power cuts and must not be interpreted
+    // against a store this run has since replaced.
+    let trials = read_trials(path);
     CrashResult {
         tier_a_sigkill: tier_a_sigkill(path, durability, run_ms),
         tier_b_wal_loss: tier_b_wal_loss(path, durability, prefix_events, tail_events),
-        tier_c_power_cut: tier_c_not_run(),
+        tier_c_power_cut: tier_c_from_trials(&trials),
+        tier_c_trials: trials.len() as u64,
     }
 }
 
@@ -395,5 +787,182 @@ mod tests {
         ];
         let unique: std::collections::HashSet<_> = tokens.iter().collect();
         assert_eq!(unique.len(), 4);
+    }
+
+    // -----------------------------------------------------------------------
+    // Tier C — the judgement is pure, so it is tested without a power supply
+    // -----------------------------------------------------------------------
+
+    fn marker(gen: u64) -> ArmedMarker {
+        ArmedMarker {
+            durable_generation: gen,
+            durable_head: "deadbeef".into(),
+        }
+    }
+
+    fn intact(entries: u64) -> Result<ChainStatus, String> {
+        Ok(ChainStatus::Intact {
+            entries,
+            head: "deadbeef".into(),
+            compacted_windows: 0,
+            redacted: 0,
+        })
+    }
+
+    #[test]
+    fn a_surviving_fsynced_prefix_passes() {
+        let r = judge_trial(1, Some(&marker(400)), &intact(400));
+        assert!(matches!(r.outcome, TierOutcome::Pass(_)), "{r:?}");
+    }
+
+    #[test]
+    fn losing_only_the_unfsynced_tail_passes() {
+        // The tail is appended without a checkpoint precisely so it can be
+        // lost; more events than the prefix came back, which is also fine.
+        let r = judge_trial(1, Some(&marker(400)), &intact(512));
+        assert!(matches!(r.outcome, TierOutcome::Pass(_)), "{r:?}");
+    }
+
+    #[test]
+    fn losing_an_fsynced_event_is_the_durability_violation_tier_c_exists_for() {
+        let r = judge_trial(1, Some(&marker(400)), &intact(399));
+        match r.outcome {
+            TierOutcome::Fail(d) => assert!(
+                d.contains("DURABILITY VIOLATION"),
+                "must name the failure plainly: {d}"
+            ),
+            other => panic!("a lost acknowledged write must FAIL, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_broken_chain_after_a_cut_fails() {
+        let r = judge_trial(
+            1,
+            Some(&marker(400)),
+            &Ok(ChainStatus::Broken { at_generation: 7 }),
+        );
+        assert!(matches!(r.outcome, TierOutcome::Fail(_)), "{r:?}");
+    }
+
+    #[test]
+    fn an_unreadable_store_after_a_cut_fails() {
+        let r = judge_trial(1, Some(&marker(400)), &Err("disk I/O error".into()));
+        assert!(matches!(r.outcome, TierOutcome::Fail(_)), "{r:?}");
+    }
+
+    #[test]
+    fn an_unarmed_trial_is_inconclusive_not_a_pass() {
+        // Nothing states what should have survived, so a survived cut proves
+        // nothing — the exact shape of vacuity the tier must refuse.
+        let r = judge_trial(1, None, &intact(9_999));
+        assert!(matches!(r.outcome, TierOutcome::Inconclusive(_)), "{r:?}");
+        assert!(r.outcome.fails_the_run());
+    }
+
+    #[test]
+    fn no_trials_stays_not_run_and_does_not_fail_the_run() {
+        // The default for every automated run. If this ever failed the run,
+        // CI would be red permanently and the exit code would stop meaning
+        // anything.
+        let o = tier_c_from_trials(&[]);
+        assert_eq!(o.token(), "NOT-RUN");
+        assert!(!o.fails_the_run());
+    }
+
+    fn passing_trial(n: u64) -> TrialRecord {
+        judge_trial(n, Some(&marker(400)), &intact(400))
+    }
+
+    #[test]
+    fn fewer_than_the_required_trials_is_inconclusive() {
+        for n in 1..MIN_TIER_C_TRIALS {
+            let trials: Vec<_> = (1..=n).map(passing_trial).collect();
+            let o = tier_c_from_trials(&trials);
+            assert_eq!(o.token(), "INCONCLUSIVE", "{n} trial(s) must not pass");
+            assert!(o.fails_the_run());
+        }
+    }
+
+    #[test]
+    fn the_required_number_of_clean_trials_passes() {
+        let trials: Vec<_> = (1..=MIN_TIER_C_TRIALS).map(passing_trial).collect();
+        let o = tier_c_from_trials(&trials);
+        assert_eq!(o.token(), "PASS", "{}", o.detail());
+        assert!(!o.fails_the_run());
+    }
+
+    #[test]
+    fn one_failure_among_many_passes_still_fails() {
+        // A durability violation is not outvoted by successful trials: the
+        // device demonstrated it can lose an acknowledged write.
+        let mut trials: Vec<_> = (1..=MIN_TIER_C_TRIALS + 3).map(passing_trial).collect();
+        trials[4] = judge_trial(5, Some(&marker(400)), &intact(12));
+        let o = tier_c_from_trials(&trials);
+        assert_eq!(o.token(), "FAIL");
+        assert!(o.detail().contains("trial 5"), "{}", o.detail());
+    }
+
+    #[test]
+    fn the_marker_round_trips() {
+        let m = marker(1234);
+        let back = ArmedMarker::parse(&m.render()).expect("parses");
+        assert_eq!(back.durable_generation, 1234);
+        assert_eq!(back.durable_head, "deadbeef");
+    }
+
+    #[test]
+    fn a_truncated_marker_is_not_silently_zero() {
+        // A marker torn by the very power cut it was recording must read as
+        // absent, which makes the trial inconclusive — not as generation 0,
+        // which would make every trial trivially pass.
+        assert!(ArmedMarker::parse("").is_none());
+        assert!(ArmedMarker::parse("400").is_none());
+        assert!(ArmedMarker::parse("notanumber\nhead\n").is_none());
+    }
+
+    #[test]
+    fn the_ledger_round_trips_through_its_own_writer() {
+        let db = temp("tierc-ledger");
+        let _ = std::fs::remove_file(trials_ledger_path(&db));
+        let written = [
+            passing_trial(1),
+            judge_trial(2, Some(&marker(400)), &intact(3)),
+            judge_trial(3, None, &intact(400)),
+        ];
+        for r in &written {
+            append_trial(&db, r).expect("append");
+        }
+
+        let read = read_trials(&db);
+        assert_eq!(read.len(), 3);
+        for (w, r) in written.iter().zip(&read) {
+            assert_eq!(w.trial, r.trial);
+            assert_eq!(w.outcome.token(), r.outcome.token());
+            assert_eq!(w.durable_generation, r.durable_generation);
+            assert_eq!(w.recovered_generation, r.recovered_generation);
+        }
+        let _ = std::fs::remove_file(trials_ledger_path(&db));
+    }
+
+    #[test]
+    fn a_torn_final_ledger_line_does_not_discard_earlier_trials() {
+        use std::io::Write;
+        let db = temp("tierc-torn");
+        let path = trials_ledger_path(&db);
+        let _ = std::fs::remove_file(&path);
+        append_trial(&db, &passing_trial(1)).expect("append");
+        append_trial(&db, &passing_trial(2)).expect("append");
+        // The ledger is appended to on a machine that is about to lose power
+        // again, so a half-written last line is an expected state.
+        let mut f = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .expect("open");
+        write!(f, "{{\"trial\":3,\"outcome\":\"PA").expect("write");
+        drop(f);
+
+        assert_eq!(read_trials(&db).len(), 2);
+        let _ = std::fs::remove_file(&path);
     }
 }

--- a/tools/wm2-persistence-harness/src/main.rs
+++ b/tools/wm2-persistence-harness/src/main.rs
@@ -49,6 +49,12 @@ COMMANDS:
     pressure    Disk-pressure behaviour + reclamation cost (ADR-0041 §SQLite config)
     all         Every command above, into one result stream
 
+  Tier C (manual, needs a power switch — see the drill §8):
+    powercut arm     Fsync a known prefix, record it, then append until the
+                     power is cut. Does not return.
+    powercut verify  After reboot: check the fsynced prefix survived and the
+                     chain is intact; append the result to the trials ledger.
+
 OPTIONS:
     --db <path>              Working database (default: a temp file)
     --out <path>             Append JSONL results here (default: stdout)
@@ -62,6 +68,7 @@ OPTIONS:
     --events-per-day <n>     For the growth projection (default: 864000 = 10 Hz)
     --budget-gib <n>         Storage budget for the projection (default: 8)
     --crash-run-ms <n>       How long the crash child runs before SIGKILL (default: 750)
+    --trial <n>              Power-cut trial number, for `powercut verify`
     --assert-target          Operator asserts this is target hardware under
                              representative storage, power and thermal conditions
 
@@ -84,6 +91,9 @@ struct Args {
     events_per_day: f64,
     budget_gib: f64,
     crash_run_ms: u64,
+    trial: u64,
+    /// Positional word after the command, used only by `powercut arm|verify`.
+    subcommand: Option<String>,
     assert_target: bool,
 }
 
@@ -110,10 +120,27 @@ fn parse_args() -> Result<Args, String> {
         events_per_day: 864_000.0,
         budget_gib: 8.0,
         crash_run_ms: 750,
+        trial: 0,
+        subcommand: None,
         assert_target: false,
     };
 
+    // A single positional word may follow `powercut`, and only `powercut`.
+    // Anywhere else it is a typo, and swallowing it silently would run a
+    // different experiment than the one that was asked for.
     let mut i = 1;
+    if let Some(word) = raw.get(1) {
+        if !word.starts_with("--") {
+            if a.command != "powercut" {
+                return Err(format!(
+                    "unexpected argument `{word}` after `{}`\n\n{USAGE}",
+                    a.command
+                ));
+            }
+            a.subcommand = Some(word.clone());
+            i = 2;
+        }
+    }
     while i < raw.len() {
         let flag = raw[i].as_str();
         // Every flag but --assert-target takes a value; missing it is a usage
@@ -137,6 +164,7 @@ fn parse_args() -> Result<Args, String> {
             "--repeats" => a.repeats = parse_num(&value(flag)?, flag)? as usize,
             "--seed" => a.seed = parse_num(&value(flag)?, flag)?,
             "--crash-run-ms" => a.crash_run_ms = parse_num(&value(flag)?, flag)?,
+            "--trial" => a.trial = parse_num(&value(flag)?, flag)?,
             "--events-per-day" => a.events_per_day = parse_float(&value(flag)?, flag)?,
             "--budget-gib" => a.budget_gib = parse_float(&value(flag)?, flag)?,
             "--durability" => {
@@ -198,6 +226,13 @@ fn stamp(class: &platform::Classification, facts: &platform::PlatformFacts, a: &
         .str("harness_version", env!("CARGO_PKG_VERSION"))
         .str("sqlite_version", rusqlite::version())
         .str("build_profile", &facts.build_profile)
+        // Build identity: which binary produced this number. `build_profile`
+        // says release-or-debug; these say *which* release. Captured in
+        // build.rs — see its header for why a dirty tree is labelled rather
+        // than rejected.
+        .str("rustc_version", env!("WM2_RUSTC_VERSION"))
+        .str("git_commit", env!("WM2_GIT_COMMIT"))
+        .str("source_digest", env!("WM2_SOURCE_DIGEST"))
         .str("arch", &facts.arch)
         .opt_str("device_model", facts.model.as_deref())
         .opt_str("db_fs_type", facts.db_fs_type.as_deref())
@@ -225,6 +260,55 @@ fn main() {
     // append until killed.
     if args.command == "crash-child" {
         crash::crash_child(&args.db, args.durability.unwrap_or(Durability::Full));
+    }
+
+    // Tier C. Deliberately outside the reporting pipeline: `arm` never returns
+    // (the operator ends it with the power switch) and `verify` runs after a
+    // reboot, so neither fits the run/stage shape the other commands share.
+    if args.command == "powercut" {
+        if let Some(parent) = args.db.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        match args.subcommand.as_deref() {
+            Some("arm") => {
+                crash::powercut_arm(&args.db, 400, args.entities, args.seed);
+            }
+            Some("verify") => {
+                if args.trial == 0 {
+                    eprintln!(
+                        "powercut verify requires --trial <n> (1-based). The number is \
+                         recorded in the ledger so trials can be counted and re-run \
+                         individually."
+                    );
+                    std::process::exit(2);
+                }
+                let rec = crash::powercut_verify(&args.db, args.trial);
+                println!(
+                    "trial {}: {} — {}",
+                    rec.trial,
+                    rec.outcome.token(),
+                    rec.outcome.detail()
+                );
+                let all = crash::read_trials(&args.db);
+                let agg = crash::tier_c_from_trials(&all);
+                println!(
+                    "\ntier C after {} trial(s): {} — {}",
+                    all.len(),
+                    agg.token(),
+                    agg.detail()
+                );
+                // A failed or still-insufficient tier C exits non-zero, for the
+                // same reason every other unusable measurement does.
+                std::process::exit(i32::from(agg.fails_the_run()));
+            }
+            other => {
+                eprintln!(
+                    "powercut needs a subcommand: `arm` or `verify` (got {})",
+                    other.unwrap_or("nothing")
+                );
+                std::process::exit(2);
+            }
+        }
     }
 
     if let Some(parent) = args.db.parent() {
@@ -546,7 +630,28 @@ fn main() {
                     .int("bytes_before", r.bytes_before)
                     .int("bytes_after", r.bytes_after)
                     .float("bytes_freed", r.bytes_freed as f64)
-                    .float("bytes_per_ms", r.bytes_per_ms),
+                    .float("bytes_per_ms", r.bytes_per_ms)
+                    // Transient cost. `transient_overhead_bytes` — not
+                    // `bytes_freed` — is what a minimum-free-space reserve has
+                    // to be set from: VACUUM materialises a second copy before
+                    // it can shrink anything.
+                    .int("peak_bytes_during", r.peak_bytes_during)
+                    .float(
+                        "transient_overhead_bytes",
+                        r.transient_overhead_bytes as f64,
+                    )
+                    .float("transient_overhead_ratio", r.transient_overhead_ratio)
+                    .int("footprint_samples", r.footprint_samples)
+                    // Where the second copy lands. A volatile temp filesystem
+                    // means reclamation runs through RAM.
+                    .str("temp_dir", &r.temp_dir)
+                    .opt_str("temp_dir_fs_type", r.temp_dir_fs_type.as_deref())
+                    .bool("temp_on_same_fs_as_db", r.temp_on_same_fs_as_db)
+                    .bool("temp_fs_is_volatile", r.temp_fs_is_volatile)
+                    // Availability: what a robot cannot do while this runs.
+                    .int("concurrent_append_attempts", r.concurrent_append_attempts)
+                    .int("concurrent_appends_blocked", r.concurrent_appends_blocked)
+                    .float("max_append_stall_ms", r.max_append_stall_ms),
             ),
             Err(e) => {
                 failures += 1;
@@ -572,6 +677,12 @@ fn main() {
                     .str("tier", tier)
                     .str("durability", d.pragma())
                     .str("outcome", outcome.token())
+                    // Recorded manual power-cut trials found next to the
+                    // database. Stamped on every tier so a reader of any one
+                    // row can tell a genuine NOT-RUN from a drill that
+                    // stopped short of the required count.
+                    .int("tier_c_trials_recorded", r.tier_c_trials)
+                    .int("tier_c_trials_required", crash::MIN_TIER_C_TRIALS)
                     .str("detail", outcome.detail()),
             );
         }
@@ -692,6 +803,8 @@ mod tests {
             events_per_day: 1.0,
             budget_gib: 1.0,
             crash_run_ms: 1,
+            trial: 0,
+            subcommand: None,
             assert_target: false,
         };
         let rendered = stamp(&class, &facts, &args).render();
@@ -722,6 +835,8 @@ mod tests {
             events_per_day: 1.0,
             budget_gib: 1.0,
             crash_run_ms: 1,
+            trial: 0,
+            subcommand: None,
             assert_target: false,
         };
         assert_eq!(durabilities(&a).len(), 3);

--- a/tools/wm2-persistence-harness/src/platform.rs
+++ b/tools/wm2-persistence-harness/src/platform.rs
@@ -260,6 +260,35 @@ pub fn gather(db_path: &std::path::Path, operator_asserted_target: bool) -> Plat
     }
 }
 
+/// Whether a filesystem type cannot carry a durability measurement.
+///
+/// Exposed so the reclamation stage can ask the same question of the *temp*
+/// directory that classification asks of the database directory: a `VACUUM`
+/// whose working copy lands on `tmpfs` is building it in RAM, which fails
+/// differently and worse than running out of disk.
+pub fn is_non_durable_fs(fs: &str) -> bool {
+    NON_DURABLE_FS.contains(&fs)
+}
+
+/// Filesystem type backing `dir`, resolved through `/proc/self/mountinfo`.
+pub fn fs_type_of(dir: &std::path::Path) -> Option<String> {
+    mount_of(dir).map(|(fs, _)| fs)
+}
+
+/// Mount source (backing device) for `dir`.
+///
+/// Distinct from the type: two separate ext4 volumes share a type but not a
+/// device, and treating them as one would understate a free-space reserve.
+pub fn fs_source_of(dir: &std::path::Path) -> Option<String> {
+    mount_of(dir).map(|(_, src)| src)
+}
+
+fn mount_of(dir: &std::path::Path) -> Option<(String, String)> {
+    let canonical = std::fs::canonicalize(dir).unwrap_or_else(|_| dir.to_path_buf());
+    let info = std::fs::read_to_string("/proc/self/mountinfo").ok()?;
+    resolve_mount(&info, &canonical.to_string_lossy())
+}
+
 /// `debug_assertions` is the only profile signal available without a build
 /// script, and it is the one that matters: it is on exactly when the
 /// optimiser is not doing the work the benchmark is meant to measure.

--- a/tools/wm2-persistence-harness/src/pressure.rs
+++ b/tools/wm2-persistence-harness/src/pressure.rs
@@ -41,8 +41,9 @@
 
 use crate::gen;
 use crate::standin::{ChainStatus, Durability, Store};
-use std::path::Path;
-use std::time::Instant;
+use rusqlite::Connection;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
 
 pub struct PressureResult {
     pub events_before_full: u64,
@@ -206,22 +207,166 @@ pub struct ReclaimResult {
     pub bytes_after: u64,
     pub bytes_freed: i64,
     pub bytes_per_ms: f64,
+
+    // --- transient cost: what reclamation *needs*, not what it returns ------
+    /// Peak combined footprint (database directory + temp directory) observed
+    /// while the `VACUUM` was running.
+    pub peak_bytes_during: u64,
+    /// `peak_bytes_during - bytes_before`: the free space a `VACUUM` consumes
+    /// **on top of** the database it is shrinking. This, not `bytes_freed`, is
+    /// the number a minimum-free-space reserve has to be set from.
+    pub transient_overhead_bytes: i64,
+    /// `peak_bytes_during / bytes_before`.
+    ///
+    /// Measured at 1.36 on the host baseline, *not* the 2.0 a "VACUUM needs
+    /// twice the space" rule of thumb predicts — because the copy it builds is
+    /// the size of the **result**, not of the source. The overhead therefore
+    /// scales with what will remain, and the worst case is a store with
+    /// nothing to reclaim (copy ≈ source ⇒ ratio ≈ 2.0), not a bloated one.
+    ///
+    /// The conservative reserve is consequently ~1× the current database size
+    /// rather than the measured 0.36×: a maintenance window that only ever ran
+    /// when there was a lot to reclaim would be sized from the easy case.
+    pub transient_overhead_ratio: f64,
+    pub footprint_samples: u64,
+
+    // --- where the second copy lands ---------------------------------------
+    pub temp_dir: String,
+    pub temp_dir_fs_type: Option<String>,
+    /// True when the temp copy shares a filesystem with the database, so the
+    /// reserve must cover both.
+    pub temp_on_same_fs_as_db: bool,
+    /// True when the temp directory is `tmpfs`/`ramfs` — the copy is built in
+    /// **RAM**, and the failure mode is the OOM killer rather than `ENOSPC`.
+    pub temp_fs_is_volatile: bool,
+
+    // --- availability during reclamation ------------------------------------
+    /// Appends attempted from a second connection while the `VACUUM` ran.
+    pub concurrent_append_attempts: u64,
+    /// How many of those were refused or blocked. `VACUUM` takes an exclusive
+    /// lock, so a robot cannot record events for its duration.
+    pub concurrent_appends_blocked: u64,
+    pub max_append_stall_ms: f64,
 }
 
+/// Time a `VACUUM` on a populated store, and measure what it costs the *system*
+/// — not just how long it takes.
+///
+/// Three things beyond duration matter to ADR-0041's reclamation preconditions,
+/// and none of them are visible from `bytes_freed`:
+///
+/// 1. **Transient space.** `VACUUM` writes a complete copy and only then swaps
+///    it in, so it *consumes* free space in order to release it. A device that
+///    waits until it is nearly full to reclaim is a device that cannot
+///    reclaim. The reserve threshold follows from `transient_overhead_bytes`,
+///    not from the reclaimed figure — and see that field's note for why the
+///    conservative reserve is ~1× the database size even though the measured
+///    overhead is smaller.
+/// 2. **Where the copy goes.** SQLite builds it in the temp directory, which
+///    may be a different filesystem — and on a Jetson is frequently `tmpfs`.
+///    Reclaiming an 8 GiB store through RAM is a different and worse failure
+///    than running out of disk, so the medium is reported, not assumed.
+/// 3. **Availability.** `VACUUM` holds an exclusive lock for its whole
+///    duration. The store cannot accept events during it, which is precisely
+///    why the ADR now requires a robot state rather than an opportunistic
+///    schedule. The stall is measured from a second connection rather than
+///    argued from the documentation.
 pub fn reclaim(store: &Store, path: &Path) -> Result<ReclaimResult, String> {
+    use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+    use std::sync::Arc;
+
     store.durable_checkpoint().map_err(|e| e.to_string())?;
     let bytes_before = crate::bench::db_bytes(path);
 
+    let db_dir = path
+        .parent()
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| PathBuf::from("."));
+    let temp_dir = resolve_sqlite_temp_dir();
+    let temp_fs = crate::platform::fs_type_of(&temp_dir);
+    let db_fs = crate::platform::fs_type_of(&db_dir);
+
+    let running = Arc::new(AtomicBool::new(true));
+    let peak = Arc::new(AtomicU64::new(bytes_before));
+    let samples = Arc::new(AtomicU64::new(0));
+
+    // Footprint sampler. Directory-summing rather than free-space polling: it
+    // is attributable to this operation, where free space on a shared
+    // filesystem moves for reasons that have nothing to do with the VACUUM.
+    let sampler = {
+        let running = Arc::clone(&running);
+        let peak = Arc::clone(&peak);
+        let samples = Arc::clone(&samples);
+        let db_dir = db_dir.clone();
+        let temp_dir = temp_dir.clone();
+        std::thread::spawn(move || {
+            while running.load(Ordering::Relaxed) {
+                let total = dir_bytes(&db_dir) + sqlite_temp_bytes(&temp_dir);
+                peak.fetch_max(total, Ordering::Relaxed);
+                samples.fetch_add(1, Ordering::Relaxed);
+                std::thread::sleep(Duration::from_millis(1));
+            }
+        })
+    };
+
+    // Availability probe: a second connection trying to do what a robot would
+    // be doing. Opened before the VACUUM so connection setup is not counted as
+    // a stall.
+    let attempts = Arc::new(AtomicU64::new(0));
+    let blocked = Arc::new(AtomicU64::new(0));
+    let max_stall_us = Arc::new(AtomicU64::new(0));
+    let writer = {
+        let running = Arc::clone(&running);
+        let attempts = Arc::clone(&attempts);
+        let blocked = Arc::clone(&blocked);
+        let max_stall_us = Arc::clone(&max_stall_us);
+        let path = path.to_path_buf();
+        std::thread::spawn(move || {
+            // A short busy timeout: the question is whether writes stall, so
+            // waiting indefinitely would measure nothing and hang the probe.
+            let Ok(conn) = Connection::open(&path) else {
+                return;
+            };
+            let _ = conn.busy_timeout(Duration::from_millis(50));
+            while running.load(Ordering::Relaxed) {
+                let t = Instant::now();
+                let r = conn.execute_batch(
+                    "BEGIN IMMEDIATE; \
+                     INSERT INTO projection_checkpoints(name, generation) \
+                     VALUES ('reclaim_probe', 1) \
+                     ON CONFLICT(name) DO UPDATE SET generation = generation + 1; \
+                     COMMIT;",
+                );
+                let us = t.elapsed().as_micros() as u64;
+                attempts.fetch_add(1, Ordering::Relaxed);
+                if r.is_err() {
+                    blocked.fetch_add(1, Ordering::Relaxed);
+                    // A failed BEGIN IMMEDIATE leaves no transaction, but a
+                    // failure after it would; roll back defensively so the
+                    // probe cannot itself hold a lock.
+                    let _ = conn.execute_batch("ROLLBACK;");
+                }
+                max_stall_us.fetch_max(us, Ordering::Relaxed);
+                std::thread::sleep(Duration::from_millis(5));
+            }
+        })
+    };
+
     let t = Instant::now();
-    store
-        .conn
-        .execute_batch("VACUUM;")
-        .map_err(|e| e.to_string())?;
+    let vacuum = store.conn.execute_batch("VACUUM;");
     let vacuum_ms = t.elapsed().as_secs_f64() * 1e3;
+
+    running.store(false, Ordering::Relaxed);
+    let _ = sampler.join();
+    let _ = writer.join();
+
+    vacuum.map_err(|e| e.to_string())?;
 
     store.durable_checkpoint().map_err(|e| e.to_string())?;
     let bytes_after = crate::bench::db_bytes(path);
     let bytes_freed = bytes_before as i64 - bytes_after as i64;
+
+    let peak_bytes_during = peak.load(Ordering::Relaxed).max(bytes_before);
 
     Ok(ReclaimResult {
         vacuum_ms,
@@ -233,7 +378,106 @@ pub fn reclaim(store: &Store, path: &Path) -> Result<ReclaimResult, String> {
         } else {
             f64::NAN
         },
+        peak_bytes_during,
+        transient_overhead_bytes: peak_bytes_during as i64 - bytes_before as i64,
+        transient_overhead_ratio: if bytes_before > 0 {
+            peak_bytes_during as f64 / bytes_before as f64
+        } else {
+            f64::NAN
+        },
+        footprint_samples: samples.load(Ordering::Relaxed),
+        temp_dir: temp_dir.to_string_lossy().into_owned(),
+        temp_on_same_fs_as_db: match (&temp_fs, &db_fs) {
+            (Some(a), Some(b)) => a == b && same_device(&temp_dir, &db_dir),
+            _ => false,
+        },
+        temp_fs_is_volatile: temp_fs
+            .as_deref()
+            .is_some_and(crate::platform::is_non_durable_fs),
+        temp_dir_fs_type: temp_fs,
+        concurrent_append_attempts: attempts.load(Ordering::Relaxed),
+        concurrent_appends_blocked: blocked.load(Ordering::Relaxed),
+        max_append_stall_ms: max_stall_us.load(Ordering::Relaxed) as f64 / 1e3,
     })
+}
+
+/// Where SQLite will build the `VACUUM` copy, following its unix temp-file
+/// search order.
+///
+/// Replicated rather than queried because there is no pragma that reports the
+/// resolved answer — `temp_store_directory` reports only an override, and is
+/// deprecated. Being explicit about the order is the point: on a Jetson the
+/// difference between `/var/tmp` and a `tmpfs` `/tmp` is the difference between
+/// a slow reclamation and an out-of-memory kill.
+fn resolve_sqlite_temp_dir() -> PathBuf {
+    for var in ["SQLITE_TMPDIR", "TMPDIR"] {
+        if let Ok(v) = std::env::var(var) {
+            if !v.is_empty() && Path::new(&v).is_dir() {
+                return PathBuf::from(v);
+            }
+        }
+    }
+    for fallback in ["/var/tmp", "/usr/tmp", "/tmp"] {
+        if Path::new(fallback).is_dir() {
+            return PathBuf::from(fallback);
+        }
+    }
+    PathBuf::from(".")
+}
+
+/// Total bytes of regular files directly in `dir`.
+///
+/// Non-recursive: the database directory's own contents are what a reserve has
+/// to cover, and descending into unrelated subdirectories would attribute
+/// someone else's data to this operation.
+fn dir_bytes(dir: &Path) -> u64 {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return 0;
+    };
+    entries
+        .flatten()
+        .filter_map(|e| e.metadata().ok())
+        .filter(|m| m.is_file())
+        .map(|m| m.len())
+        .sum()
+}
+
+/// Bytes of SQLite's own temp files in `dir`.
+///
+/// SQLite names them `etilqs_*` ("sqlite" reversed). Filtering by that prefix
+/// keeps an unrelated large file in `/tmp` from being charged to the VACUUM.
+fn sqlite_temp_bytes(dir: &Path) -> u64 {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return 0;
+    };
+    entries
+        .flatten()
+        .filter(|e| {
+            e.file_name()
+                .to_string_lossy()
+                .starts_with(SQLITE_TEMP_PREFIX)
+        })
+        .filter_map(|e| e.metadata().ok())
+        .filter(|m| m.is_file())
+        .map(|m| m.len())
+        .sum()
+}
+
+const SQLITE_TEMP_PREFIX: &str = "etilqs_";
+
+/// Whether two paths resolve to the same mount source.
+///
+/// Filesystem *type* matching is not sufficient — two separate ext4 volumes
+/// would compare equal and understate the reserve, which is the unsafe
+/// direction.
+fn same_device(a: &Path, b: &Path) -> bool {
+    match (
+        crate::platform::fs_source_of(a),
+        crate::platform::fs_source_of(b),
+    ) {
+        (Some(x), Some(y)) => x == y,
+        _ => false,
+    }
 }
 
 #[cfg(test)]

--- a/tools/wm2-persistence-harness/src/pressure.rs
+++ b/tools/wm2-persistence-harness/src/pressure.rs
@@ -286,6 +286,13 @@ pub fn reclaim(store: &Store, path: &Path) -> Result<ReclaimResult, String> {
     let temp_fs = crate::platform::fs_type_of(&temp_dir);
     let db_fs = crate::platform::fs_type_of(&db_dir);
 
+    // When SQLite's temp directory IS the database directory, `dir_bytes`
+    // already counts the `etilqs_*` files and adding `sqlite_temp_bytes` would
+    // count them twice — inflating the peak and over-sizing the free-space
+    // reserve derived from it. Resolved once, through `canonicalize`, so
+    // `/tmp` and a symlink to it are recognised as the same place.
+    let temp_dir_is_db_dir = canonical(&temp_dir) == canonical(&db_dir);
+
     let running = Arc::new(AtomicBool::new(true));
     let peak = Arc::new(AtomicU64::new(bytes_before));
     let samples = Arc::new(AtomicU64::new(0));
@@ -301,7 +308,7 @@ pub fn reclaim(store: &Store, path: &Path) -> Result<ReclaimResult, String> {
         let temp_dir = temp_dir.clone();
         std::thread::spawn(move || {
             while running.load(Ordering::Relaxed) {
-                let total = dir_bytes(&db_dir) + sqlite_temp_bytes(&temp_dir);
+                let total = sampled_footprint(&db_dir, &temp_dir, temp_dir_is_db_dir);
                 peak.fetch_max(total, Ordering::Relaxed);
                 samples.fetch_add(1, Ordering::Relaxed);
                 std::thread::sleep(Duration::from_millis(1));
@@ -423,6 +430,31 @@ fn resolve_sqlite_temp_dir() -> PathBuf {
         }
     }
     PathBuf::from(".")
+}
+
+/// One footprint sample: the database directory, plus SQLite's temp files
+/// **only when they are somewhere else**.
+///
+/// Extracted from the sampler thread so the double-count this avoids is
+/// testable. Getting it wrong is not a cosmetic inflation — `peak_bytes_during`
+/// is what `transient_overhead_bytes` is derived from, and that is what the
+/// minimum-free-space reserve is set from, so an over-count here becomes an
+/// over-large reserve that keeps a device from ever reclaiming.
+fn sampled_footprint(db_dir: &Path, temp_dir: &Path, temp_dir_is_db_dir: bool) -> u64 {
+    let base = dir_bytes(db_dir);
+    if temp_dir_is_db_dir {
+        // `dir_bytes` already counted the `etilqs_*` files.
+        base
+    } else {
+        base + sqlite_temp_bytes(temp_dir)
+    }
+}
+
+/// Resolve a directory for identity comparison, so `/tmp` and a symlink to it
+/// are recognised as the same place. Falls back to the literal path when the
+/// directory cannot be canonicalised.
+fn canonical(dir: &Path) -> PathBuf {
+    std::fs::canonicalize(dir).unwrap_or_else(|_| dir.to_path_buf())
 }
 
 /// Total bytes of regular files directly in `dir`.
@@ -587,5 +619,83 @@ mod tests {
             "implausible reclaim on a dense store"
         );
         let _ = std::fs::remove_file(p);
+    }
+
+    #[test]
+    fn a_temp_dir_inside_the_db_dir_is_not_counted_twice() {
+        // The case: SQLite resolves its temp directory to the same place the
+        // database lives (both under /tmp, say). `dir_bytes` already sees the
+        // `etilqs_*` files, so adding `sqlite_temp_bytes` on top would inflate
+        // the peak — and the free-space reserve is derived from that peak, so
+        // the error propagates into an over-large reserve that could stop a
+        // device reclaiming at all.
+        let mut dir = std::env::temp_dir();
+        dir.push(format!("wm2-footprint-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("mkdir");
+
+        std::fs::write(dir.join("w.sqlite"), vec![0u8; 1000]).expect("db");
+        std::fs::write(dir.join("etilqs_abc123"), vec![0u8; 4000]).expect("temp");
+
+        let shared = sampled_footprint(&dir, &dir, true);
+        assert_eq!(shared, 5000, "the temp file must be counted exactly once");
+
+        let double = sampled_footprint(&dir, &dir, false);
+        assert_eq!(
+            double, 9000,
+            "sanity: without the guard the temp file IS counted twice, so the \
+             guard is doing real work rather than being a no-op"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_separate_temp_dir_is_added_rather_than_ignored() {
+        // The other direction: when the temp copy lands elsewhere it must
+        // still be charged to the VACUUM, or the reserve would be understated
+        // — the unsafe direction.
+        let base = std::env::temp_dir();
+        let db_dir = base.join(format!("wm2-fp-db-{}", std::process::id()));
+        let tmp_dir = base.join(format!("wm2-fp-tmp-{}", std::process::id()));
+        for d in [&db_dir, &tmp_dir] {
+            let _ = std::fs::remove_dir_all(d);
+            std::fs::create_dir_all(d).expect("mkdir");
+        }
+
+        std::fs::write(db_dir.join("w.sqlite"), vec![0u8; 1000]).expect("db");
+        std::fs::write(tmp_dir.join("etilqs_xyz"), vec![0u8; 4000]).expect("temp");
+        // An unrelated large file in the temp directory must NOT be charged to
+        // this VACUUM — that is what the `etilqs_` prefix filter is for.
+        std::fs::write(tmp_dir.join("someone-elses.bin"), vec![0u8; 1_000_000]).expect("other");
+
+        assert_eq!(sampled_footprint(&db_dir, &tmp_dir, false), 5000);
+
+        for d in [&db_dir, &tmp_dir] {
+            let _ = std::fs::remove_dir_all(d);
+        }
+    }
+
+    #[test]
+    fn canonical_sees_through_a_symlink_to_the_same_directory() {
+        // Why identity is `canonicalize`d rather than a string compare: a
+        // TMPDIR of `/tmp` against a database under a symlinked path is the
+        // same directory, and comparing the literal strings would miss it and
+        // double-count.
+        let base = std::env::temp_dir();
+        let real = base.join(format!("wm2-canon-{}", std::process::id()));
+        let link = base.join(format!("wm2-canon-link-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&real);
+        let _ = std::fs::remove_file(&link);
+        std::fs::create_dir_all(&real).expect("mkdir");
+
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink(&real, &link).expect("symlink");
+            assert_eq!(canonical(&link), canonical(&real));
+        }
+
+        let _ = std::fs::remove_file(&link);
+        let _ = std::fs::remove_dir_all(&real);
     }
 }

--- a/tools/wm2-persistence-harness/tests/crash_tier_a.rs
+++ b/tools/wm2-persistence-harness/tests/crash_tier_a.rs
@@ -162,3 +162,109 @@ fn a_flag_missing_its_value_is_rejected() {
         .expect("did not run");
     assert_eq!(status.code(), Some(2));
 }
+
+#[test]
+fn a_stray_positional_word_is_rejected_outside_powercut() {
+    // `powercut` takes a positional subcommand, so the parser accepts one
+    // bare word. It must not accept one anywhere else, or a mistyped
+    // invocation quietly runs a different experiment than was asked for.
+    let status = Command::new(BIN)
+        .args(["all", "verify"])
+        .status()
+        .expect("did not run");
+    assert_eq!(
+        status.code(),
+        Some(2),
+        "a bare word after a normal command must be a usage error"
+    );
+}
+
+#[test]
+fn powercut_requires_a_subcommand_and_verify_requires_a_trial_number() {
+    for args in [
+        vec!["powercut"],
+        vec!["powercut", "sideways"],
+        vec!["powercut", "verify"], // no --trial
+    ] {
+        let status = Command::new(BIN).args(&args).status().expect("did not run");
+        assert_eq!(
+            status.code(),
+            Some(2),
+            "`{}` must be a usage error, not a silent no-op",
+            args.join(" ")
+        );
+    }
+}
+
+/// The full tier C loop, with `SIGKILL` standing in for the power switch.
+///
+/// This does **not** make tier C automatable — a signal leaves the page cache
+/// intact, which is exactly why tier C needs a power supply and why the harness
+/// refuses to claim it. What it proves is that the *recording* machinery works:
+/// the marker survives, `verify` judges against it, the ledger accumulates, and
+/// the aggregate still refuses to pass below the required trial count.
+#[test]
+fn the_powercut_ledger_accumulates_and_still_refuses_to_pass_early() {
+    use std::io::Read;
+
+    let mut db = scratch("powercut-loop");
+    db.push("w.sqlite");
+    for suffix in ["", "-wal", "-shm", "-tierc-armed", "-tierc-trials.jsonl"] {
+        let _ = std::fs::remove_file(format!("{}{suffix}", db.display()));
+    }
+
+    // Arm never returns, so it is killed the way the mains would kill it.
+    let mut child = Command::new(BIN)
+        .args(["powercut", "arm", "--db", &db.to_string_lossy()])
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn arm");
+
+    // Wait for it to announce that the prefix is fsynced and recorded, so the
+    // kill lands on the tail rather than on the prefix.
+    let mut out = child.stdout.take().expect("stdout");
+    let mut seen = String::new();
+    let mut byte = [0u8; 1];
+    while !seen.contains("ARMED:") {
+        match out.read(&mut byte) {
+            Ok(0) | Err(_) => break,
+            Ok(_) => seen.push(byte[0] as char),
+        }
+    }
+    assert!(seen.contains("ARMED:"), "arm never armed: {seen}");
+    std::thread::sleep(std::time::Duration::from_millis(150));
+    let _ = child.kill();
+    let _ = child.wait();
+
+    // Three trials: below the required five, so the tier must still refuse.
+    for trial in 1..=3 {
+        let status = Command::new(BIN)
+            .args([
+                "powercut",
+                "verify",
+                "--db",
+                &db.to_string_lossy(),
+                "--trial",
+                &trial.to_string(),
+            ])
+            .status()
+            .expect("did not run");
+        assert_eq!(
+            status.code(),
+            Some(1),
+            "trial {trial}: an incomplete tier C must exit non-zero"
+        );
+    }
+
+    let ledger = std::fs::read_to_string(format!("{}-tierc-trials.jsonl", db.display()))
+        .expect("ledger written");
+    let lines: Vec<&str> = ledger.lines().filter(|l| !l.trim().is_empty()).collect();
+    assert_eq!(lines.len(), 3, "one row per trial: {ledger}");
+    for line in &lines {
+        assert!(
+            line.contains("\"outcome\":\"PASS\""),
+            "a SIGKILL must not lose the fsynced prefix — that would be a real \
+             finding, not a test artefact: {line}"
+        );
+    }
+}


### PR DESCRIPTION
The R2 drill needs the hardware. What it did **not** need was for the operator to hand-assemble the record afterwards — and three items on the acceptance list had no field behind them, so a single run could not have produced the evidence the run exists to produce.

**No ADR status changes. ADR-0041 stays Proposed, the domain-logic gate stays HOLDING, and nothing here is ratification evidence** — it is host-indicative by construction, and the harness says so.

---

## 1. Build identity — *which* release said this

`build_profile` answered release-or-debug, which is the difference between measuring SQLite and measuring rustc. It did not answer which release, and a figure that will sit in an ADR for years needs that to be reproducible.

Now stamped on every record, from a `build.rs` that adds **no dependency** (the one-dependency rule is load-bearing):

| Field | |
|---|---|
| `rustc_version` | optimisation output moves between versions, and this harness reports microsecond-scale latencies |
| `git_commit` | with an explicit `-dirty` suffix when the tree had uncommitted changes. A dirty build is not disqualifying — it must be *visible* |
| `source_digest` | SHA-256 over the harness sources |

The commit says what *should* have been built; the digest says what *was*. They diverge exactly when a file was edited to make a number come out better.

Confirmed working, including its own honesty: builds from this working tree report `626443a16472-dirty`.

## 2. VACUUM system impact — measured instead of guessed

`vacuum_ms` and `bytes_freed` describe what reclamation *returns*. The ADR-0041 revision has to set a **minimum free-space reserve**, which is a question about what reclamation *costs while running* — and nothing measured that.

Now measured: peak combined footprint sampled during the `VACUUM`, transient overhead over the starting size, where SQLite actually resolves its temp directory, whether that directory is on the same filesystem, whether it is volatile, and — from a second connection — how many appends are refused and the longest stall.

**Two findings, recorded rather than predicted:**

> **The transient overhead measured 1.36×, not the 2.0× the "VACUUM needs twice the space" rule of thumb predicts** — because the copy it builds is the size of the **result**, not the source. The overhead therefore scales with what will *remain*, so the worst case is a store with *nothing* to reclaim, and the conservative reserve is **~1× the current database size** — not the measured 0.36×, which would size the maintenance window from the easy case.
>
> My own doc comment asserted the 2.0× before the measurement existed. It is corrected against the measurement rather than left as a plausible prediction.

> **A `tmpfs` temp directory means `VACUUM` builds its copy in RAM.** On an 8 GiB store the failure mode is the OOM killer rather than `ENOSPC` — a different and worse thing to discover in the field. The medium is now reported (`temp_fs_is_volatile`), not assumed.

`max_append_stall_ms` and `concurrent_appends_blocked` answer the remaining reclamation-precondition question directly: `VACUUM` holds an exclusive lock for its whole duration, so the store cannot record events while it runs. That is measured from a second connection rather than argued from the documentation.

## 3. Tier C — power-cut evidence, structured

Five power cuts were required and **unrecordable**: the tier was `NOT-RUN` by construction with no way to enter a result, so the evidence would have been prose.

Software still cannot cut power. That has not changed and is not claimed. It *can* state beforehand what must survive and check afterwards whether it did:

- **`powercut arm`** appends a prefix at `synchronous=FULL`, checkpoints it into the main file, fsyncs a marker recording the durable generation and head digest (plus the directory, so the file's *existence* survives), and only then begins an un-checkpointed tail. Without that marker a survived cut is unfalsifiable — indistinguishable from a cut that landed earlier than the operator thought — so an unarmed trial judges `INCONCLUSIVE`, never a pass.
- **`powercut verify --trial N`** reopens after the reboot and appends a verdict to a ledger beside the database.

The distinction it turns on is the whole tier, and it is pure and unit-tested so it does not rest on the operator's reading:

| Outcome | |
|---|---|
| `PASS` | chain intact, fsynced prefix survived. **Losing the un-fsynced tail is correct** — that is what tier B already establishes portably |
| `FAIL` — *DURABILITY VIOLATION* | fewer events came back than were fsynced and acknowledged. The device acknowledged writes it had not persisted. No `synchronous` setting compensates, and it is the only failure this tier can detect that A and B cannot |
| `INCONCLUSIVE` | no armed marker — the cut landed before `ARMED:` |

Aggregation is deliberately conservative. **Zero trials stays `NOT-RUN`**, so every automated run behaves exactly as before and the exit code keeps its meaning. One to four trials is `INCONCLUSIVE` and fails the run: device-cache loss is probabilistic and depends where in the erase-block cycle the cut lands, so a single survived cut is not evidence. One failure is not outvoted by successful trials.

## 4. A runbook bug that would have destroyed the evidence

The drill told the operator to re-verify with `crash` — which **deletes and recreates** the store tier A is given. That would have destroyed exactly the state the power cuts produced. `powercut verify` only reads, and the ledger is read before tier A runs.

## 5. Two defects in this change, found by running it

Both operator-facing, both caught before hardware:

- **The `ARMED` banner never reached a pipe.** stdout is block-buffered and `arm` never returns to flush it. An operator who cannot see `ARMED` does not know when it is safe to cut power.
- **`gen::events` takes `(start_generation, count, entities, seed)`** and I passed four `u64`s in the wrong order. It compiled cleanly and armed 1000 events while reporting 400.

## 6. Pre-VACUUM environment capture

The harness records where the temp directory resolved and whether it is volatile; it cannot record how much room or RAM there was. The drill now captures `df -hT`, `free -h`, `TMPDIR`, `findmnt /tmp` and the going-in database size, with a table mapping each to the `reclaim` field it makes interpretable. An empty `TMPDIR` is called out as a *meaningful* reading — SQLite falls through to `/var/tmp`, `/usr/tmp`, `/tmp`, which on a Jetson are frequently not the medium `/var/lib/kirra` is on.

---

## Verification

- Harness suite **87 → 108**: 13 new tier C cases including the vacuity controls (an unarmed trial cannot pass; a truncated marker reads as absent rather than generation 0), a torn-final-ledger-line case, and a full arm/verify/ledger loop with `SIGKILL` standing in for the switch — which proves the *recording machinery*, not the tier.
- `cargo fmt` and `clippy -D warnings` clean on both trees.
- A full host run still **exits 0 with tier C `NOT-RUN` at 0/5 recorded** — CI behaviour unchanged.
- All repo gates pass: domain-logic gate `HOLDING (owner assigned, ruling pending)`, fence `INTACT`, 36/36 domain-gate and 38/38 fence tests.
- Workspace unaffected — 44 packages; the harness stays detached.
- **4 World Model ADRs Proposed, 0 Accepted.**
- No runtime behaviour, safety algorithm, checker input, release-token logic or actuator behaviour changes.

## Not done here

The R2 run itself. This container is x86-64 with no Tegra and no route to the device, and the evidence gate exists to stop a Jetson claim being made from here. The two acceptance questions — **actual bytes per event on R2**, and **actual graph-query cost relative to point queries** — remain open, and the domain gate stays holding until they are measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_