### PR TITLE
feat(wm2): instruments for the scale sweep and the 29 s stall

### DIFF
--- a/docs/adr/0041-world-model-persistence-architecture.md
+++ b/docs/adr/0041-world-model-persistence-architecture.md
@@ -435,7 +435,13 @@ source; they are not migrated destructively (ADR-0040).
    29.27 s on NVMe — ~293 unrecordable observations at 10 Hz. Cause unknown;
    ext4 journal commit, NVMe garbage collection and thermal/power management
    are all candidates and are distinguishable only by re-running. Blocks open
-   question 1.
+   question 1. **An instrument now exists** (`stall`, drill §9a): it repeats the
+   configuration to establish a *rate*, reports a median throughput that one
+   pathological run cannot move, and samples PSI I/O, block-layer busy time,
+   dirty/writeback peak and thermal across each run to narrow the cause. Its
+   attribution is deliberately reluctant — `UNATTRIBUTED` unless one cause is
+   clear — because a confident wrong attribution closes the investigation.
+   **Not yet run on target.**
 10. **Graph-query placement (D-1).** At 13.4 ms p99 — 1 496× the point family,
    and 6.5× worse in *ratio* on target than on host — bounded-depth reach
    cannot sit on a deadline path. Whether any planned consumer needs it there
@@ -536,7 +542,7 @@ satisfied, and none may be ticked from a `HOST-INDICATIVE-NOT-TARGET` run:**
 | [ ] | **Corruption / restart experiment** — power-loss-class behaviour, in the spirit of the existing audit-chain crash-consistency drill | `crash` tiers A and B; **tier C is manual** (drill §8) and this gate is not complete without it | **Partial** — A and B PASS; **tier C `NOT-RUN`, 0 of 5 trials** |
 | [x] | **Storage growth estimate** — observations/day at realistic sensor rates, projected against the device budget | `growth` | **Met — and adverse.** See D-2 |
 | [x] | **Migration proof of concept** — a schema change applied to a populated store, fail-closed on a future schema version | `migrate` | **Met — and adverse.** See D-6 |
-| [ ] | Scale assumptions confirmed or corrected; if materially wrong, Option B is re-evaluated before acceptance | the drill §9 sweep informs it; what the deployed robot actually reaches is an operational fact the harness cannot produce | **Open** — see D-2, and the §9 sweep has not been run |
+| [ ] | Scale assumptions confirmed or corrected; if materially wrong, Option B is re-evaluated before acceptance | the drill §9 sweep, which now emits a **computed** verdict against this ADR's own reopening condition; what the deployed robot actually reaches remains an operational fact the harness cannot produce | **Open** — see D-2 and D-8; the sweep has not been run on target |
 
 **Two gates remain open, and one of them cannot be closed from software.** Tier C
 requires five physical power cuts (drill §8, `powercut arm` / `powercut verify`);
@@ -738,6 +744,37 @@ not establish that the device stays healthy. Confirming the second still needs a
 deliberately filled partition — and open question 7 (partial projections under
 pressure) remains open regardless, because a fold that is *interrupted* is a
 different case from one that is refused.
+
+### D-8 — the reopening condition is now decidable, and the obvious sweep was wrong
+
+This ADR states the condition under which it should be abandoned — *"entities in
+the millions or genuinely unbounded ad-hoc traversal"* — and the drill
+previously discharged it with a shell loop and the instruction to *look at* how
+`graph_bounded_reach` grows. Whether a curve has a knee is precisely the
+judgement that gets made favourably under deadline and re-made unfavourably by
+an assessor a year later, from the same numbers. It is now a function
+(`sweep`, drill §9) with a fail-closed verdict: `SUBLINEAR` / `LINEAR` /
+`SUPERLINEAR` / `KNEE` / `INSUFFICIENT`, where both `KNEE` and `INSUFFICIENT`
+exit non-zero.
+
+**Building it exposed a defect in the sweep the drill specified.** Sweeping
+entity count at a *fixed total event count* reduces observations-per-entity as
+the ladder rises, so graph fan-out — and cost — go **down**. On a host ladder of
+100/1 000/10 000 entities at a fixed 20 000 events the medians were 1 687 µs →
+73.7 µs → 10.9 µs, a log-log slope of **−1.10**.
+
+That ladder would have reported excellent sublinear scaling and closed this
+gate, while measuring density rather than scale. It is the most dangerous shape
+available here, because it looks like unusually good news.
+
+The sweep therefore holds observations-per-entity **constant** by default
+(`--events-per-entity`, deployment-realistic: more entities means more
+observations, not the same observations spread thinner), and the classifier
+**refuses** a steeply falling curve as `INSUFFICIENT` with the reason and the
+fix rather than praising it.
+
+No target sweep has been run, so the scale gate remains open. What changed is
+that it can now be closed with a verdict instead of an impression.
 
 ### O-1 — an unexplained ~29 second write stall (open, needs a re-run)
 

--- a/docs/adr/0041-world-model-persistence-architecture.md
+++ b/docs/adr/0041-world-model-persistence-architecture.md
@@ -544,7 +544,7 @@ the harness reports `NOT-RUN` at `0/5` and will continue to. Until both are
 closed this ADR stays **Proposed**.
 
 **No implementation should begin merely because this proposed ADR exists**, and
-in particular not because six of eight gates now read *Met*. The domain-logic
+in particular not because five of the seven gates now read *Met*. The domain-logic
 gate (ADR-0042 Decision 5) is a separate and independent hold.
 
 ---

--- a/docs/evidence/wm2-jetson-20260803/README.md
+++ b/docs/evidence/wm2-jetson-20260803/README.md
@@ -90,14 +90,35 @@ self-consistent but no longer tied to a revision anybody can find. It has not
 drifted here:
 
 `4ecdb939…` — the archived copy — is byte-identical to
-`docs/hardware/JETSON_WM2_PERSISTENCE_DRILL.md` at commit `021ec82379be`, the
-same commit the harness binary was built from, and to the tracked copy at
-`HEAD`.
+`docs/hardware/JETSON_WM2_PERSISTENCE_DRILL.md` **at commit `021ec82379be`**,
+the same commit the harness binary was built from.
 
 So the bundle answers both questions independently: **what was run** (the
 digests verify in place, offline, with no repository) and **which tracked
-revision it corresponds to** (the drill digest matches a commit). If the two
-ever diverge, that is a finding — re-check before citing anything here.
+revision it corresponds to** (the drill digest matches a commit).
+
+#### The tracked drill has since moved — and that is correct
+
+`HEAD`'s copy no longer matches `4ecdb939…`. The drill gained a rewritten §9
+(scale sweep with a computed verdict) and a new §9a (the ~29 s stall
+investigation) *after* this run.
+
+**The archived copy must not be updated to match.** It records the procedure
+that was actually followed on the device, and rewriting it would make this
+bundle describe a run that never happened. A frozen copy going stale relative
+to a living document is the expected, healthy behaviour of a pin — the failure
+mode it guards against is the opposite one, where an archived copy is quietly
+edited and the evidence silently comes to describe something else.
+
+Verify the pin against the commit rather than against `HEAD`:
+
+```sh
+git show 021ec82379be:docs/hardware/JETSON_WM2_PERSISTENCE_DRILL.md | sha256sum
+# 4ecdb93972d474d6ebc68802e46cbbb7f45a501786f6fcda1a128512c6f98584
+```
+
+If *that* ever stops matching, this bundle's provenance is broken and nothing
+in it should be cited until the discrepancy is explained.
 
 > **`results.jsonl` has not been committed.** It exists on the device at
 > `~/wm2-jetson-evidence-20260803-083703/`. It is deliberately *not*

--- a/docs/hardware/JETSON_WM2_PERSISTENCE_DRILL.md
+++ b/docs/hardware/JETSON_WM2_PERSISTENCE_DRILL.md
@@ -30,7 +30,7 @@ This drill produces those recordings. The instrument is
 | Migration proof of concept | ✅ | `migrate` |
 | Compaction-with-citation (§11.3; not a numbered gate, but the retention policy the growth number makes urgent) | ✅ | `compact` |
 | Disk-pressure + reclamation behaviour (ADR-0041 SQLite-config table; not a numbered gate) | ⚠️ **partly** | `pressure` proves clean refusal at the SQLite layer; a genuinely full partition needs the device |
-| Scale assumptions confirmed or corrected | ⚠️ **partly** | the §9 sweep informs it; the operational answer needs real deployment |
+| Scale assumptions confirmed or corrected | ⚠️ **partly** | the §9 sweep now emits a computed `sweep_summary` verdict (`SUBLINEAR`/`LINEAR`/`SUPERLINEAR`/`KNEE`/`INSUFFICIENT`) rather than a curve to eyeball; the operational answer still needs real deployment |
 
 Two of the seven are deliberately marked partial. Marking them complete on the
 strength of this harness alone would be the exact failure the measurement gate
@@ -83,7 +83,9 @@ Expect **tens of minutes**. The append benchmark alone runs six configurations
 is one fsync per event by construction.
 
 Individual stages run on their own: `platform`, `append`, `replay`, `query`,
-`growth`, `migrate`, `compact`, `pressure`, `crash`. Start with `platform` — it prints, in about a
+`growth`, `migrate`, `compact`, `pressure`, `crash`. Two more are **explicit-only**
+and deliberately outside `all`, because each multiplies the runtime: `sweep`
+(§9) and `stall` (§9a). Start with `platform` — it prints, in about a
 millisecond, whether anything you run afterwards will be citable.
 
 Exit status is `1` if any measurement failed **or was unusable** — a query family
@@ -494,21 +496,137 @@ reopened."*
 Sweep past the assumption rather than confirming it:
 
 ```sh
-for e in 1000 10000 100000; do
-  ./target/release/wm2-persistence-harness query \
-      --db /var/lib/kirra/wm2/scale.sqlite \
-      --out ~/wm2-scale.jsonl \
-      --events 1000000 --entities "$e" --assert-target
-done
+./target/release/wm2-persistence-harness sweep \
+    --db /var/lib/kirra/wm2/scale.sqlite \
+    --out ~/wm2-scale.jsonl \
+    --entity-ladder 1000,10000,100000 \
+    --events-per-entity 100 \
+    --sweep-family graph \
+    --assert-target
 ```
 
-Then look at how `graph_bounded_reach` and `temporal_changes_since` grow against
-entity count. Sub-linear or gently linear supports Option A. A knee supports
-reopening in favour of Option B.
+Then repeat with `--sweep-family temporal`. Each rung emits a `sweep_point`
+record; the ladder as a whole emits a `sweep_summary` carrying the **verdict**.
 
