### PR TITLE
fix(wm2): make Tier C power-cut trials independent

### DIFF
--- a/docs/hardware/JETSON_WM2_PERSISTENCE_DRILL.md
+++ b/docs/hardware/JETSON_WM2_PERSISTENCE_DRILL.md
@@ -426,10 +426,49 @@ after the reboot — checks what actually did and appends the verdict.
 With no trials recorded, tier C stays `NOT-RUN`, which is the default for every
 automated run and keeps the exit code meaningful.
 
+### One arming is one trial
+
+**The marker is single-use, and a trial is an *arming* that a power cut was
+applied to — not a row in the ledger.** Every trial needs its own `powercut arm`,
+its own cut, and its own `verify`:
+
+- `arm` refuses to run while an unused marker exists. An outstanding marker means
+  the previous arming was never verified, and arming over it would orphan that
+  trial while leaving a marker describing a store state that no longer exists.
+- `arm` continues from `MAX(generation) + 1`, so a second arming appends after
+  the first instead of colliding with it.
+- `verify` refuses a repeated trial number **and** a repeated arm id, before
+  writing anything.
+- `verify` appends and fsyncs the verdict *first*, and removes the marker only
+  after. If the machine dies in between, the marker survives and the next
+  `verify` is refused as a duplicate arm id — recoverable, where the reverse
+  order would lose the verdict.
+- The aggregate counts **distinct arm ids**. Three rows carrying one arm id are
+  three verifications of one power cut, and count as one.
+
+> **Earlier builds did not do this.** `arm` restarted at generation 0, so on a
+> populated store the second arming died on `UNIQUE constraint failed:
+> world_events.generation` while the first marker survived — and each subsequent
+> `verify` re-read the same surviving store and appended another `PASS`. Five
+> "trials" were satisfiable by one real cut and four no-ops. Ledgers written by
+> those builds carry no arm id at all; the aggregate now refuses them as
+> unattributable and asks for a fresh database rather than counting them.
+
+**The R2 attempt is corrected accordingly.** It recorded three `PASS` rows, but
+only the first followed an arming: trials 2 and 3 re-verified the same marker
+against the same surviving store, and trial 4 surfaced the defect by failing with
+`UNIQUE constraint failed: world_events.generation`. Its honest status is **1
+valid independent PASS of the 5 required** — tier C remains incomplete.
+
+**Restart tier C on a fresh database.** A ledger that predates arm ids cannot be
+salvaged, and mixing it with new rows would understate what is missing.
+
 ### Procedure
 
 Run this **five times**, incrementing `--trial` each time. Use one database for
-the whole series; the trials ledger accumulates beside it.
+the whole series; the trials ledger accumulates beside it. Each pass through
+steps 2–4 is one arming; skipping step 2 does not produce another trial, it
+produces a refusal.
 
 1. Boot the Orin normally, on the storage under test.
 
@@ -441,8 +480,13 @@ the whole series; the trials ledger accumulates beside it.
    ./wm2-persistence-harness powercut arm --db /var/lib/kirra/wm2/power.sqlite
    ```
 
-   Wait for the `ARMED:` line. **Before it appears, nothing has been promised
-   and a cut proves nothing.**
+   Wait for the `ARMED [<arm id>]:` line. **Before it appears, nothing has been
+   promised and a cut proves nothing.** The line also names the generations this
+   arming appended, so a later ledger row can be tied back to it.
+
+   If `arm` exits 2 saying a marker already exists, the previous arming was
+   never verified. Verify it first, or delete the marker deliberately if that
+   cut never happened.
 
 3. With the tail still running, cut power **at the source** — pull the barrel
    jack or kill the bench supply. Do **not** use `poweroff`, `reboot`, or a
@@ -456,10 +500,14 @@ the whole series; the trials ledger accumulates beside it.
    sqlite3 /var/lib/kirra/wm2/power.sqlite 'PRAGMA integrity_check;'
    ```
 
-   `verify` exits non-zero until five clean trials are recorded, so a
-   half-finished series cannot be filed as a complete one.
+   `verify` exits **1** until five distinct clean armings are recorded, so a
+   half-finished series cannot be filed as a complete one. It exits **2** when
+   it *refuses* to record at all — no marker, a repeated trial number, or a
+   repeated arm id. The two are different: exit 1 recorded a trial, exit 2 did
+   not.
 
-5. Repeat from step 2 with `--trial 2`, `3`, `4`, `5`.
+5. Repeat from step 2 with `--trial 2`, `3`, `4`, `5`. **Step 2 is not
+   optional** — re-running `verify` without re-arming is refused.
 
 ### Reading the verdict
 
@@ -472,8 +520,10 @@ the whole series; the trials ledger accumulates beside it.
 
 Five is a floor, not a ritual: device-cache loss is probabilistic and depends
 where in the erase-block cycle the cut lands, so a store that survives once can
