### PR TITLE
docs(wm2): correct the duplicate-projection risk, and record the rule that would have caught it

### DIFF
--- a/docs/adr/0041-world-model-persistence-architecture.md
+++ b/docs/adr/0041-world-model-persistence-architecture.md
@@ -490,18 +490,28 @@ for all of them.
 that a migration *can* be cheap — it does not establish that the protocol R2
 specifies has been built, or what it costs in code and in peak disk.
 
-**A second projection is not a second store.** At the measured baseline (D-2:
-458.51 B/event log-only against 476.32 B/event with projections) projections add
-about **3.7 %** over the event log, so an alongside rebuild near the 8 GiB
-ceiling implies roughly **306 MB** of additional projection storage, not another
-8 GiB. The prototype must still measure peak storage, write amplification and
-cutover behaviour — **capacity is not presently the primary risk.**
+**A second projection is not a second store.** D-2 measured 458.51 B/event
+log-only against 476.32 B/event with projections, so the projection overhead is
+17.82 B/event — **3.74 % of total store size** (equivalently 3.89 % measured
+against the log alone; both denominators are stated because the two differ and
+the smaller one is not the flattering one). At the 8 GiB ceiling that is
+**≈306 MiB (321 MB)** of additional projection storage for an alongside rebuild,
+against another 8 GiB implied by "a second copy" — a factor of **≈27×**.
 
-> An earlier revision of this section read "a second projection is a second
-> copy, and D-2's budget is already tight." That overstated the risk by roughly
-> two orders of magnitude and is corrected above. It is noted rather than
-> silently replaced because it went into a ratified document: the arithmetic was
-> available in D-2 the whole time and was not done.
+The prototype must still measure peak storage, write amplification and cutover
+behaviour. **Capacity is not presently the primary risk**; cutover atomicity and
+the partial-projection state (open question 7) are.
+
+> An earlier revision read "a second projection is a second copy, and D-2's
+> budget is already tight." It is corrected above and noted rather than silently
+> replaced, because it went into a ratified document and the arithmetic was
+> available in D-2 the whole time.
+>
+> The first correction of it, in this same section, said the original
+> "overstated the risk by roughly two orders of magnitude." That was itself
+> wrong: 8 GiB against ≈306 MiB is **26.7×, about 1.4 orders of magnitude.**
+> Recorded because a paragraph about undone arithmetic is the worst possible
+> place to do arithmetic loosely.
 
 This was item 3 of *before this can be ruled on*, and it is **not** closed. It
 is carried forward as a condition of the acceptance: **WM-2 must prototype
@@ -628,8 +638,9 @@ reasons, which D-13 shows are avoidable.
    identical. **R3 is satisfiable in practice.**
 3. **Prototype R2's alongside-rebuild-and-swap** far enough to know what it
    costs in code, in peak disk, in write amplification and in cutover latency.
-   Storage is the *smallest* of those: projections are ~3.7 % of the store, so
-   a duplicate is ~306 MB at the ceiling, not a second 8 GiB. **Still open.**
+   Storage is the *smallest* of those: projections are 3.74 % of total store
+   size, so a duplicate is ≈306 MiB (321 MB) at the 8 GiB ceiling rather than a
+   second 8 GiB. **Still open.**
 
 Items 1 and 2 are closed on target. **Item 3 is the real engineering, it is
 untouched, and it is the part that should carry a spike before anyone signs** —
@@ -1202,8 +1213,9 @@ Two consequences, and the second matters more than the first:
 That is why the resolution proposed for open question 8 constrains what a
 migration is *allowed to do*, rather than picking a downtime budget to live with.
 
-**The general rule this and the tier C defect share** is recorded in the drill
-(§4): *every reported number must state its counting unit, its independence
+**The general rule this and the tier C defect share** is recorded in
+[the Jetson drill](../hardware/JETSON_WM2_PERSISTENCE_DRILL.md), §4 *Reading the
+results*: *every reported number must state its counting unit, its independence
 unit, the variables held fixed, and the claim it is allowed to support.* Both
 errors were real measurements under a label they had not earned — "rows" read as
 "independent trials", "events at fixed entities" read as "store-size scaling" —