-The sweep informs the scale question; it does not settle it. What entity counts
-the deployed robot actually reaches is an operational fact this harness cannot
-produce.
+### The verdict is computed, not eyeballed
+
+Whether a curve "has a knee" is exactly the kind of judgement that gets made
+favourably by someone with a deadline and re-made unfavourably by an assessor a
+year later, from the same numbers. So it is a function, and it is fail-closed:
+
+| Verdict | Meaning | Exit |
+|---|---|---|
+| `SUBLINEAR` / `LINEAR` | cost grows no faster than entity count — **supports Option A** | 0 |
+| `SUPERLINEAR` | uniformly steeper than proportional, but no inflection. Expensive and *predictable*: a bound on how far this may be scaled, not a reopening trigger | 0 |
+| `KNEE` | **the exponent increases along the ladder** — the shape ADR-0041's reopening condition describes. Option B becomes materially stronger | **1** |
+| `INSUFFICIENT` | the ladder cannot be classified | **1** |
+
+A knee exits non-zero deliberately. A sweep that reports the finding and then
+exits 0 invites the finding to be skimmed past.
+
+### Hold the density constant — this is not optional
+
+`--events-per-entity` makes each rung use `entities × n` events, so the number
+of observations *per entity* stays fixed while the entity count grows. That is
+the deployment-realistic shape: more entities means more observations, not the
+same observations spread thinner.
+
+The obvious alternative — sweep entity count at a fixed total event count — is
+wrong, and wrong in the direction that looks like good news. It makes each
+entity thinner, so graph fan-out and cost go **down**. Measured on a host ladder
+of 100/1 000/10 000 entities at a fixed 20 000 events:
+
+```
+entities=  100  median 1687.0 us
+entities= 1000  median   73.7 us
+entities=10000  median   10.9 us     log-log slope -1.10
+```
+
+Falling cost as scale rises is not sublinear scaling; it is a ladder that
+diluted. `--events-per-entity 0` selects that ladder, and the classifier
+**refuses** it (`INSUFFICIENT`, exit 1) with the reason and the fix, rather than
+reporting excellent scaling from a measurement of density.
+
+### What the sweep still cannot settle
+
+It measures the stand-in schema against synthetic load. What entity counts the
+deployed robot actually reaches is an operational fact no benchmark produces,
+and ADR-0041 says so. The sweep narrows the question from "does SQLite scale" to
+"does it scale *on this shape, to this point*" — the answerable half.
+
+---
+
+## 9a. The ~29 second write stall (ADR-0041 open question 9)
+
+The merged R2 run recorded one commit taking **29.27 s** under
+`synchronous=NORMAL` at batch=64, on NVMe. It inverted the durability ordering —
+`NORMAL` came out slower than `FULL` at the same batch — and accounted for ~91 %
+of that stage's wall time, so that row's throughput figure is unusable and **no
+`synchronous` policy may be ratified until this is characterised.**
+
+At 10 Hz, 29 s is ~293 observations that cannot be recorded. That is the reason
+to understand it rather than re-run until it disappears.
+
+```sh
+./target/release/wm2-persistence-harness stall \
+    --db /var/lib/kirra/wm2/stall.sqlite \
+    --out ~/wm2-stall.jsonl \
+    --durability normal --batch 64 \
+    --events 100000 --stall-repeats 20 \
+    --assert-target
+```
+
+Then repeat with `--durability full` and `--durability off`, and with
+`--batch 1`. The question is not only *how big* the stall is but *which
+configurations produce it* — if it appears at every setting, it is not about
+durability at all.
+
+`stall` is deliberately **not** part of `all`: it repeats an append 20 times
+and would multiply every routine drill.
+
+### What it adds over a single run
+
+- **Repetition**, so the stall gets a *rate*. One-in-fifty and one-in-two are
+  different engineering problems at identical magnitude.
+- **`median_throughput_eps`**, a median across repetitions. One pathological run
+  cannot move it, so throughput and stall rate become two separate facts rather
+  than the single contaminated one the original benchmark produced.
+- **Concurrent system counters**, sampled across each run: PSI `full` I/O stall,
+  `/proc/diskstats` busy-milliseconds, peak dirty+writeback, hottest thermal
+  zone.
+
+### Attribution is deliberately reluctant
+
+| Verdict | What the evidence showed |
+|---|---|
+| `IO-DEVICE` | block layer busy for most of the stall, **no** large dirty backlog. On NVMe: garbage collection or an SLC-cache cliff. Confirm against the drive's SMART counters — the harness cannot read them |
+| `WRITEBACK-BACKLOG` | block layer busy **and** a large dirty/writeback backlog. The flush is the work: page cache and journal, not the device |
+| `THERMAL` | block layer idle, hottest zone ≥ 85 °C. Confirm against the Jetson's power mode and `tegrastats` |
+| `UNATTRIBUTED` | the counters do not discriminate — **the expected outcome**, and not a failed measurement |
+| `NO-STALL` | worst commit below the 1 000 ms threshold |
+
+`UNATTRIBUTED` is common by design. A confident wrong attribution closes the
+investigation, which costs more than an honest shrug. Note also that thermal is
+only considered when the block layer was *idle*: a hot SoC during heavy I/O is a
+consequence, not a cause, and blaming it would send the investigation the wrong
+way.
+
+**Observing zero stalls is a result, not a failure.** It bounds the rate. The
+run exits non-zero only if no repetition completed — treating "no stall seen" as
+failure would pressure an operator into re-running until one appeared, which
+turns a rate estimate into fiction.
+
+### Capture alongside
+
+The harness reads `/proc` and `/sys`; it does not read the drive or the SoC.
+Capture these around the run so a device-side answer is available:
+
+```sh
+sudo nvme smart-log /dev/nvme0n1     # media errors, wear, thermal throttle counters
+sudo tegrastats --interval 1000      # SoC clocks and thermal throttling
+cat /sys/block/nvme0n1/queue/scheduler
+cat /proc/sys/vm/dirty_background_ratio /proc/sys/vm/dirty_ratio
+```
 
 ---
 
@@ -544,6 +662,8 @@ retyping of one.
 | Disk-pressure behaviour | `pressure` → the seven boolean checks |
 | Tier A / B | `crash` → `outcome` + `detail` |
 | Tier C | the trials ledger, plus `tier_c_trials_recorded` / `tier_c_trials_required` |
+| **Scale sweep** (§9) | `sweep_point` rows + the `sweep_summary` `verdict` / `supports_option_a` |
+| **The ~29 s stall** (§9a) | `stall` → `stall_rate`, `median_throughput_eps`, `attribution`, and the four system-counter fields |
 
 Three of those deserve to be read rather than filed:
 

--- a/tools/wm2-persistence-harness/README.md
+++ b/tools/wm2-persistence-harness/README.md
@@ -82,6 +82,8 @@ loss is probabilistic, so one survived cut is not evidence.
 | `bench.rs` | Append, replay, the four §12 query families, growth, migration |
 | `crash.rs` | Corruption / restart tiers A, B, and tier C's arm/verify/ledger machinery |
 | `pressure.rs` | Disk-full behaviour, and what `VACUUM` costs the system while it runs |
+| `sweep.rs` | The scale ladder, with a computed fail-closed verdict against ADR-0041's own reopening condition |
+| `stall.rs` | The ~29 s write-stall investigation: repetition, a stall rate, and system counters sampled across each run |
 | `json.rs`, `sha256.rs` | Minimal writer and the local hash — see above |
 | `build.rs` | Build identity: rustc version, git commit (`-dirty` when it is), source digest |
 | `tests/crash_tier_a.rs` | Tier A end-to-end against the real binary (a unit test would exercise the spawn-failure path forever and look like coverage) |

--- a/tools/wm2-persistence-harness/src/main.rs
+++ b/tools/wm2-persistence-harness/src/main.rs
@@ -803,7 +803,13 @@ fn main() {
                     .into(),
             )
         };