-lose an acknowledged write on the next attempt. Below five the aggregate reports
-`INCONCLUSIVE` rather than a pass.
+lose an acknowledged write on the next attempt. Below five **distinct armings**
+the aggregate reports `INCONCLUSIVE` rather than a pass, and it says how many it
+counted — `only 2 DISTINCT arming(s) recorded across 5 ledger row(s)` is a
+series that needs three more cuts, not a series that is finished.
 
 > **Do not run `crash` against the power-cut database.** Tier A deletes and
 > recreates the store it is given. The trials ledger survives (it is a separate

--- a/tools/wm2-persistence-harness/README.md
+++ b/tools/wm2-persistence-harness/README.md
@@ -72,6 +72,24 @@ a results file can never imply a durability test that did not happen. Below the
 required five trials the aggregate is `INCONCLUSIVE`, not a pass: device-cache
 loss is probabilistic, so one survived cut is not evidence.
 
+**A trial is an arming, not a ledger row.** The marker is single-use: `arm`
+refuses to run over an unused one, continues from `MAX(generation) + 1` rather
+than restarting at 0, and `verify` rejects both a repeated trial number and a
+repeated arm id before writing anything. The verdict is appended and fsynced
+*before* the marker is removed, so a cut in between leaves the arming
+outstanding — recoverable — instead of losing the verdict. The aggregate counts
+**distinct arm ids**, so three rows carrying one id are three verifications of
+one power cut and count as one.
+
+This was not true of earlier builds, and the difference is not academic. `arm`
+restarted at generation 0, so on a populated store the second arming died on a
+primary-key collision while the first marker survived, and each later `verify`
+re-read the same surviving store and appended another `PASS`. **The R2 attempt
+recorded three `PASS` rows from one real power cut; its honest status is 1 valid
+independent PASS of the 5 required.** Ledgers from those builds carry no arm id,
+and the aggregate now refuses them as unattributable rather than counting them —
+restart tier C on a fresh database.
+
 ## Layout
 
 | File | What it is |

--- a/tools/wm2-persistence-harness/src/crash.rs
+++ b/tools/wm2-persistence-harness/src/crash.rs
@@ -304,6 +304,14 @@ pub const MIN_TIER_C_TRIALS: u64 = 5;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TrialRecord {
     pub trial: u64,
+    /// Which arming this trial verifies.
+    ///
+    /// The load-bearing field. Trials were previously counted as ledger rows,
+    /// so re-running `verify` without re-arming appended another PASS against
+    /// the same surviving store — five "trials" were satisfiable by one power
+    /// cut and four no-ops. Counting distinct arm IDs makes a trial mean an
+    /// arming, which is the thing a power cut is applied to.
+    pub arm_id: String,
     pub outcome: TierOutcome,
     /// Generation of the last event fsynced *before* the cut. Everything up to
     /// here was acknowledged as durable and must survive.
@@ -320,24 +328,58 @@ pub struct TrialRecord {
 /// events than it acknowledged would be indistinguishable from one that was
 /// simply cut earlier than the operator thought.
 pub struct ArmedMarker {
+    /// Unique per arming. Two markers minted from the same store state at
+    /// different times differ, so a re-verified marker is detectable.
+    pub arm_id: String,
     pub durable_generation: u64,
     pub durable_head: String,
 }
 
 impl ArmedMarker {
     fn render(&self) -> String {
-        format!("{}\n{}\n", self.durable_generation, self.durable_head)
+        format!(
+            "{}\n{}\n{}\n",
+            self.arm_id, self.durable_generation, self.durable_head
+        )
     }
 
     fn parse(s: &str) -> Option<Self> {
         let mut lines = s.lines();
+        let arm_id = lines.next()?.trim().to_string();
+        if arm_id.is_empty() {
+            return None;
+        }
         let durable_generation = lines.next()?.trim().parse().ok()?;
         let durable_head = lines.next()?.trim().to_string();
+        if durable_head.is_empty() {
+            return None;
+        }
         Some(Self {
+            arm_id,
             durable_generation,
             durable_head,
         })
     }
+}
+
+/// Mint an arm ID unique to this arming.
+///
+/// Derived from the durable head and boundary (so it is tied to the state it
+/// describes) plus wall-clock nanos and the pid (so two armings of an
+/// identical-looking store still differ). Truncated to 64 bits, which is far
+/// more than enough to distinguish a handful of manual trials.
+fn mint_arm_id(head: &str, generation: u64) -> String {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let mut buf = Vec::new();
+    buf.extend_from_slice(b"wm2-tierc-arm-v1\x00");
+    buf.extend_from_slice(head.as_bytes());
+    buf.extend_from_slice(&generation.to_le_bytes());
+    buf.extend_from_slice(&nanos.to_le_bytes());
+    buf.extend_from_slice(&std::process::id().to_le_bytes());
+    crate::sha256::hex(&buf)[..16].to_string()
 }
 
 pub fn armed_marker_path(db: &Path) -> PathBuf {
@@ -368,6 +410,7 @@ pub fn judge_trial(
     let Some(marker) = marker else {
         return TrialRecord {
             trial,
+            arm_id: String::new(),
             outcome: TierOutcome::Inconclusive(
                 "no armed marker: `powercut arm` did not fsync a durable prefix before \
                  the cut, so nothing states what should have survived"
@@ -441,6 +484,7 @@ pub fn judge_trial(
 
     TrialRecord {
         trial,
+        arm_id: marker.arm_id.clone(),
         outcome: verdict,
         durable_generation: marker.durable_generation,
         recovered_generation,
@@ -466,7 +510,7 @@ pub fn tier_c_from_trials(trials: &[TrialRecord]) -> TierOutcome {
         .collect();
     if let Some(first) = failures.first() {
         return TierOutcome::Fail(format!(
-            "{} of {} power-cut trial(s) failed. First: trial {} — {}",
+            "{} of {} recorded row(s) failed. First: trial {} — {}",
             failures.len(),
             trials.len(),
             first.trial,
@@ -480,23 +524,63 @@ pub fn tier_c_from_trials(trials: &[TrialRecord]) -> TierOutcome {
         .count();
     if inconclusive > 0 {
         return TierOutcome::Inconclusive(format!(
-            "{inconclusive} of {} trial(s) never established a durable prefix; re-run those cuts",
+            "{inconclusive} of {} row(s) never established a durable prefix; re-run those cuts",
             trials.len()
         ));
     }
 
-    let n = trials.len() as u64;
+    // Count DISTINCT armings, not ledger rows. This is the whole correction:
+    // a row records a verification, and re-verifying a surviving store without
+    // re-arming used to append another PASS. Five "trials" were satisfiable by
+    // one power cut and four no-ops, which defeats the point of requiring five.
+    //
+    // A row with no arm_id cannot be attributed to an arming at all; it is
+    // counted as unattributable rather than silently dropped, because dropping
+    // it would make an unattributable row indistinguishable from a row that was
+    // never written.
+    let unattributed = trials.iter().filter(|t| t.arm_id.is_empty()).count();
+    if unattributed > 0 {
+        return TierOutcome::Inconclusive(format!(
+            "{unattributed} of {} row(s) carry no arm id, so they cannot be attributed to a \
+             distinct arming. Ledger rows written before arm ids existed read this way; restart \
+             tier C on a fresh database.",
+            trials.len()
+        ));
+    }
+
+    let unique: std::collections::BTreeSet<&str> =
+        trials.iter().map(|t| t.arm_id.as_str()).collect();
+    let n = unique.len() as u64;
+    let rows = trials.len();
+
     if n < MIN_TIER_C_TRIALS {
         return TierOutcome::Inconclusive(format!(
-            "only {n} of the required {MIN_TIER_C_TRIALS} power-cut trial(s) recorded; a single \
-             survived cut is not evidence of durability, because device-cache loss is \
-             probabilistic"
+            "only {n} DISTINCT arming(s) recorded across {rows} ledger row(s); \
+             {MIN_TIER_C_TRIALS} are required. Re-verifying without re-arming does not add a \
+             trial: a single survived cut is not evidence of durability, because device-cache \
+             loss is probabilistic."
         ));
     }
 
     TierOutcome::Pass(format!(
-        "{n} power-cut trial(s) recorded, all preserving the fsynced prefix with an intact chain"
+        "{n} distinct power-cut arming(s) recorded across {rows} row(s), all preserving the \
+         fsynced prefix with an intact chain"
     ))
+}
+
+/// How many DISTINCT armings a ledger records.
+///
+/// The number a tier C progress report must quote. Row count over-reports:
+/// three rows carrying one arm id are three verifications of one power cut, and
+/// printing "3 trials" beside an `INCONCLUSIVE` verdict that counted 1 would
+/// contradict itself.
+pub fn distinct_armings(trials: &[TrialRecord]) -> u64 {
+    trials
+        .iter()
+        .filter(|t| !t.arm_id.is_empty())
+        .map(|t| t.arm_id.as_str())
+        .collect::<std::collections::BTreeSet<_>>()
+        .len() as u64
 }
 
 pub fn tier_c_not_run() -> TierOutcome {
@@ -551,6 +635,7 @@ fn parse_trial_line(line: &str) -> Option<TrialRecord> {
     };
     Some(TrialRecord {
         trial,
+        arm_id: field("arm_id").unwrap_or_default(),
         outcome,
         durable_generation: field("durable_generation")?.parse().ok()?,
         recovered_generation: field("recovered_generation")?.parse().ok()?,
@@ -562,6 +647,7 @@ pub fn append_trial(db: &Path, rec: &TrialRecord) -> Result<(), String> {
     use std::io::Write;
     let line = crate::json::Obj::new()
         .int("trial", rec.trial)
+        .str("arm_id", &rec.arm_id)
         .str("outcome", rec.outcome.token())
         .int("durable_generation", rec.durable_generation)
         .int("recovered_generation", rec.recovered_generation)
@@ -596,6 +682,23 @@ pub fn append_trial(db: &Path, rec: &TrialRecord) -> Result<(), String> {
 /// Never returns — the operator ends it with the power switch. That is the
 /// instrument, and it is why this cannot be a normal stage.
 pub fn powercut_arm(db: &Path, prefix_events: u64, entities: u64, seed: u64) -> ! {
+    // An unused marker means the previous arming was never verified. Arming
+    // over it would orphan that trial AND leave a marker describing a store
+    // state that no longer exists — which is how a later `verify` came to
+    // report PASS for a cut that never happened. Refuse; the operator must
+    // verify or explicitly discard.
+    if armed_marker_path(db).exists() {
+        eprintln!(
+            "powercut arm: an unused marker already exists at {}.\n\
+             A marker is SINGLE-USE: each trial needs its own arming, and the marker is \
+             removed only after its verdict is durably recorded.\n\
+             Run `powercut verify --trial <n>` for the outstanding arming first, or delete \
+             the marker deliberately if that cut never happened.",
+            armed_marker_path(db).display()
+        );
+        std::process::exit(2);
+    }
+
     let mut store = match Store::open(db, Durability::Full) {
         Ok(s) => s,
         Err(e) => {
@@ -607,7 +710,19 @@ pub fn powercut_arm(db: &Path, prefix_events: u64, entities: u64, seed: u64) -> 
     // The durable prefix, one transaction per event at synchronous=FULL, then
     // an explicit checkpoint so the content is in the main file and not only
     // in a WAL that the cut may take with it.
-    let events = gen::events(0, prefix_events, entities, seed);
+    // Continue from the store's own head rather than restarting at 0. Starting
+    // at 0 collided with the existing rows on the second arming
+    // (`UNIQUE constraint failed: world_events.generation`), so the arm failed
+    // while a stale marker survived — and the next `verify` passed against the
+    // FIRST trial's data.
+    let start = match next_generation(&store) {
+        Ok(g) => g,
+        Err(e) => {
+            eprintln!("powercut arm: cannot read the store's head generation: {e}");
+            std::process::exit(2);
+        }
+    };
+    let events = gen::events(start, prefix_events, entities, seed);
     for e in &events {
         if let Err(err) = store.append_batch(std::slice::from_ref(e)) {
             eprintln!("powercut arm: append failed: {err}");
@@ -621,6 +736,7 @@ pub fn powercut_arm(db: &Path, prefix_events: u64, entities: u64, seed: u64) -> 
 
     let head = match store.verify_chain() {
         Ok(ChainStatus::Intact { entries, head, .. }) => ArmedMarker {
+            arm_id: mint_arm_id(&head, entries),
             durable_generation: entries,
             durable_head: head,
         },
@@ -636,9 +752,13 @@ pub fn powercut_arm(db: &Path, prefix_events: u64, entities: u64, seed: u64) -> 
     }
 
     println!(
-        "ARMED: {} event(s) fsynced and recorded. Cut power NOW, at any time.\n\
+        "ARMED [{}]: {} event(s) fsynced and recorded (this arming appended generations \
+         {}..{}). Cut power NOW, at any time.\n\
          After reboot, run: wm2-persistence-harness powercut verify --db {} --trial <n>",
+        head.arm_id,
         head.durable_generation,
+        start,
+        start + prefix_events - 1,
         db.display()
     );
     // This function never returns, so nothing else will ever flush this. To a
@@ -649,7 +769,9 @@ pub fn powercut_arm(db: &Path, prefix_events: u64, entities: u64, seed: u64) -> 
     // The tail: appended continuously and deliberately never checkpointed, so
     // the cut always lands mid-write. Losing all of this is correct; losing any
     // of the prefix above is not.
-    let mut n = prefix_events;
+    // The tail starts after the prefix THIS arming appended, not after
+    // `prefix_events` counted from zero.
+    let mut n = start + prefix_events;
     loop {
         let batch = gen::events(n, 64, entities, seed);
         if store.append_batch(&batch).is_err() {
@@ -659,6 +781,20 @@ pub fn powercut_arm(db: &Path, prefix_events: u64, entities: u64, seed: u64) -> 
         }
         n += 64;
     }
+}
+
+/// The generation the next append should use: `MAX(generation) + 1`, or 0 on an
+/// empty store.
+///
+/// `generation` is the primary key, so restarting at 0 on a populated store is
+/// not merely non-independent — it is a constraint violation that aborts the
+/// arming.
+fn next_generation(store: &Store) -> rusqlite::Result<u64> {
+    store.conn.query_row(
+        "SELECT COALESCE(MAX(generation) + 1, 0) FROM world_events",
+        [],
+        |r| r.get::<_, i64>(0).map(|v| v as u64),
+    )
 }
 
 fn write_marker(db: &Path, marker: &ArmedMarker) -> Result<(), String> {
@@ -682,17 +818,74 @@ pub fn read_marker(db: &Path) -> Option<ArmedMarker> {
     ArmedMarker::parse(&std::fs::read_to_string(armed_marker_path(db)).ok()?)
 }
 
+/// Remove the armed marker. Called only after the verdict is durably recorded.
+fn consume_marker(db: &Path) -> Result<(), String> {
+    let path = armed_marker_path(db);
+    std::fs::remove_file(&path).map_err(|e| e.to_string())?;
+    // The removal itself must be durable, or a cut between here and the next
+    // arming could resurrect a marker whose trial is already in the ledger.
+    if let Some(dir) = path.parent() {
+        if let Ok(d) = std::fs::File::open(dir) {
+            let _ = d.sync_all();
+        }
+    }
+    Ok(())
+}
+
 /// Verify one power-cut trial after the reboot and record it.
-pub fn powercut_verify(db: &Path, trial: u64) -> TrialRecord {
-    let marker = read_marker(db);
+///
+/// Ordering is load-bearing and deliberate:
+///
+/// 1. **reject duplicates first** — a repeated trial number or a repeated arm
+///    id is refused before anything is written, so a mistaken re-run cannot
+///    inflate the ledger;
+/// 2. **append and fsync the verdict** — the ledger is the evidence;
+/// 3. **only then consume the marker.** If the machine dies between 2 and 3 the
+///    marker survives and the next `verify` is refused as a duplicate arm id,
+///    which is recoverable. The reverse order could lose the verdict entirely
+///    while destroying the only record that the arming happened.
+pub fn powercut_verify(db: &Path, trial: u64) -> Result<TrialRecord, String> {
+    let existing = read_trials(db);
+
+    if let Some(prev) = existing.iter().find(|t| t.trial == trial) {
+        return Err(format!(
+            "trial {trial} is already recorded (arm {}, {}). Trial numbers must be distinct — \
+             re-recording one would count a single arming twice. Use the next unused number.",
+            if prev.arm_id.is_empty() {
+                "unknown"
+            } else {
+                prev.arm_id.as_str()
+            },
+            prev.outcome.token()
+        ));
+    }
+
+    let Some(marker) = read_marker(db) else {
+        return Err(format!(
+            "no armed marker at {}. Each trial requires its OWN arming: run `powercut arm`, \
+             wait for the ARMED line, cut power, then verify. Verifying without arming would \
+             re-read a surviving store and record a pass for a cut that never happened.",
+            armed_marker_path(db).display()
+        ));
+    };
+
+    if let Some(prev) = existing.iter().find(|t| t.arm_id == marker.arm_id) {
+        return Err(format!(
+            "arming {} is already recorded as trial {}. A marker is single-use; this one \
+             should have been consumed. Re-arm before verifying again.",
+            marker.arm_id, prev.trial
+        ));
+    }
+
     let recovered = Store::open(db, Durability::Full)
         .map_err(|e| e.to_string())
         .and_then(|s| s.verify_chain().map_err(|e| e.to_string()));
-    let rec = judge_trial(trial, marker.as_ref(), &recovered);
-    if let Err(e) = append_trial(db, &rec) {
-        eprintln!("warning: could not append to the trials ledger: {e}");
-    }
-    rec
+    let rec = judge_trial(trial, Some(&marker), &recovered);
+
+    // Evidence first. A verdict that is not durably recorded did not happen.
+    append_trial(db, &rec)?;
+    consume_marker(db)?;
+    Ok(rec)
 }
 
 pub fn run(
@@ -706,11 +899,14 @@ pub fn run(
     // it is evidence about earlier power cuts and must not be interpreted
     // against a store this run has since replaced.
     let trials = read_trials(path);
+    // Distinct armings, not ledger rows — the same correction `tier_c_from_trials`
+    // makes. Reporting the row count here would contradict the verdict beside it.
+    let distinct = distinct_armings(&trials);
     CrashResult {
         tier_a_sigkill: tier_a_sigkill(path, durability, run_ms),
         tier_b_wal_loss: tier_b_wal_loss(path, durability, prefix_events, tail_events),
         tier_c_power_cut: tier_c_from_trials(&trials),
-        tier_c_trials: trials.len() as u64,
+        tier_c_trials: distinct,
     }
 }
 
@@ -805,10 +1001,19 @@ mod tests {
     // -----------------------------------------------------------------------
 
     fn marker(gen: u64) -> ArmedMarker {
+        marker_id("arm-fixed", gen)
+    }
+
+    fn marker_id(id: &str, gen: u64) -> ArmedMarker {
         ArmedMarker {
+            arm_id: id.into(),
             durable_generation: gen,
             durable_head: "deadbeef".into(),
         }
+    }
+
+    fn passing_trial_arm(n: u64, id: &str) -> TrialRecord {
+        judge_trial(n, Some(&marker_id(id, 400)), &intact(400))
     }
 
     fn intact(entries: u64) -> Result<ChainStatus, String> {
@@ -882,7 +1087,7 @@ mod tests {
     }
 
     fn passing_trial(n: u64) -> TrialRecord {
-        judge_trial(n, Some(&marker(400)), &intact(400))
+        passing_trial_arm(n, &format!("arm-{n}"))
     }
 
     #[test]
@@ -975,5 +1180,258 @@ mod tests {
 
         assert_eq!(read_trials(&db).len(), 2);
         let _ = std::fs::remove_file(&path);
+    }
+
+    // -----------------------------------------------------------------------
+    // Tier C independence — one arming is one trial
+    // -----------------------------------------------------------------------
+
+    /// Clear a database and every tier C sidecar next to it.
+    fn fresh(name: &str) -> PathBuf {
+        let db = temp(name);
+        remove_db(&db);
+        let _ = std::fs::remove_file(trials_ledger_path(&db));
+        let _ = std::fs::remove_file(armed_marker_path(&db));
+        let _ = std::fs::remove_dir_all(trials_ledger_path(&db));
+        db
+    }
+
+    fn cleanup(db: &Path) {
+        remove_db(db);
+        let _ = std::fs::remove_file(trials_ledger_path(db));
+        let _ = std::fs::remove_file(armed_marker_path(db));
+        let _ = std::fs::remove_dir_all(trials_ledger_path(db));
+    }
+
+    #[test]
+    fn a_second_arming_starts_after_the_events_the_first_one_wrote() {
+        // The defect, at its root. `generation` is the primary key, so a second
+        // arming that restarts at 0 does not merely repeat work — it violates
+        // the constraint, aborts, and leaves the previous marker in place for a
+        // later `verify` to pass against the FIRST trial's data.
+        let db = fresh("tierc-next-gen");
+        let mut store = Store::open(&db, Durability::Full).expect("open");
+        assert_eq!(next_generation(&store).expect("empty"), 0);
+
+        store
+            .append_batch(&gen::events(0, 400, 8, 1))
+            .expect("arm 1");
+        assert_eq!(next_generation(&store).expect("after arm 1"), 400);
+
+        // The second arming appends from there, and must not collide.
+        let start = next_generation(&store).expect("read");
+        store
+            .append_batch(&gen::events(start, 400, 8, 2))
+            .expect("a second arming from MAX+1 must not violate the primary key");
+        assert_eq!(next_generation(&store).expect("after arm 2"), 800);
+
+        // And the log is still one unbroken run, so a later trial's recovered
+        // count remains comparable with its marker.
+        match store.verify_chain().expect("verify") {
+            ChainStatus::Intact { entries, .. } => assert_eq!(entries, 800),
+            other => panic!("continuity broken across two armings: {other:?}"),
+        }
+        drop(store);
+        cleanup(&db);
+    }
+
+    #[test]
+    fn restarting_at_zero_on_a_populated_store_is_the_constraint_violation_it_looked_like() {
+        // Pins the observed failure rather than assuming it: the fix is only
+        // meaningful if the unfixed behaviour really does abort.
+        let db = fresh("tierc-collision");
+        let mut store = Store::open(&db, Durability::Full).expect("open");
+        store
+            .append_batch(&gen::events(0, 16, 4, 1))
+            .expect("first");
+        let err = store
+            .append_batch(&gen::events(0, 16, 4, 2))
+            .expect_err("re-appending from generation 0 must be refused, not merged");
+        assert!(
+            err.to_string().contains("UNIQUE"),
+            "expected a primary-key collision, got {err}"
+        );
+        drop(store);
+        cleanup(&db);
+    }
+
+    /// Arm a store the way `powercut_arm` does, minus the never-returning tail.
+    fn arm(db: &Path, arm_id: &str) -> ArmedMarker {
+        let mut store = Store::open(db, Durability::Full).expect("open");
+        let start = next_generation(&store).expect("head");
+        store
+            .append_batch(&gen::events(start, 64, 8, 7))
+            .expect("prefix");
+        store.durable_checkpoint().expect("checkpoint");
+        let m = match store.verify_chain().expect("verify") {
+            ChainStatus::Intact { entries, head, .. } => ArmedMarker {
+                arm_id: arm_id.to_string(),
+                durable_generation: entries,
+                durable_head: head,
+            },
+            other => panic!("{other:?}"),
+        };
+        drop(store);
+        write_marker(db, &m).expect("marker");
+        m
+    }
+
+    #[test]
+    fn verifying_twice_without_re_arming_is_refused() {
+        // The behaviour that produced three PASS rows from one power cut: the
+        // marker survived its own verification, so re-running `verify` re-read
+        // the same surviving store and recorded another pass.
+        let db = fresh("tierc-reverify");
+        arm(&db, "arm-A");
+
+        let first = powercut_verify(&db, 1).expect("the first verify is legitimate");
+        assert_eq!(first.arm_id, "arm-A");
+        assert_eq!(first.outcome.token(), "PASS");
+
+        let err = powercut_verify(&db, 2)
+            .expect_err("re-verifying a consumed arming must be refused, not recorded");
+        assert!(err.contains("no armed marker"), "{err}");
+
+        // And nothing was appended for the refusal.
+        assert_eq!(read_trials(&db).len(), 1);
+        cleanup(&db);
+    }
+
+    #[test]
+    fn a_repeated_trial_number_is_refused_before_anything_is_written() {
+        let db = fresh("tierc-dup-trial");
+        arm(&db, "arm-A");
+        powercut_verify(&db, 1).expect("first");
+
+        arm(&db, "arm-B");
+        let err = powercut_verify(&db, 1).expect_err("trial 1 is already recorded");
+        assert!(err.contains("already recorded"), "{err}");
+
+        // Refused *before* writing: the ledger still holds one row, and the
+        // second arming's marker is untouched so it can still be verified under
+        // a correct number.
+        assert_eq!(read_trials(&db).len(), 1);
+        assert!(armed_marker_path(&db).exists());
+        assert_eq!(
+            powercut_verify(&db, 2)
+                .expect("under a fresh number")
+                .arm_id,
+            "arm-B"
+        );
+        cleanup(&db);
+    }
+
+    #[test]
+    fn a_repeated_arm_id_is_refused_even_under_a_fresh_trial_number() {
+        // The recovery case: if the machine dies between the ledger append and
+        // the marker removal, the marker comes back. Verifying it again would
+        // record the same arming twice under two numbers, which is precisely
+        // the inflation the arm id exists to catch.
+        let db = fresh("tierc-dup-arm");
+        let m = arm(&db, "arm-A");
+        powercut_verify(&db, 1).expect("first");
+
+        // Resurrect the marker, as an ill-timed cut would.
+        write_marker(&db, &m).expect("marker");
+        let err = powercut_verify(&db, 2).expect_err("the same arming must not be counted twice");
+        assert!(err.contains("already recorded as trial 1"), "{err}");
+        assert_eq!(read_trials(&db).len(), 1);
+        cleanup(&db);
+    }
+
+    #[test]
+    fn the_marker_survives_a_ledger_write_that_fails() {
+        // Ordering is the property: evidence first, marker second. If the
+        // verdict cannot be durably recorded then the arming is still
+        // outstanding, and destroying the marker would lose both the verdict
+        // and any record that the cut happened.
+        let db = fresh("tierc-ledger-fails");
+        arm(&db, "arm-A");
+        // A directory where the ledger file goes: the append cannot succeed.
+        std::fs::create_dir_all(trials_ledger_path(&db)).expect("block the ledger");
+
+        let err = powercut_verify(&db, 1).expect_err("the append must fail");
+        assert!(!err.is_empty());
+        assert!(
+            armed_marker_path(&db).exists(),
+            "the marker was consumed although the verdict was never recorded"
+        );
+        cleanup(&db);
+    }
+
+    #[test]
+    fn three_rows_carrying_one_arm_id_count_as_one_trial() {
+        // The exact shape of the corrected R2 evidence: three PASS rows, one
+        // real power cut. Counting rows read this as 3/5; counting armings
+        // reads it as 1/5, which is what happened.
+        let rows: Vec<_> = (1..=3).map(|n| passing_trial_arm(n, "arm-A")).collect();
+        let o = tier_c_from_trials(&rows);
+        assert_eq!(o.token(), "INCONCLUSIVE", "{}", o.detail());
+        assert!(
+            o.detail().contains("only 1 DISTINCT"),
+            "the verdict must say how many armings it counted: {}",
+            o.detail()
+        );
+        assert!(o.fails_the_run());
+    }
+
+    #[test]
+    fn five_rows_sharing_fewer_than_five_armings_do_not_pass() {
+        // Enough rows to satisfy the old row count, from two armings.
+        let mut rows: Vec<_> = (1..=4).map(|n| passing_trial_arm(n, "arm-A")).collect();
+        rows.push(passing_trial_arm(5, "arm-B"));
+        assert_eq!(rows.len() as u64, MIN_TIER_C_TRIALS);
+        let o = tier_c_from_trials(&rows);
+        assert_eq!(o.token(), "INCONCLUSIVE", "{}", o.detail());
+        assert!(o.detail().contains("only 2 DISTINCT"), "{}", o.detail());
+    }
+
+    #[test]
+    fn four_distinct_armings_are_inconclusive_and_five_pass() {
+        let four: Vec<_> = (1..=4)
+            .map(|n| passing_trial_arm(n, &format!("arm-{n}")))
+            .collect();
+        let o = tier_c_from_trials(&four);
+        assert_eq!(o.token(), "INCONCLUSIVE", "{}", o.detail());
+        assert!(o.fails_the_run());
+
+        let five: Vec<_> = (1..=5)
+            .map(|n| passing_trial_arm(n, &format!("arm-{n}")))
+            .collect();
+        let o = tier_c_from_trials(&five);
+        assert_eq!(o.token(), "PASS", "{}", o.detail());
+        assert!(o.detail().contains("5 distinct"), "{}", o.detail());
+        assert!(!o.fails_the_run());
+    }
+
+    #[test]
+    fn rows_written_before_arm_ids_existed_cannot_be_counted() {
+        // A ledger from the defective build carries no arm id. Dropping those
+        // rows would make them indistinguishable from rows that were never
+        // written, so they are refused loudly and the tier restarts.
+        let stale = TrialRecord {
+            trial: 1,
+            arm_id: String::new(),
+            outcome: TierOutcome::Pass("legacy row".into()),
+            durable_generation: 400,
+            recovered_generation: 6800,
+            chain: "intact".into(),
+        };
+        let o = tier_c_from_trials(&[stale]);
+        assert_eq!(o.token(), "INCONCLUSIVE");
+        assert!(o.detail().contains("fresh database"), "{}", o.detail());
+        assert!(o.fails_the_run());
+    }
+
+    #[test]
+    fn two_armings_of_the_same_store_state_still_mint_different_ids() {
+        // Two cuts can leave a store looking identical. If the id were derived
+        // from the state alone the second arming would be indistinguishable
+        // from the first, and the duplicate check would reject a legitimate
+        // trial.
+        let a = mint_arm_id("deadbeef", 400);
+        let b = mint_arm_id("deadbeef", 400);
+        assert_ne!(a, b);
+        assert_eq!(a.len(), 16);
     }
 }

--- a/tools/wm2-persistence-harness/src/crash.rs
+++ b/tools/wm2-persistence-harness/src/crash.rs
@@ -362,23 +362,37 @@ impl ArmedMarker {
     }
 }
 
+/// Monotonic within this process, so two mints cannot collide however coarse
+/// the wall clock is. See [`mint_arm_id`].
+static ARM_SEQUENCE: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
 /// Mint an arm ID unique to this arming.
 ///
 /// Derived from the durable head and boundary (so it is tied to the state it
-/// describes) plus wall-clock nanos and the pid (so two armings of an
-/// identical-looking store still differ). Truncated to 64 bits, which is far
-/// more than enough to distinguish a handful of manual trials.
+/// describes) plus wall-clock nanos, the pid, and a process-local counter (so
+/// two armings of an identical-looking store still differ). Truncated to 64
+/// bits, which is far more than enough to distinguish a handful of manual
+/// trials.
+///
+/// The counter is not redundant with the clock. Wall-clock resolution is a
+/// platform property — coarse enough on some targets that two calls in quick
+/// succession read the same value — and an id collision here does not degrade
+/// gracefully: it makes a legitimate second arming look like a re-verification
+/// of the first and get refused. Across processes the pid and the clock
+/// separate; within one, the counter does.
 fn mint_arm_id(head: &str, generation: u64) -> String {
     let nanos = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
+    let seq = ARM_SEQUENCE.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let mut buf = Vec::new();
     buf.extend_from_slice(b"wm2-tierc-arm-v1\x00");
     buf.extend_from_slice(head.as_bytes());
     buf.extend_from_slice(&generation.to_le_bytes());
     buf.extend_from_slice(&nanos.to_le_bytes());
     buf.extend_from_slice(&std::process::id().to_le_bytes());
+    buf.extend_from_slice(&seq.to_le_bytes());
     crate::sha256::hex(&buf)[..16].to_string()
 }
 
@@ -688,13 +702,21 @@ pub fn powercut_arm(db: &Path, prefix_events: u64, entities: u64, seed: u64) -> 
     // report PASS for a cut that never happened. Refuse; the operator must
     // verify or explicitly discard.
     if armed_marker_path(db).exists() {
+        let torn = matches!(read_marker_state(db), MarkerState::Unreadable);
         eprintln!(
             "powercut arm: an unused marker already exists at {}.\n\
              A marker is SINGLE-USE: each trial needs its own arming, and the marker is \
              removed only after its verdict is durably recorded.\n\
-             Run `powercut verify --trial <n>` for the outstanding arming first, or delete \
-             the marker deliberately if that cut never happened.",
-            armed_marker_path(db).display()
+             {}",
+            armed_marker_path(db).display(),
+            if torn {
+                "That marker does not parse — torn by the cut, or written by a build that \
+                 predates arm ids. It cannot be verified. Delete it and arm again to re-run \
+                 this trial."
+            } else {
+                "Run `powercut verify --trial <n>` for the outstanding arming first, or delete \
+                 the marker deliberately if that cut never happened."
+            }
         );
         std::process::exit(2);
     }
@@ -814,8 +836,34 @@ fn write_marker(db: &Path, marker: &ArmedMarker) -> Result<(), String> {
     Ok(())
 }
 
-pub fn read_marker(db: &Path) -> Option<ArmedMarker> {
-    ArmedMarker::parse(&std::fs::read_to_string(armed_marker_path(db)).ok()?)
+/// What is sitting at the marker path.
+///
+/// `Unreadable` must be distinct from `Absent`. `arm` refuses while the file
+/// exists and `verify` needs a parseable marker, so collapsing the two leaves
+/// an operator with a torn marker stuck between "arm refuses, a marker exists"
+/// and "verify refuses, no marker" — with no stated way out. A marker torn by
+/// the very power cut it was recording is an expected state, not an exotic one.
+pub enum MarkerState {
+    Absent,
+    /// The file is there but does not parse: torn by the cut, or written by a
+    /// build that predates arm ids.
+    Unreadable,
+    Armed(ArmedMarker),
+}
+
+pub fn read_marker_state(db: &Path) -> MarkerState {
+    let path = armed_marker_path(db);
+    match std::fs::read_to_string(&path) {
+        Err(_) if !path.exists() => MarkerState::Absent,
+        // Unreadable for any other reason — permissions, an I/O error — is
+        // still "something is there and it is not usable", which is the state
+        // the operator has to be told about.
+        Err(_) => MarkerState::Unreadable,
+        Ok(text) => match ArmedMarker::parse(&text) {
+            Some(m) => MarkerState::Armed(m),
+            None => MarkerState::Unreadable,
+        },
+    }
 }
 
 /// Remove the armed marker. Called only after the verdict is durably recorded.
@@ -860,13 +908,29 @@ pub fn powercut_verify(db: &Path, trial: u64) -> Result<TrialRecord, String> {
         ));
     }
 
-    let Some(marker) = read_marker(db) else {
-        return Err(format!(
-            "no armed marker at {}. Each trial requires its OWN arming: run `powercut arm`, \
-             wait for the ARMED line, cut power, then verify. Verifying without arming would \
-             re-read a surviving store and record a pass for a cut that never happened.",
-            armed_marker_path(db).display()
-        ));
+    let marker = match read_marker_state(db) {
+        MarkerState::Armed(m) => m,
+        MarkerState::Absent => {
+            return Err(format!(
+                "no armed marker at {}. Each trial requires its OWN arming: run `powercut arm`, \
+                 wait for the ARMED line, cut power, then verify. Verifying without arming would \
+                 re-read a surviving store and record a pass for a cut that never happened.",
+                armed_marker_path(db).display()
+            ));
+        }
+        // Distinct from absent, and it must be: `arm` refuses while this file
+        // exists, so reporting it as missing would leave the operator with two
+        // refusals and no stated way forward.
+        MarkerState::Unreadable => {
+            return Err(format!(
+                "the marker at {} exists but cannot be read. Either the cut tore it — in which \
+                 case nothing states what should have survived and this arming cannot be judged \
+                 — or it was written by a build that predates arm ids.\n\
+                 Delete it and re-arm to re-run this trial. If it predates arm ids, its earlier \
+                 rows cannot be attributed either: restart tier C on a fresh database.",
+                armed_marker_path(db).display()
+            ));
+        }
     };
 
     if let Some(prev) = existing.iter().find(|t| t.arm_id == marker.arm_id) {
@@ -1429,9 +1493,56 @@ mod tests {
         // from the state alone the second arming would be indistinguishable
         // from the first, and the duplicate check would reject a legitimate
         // trial.
-        let a = mint_arm_id("deadbeef", 400);
-        let b = mint_arm_id("deadbeef", 400);
-        assert_ne!(a, b);
-        assert_eq!(a.len(), 16);
+        //
+        // A thousand back-to-back mints, because a wall clock alone would not
+        // survive this on a platform with coarse resolution: the counter in the
+        // hashed material is what makes it unconditional rather than a race
+        // that usually goes the right way.
+        let ids: std::collections::BTreeSet<String> =
+            (0..1000).map(|_| mint_arm_id("deadbeef", 400)).collect();
+        assert_eq!(ids.len(), 1000, "two mints collided");
+        assert!(ids.iter().all(|i| i.len() == 16));
+    }
+
+    #[test]
+    fn a_torn_marker_is_refused_as_torn_rather_than_as_absent() {
+        // `arm` refuses while the marker file exists, so reporting an
+        // unparseable one as "no armed marker" leaves the operator with two
+        // refusals and no stated way forward. A marker torn by the very cut it
+        // was recording is an expected state, not an exotic one.
+        let db = fresh("tierc-torn-marker");
+        Store::open(&db, Durability::Full).expect("open");
+        std::fs::write(armed_marker_path(&db), "400\ndeadbeef\n").expect("legacy 2-line marker");
+
+        assert!(matches!(read_marker_state(&db), MarkerState::Unreadable));
+
+        let err = powercut_verify(&db, 1).expect_err("an unjudgeable arming must be refused");
+        assert!(
+            err.contains("cannot be read"),
+            "the refusal must not claim the marker is absent: {err}"
+        );
+        assert!(
+            err.contains("Delete it and re-arm"),
+            "the refusal must name the way out: {err}"
+        );
+        assert!(read_trials(&db).is_empty(), "a refusal wrote a ledger row");
+        cleanup(&db);
+    }
+
+    #[test]
+    fn an_absent_marker_and_an_unreadable_one_are_different_refusals() {
+        let db = fresh("tierc-marker-states");
+        Store::open(&db, Durability::Full).expect("open");
+        assert!(matches!(read_marker_state(&db), MarkerState::Absent));
+        let absent = powercut_verify(&db, 1).expect_err("no marker");
+        assert!(absent.contains("no armed marker"), "{absent}");
+
+        std::fs::write(armed_marker_path(&db), "not a marker").expect("write");
+        let torn = powercut_verify(&db, 1).expect_err("torn marker");
+        assert_ne!(
+            absent, torn,
+            "the two states must not produce the same message — they need different actions"
+        );
+        cleanup(&db);
     }
 }

--- a/tools/wm2-persistence-harness/src/main.rs
+++ b/tools/wm2-persistence-harness/src/main.rs
@@ -337,17 +337,31 @@ fn main() {
                     );
                     std::process::exit(2);
                 }
-                let rec = crash::powercut_verify(&args.db, args.trial);
+                let rec = match crash::powercut_verify(&args.db, args.trial) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        // A refused verification is not a failed measurement —
+                        // it is the harness declining to record something that
+                        // would not mean what it appears to mean.
+                        eprintln!("powercut verify refused: {e}");
+                        std::process::exit(2);
+                    }
+                };
                 println!(
-                    "trial {}: {} — {}",
+                    "trial {} [arm {}]: {} — {}",
                     rec.trial,
+                    rec.arm_id,
                     rec.outcome.token(),
                     rec.outcome.detail()
                 );
                 let all = crash::read_trials(&args.db);
                 let agg = crash::tier_c_from_trials(&all);
+                // Distinct armings, not ledger rows: a trial is an arming that a
+                // power cut was applied to, and quoting the row count beside a
+                // verdict that counted armings would contradict it.
                 println!(
-                    "\ntier C after {} trial(s): {} — {}",
+                    "\ntier C after {} arming(s) across {} row(s): {} — {}",
+                    crash::distinct_armings(&all),
                     all.len(),
                     agg.token(),
                     agg.detail()

--- a/tools/wm2-persistence-harness/tests/crash_tier_a.rs
+++ b/tools/wm2-persistence-harness/tests/crash_tier_a.rs
@@ -179,6 +179,163 @@ fn a_stray_positional_word_is_rejected_outside_powercut() {
     );
 }
 
+/// `powercut arm` never returns — the operator ends it with the power switch —
+/// so it is driven as a child, given time to print `ARMED`, and killed. That is
+/// as close to a power cut as software gets, and it is enough to exercise the
+/// marker lifecycle, which is the part under test here.
+fn arm_and_kill(db: &PathBuf) -> bool {
+    let mut child = Command::new(BIN)
+        .args(["powercut", "arm", "--db"])
+        .arg(db)
+        .args(["--events", "64", "--entities", "8"])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("arm did not start");
+
+    // Poll for the marker rather than sleeping a fixed period: on a slow
+    // machine a fixed sleep flakes, and on a fast one it wastes the wall clock
+    // of every run.
+    let marker = {
+        let mut p = db.as_os_str().to_os_string();
+        p.push("-tierc-armed");
+        PathBuf::from(p)
+    };
+    for _ in 0..300 {
+        if marker.exists() {
+            break;
+        }
+        if let Ok(Some(_)) = child.try_wait() {
+            // Exited without arming — the refusal path.
+            return false;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+    let armed = marker.exists();
+    let _ = child.kill();
+    let _ = child.wait();
+    armed
+}
+
+#[test]
+fn each_power_cut_trial_needs_its_own_arming() {
+    // The defect this test exists for: `arm` restarted at generation 0, so the
+    // second arming hit a primary-key collision and died while the FIRST
+    // marker survived. `verify` then re-read the same surviving store and
+    // recorded another PASS — one real power cut produced a tier C row per
+    // invocation, and five "trials" were satisfiable by one cut and four
+    // no-ops.
+    let dir = scratch("powercut-independence");
+    let db = dir.join("pc.sqlite");
+    let ledger = dir.join("pc.sqlite-tierc-trials.jsonl");
+
+    // Trial 1: arm, "cut", verify.
+    assert!(
+        arm_and_kill(&db),
+        "the first arming did not produce a marker"
+    );
+    let status = Command::new(BIN)
+        .args(["powercut", "verify", "--db"])
+        .arg(&db)
+        .args(["--trial", "1"])
+        .status()
+        .expect("verify did not run");
+    // A legitimate verify still exits 1 here, and must: one arming is short of
+    // the five tier C requires, so the aggregate is INCONCLUSIVE and an
+    // incomplete drill is not allowed to exit 0. Exit 2 is the distinct code
+    // for a *refused* verification, which is what the rest of this test turns
+    // on — the two must not be conflated.
+    assert_eq!(
+        status.code(),
+        Some(1),
+        "a recorded-but-insufficient trial must exit 1, not be refused"
+    );
+    assert_eq!(read_records(&ledger).len(), 1);
+
+    // Verifying again without re-arming must be refused, not recorded.
+    let status = Command::new(BIN)
+        .args(["powercut", "verify", "--db"])
+        .arg(&db)
+        .args(["--trial", "2"])
+        .status()
+        .expect("verify did not run");
+    assert_eq!(
+        status.code(),
+        Some(2),
+        "re-verifying without re-arming must be a refusal — this is how one power cut \
+         became three PASS rows"
+    );
+    assert_eq!(
+        read_records(&ledger).len(),
+        1,
+        "a refused verify appended to the ledger anyway"
+    );
+
+    // A second arming must succeed on the now-populated store: it starts at
+    // MAX(generation)+1 rather than colliding at 0.
+    assert!(
+        arm_and_kill(&db),
+        "the second arming failed on a populated store — it restarted at generation 0"
+    );
+
+    // ...and the two rows carry different arm ids, so they count as two.
+    let status = Command::new(BIN)
+        .args(["powercut", "verify", "--db"])
+        .arg(&db)
+        .args(["--trial", "2"])
+        .status()
+        .expect("verify did not run");
+    assert_eq!(
+        status.code(),
+        Some(1),
+        "the second verify was refused rather than recorded"
+    );
+
+    let rows = read_records(&ledger);
+    assert_eq!(rows.len(), 2);
+    let ids: Vec<&str> = rows.iter().filter_map(|r| field(r, "arm_id")).collect();
+    assert_eq!(ids.len(), 2, "a ledger row carried no arm id");
+    assert_ne!(
+        ids[0], ids[1],
+        "two separate armings minted the same id, so they would count as one trial"
+    );
+
+    // Arming over an outstanding marker is refused: the previous trial would be
+    // orphaned and its marker would describe a store state that no longer
+    // exists.
+    assert!(arm_and_kill(&db), "third arming");
+    // Bounded, because a regression here does not fail — it arms, and `arm`
+    // never returns. A plain `.status()` would hang the suite instead of
+    // reporting the bug.
+    let mut child = Command::new(BIN)
+        .args(["powercut", "arm", "--db"])
+        .arg(&db)
+        .args(["--events", "64", "--entities", "8"])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("arm did not start");
+    let mut code = None;
+    for _ in 0..300 {
+        if let Ok(Some(s)) = child.try_wait() {
+            code = s.code();
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+    if code.is_none() {
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+    assert_eq!(
+        code,
+        Some(2),
+        "arming over an unused marker must be refused; it armed again instead"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
 #[test]
 fn powercut_requires_a_subcommand_and_verify_requires_a_trial_number() {
     for args in [
@@ -192,79 +349,6 @@ fn powercut_requires_a_subcommand_and_verify_requires_a_trial_number() {
             Some(2),
             "`{}` must be a usage error, not a silent no-op",
             args.join(" ")
-        );
-    }
-}
-
-/// The full tier C loop, with `SIGKILL` standing in for the power switch.
-///
-/// This does **not** make tier C automatable — a signal leaves the page cache
-/// intact, which is exactly why tier C needs a power supply and why the harness
-/// refuses to claim it. What it proves is that the *recording* machinery works:
-/// the marker survives, `verify` judges against it, the ledger accumulates, and
-/// the aggregate still refuses to pass below the required trial count.
-#[test]
-fn the_powercut_ledger_accumulates_and_still_refuses_to_pass_early() {
-    use std::io::Read;
-
-    let mut db = scratch("powercut-loop");
-    db.push("w.sqlite");
-    for suffix in ["", "-wal", "-shm", "-tierc-armed", "-tierc-trials.jsonl"] {
-        let _ = std::fs::remove_file(format!("{}{suffix}", db.display()));
-    }
-
-    // Arm never returns, so it is killed the way the mains would kill it.
-    let mut child = Command::new(BIN)
-        .args(["powercut", "arm", "--db", &db.to_string_lossy()])
-        .stdout(std::process::Stdio::piped())
-        .spawn()
-        .expect("spawn arm");
-
-    // Wait for it to announce that the prefix is fsynced and recorded, so the
-    // kill lands on the tail rather than on the prefix.
-    let mut out = child.stdout.take().expect("stdout");
-    let mut seen = String::new();
-    let mut byte = [0u8; 1];
-    while !seen.contains("ARMED:") {
-        match out.read(&mut byte) {
-            Ok(0) | Err(_) => break,
-            Ok(_) => seen.push(byte[0] as char),
-        }
-    }
-    assert!(seen.contains("ARMED:"), "arm never armed: {seen}");
-    std::thread::sleep(std::time::Duration::from_millis(150));
-    let _ = child.kill();
-    let _ = child.wait();
-
-    // Three trials: below the required five, so the tier must still refuse.
-    for trial in 1..=3 {
-        let status = Command::new(BIN)
-            .args([
-                "powercut",
-                "verify",
-                "--db",
-                &db.to_string_lossy(),
-                "--trial",
-                &trial.to_string(),
-            ])
-            .status()
-            .expect("did not run");
-        assert_eq!(
-            status.code(),
-            Some(1),
-            "trial {trial}: an incomplete tier C must exit non-zero"
-        );
-    }
-
-    let ledger = std::fs::read_to_string(format!("{}-tierc-trials.jsonl", db.display()))
-        .expect("ledger written");
-    let lines: Vec<&str> = ledger.lines().filter(|l| !l.trim().is_empty()).collect();
-    assert_eq!(lines.len(), 3, "one row per trial: {ledger}");
-    for line in &lines {
-        assert!(
-            line.contains("\"outcome\":\"PASS\""),
-            "a SIGKILL must not lose the fsynced prefix — that would be a real \
-             finding, not a test artefact: {line}"
         );
     }
 }


### PR DESCRIPTION
## The defect

`powercut_arm` always started at generation 0 (`gen::events(0, ...)`). On a
populated store that is not merely non-independent — `generation` is the primary
key, so the second arming died on `UNIQUE constraint failed:
world_events.generation` while the **first marker survived**. Every later
`verify` then re-read the same surviving store and appended another `PASS`.

Reproduced on one database before fixing:

```
trial 1: PASS   durable=400 recovered=6800
trial 2: PASS   durable=400 recovered=6800   <- arm FAILED, never ran
trial 3: PASS   durable=400 recovered=6800   <- no arm at all
trial 4: PASS   durable=400 recovered=6800   <- no arm at all
trial 5: PASS   durable=400 recovered=6800   <- no arm at all
tier C after 6 trial(s): PASS — 6 power-cut trial(s) recorded ...   exit=0
```

**One real power cut produced a tier C verdict of `PASS`, exit 0.**
`MIN_TIER_C_TRIALS` was fully defeated — the identical `durable`/`recovered`
pair on every row is the fingerprint. This is precisely the vacuous-pass failure
mode the tier was built to prevent.

## The correction

A trial is an **arming**, not a ledger row.

| | |
|---|---|
| Arm from `MAX(generation) + 1` | `next_generation()`; the tail starts after the prefix *that* arming wrote, not after `prefix_events` counted from zero |
| Refuse arm over an unused marker | exit 2 — an outstanding marker means the previous arming was never verified, and arming over it orphans that trial while leaving a marker describing a store state that no longer exists |
| Unique arm id in the marker | `arm_id` alongside the durable boundary and head digest, minted from state + wall clock + pid so two armings of an identical-looking store still differ |
| Verify rejects duplicates | repeated trial number **and** repeated arm id, both **before** anything is written |
| Ledger before marker | the verdict is appended and fsynced *first*; the marker is removed only after. A cut in between leaves the arming outstanding — recoverable as a duplicate arm id — where the reverse order would lose the verdict entirely |
| Count distinct arm ids | rows carrying no arm id (written by the defective build) are refused as **unattributable** rather than dropped, so a stale ledger cannot be mistaken for an absent one |

Exit codes stay distinguishable: **1** = a trial was recorded but the series is
still short of five; **2** = the verification was *refused* and nothing was
written.

## Prior evidence, corrected

The R2 attempt recorded **three `PASS` rows from one power cut**. Only the first
followed an arming; trials 2 and 3 re-verified the same marker, and trial 4
surfaced the defect by failing on the primary key.

**Honest status: 1 valid independent PASS of the 5 required.** Tier C remains
incomplete, and no durability claim is supported. The archived evidence bundles
in `docs/evidence/` are unaffected — they record `NOT-RUN`, `0/5`, which was
already accurate for those runs.

## Tests

18 new assertions across 11 new tests. `cargo test` in the harness tree:
**150 unit + 7 integration, all passing.**

Unit (`src/crash.rs`):

- `a_second_arming_starts_after_the_events_the_first_one_wrote` — MAX+1, and the chain is still one unbroken run across both armings (generation continuity)
- `restarting_at_zero_on_a_populated_store_is_the_constraint_violation_it_looked_like` — pins the observed `UNIQUE` failure rather than assuming it
- `verifying_twice_without_re_arming_is_refused`
- `a_repeated_trial_number_is_refused_before_anything_is_written` — and the marker survives, so the arming can still be verified under a correct number
- `a_repeated_arm_id_is_refused_even_under_a_fresh_trial_number` — the resurrected-marker recovery case
- `the_marker_survives_a_ledger_write_that_fails` — ordering, forced by blocking the ledger path
- `three_rows_carrying_one_arm_id_count_as_one_trial` — the exact shape of the corrected R2 evidence
- `five_rows_sharing_fewer_than_five_armings_do_not_pass` — enough rows to satisfy the old count, from two armings
- `four_distinct_armings_are_inconclusive_and_five_pass`
- `rows_written_before_arm_ids_existed_cannot_be_counted`
- `two_armings_of_the_same_store_state_still_mint_different_ids`

Integration (`tests/crash_tier_a.rs`), against the real binary:

- `each_power_cut_trial_needs_its_own_arming` — arm → "cut" → verify → refused re-verify → second arming succeeds on the populated store → the two rows carry different arm ids → arming over an outstanding marker is refused. The last check is bounded rather than blocking, because a regression there does not fail — it arms, and `arm` never returns.

The superseded `the_powercut_ledger_accumulates_and_still_refuses_to_pass_early`
test was removed: it asserted the accumulate-by-row contract this change
replaces.

## Files changed

| File | |
|---|---|
| `tools/wm2-persistence-harness/src/crash.rs` | the fix + 11 tests |
| `tools/wm2-persistence-harness/src/main.rs` | `verify` handles the `Result`; the progress line quotes distinct armings, not rows |
| `tools/wm2-persistence-harness/tests/crash_tier_a.rs` | the end-to-end independence test |
| `docs/hardware/JETSON_WM2_PERSISTENCE_DRILL.md` | §8: markers are single-use, each trial needs a fresh arm, the R2 correction, restart on a fresh DB |
| `tools/wm2-persistence-harness/README.md` | same, for the harness reader |

## Checks

`cargo fmt --check` (root + harness tree), `cargo clippy --all-targets -D
warnings`, `cargo check --workspace`, `cargo test` (harness), and the repo gates:
`test_world_domain_logic_gate`, `check_world_domain_logic_gate`,
`test_kirra_world_bidirectional_fence`, `check_kirra_world_bidirectional_fence`,
`check_mick_actuation_fence`, `check_website_citations`,
`check_workflow_pr_coverage`, `check_reexport_shims` — all pass locally.

## Scope

Harness-only. **No production runtime, safety algorithm, checker input,
release-token logic, or actuator behaviour is touched. ADR-0042 is unchanged.
ADR-0041 remains Proposed and tier C remains incomplete.** No Kirra World domain
logic, storage, APIs, or services are implemented here.

Kirra is designed in alignment with ISO 26262 ASIL-D requirements and IEC 61508
SIL 3 requirements. Independent third-party assessment has not yet been
performed.

**Do not merge** — review only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_