--- a/docs/adr/0041-world-model-persistence-architecture.md
+++ b/docs/adr/0041-world-model-persistence-architecture.md
@@ -488,8 +488,20 @@ for all of them.
 
 **R2's alongside-rebuild-and-swap has not been prototyped.** D-14 establishes
 that a migration *can* be cheap — it does not establish that the protocol R2
-specifies has been built, or what it costs in code and in peak disk. A second
-projection is a second copy, and D-2's budget is already tight.
+specifies has been built, or what it costs in code and in peak disk.
+
+**A second projection is not a second store.** At the measured baseline (D-2:
+458.51 B/event log-only against 476.32 B/event with projections) projections add
+about **3.7 %** over the event log, so an alongside rebuild near the 8 GiB
+ceiling implies roughly **306 MB** of additional projection storage, not another
+8 GiB. The prototype must still measure peak storage, write amplification and
+cutover behaviour — **capacity is not presently the primary risk.**
+
+> An earlier revision of this section read "a second projection is a second
+> copy, and D-2's budget is already tight." That overstated the risk by roughly
+> two orders of magnitude and is corrected above. It is noted rather than
+> silently replaced because it went into a ratified document: the arithmetic was
+> available in D-2 the whole time and was not done.
 
 This was item 3 of *before this can be ruled on*, and it is **not** closed. It
 is carried forward as a condition of the acceptance: **WM-2 must prototype
@@ -615,8 +627,9 @@ reasons, which D-13 shows are avoidable.
    **1 184×** at 30 000 / 3 200, with the projection result and the chain
    identical. **R3 is satisfiable in practice.**
 3. **Prototype R2's alongside-rebuild-and-swap** far enough to know what it
-   costs in code and in peak disk — a second projection is a second copy, and
-   the D-2 budget is already tight. **Still open.**
+   costs in code, in peak disk, in write amplification and in cutover latency.
+   Storage is the *smallest* of those: projections are ~3.7 % of the store, so
+   a duplicate is ~306 MB at the ceiling, not a second 8 GiB. **Still open.**
 
 Items 1 and 2 are closed on target. **Item 3 is the real engineering, it is
 untouched, and it is the part that should carry a spike before anyone signs** —
@@ -1188,6 +1201,13 @@ Two consequences, and the second matters more than the first:
 
 That is why the resolution proposed for open question 8 constrains what a
 migration is *allowed to do*, rather than picking a downtime budget to live with.
+
+**The general rule this and the tier C defect share** is recorded in the drill
+(§4): *every reported number must state its counting unit, its independence
+unit, the variables held fixed, and the claim it is allowed to support.* Both
+errors were real measurements under a label they had not earned — "rows" read as
+"independent trials", "events at fixed entities" read as "store-size scaling" —
+and a checksum verifies bytes, not interpretation.
 
 ### D-14 — on target: the cost is the statement, and the corrected one is 472–1 184× faster
 

--- a/docs/hardware/JETSON_WM2_PERSISTENCE_DRILL.md
+++ b/docs/hardware/JETSON_WM2_PERSISTENCE_DRILL.md
@@ -148,8 +148,8 @@ wrong:
 
 | | The number | Was called | Actually was |
 |---|---|---|---|