-        if verdict.fails_the_run() {
+        // Only count the verdict when the ladder itself measured cleanly. A
+        // broken rung already incremented `failures`, and the resulting
+        // INSUFFICIENT verdict is a CONSEQUENCE of that same problem — counting
+        // both inflates the "N measurement(s) failed" summary and makes one
+        // fault look like two. The exit code is unaffected either way, because
+        // the rung failure alone already fails the run.
+        if ladder_ok && verdict.fails_the_run() {
             failures += 1;
         }
         sink.emit(

--- a/tools/wm2-persistence-harness/src/main.rs
+++ b/tools/wm2-persistence-harness/src/main.rs
@@ -23,7 +23,9 @@ mod json;
 mod platform;
 mod pressure;
 mod sha256;
+mod stall;
 mod standin;
+mod sweep;
 
 use json::Obj;
 use platform::EvidenceStatus;
@@ -47,6 +49,10 @@ COMMANDS:
     crash       Corruption / restart experiment (tiers A and B; C is manual)
     compact     Compaction-with-citation experiment (ADR-0041 §11.3)
     pressure    Disk-pressure behaviour + reclamation cost (ADR-0041 §SQLite config)
+    sweep       Scale ladder across entity counts; classifies the growth curve
+                against ADR-0041's own reopening condition (drill §9)
+    stall       Repeat one append configuration and hunt the ~29 s write stall,
+                sampling system counters across it (ADR-0041 open question 9)
     all         Every command above, into one result stream
 
   Tier C (manual, needs a power switch — see the drill §8):
@@ -69,6 +75,13 @@ OPTIONS:
     --budget-gib <n>         Storage budget for the projection (default: 8)
     --crash-run-ms <n>       How long the crash child runs before SIGKILL (default: 750)
     --trial <n>              Power-cut trial number, for `powercut verify`
+    --entity-ladder <a,b,c>  Entity counts for `sweep` (default: 1000,10000,100000)
+    --events-per-entity <n>  Hold density CONSTANT across the ladder: each rung
+                             uses entities x n events (default: 100). Set 0 to
+                             use a fixed --events instead, which DILUTES the
+                             ladder and cannot answer the scale question
+    --sweep-family <name>    Family to classify: graph | temporal (default: graph)
+    --stall-repeats <n>      Repetitions for `stall` (default: 20)
     --assert-target          Operator asserts this is target hardware under
                              representative storage, power and thermal conditions
 
@@ -92,6 +105,10 @@ struct Args {
     budget_gib: f64,
     crash_run_ms: u64,
     trial: u64,
+    entity_ladder: Vec<u64>,
+    events_per_entity: u64,
+    sweep_family: String,
+    stall_repeats: usize,
     /// Positional word after the command, used only by `powercut arm|verify`.
     subcommand: Option<String>,
     assert_target: bool,
@@ -121,6 +138,10 @@ fn parse_args() -> Result<Args, String> {
         budget_gib: 8.0,
         crash_run_ms: 750,
         trial: 0,
+        entity_ladder: vec![1_000, 10_000, 100_000],
+        events_per_entity: 100,
+        sweep_family: "graph".into(),
+        stall_repeats: 20,
         subcommand: None,
         assert_target: false,
     };
@@ -165,6 +186,40 @@ fn parse_args() -> Result<Args, String> {
             "--seed" => a.seed = parse_num(&value(flag)?, flag)?,
             "--crash-run-ms" => a.crash_run_ms = parse_num(&value(flag)?, flag)?,
             "--trial" => a.trial = parse_num(&value(flag)?, flag)?,
+            "--stall-repeats" => a.stall_repeats = parse_num(&value(flag)?, flag)? as usize,
+            "--events-per-entity" => a.events_per_entity = parse_num(&value(flag)?, flag)?,
+            "--sweep-family" => {
+                let v = value(flag)?;
+                if v != "graph" && v != "temporal" {
+                    return Err(format!(
+                        "--sweep-family expects `graph` or `temporal`, got `{v}`"
+                    ));
+                }
+                a.sweep_family = v;
+            }
+            "--entity-ladder" => {
+                let v = value(flag)?;
+                let mut out = Vec::new();
+                for part in v.split(',') {
+                    let part = part.trim();
+                    if part.is_empty() {
+                        continue;
+                    }
+                    out.push(parse_num(part, "--entity-ladder")?);
+                }
+                // A ladder shorter than the classifier's minimum cannot yield a
+                // verdict, so reject it here rather than running a long sweep
+                // that is guaranteed to report INSUFFICIENT.
+                if out.len() < sweep::MIN_SWEEP_POINTS {
+                    return Err(format!(
+                        "--entity-ladder needs at least {} values (got {}): two points define \
+                         a slope, and detecting a CHANGE in slope needs three",
+                        sweep::MIN_SWEEP_POINTS,
+                        out.len()
+                    ));
+                }
+                a.entity_ladder = out;
+            }
             "--events-per-day" => a.events_per_day = parse_float(&value(flag)?, flag)?,
             "--budget-gib" => a.budget_gib = parse_float(&value(flag)?, flag)?,
             "--durability" => {
@@ -660,6 +715,173 @@ fn main() {
         }
     }
 
+    // `sweep` and `stall` are explicit-only, NOT part of `all`. The sweep runs
+    // the full query suite once per ladder rung and the stall repeats an append
+    // --stall-repeats times; folding either into the routine run would multiply
+    // every drill by a large constant and pressure people into skipping `all`.
+    if args.command == "sweep" {
+        // ADR-0041's reopening condition is about a CHANGE in exponent, so the
+        // ladder is measured end to end and classified as a whole. Emitting the
+        // points without the verdict would put the judgement back where it was:
+        // in whoever reads the file.
+        let d = args.durability.unwrap_or(Durability::Normal);
+        let mut points: Vec<sweep::SweepPoint> = Vec::new();
+        let mut ladder_ok = true;
+
+        for &entities in &args.entity_ladder {
+            // Constant density by default. Sweeping entity count at a FIXED
+            // total event count makes each entity thinner, so fan-out and cost
+            // FALL — which measures density, not scale, and cannot answer the
+            // reopening condition. `--events-per-entity 0` opts back into the
+            // fixed-events ladder; the classifier refuses the result.
+            let events = if args.events_per_entity > 0 {
+                entities.saturating_mul(args.events_per_entity)
+            } else {
+                args.events
+            };
+            match bench::queries(&args.db, d, events, entities, args.seed, args.repeats) {
+                Ok(q) => {
+                    let want = if args.sweep_family == "graph" {
+                        "graph_bounded_reach"
+                    } else {
+                        "temporal_changes_since"
+                    };
+                    let t = q.timings.iter().find(|t| t.label == want);
+                    let rows = q
+                        .rows_returned
+                        .iter()
+                        .find(|(l, _)| l == want)
+                        .map(|(_, n)| *n)
+                        .unwrap_or(0);
+                    match t {
+                        Some(t) => {
+                            points.push(sweep::SweepPoint {
+                                entities,
+                                median_us: t.median_us,
+                            });
+                            sink.emit(
+                                stamp(&class, &facts, &args)
+                                    .str("record", "sweep_point")
+                                    .str("family", want)
+                                    .int("entities", entities)
+                                    .int("events", events)
+                                    .int("events_per_entity", args.events_per_entity)
+                                    .float("median_us", t.median_us)
+                                    .float("p99_us", t.p99_us)
+                                    .int("rows_matched_total", rows),
+                            );
+                        }
+                        None => {
+                            ladder_ok = false;
+                            failures += 1;
+                            sink.emit(error_record(
+                                &class,
+                                &facts,
+                                &args,
+                                "sweep_point",
+                                &format!("family `{want}` missing from the query result"),
+                            ));
+                        }
+                    }
+                }
+                Err(e) => {
+                    ladder_ok = false;
+                    failures += 1;
+                    sink.emit(error_record(&class, &facts, &args, "sweep_point", &e));
+                }
+            }
+        }
+
+        // A ladder with a hole cannot be classified: the missing point might be
+        // the knee. Refuse rather than classifying the survivors.
+        let verdict = if ladder_ok {
+            sweep::classify_scaling(&points)
+        } else {
+            sweep::ScalingVerdict::Insufficient(
+                "one or more ladder points failed to measure; the missing point may be the \
+                 knee, so the survivors are not classifiable"
+                    .into(),
+            )
+        };
+        if verdict.fails_the_run() {
+            failures += 1;
+        }
+        sink.emit(
+            stamp(&class, &facts, &args)
+                .str("record", "sweep_summary")
+                .str(
+                    "family",
+                    if args.sweep_family == "graph" {
+                        "graph_bounded_reach"
+                    } else {
+                        "temporal_changes_since"
+                    },
+                )
+                .int("points", points.len() as u64)
+                .int("min_points_required", sweep::MIN_SWEEP_POINTS as u64)
+                .str("verdict", verdict.token())
+                .bool("supports_option_a", verdict.supports_option_a())
+                .str("detail", verdict.detail()),
+        );
+    }
+
+    if args.command == "stall" {
+        // Deliberately NOT part of `all`: it is a targeted investigation of one
+        // configuration, and folding it into the standard run would multiply
+        // every drill by --stall-repeats.
+        let d = args.durability.unwrap_or(Durability::Normal);
+        let r = stall::run(
+            &args.db,
+            d,
+            args.events,
+            args.entities,
+            args.batch,
+            args.seed,
+            args.stall_repeats,
+        );
+        if r.fails_the_run() {
+            failures += 1;
+        }
+        sink.emit(
+            stamp(&class, &facts, &args)
+                .str("record", "stall")
+                .str("durability", d.pragma())
+                .int("batch", args.batch as u64)
+                .int("repeats", r.repeats as u64)
+                .int("completed", r.completed as u64)
+                .int("stalls_observed", r.stalls_observed as u64)
+                .float("stall_rate", r.stall_rate())
+                .float("stall_threshold_ms", stall::STALL_THRESHOLD_MS)
+                .float("worst_commit_ms", r.worst_commit_ms)
+                .float("median_worst_ms", r.median_worst_ms)
+                .float("median_throughput_eps", r.median_throughput_eps())
+                .str("attribution", r.attribution.token())
+                .str("detail", r.attribution.detail())
+                .float(
+                    "psi_io_stall_us",
+                    r.delta_at_worst
+                        .psi_io_stall_us
+                        .map_or(f64::NAN, |v| v as f64),
+                )
+                .float(
+                    "disk_io_ms",
+                    r.delta_at_worst.disk_io_ms.map_or(f64::NAN, |v| v as f64),
+                )
+                .float(
+                    "peak_dirty_writeback_kb",
+                    r.delta_at_worst
+                        .peak_dirty_writeback_kb
+                        .map_or(f64::NAN, |v| v as f64),
+                )
+                .float(
+                    "thermal_max_mc",
+                    r.delta_at_worst
+                        .thermal_max_mc
+                        .map_or(f64::NAN, |v| v as f64),
+                ),
+        );
+    }
+
     if run("crash") {
         let d = args.durability.unwrap_or(Durability::Full);
         let r = crash::run(&args.db, d, args.crash_run_ms, 400, 400);
@@ -804,6 +1026,10 @@ mod tests {
             budget_gib: 1.0,
             crash_run_ms: 1,
             trial: 0,
+            entity_ladder: vec![1_000, 10_000, 100_000],
+            events_per_entity: 100,
+            sweep_family: "graph".into(),
+            stall_repeats: 20,
             subcommand: None,
             assert_target: false,
         };
@@ -836,6 +1062,10 @@ mod tests {
             budget_gib: 1.0,
             crash_run_ms: 1,
             trial: 0,
+            entity_ladder: vec![1_000, 10_000, 100_000],
+            events_per_entity: 100,
+            sweep_family: "graph".into(),
+            stall_repeats: 20,
             subcommand: None,
             assert_target: false,
         };

--- a/tools/wm2-persistence-harness/src/stall.rs
+++ b/tools/wm2-persistence-harness/src/stall.rs
@@ -47,7 +47,12 @@ pub const STALL_THRESHOLD_MS: f64 = 1_000.0;
 pub struct SystemSample {
     /// `/proc/pressure/io` total stall microseconds (PSI). Monotonic.
     pub psi_io_total_us: Option<u64>,
-    /// `/proc/diskstats` field 10 summed: milliseconds spent doing I/O.
+    /// `/proc/diskstats` **field 13** summed: milliseconds spent doing I/O.
+    ///
+    /// Field 13 in the kernel's 1-based numbering (`f[12]` zero-indexed after
+    /// major/minor/name) is *time spent doing I/Os*. Naming it correctly
+    /// matters: an operator reading `IO-DEVICE` needs to know the attribution
+    /// rests on device busy-time, not on a queue depth or a byte count.
     pub disk_io_ms: Option<u64>,
     /// `/proc/meminfo` `Dirty:` in kB.
     pub dirty_kb: Option<u64>,
@@ -269,7 +274,12 @@ fn read_psi_io_total_us() -> Option<u64> {
     None
 }
 
-/// Summed field 10 of `/proc/diskstats` — milliseconds spent doing I/O.
+/// Summed **field 13** of `/proc/diskstats` — milliseconds spent doing I/O.
+///
+/// 1-based kernel numbering: fields 1–3 are major, minor and device name, so
+/// field 13 is `f[12]` here. It is the cumulative time the device had I/O in
+/// flight, which is what "the block layer was busy" means in
+/// [`attribute_stall`].
 ///
 /// Partitions are skipped (they double-count their parent device) by taking
 /// only entries whose name has no trailing digit-after-letter partition suffix

--- a/tools/wm2-persistence-harness/src/stall.rs
+++ b/tools/wm2-persistence-harness/src/stall.rs
@@ -1,0 +1,638 @@
+//! Characterising the ~29 second write stall (ADR-0041 open question 9).
+//!
+//! The merged R2 run recorded a single commit taking **29.27 s** under
+//! `synchronous=NORMAL` at batch=64, on NVMe. It inverted the durability
+//! ordering — `NORMAL` came out slower than `FULL` at the same batch size,
+//! which no durability model predicts — and it accounted for ~91 % of that
+//! stage's wall time, so the throughput figure for that row is not usable.
+//!
+//! At 10 Hz a 29 s stall is ~293 observations that cannot be recorded. That
+//! matters more than the benchmark it corrupted, so it needs to be understood
+//! rather than re-run until it goes away.
+//!
+//! # Why one sample could not answer it
+//!
+//! The candidate causes — ext4 journal commit, NVMe garbage collection,
+//! thermal or power management — are indistinguishable from a latency number
+//! alone. All of them produce "one commit took a long time". Telling them apart
+//! needs two things the original run did not have:
+//!
+//! 1. **Repetition**, to establish whether the stall is reproducible and at
+//!    what rate. A one-in-fifty event and a one-in-two event are different
+//!    engineering problems even at identical magnitude.
+//! 2. **Concurrent system state**, sampled across the stall. A stall with the
+//!    block layer busy is not the same finding as a stall with the block layer
+//!    idle and the CPU thermally capped.
+//!
+//! # Attribution is deliberately reluctant
+//!
+//! [`attribute_stall`] returns `Unattributed` unless the evidence is clear, and
+//! that is the common case by design. A confident wrong attribution is worse
+//! than an honest shrug: it closes the investigation. The signals here narrow
+//! the field; they do not close it, and the drill says so.
+
+use std::path::Path;
+
+/// A stall worth investigating. Chosen well above the p99 of every healthy
+/// configuration measured on target (`OFF`/64 max was 3.68 ms, `FULL`/64 max
+/// 8.75 ms), so this cannot fire on ordinary tail latency.
+pub const STALL_THRESHOLD_MS: f64 = 1_000.0;
+
+/// System counters sampled around a commit.
+///
+/// All fields are `Option` because every one of them is absent on some
+/// kernel, filesystem or container configuration, and a missing counter must
+/// read as "not observed" rather than zero — zero is a measurement.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct SystemSample {
+    /// `/proc/pressure/io` total stall microseconds (PSI). Monotonic.
+    pub psi_io_total_us: Option<u64>,
+    /// `/proc/diskstats` field 10 summed: milliseconds spent doing I/O.
+    pub disk_io_ms: Option<u64>,
+    /// `/proc/meminfo` `Dirty:` in kB.
+    pub dirty_kb: Option<u64>,
+    /// `/proc/meminfo` `Writeback:` in kB.
+    pub writeback_kb: Option<u64>,
+    /// Hottest `/sys/class/thermal/thermal_zone*/temp`, in milli-degrees C.
+    pub thermal_max_mc: Option<u64>,
+}
+
+/// The difference across a commit, which is what carries information —
+/// the absolute values of monotonic counters do not.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct SystemDelta {
+    pub psi_io_stall_us: Option<u64>,
+    pub disk_io_ms: Option<u64>,
+    /// Peak dirty+writeback observed during the commit, in kB.
+    pub peak_dirty_writeback_kb: Option<u64>,
+    pub thermal_max_mc: Option<u64>,
+}
+
+/// What the evidence supports. Deliberately coarse: these are *directions to
+/// look*, not root causes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StallAttribution {
+    /// The block layer was busy for most of the stall — device-side. On NVMe
+    /// that points at garbage collection or an SLC-cache exhaustion cliff.
+    IoDevice(String),
+    /// A large dirty/writeback backlog was being flushed — the page cache and
+    /// filesystem journal, not the device.
+    WritebackBacklog(String),
+    /// The CPU was thermally capped across the stall.
+    Thermal(String),
+    /// The signals do not discriminate. The expected outcome unless one cause
+    /// is clear, and not a failure of the run.
+    Unattributed(String),
+    /// No stall occurred, so there is nothing to attribute.
+    NoStall(String),
+}
+
+impl StallAttribution {
+    pub fn token(&self) -> &'static str {
+        match self {
+            Self::IoDevice(_) => "IO-DEVICE",
+            Self::WritebackBacklog(_) => "WRITEBACK-BACKLOG",
+            Self::Thermal(_) => "THERMAL",
+            Self::Unattributed(_) => "UNATTRIBUTED",
+            Self::NoStall(_) => "NO-STALL",
+        }
+    }
+
+    pub fn detail(&self) -> &str {
+        match self {
+            Self::IoDevice(d)
+            | Self::WritebackBacklog(d)
+            | Self::Thermal(d)
+            | Self::Unattributed(d)
+            | Self::NoStall(d) => d,
+        }
+    }
+}
+
+/// Fraction of the stall the block layer must be busy for to call it device-side.
+const IO_BUSY_FRACTION: f64 = 0.5;
+/// PSI I/O stall must cover at least this fraction of the wall time.
+const PSI_FRACTION: f64 = 0.5;
+/// Dirty + writeback above this during the stall points at a flush backlog.
+const WRITEBACK_BACKLOG_KB: u64 = 256 * 1024;
+/// Sustained temperature (milli-degrees C) suggesting thermal capping.
+const THERMAL_HOT_MC: u64 = 85_000;
+
+/// Attribute one stall from its duration and the system delta across it.
+///
+/// The ordering matters. Device-side I/O is checked before writeback because a
+/// writeback flush *also* drives the block layer busy, so "disk busy" alone
+/// cannot distinguish them — the discriminator is whether a large dirty backlog
+/// was present. Thermal is checked last and only in the absence of I/O
+/// evidence, because a hot SoC during heavy I/O is a consequence, not a cause.
+pub fn attribute_stall(stall_ms: f64, d: &SystemDelta) -> StallAttribution {
+    if stall_ms < STALL_THRESHOLD_MS {
+        return StallAttribution::NoStall(format!(
+            "worst commit {stall_ms:.1} ms is below the {STALL_THRESHOLD_MS:.0} ms threshold"
+        ));
+    }
+
+    let backlog = d
+        .peak_dirty_writeback_kb
+        .is_some_and(|kb| kb >= WRITEBACK_BACKLOG_KB);
+
+    let io_busy = d
+        .disk_io_ms
+        .map(|ms| ms as f64 >= stall_ms * IO_BUSY_FRACTION);
+    let psi_busy = d
+        .psi_io_stall_us
+        .map(|us| us as f64 / 1e3 >= stall_ms * PSI_FRACTION);
+    let io_evidence = io_busy.unwrap_or(false) || psi_busy.unwrap_or(false);
+
+    if io_evidence && !backlog {
+        return StallAttribution::IoDevice(format!(
+            "block layer busy for most of a {stall_ms:.0} ms stall with no large dirty \
+             backlog (disk_io_ms={:?}, psi_io_stall_us={:?}, peak_dirty_writeback_kb={:?}). \
+             Device-side: on NVMe this points at garbage collection or an SLC-cache cliff. \
+             Confirm with the drive's own SMART/health counters — this harness cannot read \
+             them.",
+            d.disk_io_ms, d.psi_io_stall_us, d.peak_dirty_writeback_kb
+        ));
+    }
+
+    if io_evidence && backlog {
+        return StallAttribution::WritebackBacklog(format!(
+            "a {stall_ms:.0} ms stall with the block layer busy AND a large dirty/writeback \
+             backlog (peak {} kB). The flush is the work, so this is page cache and \
+             filesystem journal rather than the device. Re-check with a smaller \
+             dirty_background_ratio before concluding.",
+            d.peak_dirty_writeback_kb.unwrap_or(0)
+        ));
+    }
+
+    if !io_evidence && d.thermal_max_mc.is_some_and(|t| t >= THERMAL_HOT_MC) {
+        return StallAttribution::Thermal(format!(
+            "a {stall_ms:.0} ms stall with the block layer NOT busy and the hottest zone at \
+             {:.1} C. Thermal capping is the leading candidate; confirm against the Jetson's \
+             power mode and tegrastats, which this harness does not read.",
+            d.thermal_max_mc.unwrap_or(0) as f64 / 1000.0
+        ));
+    }
+
+    StallAttribution::Unattributed(format!(
+        "a {stall_ms:.0} ms stall whose concurrent counters do not discriminate \
+         (disk_io_ms={:?}, psi_io_stall_us={:?}, peak_dirty_writeback_kb={:?}, \
+         thermal_max_mc={:?}). This is the expected outcome unless one cause is clear, and \
+         it is not a failed measurement — a confident wrong attribution would close the \
+         investigation, which is worse.",
+        d.disk_io_ms, d.psi_io_stall_us, d.peak_dirty_writeback_kb, d.thermal_max_mc
+    ))
+}
+
+/// Summary of a repeated-configuration stall hunt.
+pub struct StallResult {
+    pub repeats: usize,
+    pub completed: usize,
+    pub stalls_observed: usize,
+    /// Worst single-commit latency across every repetition, milliseconds.
+    pub worst_commit_ms: f64,
+    /// Median of the per-run worst commit — how bad a *typical* run gets.
+    pub median_worst_ms: f64,
+    pub throughput_eps: Vec<f64>,
+    pub attribution: StallAttribution,
+    pub delta_at_worst: SystemDelta,
+}
+
+impl StallResult {
+    /// Median throughput across repetitions.
+    ///
+    /// This is the figure the original benchmark could not produce. A single
+    /// run reports one number, and one 29 s stall inside it dragged the
+    /// `NORMAL`/batch=64 row down to 3 123 ev/s — below `NORMAL`/batch=1,
+    /// inverting the durability ordering and making the row unusable. The
+    /// median across repetitions is robust to exactly that: one pathological
+    /// run cannot move it, so the throughput and the stall rate can be read as
+    /// two separate facts instead of one contaminated one.
+    pub fn median_throughput_eps(&self) -> f64 {
+        if self.throughput_eps.is_empty() {
+            return f64::NAN;
+        }
+        let mut v = self.throughput_eps.clone();
+        v.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        v[v.len() / 2]
+    }
+
+    /// Stalls per run, as a fraction.
+    pub fn stall_rate(&self) -> f64 {
+        if self.completed == 0 {
+            f64::NAN
+        } else {
+            self.stalls_observed as f64 / self.completed as f64
+        }
+    }
+
+    /// A run that completed no repetitions measured nothing.
+    ///
+    /// Note what does NOT fail: observing zero stalls. That is a real and
+    /// useful result — it bounds the rate — and treating it as a failure would
+    /// pressure the operator toward re-running until a stall appears, which is
+    /// how a rate estimate becomes fiction.
+    pub fn fails_the_run(&self) -> bool {
+        self.completed == 0
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Sampling
+// ---------------------------------------------------------------------------
+
+fn read_u64_after(path: &str, key: &str) -> Option<u64> {
+    let text = std::fs::read_to_string(path).ok()?;
+    for line in text.lines() {
+        if let Some(rest) = line.trim().strip_prefix(key) {
+            return rest.split_whitespace().next().and_then(|v| v.parse().ok());
+        }
+    }
+    None
+}
+
+/// `/proc/pressure/io` — the `full` line's `total=` field.
+///
+/// `full` rather than `some`: it counts time when *every* runnable task was
+/// stalled on I/O, which is the condition that halts a single-threaded writer.
+fn read_psi_io_total_us() -> Option<u64> {
+    let text = std::fs::read_to_string("/proc/pressure/io").ok()?;
+    for line in text.lines() {
+        if line.starts_with("full") {
+            for field in line.split_whitespace() {
+                if let Some(v) = field.strip_prefix("total=") {
+                    return v.parse().ok();
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Summed field 10 of `/proc/diskstats` — milliseconds spent doing I/O.
+///
+/// Partitions are skipped (they double-count their parent device) by taking
+/// only entries whose name has no trailing digit-after-letter partition suffix
+/// pattern; imperfect, but it errs toward under-counting, and an under-count
+/// makes `IoDevice` *harder* to conclude rather than easier.
+fn read_disk_io_ms() -> Option<u64> {
+    let text = std::fs::read_to_string("/proc/diskstats").ok()?;
+    let mut total = 0u64;
+    let mut any = false;
+    for line in text.lines() {
+        let f: Vec<&str> = line.split_whitespace().collect();
+        if f.len() < 13 {
+            continue;
+        }
+        let name = f[2];
+        // Skip loop/ram devices and obvious partitions.
+        if name.starts_with("loop") || name.starts_with("ram") {
+            continue;
+        }
+        let is_partition = name.chars().last().is_some_and(|c| c.is_ascii_digit())
+            && (name.starts_with("sd") || name.contains('p'));
+        if is_partition {
+            continue;
+        }
+        if let Ok(v) = f[12].parse::<u64>() {
+            total += v;
+            any = true;
+        }
+    }
+    any.then_some(total)
+}
+
+fn read_thermal_max_mc() -> Option<u64> {
+    let dir = std::fs::read_dir("/sys/class/thermal").ok()?;
+    let mut max: Option<u64> = None;
+    for e in dir.flatten() {
+        let name = e.file_name();
+        if !name.to_string_lossy().starts_with("thermal_zone") {
+            continue;
+        }
+        if let Ok(t) = std::fs::read_to_string(e.path().join("temp")) {
+            if let Ok(v) = t.trim().parse::<u64>() {
+                max = Some(max.map_or(v, |m: u64| m.max(v)));
+            }
+        }
+    }
+    max
+}
+
+pub fn sample_system() -> SystemSample {
+    SystemSample {
+        psi_io_total_us: read_psi_io_total_us(),
+        disk_io_ms: read_disk_io_ms(),
+        dirty_kb: read_u64_after("/proc/meminfo", "Dirty:"),
+        writeback_kb: read_u64_after("/proc/meminfo", "Writeback:"),
+        thermal_max_mc: read_thermal_max_mc(),
+    }
+}
+
+/// Difference two samples, with a peak dirty+writeback carried through.
+///
+/// Monotonic counters subtract; a counter that went *backwards* (a reset, or a
+/// device that disappeared) yields `None` rather than a wrapped huge number.
+pub fn delta(before: &SystemSample, after: &SystemSample, peak_dw_kb: Option<u64>) -> SystemDelta {
+    fn sub(a: Option<u64>, b: Option<u64>) -> Option<u64> {
+        match (a, b) {
+            (Some(x), Some(y)) if y >= x => Some(y - x),
+            _ => None,
+        }
+    }
+    SystemDelta {
+        psi_io_stall_us: sub(before.psi_io_total_us, after.psi_io_total_us),
+        disk_io_ms: sub(before.disk_io_ms, after.disk_io_ms),
+        peak_dirty_writeback_kb: peak_dw_kb,
+        thermal_max_mc: after.thermal_max_mc.max(before.thermal_max_mc),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Driver
+// ---------------------------------------------------------------------------
+
+/// Repeat one append configuration and hunt for the stall.
+#[allow(clippy::too_many_arguments)]
+pub fn run(
+    path: &Path,
+    durability: crate::standin::Durability,
+    events: u64,
+    entities: u64,
+    batch: usize,
+    seed: u64,
+    repeats: usize,
+) -> StallResult {
+    let mut worst_per_run: Vec<f64> = Vec::new();
+    let mut throughput: Vec<f64> = Vec::new();
+    let mut stalls = 0usize;
+    let mut worst_overall = 0.0f64;
+    let mut worst_delta = SystemDelta::default();
+
+    for i in 0..repeats {
+        let before = sample_system();
+        let peak_dw = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let running = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
+        let sampler = {
+            use std::sync::atomic::Ordering;
+            let peak_dw = std::sync::Arc::clone(&peak_dw);
+            let running = std::sync::Arc::clone(&running);
+            std::thread::spawn(move || {
+                while running.load(Ordering::Relaxed) {
+                    let s = sample_system();
+                    if let (Some(d), Some(w)) = (s.dirty_kb, s.writeback_kb) {
+                        peak_dw.fetch_max(d + w, Ordering::Relaxed);
+                    }
+                    std::thread::sleep(std::time::Duration::from_millis(20));
+                }
+            })
+        };
+
+        let r = crate::bench::append(path, durability, events, entities, batch, seed + i as u64);
+
+        running.store(false, std::sync::atomic::Ordering::Relaxed);
+        let _ = sampler.join();
+        let after = sample_system();
+
+        let Ok(r) = r else { continue };
+        let max_ms = r.timing.max_us / 1e3;
+        worst_per_run.push(max_ms);
+        throughput.push(r.events_per_second);
+        if max_ms >= STALL_THRESHOLD_MS {
+            stalls += 1;
+        }
+        if max_ms > worst_overall {
+            worst_overall = max_ms;
+            let peak = peak_dw.load(std::sync::atomic::Ordering::Relaxed);
+            worst_delta = delta(&before, &after, (peak > 0).then_some(peak));
+        }
+    }
+
+    worst_per_run.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let median_worst = if worst_per_run.is_empty() {
+        f64::NAN
+    } else {
+        worst_per_run[worst_per_run.len() / 2]
+    };
+
+    let attribution = if worst_per_run.is_empty() {
+        StallAttribution::Unattributed(
+            "no repetition completed, so nothing was measured — raise --repeats or check the \
+             database path"
+                .into(),
+        )
+    } else {
+        attribute_stall(worst_overall, &worst_delta)
+    };
+
+    StallResult {
+        repeats,
+        completed: worst_per_run.len(),
+        stalls_observed: stalls,
+        worst_commit_ms: worst_overall,
+        median_worst_ms: median_worst,
+        throughput_eps: throughput,
+        attribution,
+        delta_at_worst: worst_delta,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn d(psi: Option<u64>, disk: Option<u64>, dw: Option<u64>, temp: Option<u64>) -> SystemDelta {
+        SystemDelta {
+            psi_io_stall_us: psi,
+            disk_io_ms: disk,
+            peak_dirty_writeback_kb: dw,
+            thermal_max_mc: temp,
+        }
+    }
+
+    #[test]
+    fn below_threshold_is_no_stall() {
+        let a = attribute_stall(8.75, &SystemDelta::default());
+        assert_eq!(a.token(), "NO-STALL");
+    }
+
+    #[test]
+    fn the_measured_29_second_event_is_over_the_threshold() {
+        // The event this module exists for: 29 271.78 ms.
+        let a = attribute_stall(29_271.78, &SystemDelta::default());
+        assert_ne!(a.token(), "NO-STALL");
+    }
+
+    #[test]
+    fn no_counters_at_all_is_unattributed_not_a_guess() {
+        let a = attribute_stall(29_271.78, &SystemDelta::default());
+        assert_eq!(a.token(), "UNATTRIBUTED", "{}", a.detail());
+    }
+
+    #[test]
+    fn busy_block_layer_without_a_backlog_points_at_the_device() {
+        // 20 s of disk-busy inside a 29 s stall, small dirty set.
+        let a = attribute_stall(29_000.0, &d(None, Some(20_000), Some(1_024), None));
+        assert_eq!(a.token(), "IO-DEVICE", "{}", a.detail());
+        assert!(a.detail().contains("SMART"), "must say what it cannot read");
+    }
+
+    #[test]
+    fn busy_block_layer_with_a_backlog_points_at_writeback_instead() {
+        // Same disk-busy evidence, but a 1 GB dirty backlog explains it.
+        let a = attribute_stall(29_000.0, &d(None, Some(20_000), Some(1_024 * 1_024), None));
+        assert_eq!(a.token(), "WRITEBACK-BACKLOG", "{}", a.detail());
+    }
+
+    #[test]
+    fn psi_alone_is_enough_io_evidence() {
+        let a = attribute_stall(29_000.0, &d(Some(20_000_000), None, Some(1_024), None));
+        assert_eq!(a.token(), "IO-DEVICE", "{}", a.detail());
+    }
+
+    #[test]
+    fn heat_with_an_idle_block_layer_points_at_thermal() {
+        let a = attribute_stall(29_000.0, &d(Some(10), Some(5), Some(1_024), Some(96_000)));
+        assert_eq!(a.token(), "THERMAL", "{}", a.detail());
+    }
+
+    #[test]
+    fn heat_during_heavy_io_is_not_blamed_on_thermal() {
+        // A hot SoC during sustained I/O is a consequence, not a cause.
+        // Blaming thermal here would send the investigation the wrong way.
+        let a = attribute_stall(29_000.0, &d(None, Some(25_000), Some(1_024), Some(96_000)));
+        assert_eq!(a.token(), "IO-DEVICE", "{}", a.detail());
+    }
+
+    #[test]
+    fn a_briefly_busy_disk_does_not_explain_a_long_stall() {
+        // 100 ms of disk activity inside a 29 s stall explains nothing.
+        let a = attribute_stall(29_000.0, &d(None, Some(100), Some(1_024), None));
+        assert_eq!(a.token(), "UNATTRIBUTED", "{}", a.detail());
+    }
+
+    #[test]
+    fn a_counter_that_went_backwards_yields_none_not_a_wrapped_value() {
+        let before = SystemSample {
+            psi_io_total_us: Some(1_000),
+            disk_io_ms: Some(500),
+            ..Default::default()
+        };
+        let after = SystemSample {
+            psi_io_total_us: Some(10),
+            disk_io_ms: Some(5),
+            ..Default::default()
+        };
+        let dd = delta(&before, &after, None);
+        assert_eq!(dd.psi_io_stall_us, None);
+        assert_eq!(dd.disk_io_ms, None);
+    }
+
+    #[test]
+    fn observing_zero_stalls_is_a_result_not_a_failure() {
+        // Failing here would push an operator to re-run until a stall appears,
+        // which turns a rate estimate into fiction.
+        let r = StallResult {
+            repeats: 20,
+            completed: 20,
+            stalls_observed: 0,
+            worst_commit_ms: 12.0,
+            median_worst_ms: 9.0,
+            throughput_eps: vec![30_000.0; 20],
+            attribution: attribute_stall(12.0, &SystemDelta::default()),
+            delta_at_worst: SystemDelta::default(),
+        };
+        assert!(!r.fails_the_run());
+        assert_eq!(r.stall_rate(), 0.0);
+        assert_eq!(r.attribution.token(), "NO-STALL");
+    }
+
+    #[test]
+    fn median_throughput_is_robust_to_one_pathological_run() {
+        // The exact failure this reports around: one 29 s stall dragged the
+        // NORMAL/batch=64 row to 3123 ev/s, below NORMAL/batch=1, inverting
+        // the durability ordering. A median over repetitions cannot be moved
+        // by one such run, so throughput and stall rate become two separate
+        // facts rather than one contaminated one.
+        let r = StallResult {
+            repeats: 5,
+            completed: 5,
+            stalls_observed: 1,
+            worst_commit_ms: 29_271.78,
+            median_worst_ms: 11.0,
+            throughput_eps: vec![36_000.0, 35_800.0, 3_123.0, 36_200.0, 35_900.0],
+            attribution: StallAttribution::Unattributed(String::new()),
+            delta_at_worst: SystemDelta::default(),
+        };
+        assert_eq!(r.median_throughput_eps(), 35_900.0);
+        assert_eq!(r.stall_rate(), 0.2);
+    }
+
+    #[test]
+    fn median_throughput_of_nothing_is_not_zero() {
+        let r = StallResult {
+            repeats: 3,
+            completed: 0,
+            stalls_observed: 0,
+            worst_commit_ms: 0.0,
+            median_worst_ms: f64::NAN,
+            throughput_eps: vec![],
+            attribution: StallAttribution::Unattributed(String::new()),
+            delta_at_worst: SystemDelta::default(),
+        };
+        assert!(r.median_throughput_eps().is_nan());
+    }
+
+    #[test]
+    fn a_run_that_completed_nothing_fails() {
+        let r = StallResult {
+            repeats: 20,
+            completed: 0,
+            stalls_observed: 0,
+            worst_commit_ms: 0.0,
+            median_worst_ms: f64::NAN,
+            throughput_eps: vec![],
+            attribution: StallAttribution::Unattributed(String::new()),
+            delta_at_worst: SystemDelta::default(),
+        };
+        assert!(r.fails_the_run());
+        assert!(r.stall_rate().is_nan());
+    }
+
+    #[test]
+    fn stall_rate_distinguishes_rare_from_frequent() {
+        let mk = |stalls| StallResult {
+            repeats: 20,
+            completed: 20,
+            stalls_observed: stalls,
+            worst_commit_ms: 29_000.0,
+            median_worst_ms: 10.0,
+            throughput_eps: vec![],
+            attribution: StallAttribution::Unattributed(String::new()),
+            delta_at_worst: SystemDelta::default(),
+        };
+        assert_eq!(mk(1).stall_rate(), 0.05);
+        assert_eq!(mk(10).stall_rate(), 0.5);
+    }
+
+    #[test]
+    fn every_attribution_token_is_distinct() {
+        let tokens = [
+            StallAttribution::IoDevice(String::new()).token(),
+            StallAttribution::WritebackBacklog(String::new()).token(),
+            StallAttribution::Thermal(String::new()).token(),
+            StallAttribution::Unattributed(String::new()).token(),
+            StallAttribution::NoStall(String::new()).token(),
+        ];
+        let unique: std::collections::HashSet<_> = tokens.iter().collect();
+        assert_eq!(unique.len(), 5);
+    }
+
+    #[test]
+    fn sampling_never_panics_on_this_host() {
+        // Every field is Option precisely because these paths are absent on
+        // some kernels and in some containers.
+        let s = sample_system();
+        let _ = delta(&s, &s, None);
+    }
+}

--- a/tools/wm2-persistence-harness/src/sweep.rs
+++ b/tools/wm2-persistence-harness/src/sweep.rs
@@ -1,0 +1,409 @@
+//! The scale sweep — ADR-0041's own reopening condition, made decidable.
+//!
+//! ADR-0041 states the condition under which it should be abandoned:
+//!
+//! > *"if measurement shows entities in the millions or genuinely unbounded
+//! > ad-hoc traversal, Option B becomes materially stronger and this ADR should
+//! > be reopened."*
+//!
+//! The drill previously discharged that with a shell `for` loop and the
+//! instruction to "look at how `graph_bounded_reach` grows". That is not a
+//! gate. Whether a curve has a knee is exactly the kind of judgement that gets
+//! made favourably by someone who wants to ship, and re-made unfavourably by an
+//! assessor a year later, from the same numbers.
+//!
+//! So the judgement is a function here, and it is fail-closed: too few points,
+//! or points that do not admit a conclusion, produce `Insufficient` — never
+//! "no knee found".
+//!
+//! # Why log-log slope
+//!
+//! The families being swept are expected to be near-linear in entity count if
+//! the substrate is adequate (`graph_bounded_reach` fans out over a bounded
+//! depth; `temporal_changes_since` scans a window). A knee is a *change in
+//! exponent*, which is a change in slope on a log-log plot and nothing simpler.
+//! Comparing raw ratios would flag ordinary linear growth as a problem, and a
+//! sweep that cries wolf gets ignored.
+//!
+//! # What this cannot do
+//!
+//! It measures the harness's stand-in schema against synthetic load. What
+//! entity counts a deployed robot actually reaches is an operational fact no
+//! benchmark produces, and the ADR says so. This narrows the question from
+//! "does SQLite scale" to "does it scale *here, on this shape, to this point*" —
+//! which is the answerable half.
+
+/// One measured point on the ladder.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SweepPoint {
+    pub entities: u64,
+    /// Median microseconds for the family being classified.
+    pub median_us: f64,
+}
+
+/// The verdict against ADR-0041's reopening condition.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ScalingVerdict {
+    /// Cost grows slower than entity count. Supports Option A.
+    Sublinear(String),
+    /// Cost grows about proportionally. Supports Option A.
+    Linear(String),
+    /// Uniformly steeper than linear, but with no inflection — expensive and
+    /// predictable. A design constraint, not a reopening trigger.
+    Superlinear(String),
+    /// The exponent *increases* along the ladder. This is the shape the ADR's
+    /// reopening condition describes, and it is the one that must not be
+    /// explained away.
+    Knee(String),
+    /// Not enough evidence to say. Fails the run rather than passing quietly.
+    Insufficient(String),
+}
+
+impl ScalingVerdict {
+    pub fn token(&self) -> &'static str {
+        match self {
+            Self::Sublinear(_) => "SUBLINEAR",
+            Self::Linear(_) => "LINEAR",
+            Self::Superlinear(_) => "SUPERLINEAR",
+            Self::Knee(_) => "KNEE",
+            Self::Insufficient(_) => "INSUFFICIENT",
+        }
+    }
+
+    pub fn detail(&self) -> &str {
+        match self {
+            Self::Sublinear(d)
+            | Self::Linear(d)
+            | Self::Superlinear(d)
+            | Self::Knee(d)
+            | Self::Insufficient(d) => d,
+        }
+    }
+
+    /// Whether this verdict should fail the run.
+    ///
+    /// `Insufficient` counts, for the same reason an inconclusive crash tier
+    /// does: a gate that cannot be evaluated has not been passed. `Knee` also
+    /// counts — it is a real finding, and a sweep that reports a knee and exits
+    /// 0 invites the finding to be skimmed past.
+    pub fn fails_the_run(&self) -> bool {
+        matches!(self, Self::Insufficient(_) | Self::Knee(_))
+    }
+
+    /// Whether this verdict supports keeping Option A (SQLite).
+    pub fn supports_option_a(&self) -> bool {
+        matches!(self, Self::Sublinear(_) | Self::Linear(_))
+    }
+}
+
+/// Minimum ladder length. Two points define a slope; detecting a *change* in
+/// slope needs at least three.
+pub const MIN_SWEEP_POINTS: usize = 3;
+
+/// Slope at or below this is treated as sublinear.
+const SUBLINEAR_MAX: f64 = 0.9;
+/// Slope above this is steeper than proportional.
+const LINEAR_MAX: f64 = 1.2;
+/// How much steeper the last segment must be than the first to count as a knee.
+const KNEE_RATIO: f64 = 1.5;
+/// A knee also requires the late slope to be genuinely superlinear; a curve
+/// that goes from 0.2 to 0.4 has "doubled its exponent" and is still cheap.
+const KNEE_MIN_LATE_SLOPE: f64 = 1.2;
+/// Overall slope below this means cost *fell* substantially as entities rose.
+///
+/// That is not a scaling result — it is a ladder that diluted. See
+/// [`classify_scaling`] for why it must be refused rather than reported as
+/// excellent sublinear scaling.
+const DILUTION_SLOPE: f64 = -0.5;
+
+/// Log-log slope between two points: d(log cost) / d(log entities).
+///
+/// Returns `None` when either coordinate is non-positive or the entity counts
+/// coincide — cases where the slope is undefined rather than zero. Treating
+/// them as zero would report flat scaling from unusable data, which is the
+/// wrong direction to be wrong in.
+pub fn segment_slope(a: SweepPoint, b: SweepPoint) -> Option<f64> {
+    if a.entities == 0 || b.entities == 0 || a.median_us <= 0.0 || b.median_us <= 0.0 {
+        return None;
+    }
+    if a.entities == b.entities {
+        return None;
+    }
+    let dx = (b.entities as f64).ln() - (a.entities as f64).ln();
+    let dy = b.median_us.ln() - a.median_us.ln();
+    if dx == 0.0 || !dy.is_finite() || !dx.is_finite() {
+        return None;
+    }
+    Some(dy / dx)
+}
+
+/// Classify a ladder against ADR-0041's reopening condition.
+///
+/// Points are expected in ascending entity order; they are not sorted here,
+/// because an unsorted ladder means the caller measured something other than
+/// what it thinks, and silently sorting would hide that.
+pub fn classify_scaling(points: &[SweepPoint]) -> ScalingVerdict {
+    if points.len() < MIN_SWEEP_POINTS {
+        return ScalingVerdict::Insufficient(format!(
+            "only {} point(s); {MIN_SWEEP_POINTS} are needed, because two points define a \
+             slope and detecting a CHANGE in slope needs three",
+            points.len()
+        ));
+    }
+    if points.windows(2).any(|w| w[1].entities <= w[0].entities) {
+        return ScalingVerdict::Insufficient(
+            "ladder is not strictly ascending in entity count; the sweep measured something \
+             other than a scale ladder"
+                .into(),
+        );
+    }
+
+    let slopes: Vec<f64> = points
+        .windows(2)
+        .filter_map(|w| segment_slope(w[0], w[1]))
+        .collect();
+    if slopes.len() + 1 < MIN_SWEEP_POINTS {
+        return ScalingVerdict::Insufficient(
+            "too many segments had undefined slope (zero or negative timings) to classify".into(),
+        );
+    }
+
+    let first = slopes[0];
+    let last = slopes[slopes.len() - 1];
+    let overall =
+        segment_slope(points[0], points[points.len() - 1]).expect("endpoints validated above");
+
+    // The knee test runs FIRST. A curve can have a benign overall slope and
+    // still bend sharply at the top of the ladder, and the top of the ladder is
+    // the part that predicts the next order of magnitude.
+    if last >= KNEE_MIN_LATE_SLOPE && first > 0.0 && last >= first * KNEE_RATIO {
+        return ScalingVerdict::Knee(format!(
+            "exponent INCREASES along the ladder: first segment {first:.2}, last segment \
+             {last:.2} ({:.1}x steeper), overall {overall:.2}. This is the shape ADR-0041's \
+             reopening condition describes — Option B becomes materially stronger and the \
+             ADR should be reopened rather than this being tuned around.",
+            last / first
+        ));
+    }
+
+    // A ladder whose cost FALLS substantially as entities rise did not scale —
+    // it diluted. This is what happens when entity count is swept at a fixed
+    // total event count: events-per-entity drops, fan-out drops with it, and
+    // the query gets cheaper. Measured on a host ladder of 100/1000/10000
+    // entities at a fixed 20 000 events: 1687 µs → 73.7 µs → 10.9 µs, slope
+    // −1.10.
+    //
+    // Reporting that as SUBLINEAR would close ADR-0041's scale gate with a
+    // result that says nothing about scale — the most dangerous outcome
+    // available here, because it looks like unusually good news.
+    if overall < DILUTION_SLOPE {
+        return ScalingVerdict::Insufficient(format!(
+            "cost FELL steeply across the ladder (overall log-log slope {overall:.2}). The \
+             ladder diluted rather than scaled: holding total events fixed while raising \
+             entity count reduces events-per-entity, so fan-out — and cost — go DOWN. This \
+             measures density, not scale, and cannot answer ADR-0041's reopening condition. \
+             Re-run holding events-per-entity constant (`--events-per-entity`)."
+        ));
+    }
+
+    if overall <= SUBLINEAR_MAX {
+        ScalingVerdict::Sublinear(format!(
+            "overall log-log slope {overall:.2} (segments {first:.2}..{last:.2}) — cost grows \
+             slower than entity count; supports Option A"
+        ))
+    } else if overall <= LINEAR_MAX {
+        ScalingVerdict::Linear(format!(
+            "overall log-log slope {overall:.2} (segments {first:.2}..{last:.2}) — about \
+             proportional to entity count; supports Option A"
+        ))
+    } else {
+        ScalingVerdict::Superlinear(format!(
+            "overall log-log slope {overall:.2} (segments {first:.2}..{last:.2}) — steeper \
+             than proportional but with no inflection. Expensive and PREDICTABLE: a design \
+             constraint on how far this may be scaled, not a reopening trigger on its own"
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ladder(pts: &[(u64, f64)]) -> Vec<SweepPoint> {
+        pts.iter()
+            .map(|&(entities, median_us)| SweepPoint {
+                entities,
+                median_us,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn two_points_cannot_show_a_knee_and_must_not_pass() {
+        let v = classify_scaling(&ladder(&[(1_000, 10.0), (10_000, 100.0)]));
+        assert_eq!(v.token(), "INSUFFICIENT");
+        assert!(v.fails_the_run());
+        assert!(!v.supports_option_a());
+    }
+
+    #[test]
+    fn an_empty_ladder_is_insufficient_not_sublinear() {
+        assert_eq!(classify_scaling(&[]).token(), "INSUFFICIENT");
+    }
+
+    #[test]
+    fn proportional_growth_is_linear_and_supports_option_a() {
+        // 10x entities -> 10x cost at every step.
+        let v = classify_scaling(&ladder(&[
+            (1_000, 10.0),
+            (10_000, 100.0),
+            (100_000, 1_000.0),
+        ]));
+        assert_eq!(v.token(), "LINEAR", "{}", v.detail());
+        assert!(v.supports_option_a());
+        assert!(!v.fails_the_run());
+    }
+
+    #[test]
+    fn a_diluting_ladder_is_refused_rather_than_praised_as_sublinear() {
+        // The real host measurement that exposed this: sweeping entity count at
+        // a FIXED total event count makes each entity thinner, so the graph
+        // query gets cheaper. Slope −1.10. Calling that SUBLINEAR would close
+        // the scale gate with a number that says nothing about scale.
+        let v = classify_scaling(&ladder(&[(100, 1_687.0), (1_000, 73.7), (10_000, 10.9)]));
+        assert_eq!(v.token(), "INSUFFICIENT", "{}", v.detail());
+        assert!(v.fails_the_run());
+        assert!(!v.supports_option_a());
+        assert!(v.detail().contains("diluted"), "{}", v.detail());
+        assert!(
+            v.detail().contains("events-per-entity"),
+            "must say how to fix it: {}",
+            v.detail()
+        );
+    }
+
+    #[test]
+    fn a_gently_falling_curve_is_still_sublinear_not_dilution() {
+        // The guard must not swallow genuine mild improvement — e.g. better
+        // index locality — or it becomes a second way to fail honestly.
+        let v = classify_scaling(&ladder(&[(1_000, 100.0), (10_000, 80.0), (100_000, 64.0)]));
+        assert_eq!(v.token(), "SUBLINEAR", "{}", v.detail());
+        assert!(v.supports_option_a());
+    }
+
+    #[test]
+    fn flat_cost_is_sublinear() {
+        let v = classify_scaling(&ladder(&[(1_000, 50.0), (10_000, 55.0), (100_000, 60.0)]));
+        assert_eq!(v.token(), "SUBLINEAR", "{}", v.detail());
+        assert!(v.supports_option_a());
+    }
+
+    #[test]
+    fn a_genuine_knee_is_caught_and_fails_the_run() {
+        // Flat, flat, then an explosion — the shape that must not be explained
+        // away as "it is only the last point".
+        let v = classify_scaling(&ladder(&[
+            (1_000, 10.0),
+            (10_000, 12.0),
+            (100_000, 2_000.0),
+        ]));
+        assert_eq!(v.token(), "KNEE", "{}", v.detail());
+        assert!(v.fails_the_run(), "a knee must not exit 0");
+        assert!(!v.supports_option_a());
+        assert!(v.detail().contains("reopen"), "{}", v.detail());
+    }
+
+    #[test]
+    fn uniform_superlinear_growth_is_not_called_a_knee() {
+        // Quadratic throughout: expensive, but predictable, and the ADR's
+        // reopening condition is about an INFLECTION rather than a steep line.
+        let v = classify_scaling(&ladder(&[
+            (1_000, 10.0),
+            (10_000, 1_000.0),
+            (100_000, 100_000.0),
+        ]));
+        assert_eq!(v.token(), "SUPERLINEAR", "{}", v.detail());
+        assert!(!v.fails_the_run());
+        assert!(!v.supports_option_a());
+    }
+
+    #[test]
+    fn a_cheap_curve_that_doubles_its_exponent_is_not_a_knee() {
+        // 0.2 -> 0.4 doubles the exponent while staying far below linear.
+        // Flagging this would make the sweep cry wolf, and a gate that cries
+        // wolf gets ignored — which costs more than the false negative.
+        let pts = ladder(&[
+            (1_000, 10.0),
+            (10_000, 10.0 * 10f64.powf(0.2)),
+            (100_000, 10.0 * 10f64.powf(0.2) * 10f64.powf(0.4)),
+        ]);
+        let v = classify_scaling(&pts);
+        assert_ne!(v.token(), "KNEE", "{}", v.detail());
+        assert!(v.supports_option_a(), "{}", v.detail());
+    }
+
+    #[test]
+    fn a_descending_ladder_is_refused_rather_than_silently_sorted() {
+        let v = classify_scaling(&ladder(&[(100_000, 10.0), (10_000, 20.0), (1_000, 30.0)]));
+        assert_eq!(v.token(), "INSUFFICIENT");
+        assert!(v.detail().contains("ascending"));
+    }
+
+    #[test]
+    fn a_repeated_entity_count_is_refused() {
+        let v = classify_scaling(&ladder(&[(1_000, 10.0), (1_000, 20.0), (10_000, 30.0)]));
+        assert_eq!(v.token(), "INSUFFICIENT");
+    }
+
+    #[test]
+    fn zero_timings_do_not_read_as_flat_scaling() {
+        // A family that matched nothing would time at ~0. Reporting that as
+        // SUBLINEAR would be the benchmark equivalent of dividing by zero and
+        // calling the answer good news.
+        let v = classify_scaling(&ladder(&[(1_000, 0.0), (10_000, 0.0), (100_000, 0.0)]));
+        assert_eq!(v.token(), "INSUFFICIENT", "{}", v.detail());
+    }
+
+    #[test]
+    fn segment_slope_is_undefined_rather_than_zero_on_bad_input() {
+        let a = SweepPoint {
+            entities: 0,
+            median_us: 1.0,
+        };
+        let b = SweepPoint {
+            entities: 10,
+            median_us: 1.0,
+        };
+        assert!(segment_slope(a, b).is_none());
+        assert!(segment_slope(b, a).is_none());
+
+        let neg = SweepPoint {
+            entities: 100,
+            median_us: -1.0,
+        };
+        assert!(segment_slope(b, neg).is_none());
+    }
+
+    #[test]
+    fn every_verdict_token_is_distinct() {
+        let tokens = [
+            ScalingVerdict::Sublinear(String::new()).token(),
+            ScalingVerdict::Linear(String::new()).token(),
+            ScalingVerdict::Superlinear(String::new()).token(),
+            ScalingVerdict::Knee(String::new()).token(),
+            ScalingVerdict::Insufficient(String::new()).token(),
+        ];
+        let unique: std::collections::HashSet<_> = tokens.iter().collect();
+        assert_eq!(unique.len(), 5);
+    }
+
+    #[test]
+    fn the_measured_jetson_point_is_not_by_itself_a_ladder() {
+        // The merged run measured ONE entity count (1000). The scale gate is
+        // open precisely because a single point cannot be classified, and this
+        // pins that so nobody closes the gate from the existing evidence.
+        let v = classify_scaling(&ladder(&[(1_000, 11_536.212)]));
+        assert_eq!(v.token(), "INSUFFICIENT");
+        assert!(v.fails_the_run());
+    }
+}

--- a/tools/wm2-persistence-harness/src/sweep.rs
+++ b/tools/wm2-persistence-harness/src/sweep.rs
@@ -158,20 +158,43 @@ pub fn classify_scaling(points: &[SweepPoint]) -> ScalingVerdict {
         );
     }
 
-    let slopes: Vec<f64> = points
-        .windows(2)
-        .filter_map(|w| segment_slope(w[0], w[1]))
-        .collect();
-    if slopes.len() + 1 < MIN_SWEEP_POINTS {
-        return ScalingVerdict::Insufficient(
-            "too many segments had undefined slope (zero or negative timings) to classify".into(),
-        );
+    // EVERY segment must be defined. Dropping the undefined ones and carrying
+    // on was a real defect: on a ladder of four or more points, one bad rung
+    // could be filtered out while enough slopes survived the length check, and
+    // then `slopes[0]` no longer described the ladder's first segment — the
+    // knee test would compare the wrong pair. The same filtering also let an
+    // endpoint with a zero timing reach the overall-slope computation, which
+    // panicked rather than failing closed.
+    //
+    // A hole in the ladder is exactly as unclassifiable as a short one: the
+    // missing rung might be the knee.
+    let mut slopes: Vec<f64> = Vec::with_capacity(points.len() - 1);
+    for (i, w) in points.windows(2).enumerate() {
+        match segment_slope(w[0], w[1]) {
+            Some(s) => slopes.push(s),
+            None => {
+                return ScalingVerdict::Insufficient(format!(
+                    "segment {i} (entities {} -> {}) has an undefined slope: a timing was zero, \
+                     negative or non-finite. A ladder with a hole cannot be classified — the \
+                     missing rung might be the knee.",
+                    w[0].entities, w[1].entities
+                ))
+            }
+        }
     }
 
     let first = slopes[0];
     let last = slopes[slopes.len() - 1];
-    let overall =
-        segment_slope(points[0], points[points.len() - 1]).expect("endpoints validated above");
+    // No `expect`: the endpoints are validated by the loop above for every
+    // ladder this can reach, but a fail-closed classifier must not depend on
+    // that argument staying true as the code changes.
+    let Some(overall) = segment_slope(points[0], points[points.len() - 1]) else {
+        return ScalingVerdict::Insufficient(
+            "the ladder endpoints do not admit an overall slope (zero, negative or non-finite \
+             timing)"
+                .into(),
+        );
+    };
 
     // The knee test runs FIRST. A curve can have a benign overall slope and
     // still bend sharply at the top of the ladder, and the top of the ladder is
@@ -362,6 +385,47 @@ mod tests {
         // calling the answer good news.
         let v = classify_scaling(&ladder(&[(1_000, 0.0), (10_000, 0.0), (100_000, 0.0)]));
         assert_eq!(v.token(), "INSUFFICIENT", "{}", v.detail());
+    }
+
+    #[test]
+    fn a_hole_in_a_long_ladder_is_refused_rather_than_panicking() {
+        // Regression: this shape used to PANIC. The first segment was dropped
+        // by a filter, three later slopes survived the length check, and then
+        // the overall-slope computation hit an `expect` on the zero endpoint.
+        // A classifier whose whole purpose is failing closed must not abort.
+        let pts = ladder(&[
+            (1_000, 0.0),
+            (10_000, 10.0),
+            (100_000, 100.0),
+            (1_000_000, 1_000.0),
+        ]);
+        let v = classify_scaling(&pts);
+        assert_eq!(v.token(), "INSUFFICIENT", "{}", v.detail());
+        assert!(v.fails_the_run());
+    }
+
+    #[test]
+    fn a_hole_in_the_middle_does_not_shift_which_segment_is_first() {
+        // The other half of the same defect: filtering a middle segment out
+        // silently re-labelled `slopes[0]`, so the knee test compared the wrong
+        // pair. Refusing the ladder makes that impossible by construction.
+        let pts = ladder(&[
+            (1_000, 10.0),
+            (10_000, 0.0),
+            (100_000, 100.0),
+            (1_000_000, 10_000.0),
+        ]);
+        let v = classify_scaling(&pts);
+        assert_eq!(v.token(), "INSUFFICIENT", "{}", v.detail());
+        assert!(v.detail().contains("segment 0") || v.detail().contains("segment 1"));
+    }
+
+    #[test]
+    fn a_non_finite_timing_is_refused() {
+        let pts = ladder(&[(1_000, 10.0), (10_000, f64::NAN), (100_000, 100.0)]);
+        assert_eq!(classify_scaling(&pts).token(), "INSUFFICIENT");
+        let pts = ladder(&[(1_000, 10.0), (10_000, f64::INFINITY), (100_000, 100.0)]);
+        assert_eq!(classify_scaling(&pts).token(), "INSUFFICIENT");
     }
 
     #[test]


### PR DESCRIPTION
The two remaining WM-2 questions both need the bench, and neither had an instrument that produced a recordable artifact. This builds them.

> **Nothing here has been run on target.** The sweep and the stall hunt are still R2's to perform. This PR makes both produce a machine-checkable verdict instead of a curve to eyeball or a latency number to squint at.

**ADR-0041 stays Proposed. ADR-0042's ruling is untouched. The domain-logic gate still reports `HOLDING (owner assigned, ruling pending)`. No Kirra World domain logic.**

Branch is synced onto current `main` (`7b318c38`) and carries the ratification-tally correction that followed the last merge.

---

## 1. The scale sweep — and a defect in the sweep the drill specified

ADR-0041 states the condition under which it should be abandoned — *"entities in the millions or genuinely unbounded ad-hoc traversal"* — and the drill discharged it with a shell loop and the instruction to **look at** how `graph_bounded_reach` grows.

Whether a curve "has a knee" is exactly the judgement that gets made favourably under deadline and re-made unfavourably by an assessor a year later, from the same numbers. It is now a function with a fail-closed verdict:

| Verdict | Meaning | Exit |
|---|---|---|
| `SUBLINEAR` / `LINEAR` | cost grows no faster than entity count — supports Option A | 0 |
| `SUPERLINEAR` | uniformly steeper, no inflection. Expensive and *predictable*: a bound on scaling, not a reopening trigger | 0 |
| `KNEE` | **the exponent increases along the ladder** — the shape the reopening condition describes | **1** |
| `INSUFFICIENT` | not classifiable | **1** |

A knee exits non-zero deliberately. A sweep that reports the finding and exits 0 invites it to be skimmed past.

### Building it exposed a defect, and it is the dangerous kind

Sweeping entity count at a **fixed total event count** reduces observations-per-entity as the ladder rises, so graph fan-out — and cost — go **down**. Measured on a host ladder of 100/1 000/10 000 entities at a fixed 20 000 events:

```
entities=  100  median 1687.0 us
entities= 1000  median   73.7 us
entities=10000  median   10.9 us     log-log slope -1.10
```

**That ladder would have reported excellent sublinear scaling and closed the scale gate — while measuring density rather than scale.** It looks like unusually good news, which is what makes it dangerous.

The sweep now holds observations-per-entity **constant** by default (`--events-per-entity`; deployment-realistic, since more entities means more observations rather than the same observations spread thinner), and the classifier **refuses** a steeply falling curve with the reason and the fix.

Verified both directions on host:

```
constant density  -> SUBLINEAR, slope 0.63, exit 0
fixed events      -> INSUFFICIENT, slope -1.13, exit 1
                     "the ladder diluted rather than scaled … re-run holding
                      events-per-entity constant"
```

## 2. The ~29 s stall

One commit took **29.27 s** under `NORMAL`/batch=64 on NVMe, inverting the durability ordering and consuming ~91 % of that stage's wall time. A single latency number cannot distinguish ext4 journal commit from NVMe garbage collection from thermal capping — all three produce *"one commit took a long time"*.

What the instrument adds:

- **Repetition**, so the stall gets a **rate**. One-in-fifty and one-in-two are different engineering problems at identical magnitude.
- **`median_throughput_eps`** across repetitions — one pathological run cannot move it, so throughput and stall rate become two separate facts rather than the single contaminated one the original benchmark produced.
- **System counters sampled across each run**: PSI `full` I/O stall, block-layer busy ms, peak dirty+writeback, hottest thermal zone.

### Attribution is deliberately reluctant

| Verdict | Evidence |
|---|---|
| `IO-DEVICE` | block layer busy, **no** large dirty backlog → NVMe GC or an SLC-cache cliff |
| `WRITEBACK-BACKLOG` | block layer busy **and** a large backlog → the flush *is* the work; page cache and journal, not the device |
| `THERMAL` | block layer **idle**, hottest zone ≥ 85 °C |
| `UNATTRIBUTED` | counters do not discriminate — **the expected outcome** |
| `NO-STALL` | worst commit below the 1 000 ms threshold |

Two orderings are load-bearing. Device-side I/O is tested **before** writeback, because a flush also drives the block layer busy — the discriminator is the backlog, not the busy-ness. And thermal is considered **only when the block layer was idle**: a hot SoC during heavy I/O is a *consequence*, not a cause, and blaming it would send the investigation the wrong way.

`UNATTRIBUTED` is common by design. A confident wrong attribution closes the investigation, which costs more than an honest shrug.

**Observing zero stalls is a result, not a failure.** It bounds the rate. Failing it would pressure an operator into re-running until a stall appeared, which turns a rate estimate into fiction. The run exits non-zero only if no repetition completed.

## 3. Both stages are explicit-only

Neither is part of `all`. The sweep runs the query suite once per rung; the stall repeats an append 20 times. Folding either in would multiply every routine drill and pressure people into skipping `all` — the opposite of what a gate should do.

## 4. The evidence pin diverged, and that is it working

The archived drill copy in `docs/evidence/wm2-jetson-20260803/` no longer matches `HEAD`'s, because this PR extends the drill. **The archived copy must not be updated to match** — it records the procedure actually followed on the device, and rewriting it would make the bundle describe a run that never happened.

A frozen copy going stale against a living document is the healthy behaviour of a pin; the failure mode it guards against is the opposite, where an archived copy is quietly edited and the evidence silently comes to describe something else. Verified still exact against the commit it pins:

```console
$ git show 021ec82379be:docs/hardware/JETSON_WM2_PERSISTENCE_DRILL.md | sha256sum
4ecdb93972d474d6ebc68802e46cbbb7f45a501786f6fcda1a128512c6f98584   ✓
$ cd docs/evidence/wm2-jetson-20260803 && sha256sum -c SHA256SUMS
results.jsonl: OK
JETSON_WM2_PERSISTENCE_DRILL.md: OK
```

The bundle README now records the divergence and gives the verify-against-the-commit command.

## Documentation

Drill **§9** rewritten (verdict table, the dilution trap with its measured numbers, what the sweep still cannot settle) and **§9a** added (stall procedure, attribution table, plus the `nvme smart-log` / `tegrastats` capture the harness explicitly *cannot* read itself). ADR-0041 gains **D-8**; open questions 1 and 9 record that instruments now exist but have **not** been run.

## Verification

- Harness suite **111 → 143**; `fmt` and `clippy -D warnings` clean.
- Both stages exercised end to end on host, including every usage-error path (`exit 2` for a ladder shorter than three rungs, a single rung, an unknown family).
- All six repo gates pass; evidence bundle still self-verifies.
- ADR-0041 **Proposed**; ADR-0042 ruling **PENDING**; domain-logic gate **HOLDING**.
- No code outside `tools/wm2-persistence-harness/`. No runtime behaviour, safety algorithm, checker input, release-token logic or actuator behaviour changes.

## Not done here

The two runs themselves. Both need R2, and the evidence gate exists so that cannot be faked from here. When they happen: `sweep` on the constant-density ladder for both families, and `stall` across all three durability settings at batch 1 and 64 — if the stall appears at every setting, it is not about durability at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_