### PR TITLE
docs(wm2): record bounded interactive query requirement

### DIFF
--- a/docs/adr/0041-world-model-persistence-architecture.md
+++ b/docs/adr/0041-world-model-persistence-architecture.md
@@ -890,6 +890,18 @@ D-10 and belong in WM-2's design:
 | **Latency watchdog** on store operations | the stall is intermittent at 2.5 %; only continuous monitoring catches it in the field |
 | **Writer isolation** | the checker and actuation path must not share a thread, connection or lock with the world-model writer |
 | **SMART telemetry capture** | `nvme smart-log` was absent, and it is what would confirm or refute the `IO-DEVICE` reading |
+| **Bounded interactive queries** | temporal p99 is 10.5 s at the top rung — a query with no declared bound has no bounded cost, whatever its scaling verdict |
+
+**Interactive temporal queries require bounded result contracts,
+pagination/window limits, or purpose-built indexing. Neither graph nor temporal
+queries may sit directly on a control or safety deadline path.** The rows above
+isolate the store from the real-time path; this one bounds the query itself, and
+both are needed — isolation stops a slow query blocking a deadline, but it does
+not stop the query being slow, and D-9 measured 10.5 s p99 at 100 000 entities
+with `LINEAR` scaling. A verdict about *shape* places no ceiling on *cost*: the
+only thing that bounds an unbounded scan is a bound. Which mechanism —
+a result contract, a window limit, or an index built for the access pattern —
+is a WM-2 design choice this ADR does not make.
 
 ### O-1 — the original ~29 second write stall (SUPERSEDED by D-10)
 


### PR DESCRIPTION
The follow-up flagged on #1320. One paragraph in D-11, plus the table row it belongs to. **Nothing else moves.**

## Why it was missing

D-11's table already carried the **isolation** half of the conclusion — bounded queue, backpressure, latency watchdog, writer isolation, SMART capture. The **query-side** half was not written down anywhere: D-9 supplies the numbers, and open question 10 says neither family may sit on a deadline path, but the remedies themselves lived only in the review conversation.

## What is recorded

> **Interactive temporal queries require bounded result contracts, pagination/window limits, or purpose-built indexing. Neither graph nor temporal queries may sit directly on a control or safety deadline path.**

Plus the table row: *temporal p99 is 10.5 s at the top rung — a query with no declared bound has no bounded cost, whatever its scaling verdict.*

## Why the two halves are not redundant

The paragraph states it rather than leaving it inferred: **isolation stops a slow query from blocking a deadline; it does not stop the query being slow.** D-9 measured 10.5 s p99 at 100 000 entities *with* a `LINEAR` verdict — a verdict about *shape* places no ceiling on *cost*, and the only thing that bounds an unbounded scan is a bound.

Which mechanism — result contract, window limit, or an index built for the access pattern — is left as a WM-2 design choice this ADR does not make.

## Deliberately unchanged

| | |
|---|---|
| Gate tally | **6 Met, 1 open** |
| ADR-0041 status | **Proposed — NOT ratified on merge** |
| Tier C | **`NOT-RUN`, 0/5** |
| ADR-0042 | untouched |
| batch-64 inversion | **no attempt to resolve it** |
| runtime / harness | no changes |

## Checks

Six repo gates PASS (domain-logic gate `HOLDING`, fence `INTACT`), `git diff --check` clean. Single-file documentation diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_