### PR TITLE
fix(wm2): make the migrate record self-describing on both cost axes

### DIFF
--- a/tools/wm2-persistence-harness/src/main.rs
+++ b/tools/wm2-persistence-harness/src/main.rs
@@ -615,6 +615,15 @@ fn main() {
                         .str("record", "migrate")
                         .str("migration_sql", args.migration_sql.token())
                         .int("events", r.events)
+                        // Self-describing on purpose. `migrate`'s cost depends
+                        // on BOTH axes (ADR-0041 D-13), so a record carrying
+                        // only `events` cannot be placed on the ladder without
+                        // pairing it against the preceding `run` record by
+                        // position. Reconstructing an axis from record ORDER is
+                        // fragile — a reordered, filtered or partially copied
+                        // file silently yields the wrong ladder — so the field
+                        // that determines the cost travels with the measurement.
+                        .int("entities", args.entities)
                         .int("version_after", r.version_after as u64)
                         .bool("future_schema_refused", r.future_schema_refused)
                         .bool("chain_intact_after", r.chain_intact_after)


### PR DESCRIPTION
The `migrate` record carried `events` but not `entities`.

That surfaced while preparing the R2 target bundle: the ladder rows can only be placed on their axis by pairing each `migrate` record against the preceding `run` record **by position**. Which is backwards for a measurement whose cost depends on *both* axes (D-13) — reconstructing an axis from record order is fragile, and a reordered, filtered or partially copied file silently yields the *wrong* ladder rather than an obviously broken one.

The field that determines the cost now travels with the measurement.

## Verified

```
$ wm2-persistence-harness migrate --events 2000 --entities 137 --migration-sql grouped
migrate record now carries: {'record': 'migrate', 'migration_sql': 'grouped',
                             'events': 2000, 'entities': 137}
```

## Scope

One field plus a comment explaining why it is there, so it does not get tidied away later. **Does not change any measurement** — only what the record says about itself.

Bundles archived before this still need order-based reconstruction, and their READMEs should say so; this fixes it going forward rather than retrospectively.

Harness only. Closes no ADR-0041 gate and changes no ADR status. ADR-0042 untouched; the domain-logic gate is not released.

## Checks

`cargo fmt --check` (root + harness), `cargo clippy --all-targets -D warnings` (0 issues), `cargo test` — **156 unit + 7 integration, 0 failed**.

Kirra is designed in alignment with ISO 26262 ASIL-D requirements and IEC 61508 SIL 3 requirements. Independent third-party assessment has not yet been performed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_