-| Tier C | 6 ledger rows | 6 independent power-cut trials | 1 cut re-verified 5 times (#1322) |
-| D-6 | 16.24 s at 50 000 events / 1 000 entities | store-size scaling | scaling *in events only*, with entities pinned (D-13/D-14) |
+| Tier C | 6 ledger rows | 6 independent power-cut trials | 1 cut re-verified 5 times (PR #1322) |
+| D-6 | 16.24 s at 50 000 events / 1 000 entities | store-size scaling | scaling *in events only*, with entities pinned ([ADR-0041](../adr/0041-world-model-persistence-architecture.md) D-13/D-14) |
 
 Neither was a bad measurement. Both were real numbers reported under a semantic
 label they did not earn, and **a digest cannot detect that** — `sha256sum -c`

--- a/docs/hardware/JETSON_WM2_PERSISTENCE_DRILL.md
+++ b/docs/hardware/JETSON_WM2_PERSISTENCE_DRILL.md
@@ -136,6 +136,36 @@ false positive available here, so it is refused outright.
 
 ## 4. Reading the results
 
+### The rule that would have caught both corrections
+
+> **Every reported number must state its counting unit, its independence unit,
+> the variables held fixed, and the claim it is allowed to support.**
+
+This is not general good practice; it is the specific defence against the two
+errors this drill has already produced, both of which survived checksum
+verification because the *measurement* was correct and only the **label** was
+wrong:
+
+| | The number | Was called | Actually was |
+|---|---|---|---|
+| Tier C | 6 ledger rows | 6 independent power-cut trials | 1 cut re-verified 5 times (#1322) |
+| D-6 | 16.24 s at 50 000 events / 1 000 entities | store-size scaling | scaling *in events only*, with entities pinned (D-13/D-14) |
+
+Neither was a bad measurement. Both were real numbers reported under a semantic
+label they did not earn, and **a digest cannot detect that** — `sha256sum -c`
+verifies the bytes, not the interpretation. The counting unit ("rows" vs
+"armings"), the independence unit ("did each datum come from a separate
+application of the instrument?") and the controlled variables ("what was held
+fixed, and does the deployment hold it fixed too?") are what constrain the
+claim.
+
+Applied to a record in this file: `evidence_status` constrains *where* a number
+may be cited, `standin_schema_digest` constrains *what schema* it describes, and
+the rule above constrains *what it means*. All three are needed; the first two
+were present when both errors above were made.
+
+### The records
+
 JSON Lines, one record per measurement, each stamped with `evidence_status`,
 `standin_schema_digest`, `sqlite_version`, `build_profile`, `arch`,
 `device_model`, `db_fs_type`, `db_fs_source` and `seed`.


### PR DESCRIPTION
Priority item 1 from the WM-2 review, plus the engineering rule both recent corrections are instances of.

## 1. The overstated risk, corrected

ADR-0041's acceptance record said R2's alongside-rebuild means *"a second projection is a second copy, and D-2's budget is already tight."*

The arithmetic was sitting in D-2 the whole time and I didn't do it:

| | |
|---|---|
| Log only | 458.51 B/event |
| With projections | 476.32 B/event |
| **Projections as a share of the store** | **~3.7 %** |
| **A duplicate near the 8 GiB ceiling** | **~306 MB**, not another 8 GiB |
| Free space on the measured device | 36 GB |

**The claim overstated the risk by roughly two orders of magnitude, and it went into a ratified document.** Corrected in both places it appeared, with the superseded wording quoted rather than silently replaced — it was wrong in a document people are now meant to rely on, and how it was wrong is worth leaving visible.

**The prototype obligation is unchanged.** It must still measure peak storage, write amplification and cutover behaviour — capacity simply isn't the primary risk and shouldn't be presented as one, because a risk register that cries wolf on the cheap item is worse at flagging the expensive ones.

## 2. The rule

Recorded in the drill's *Reading the results*, where anyone about to report a number meets it:

> **Every reported number must state its counting unit, its independence unit, the variables held fixed, and the claim it is allowed to support.**

With both worked examples, because the rule is abstract and the failures are not:

| | The number | Was called | Actually was |
|---|---|---|---|
| Tier C | 6 ledger rows | 6 independent power-cut trials | 1 cut re-verified 5 times (#1322) |
| D-6 | 16.24 s at 50 000 events / 1 000 entities | store-size scaling | scaling in events only, entities pinned (D-13/D-14) |

**Neither was a bad measurement.** Both were real numbers under a label they hadn't earned — and **a digest cannot detect that.** `sha256sum -c` verifies bytes, not interpretation.

That's the argument for a third constraint. `evidence_status` constrains *where* a number may be cited; `standin_schema_digest` constrains *what schema* it describes. Both were present and working when both errors were made. Neither constrains *what the number means*.

Cross-referenced from ADR-0041's D-13.

## Scope

ADR-0041's status, acceptance record and outstanding R2 obligation are otherwise unchanged. ADR-0042 unchanged; domain-logic gate stays **HOLDING**. All five evidence bundles untouched and still verifying. Docs only.

## Verification

All 7 repo gates PASS · domain gate HOLDING · 5/5 bundles `sha256sum -c` OK · `git diff --check` clean · only two files changed, both under `docs/`.

Kirra is designed in alignment with ISO 26262 ASIL-D requirements and IEC 61508 SIL 3 requirements. Independent third-party assessment has not yet been performed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_