### PR TITLE
design(wm2): the R2 projection rebuild-and-swap protocol, resolving OQ7 in design

### DIFF
--- a/docs/adr/0041-world-model-persistence-architecture.md
+++ b/docs/adr/0041-world-model-persistence-architecture.md
@@ -519,7 +519,7 @@ the partial-projection state (open question 7) are.
 > **Partial discharge, 2026-08-04 — the code half only.**
 > `docs/design/WM2_PROJECTION_REBUILD_PROTOCOL.md` (KIRRA-WM2-REBUILD-001)
 > specifies the protocol and prototypes it as a pure state machine
-> (`tools/wm2-persistence-harness/src/rebuild.rs`, 14 tests), which answers *what
+> (`tools/wm2-persistence-harness/src/rebuild.rs`, 15 tests), which answers *what
 > it costs in code* and resolves the partial-projection state named in the
 > paragraph above. **Peak storage, write amplification and cutover latency remain
 > unmeasured**, and the design deliberately says so rather than letting a

--- a/docs/adr/0041-world-model-persistence-architecture.md
+++ b/docs/adr/0041-world-model-persistence-architecture.md
@@ -429,11 +429,25 @@ source; they are not migrated destructively (ADR-0040).
    for a fleet, local evidence staying local?
 6. Event payload encoding — the blueprint does not fix one; JSON is
    inspectable, a binary format is compact.
-7. **Partial projections under disk pressure.** A fold writes, so it is refused
-   when the store is full. A fold interrupted that way leaves partial
-   projections with nothing marking them as incomplete. Needs either a
-   fold-in-progress marker, a transactional whole-fold, or an explicit rule that
-   projections are invalid until a checkpoint confirms them.
+7. **Partial projections under disk pressure — RESOLVED IN DESIGN 2026-08-04**,
+   with the implementation condition below still outstanding. A fold writes, so
+   it is refused when the store is full. A fold interrupted that way leaves
+   partial projections with nothing marking them as incomplete. The question
+   asked for "either a fold-in-progress marker, a transactional whole-fold, or
+   an explicit rule that projections are invalid until a checkpoint confirms
+   them". **The rebuild protocol supplies the first and third and shows they are
+   the same thing** — see `docs/design/WM2_PROJECTION_REBUILD_PROTOCOL.md`
+   (KIRRA-WM2-REBUILD-001), prototyped as a pure state machine in
+   `tools/wm2-persistence-harness/src/rebuild.rs`. A projection is authoritative
+   only in `Active`; a fold refused midway leaves `Building`, which cannot serve
+   and cannot cut over. The marker OQ7 said was missing **is the protocol state
+   itself**, so it need not be inferred from row counts or a sentinel row.
+   **Implementation condition, explicitly not met:** the protocol is correct only
+   if the store makes the rebuild-state record durable and transactional with the
+   fold progress it describes (design §8, S-1) and supplies an atomic swap
+   (S-2). Neither is built, because both are store work gated by ADR-0042
+   Decision 5. This is recorded on the same footing as open question 8 — the
+   design is adopted, the obligation is carried in the open rather than quietly.
 8. **Migration strategy — RESOLVED 2026-08-04** by adopting R1–R5 (see *Open
    question 8 — resolution*), subject to the outstanding R2 prototype obligation
    in the *Acceptance record*. Was blocking for acceptance (D-6, D-13).
@@ -502,6 +516,17 @@ The prototype must still measure peak storage, write amplification and cutover
 behaviour. **Capacity is not presently the primary risk**; cutover atomicity and
 the partial-projection state (open question 7) are.
 
+> **Partial discharge, 2026-08-04 — the code half only.**
+> `docs/design/WM2_PROJECTION_REBUILD_PROTOCOL.md` (KIRRA-WM2-REBUILD-001)
+> specifies the protocol and prototypes it as a pure state machine
+> (`tools/wm2-persistence-harness/src/rebuild.rs`, 14 tests), which answers *what
+> it costs in code* and resolves the partial-projection state named in the
+> paragraph above. **Peak storage, write amplification and cutover latency remain
+> unmeasured**, and the design deliberately says so rather than letting a
+> protocol document read as a cost result. The ≈306 MiB figure above is an
+> arithmetic consequence of D-2, not a measurement of a rebuild. This obligation
+> is therefore reduced, not closed.
+
 > An earlier revision read "a second projection is a second copy, and D-2's
 > budget is already tight." It is corrected above and noted rather than silently
 > replaced, because it went into a ratified document and the arithmetic was
@@ -538,7 +563,10 @@ done would have been a false record.
   else — the *shape* conclusions survive, the constants do not.
 - **It does not close the open questions other than 8.** Questions 7, 9 and 10
   in particular remain open, and 9 (the intermittent multi-second write stall)
-  is unresolved as to mechanism.
+  is unresolved as to mechanism. *(Later the same day, question 7 was resolved
+  **in design** — see its entry in *Open questions*. That happened after this
+  acceptance, not as part of it, and it did not close the question's
+  implementation condition. The sentence stands as written at the time.)*
 
 ### Reopening conditions
 
@@ -640,7 +668,12 @@ reasons, which D-13 shows are avoidable.
    costs in code, in peak disk, in write amplification and in cutover latency.
    Storage is the *smallest* of those: projections are 3.74 % of total store
    size, so a duplicate is ≈306 MiB (321 MB) at the 8 GiB ceiling rather than a
-   second 8 GiB. **Still open.**
+   second 8 GiB. **Partially discharged 2026-08-04 — still open.** The protocol
+   is now specified and prototyped
+   (`docs/design/WM2_PROJECTION_REBUILD_PROTOCOL.md`), which answers the *code*
+   cost and settles cutover ordering and the partial-projection state. **Peak
+   disk, write amplification and cutover latency are still unmeasured**, and
+   those are the three that need the store the design does not build.
 
 Items 1 and 2 are closed on target. **Item 3 is the real engineering, it is
 untouched, and it is the part that should carry a spike before anyone signs** —

--- a/docs/adr/0041-world-model-persistence-architecture.md
+++ b/docs/adr/0041-world-model-persistence-architecture.md
@@ -442,12 +442,26 @@ source; they are not migrated destructively (ADR-0040).
    only in `Active`; a fold refused midway leaves `Building`, which cannot serve
    and cannot cut over. The marker OQ7 said was missing **is the protocol state
    itself**, so it need not be inferred from row counts or a sentinel row.
-   **Implementation condition, explicitly not met:** the protocol is correct only
-   if the store makes the rebuild-state record durable and transactional with the
-   fold progress it describes (design §8, S-1) and supplies an atomic swap
-   (S-2). Neither is built, because both are store work gated by ADR-0042
-   Decision 5. This is recorded on the same footing as open question 8 — the
-   design is adopted, the obligation is carried in the open rather than quietly.
+   **Disposition, ruled 2026-08-04:**
+
+   > OQ7 is resolved at the protocol level. Full closure is conditional on the
+   > production store implementing and testing durable rebuild state,
+   > pinned-generation equivalence verification, and atomic cutover with restart
+   > recovery.
+
+   The split behind that ruling. The protocol answers **restart/recovery**
+   (`on_restart` is total), guarantees **old-active preservation** (no
+   transition retires a projection at all), requires an **equivalence proof
+   before activation** (`Active` is reachable only from `Verified`), and makes
+   the **state transition** atomic (`Verified → Active`, no intermediate). Two
+   load-bearing properties still depend on the store and are **not** built:
+   the equivalence *comparison* at the pinned generation (design §8, S-4), and
+   the *database* cutover being atomic for readers and durable across restart
+   (S-1, S-2). Those are store work gated by ADR-0042 Decision 5.
+
+   Recorded this way so the state machine does not stand in for unbuilt
+   persistence behaviour — the same posture as open question 8, where the design
+   is adopted and the obligation is carried in the open rather than quietly.
 8. **Migration strategy — RESOLVED 2026-08-04** by adopting R1–R5 (see *Open
    question 8 — resolution*), subject to the outstanding R2 prototype obligation
    in the *Acceptance record*. Was blocking for acceptance (D-6, D-13).

--- a/docs/design/WM2_PROJECTION_REBUILD_PROTOCOL.md
+++ b/docs/design/WM2_PROJECTION_REBUILD_PROTOCOL.md
@@ -281,12 +281,30 @@ invalid-until-confirmed rule. A fold refused midway under disk pressure leaves
 
 **Does not resolve — the same question in the live store.** OQ7 is about
 behaviour under disk pressure in a real store. The protocol says what the state
-must be; S-1 above says the state record must be durable and transactional with
-the fold; neither is implemented, because implementing it means store work that
-ADR-0042 Decision 5 gates. **OQ7 should be recorded as resolved-in-design with
-the implementation condition named**, on the same footing OQ8 was — where the
-strategy was adopted and the R2 prototype obligation carried explicitly rather
-than quietly.
+must be; §8 says the state record must be durable and transactional with the
+fold; none of it is implemented, because implementing it means store work that
+ADR-0042 Decision 5 gates.
+
+**The ruling, 2026-08-04**, recorded in ADR-0041's OQ7 entry:
+
+> OQ7 is resolved at the protocol level. Full closure is conditional on the
+> production store implementing and testing durable rebuild state,
+> pinned-generation equivalence verification, and atomic cutover with restart
+> recovery.
+
+Which properties fall on which side:
+
+| Property | Protocol | Store |
+|---|---|---|
+| Restart/recovery | **Answered** — `on_restart` is total (§7) | S-1: the durable state record it resumes from |
+| Old-active preservation on failure | **Guaranteed** — no transition retires a projection (§5, invariant 4) | — |
+| Equivalence proof before activation | **Required** — `Active` only from `Verified` (§5, invariant 6) | **S-4: the comparison itself** |
+| Cutover atomicity | **State transition** is atomic (§5, invariant 3) | **S-2: the database swap, for readers and across restart** |
+
+The two bold store entries are the load-bearing gap. Recorded this way so the
+state machine does not stand in for unbuilt persistence behaviour — the same
+posture as OQ8, where the strategy was adopted and the R2 prototype obligation
+carried explicitly rather than quietly.
 
 **Does not discharge — the R2 cost obligation.** ADR-0041's acceptance record
 carries one outstanding obligation: prototype R2's alongside-rebuild-and-swap far

--- a/docs/design/WM2_PROJECTION_REBUILD_PROTOCOL.md
+++ b/docs/design/WM2_PROJECTION_REBUILD_PROTOCOL.md
@@ -1,0 +1,322 @@
+# WM-2 projection rebuild-and-swap protocol
+
+| | |
+|---|---|
+| **Identifier** | KIRRA-WM2-REBUILD-001 |
+| **Status** | **Design — proposed.** The protocol and its tests exist; the store-side implementation does not, and is gated by ADR-0042 Decision 5. |
+| **Implements** | ADR-0041 **R2** — "Projection changes are rebuilds, not backfills, and they run alongside" |
+| **Addresses** | ADR-0041 **open question 7** — partial projections under disk pressure |
+| **Prototype** | `tools/wm2-persistence-harness/src/rebuild.rs` (pure state machine, 14 tests) |
+| **Date** | 2026-08-04 |
+
+> Kirra is designed in alignment with ISO 26262 ASIL-D requirements and IEC 61508
+> SIL 3 requirements. Independent third-party assessment has not yet been
+> performed.
+
+---
+
+## 1. Scope
+
+**In scope.** The decision protocol governing a projection rebuild: which states
+a rebuild attempt passes through, which transitions are legal, and — the only
+question a query path actually asks — *when may this projection be believed*.
+
+**Out of scope, deliberately.**
+
+- **Kirra World domain logic, storage, APIs and services.** This is a protocol
+  prototype living in the measurement harness, over the harness's stand-in
+  schema (`standin_schema_digest 630eb690aaef…`). It implements no world-model
+  semantics.
+- **The fold itself.** How rows are read and projection rows written is store
+  work. This document decides when a fold's *output* may be trusted.
+- **Robot runtime behaviour, safety algorithms, checker inputs, release-token
+  logic, actuator behaviour.** None are touched, and none are in the dependency
+  closure of the prototype.
+- **Cost.** ADR-0041's outstanding R2 obligation asks what alongside-rebuild
+  costs "in code, in peak disk, in write amplification and in cutover latency".
+  This document answers the *code* half — the protocol is 269 lines and its
+  decision surface is exhaustively testable — and answers none of the other
+  three. See §9.
+
+ADR-0042 Decision 5 still gates implementation. Nothing here asks for that gate
+to move.
+
+---
+
+## 2. Why "build alongside and swap" is not yet a protocol
+
+ADR-0041 R2 is one sentence: build the new projection beside the live one, catch
+up, and swap. That sentence is correct and it hides three races, each of which
+is a silent-wrong-answer defect rather than a crash.
+
+**Ingest does not stop.** The rebuild folds from generation 0 forward while new
+events keep landing. So:
+
+1. **Catch-up need not converge.** If ingest outruns the fold, "wait until caught
+   up" is not a step — it is a hang that looks like slowness. Without an explicit
+   convergence rule, the operator has no signal distinguishing *slow* from
+   *never*.
+
+2. **A verification goes stale the instant an event arrives.** Equivalence is
+   proven *at a generation*. If the log advances between proving equivalence and
+   acting on it, the thing that was verified is not the thing being activated.
+   An implementation that proves equivalence, then swaps, has a window in which
+   it activates an unverified projection — and reports success.
+
+3. **An interrupted fold leaves partial rows with nothing marking them.** This is
+   open question 7 verbatim. A fold writes, so disk pressure refuses it midway;
+   what is left behind is a projection that is *wrong* but *present*, and a query
+   path that reads projections by name cannot tell.
+
+All three are decisions, not computations. That is why the protocol is a state
+machine with no database access: a decision table that cannot touch a store can
+be tested exhaustively, and every invariant below is a test rather than a review
+comment.
+
+---
+
+## 3. States
+
+| State | Meaning | Authoritative? |
+|---|---|---|
+| `Building { folded_to }` | Folding forward; the projection is **partial**. | No |
+| `CaughtUp { at }` | The fold reached the log head, observed at generation `at`. Nothing has been compared yet, and the head may already have moved. | No |
+| `Verified { at }` | Equivalence against the incremental projection was proven **at generation `at`**. Valid only while the head is still `at`. | No |
+| `Active` | Serving queries. Terminal. | **Yes** |
+| `Failed(reason)` | This attempt is over. The previous projection is untouched. | No |
+
+`is_authoritative()` returns true for `Active` and nothing else. That single
+predicate is the whole answer to open question 7: a projection left partial by an
+interrupted fold sits at `Building`, which is not authoritative and cannot cut
+over. **The marker OQ7 said was missing is the protocol state itself** — it does
+not need to be inferred from row counts, a sentinel row, or a checkpoint
+heuristic.
+
+`Failed` carries *why*, because the operator response differs by reason:
+
+| Reason | What it means | Response |
+|---|---|---|
+| `CatchupDiverged` | Ingest is outrunning the fold | Capacity — shed, throttle, or rebuild off-peak |
+| `EquivalenceMismatch { at }` | The rebuilt projection ≠ the incremental one | **Defect.** The fold is not deterministic. Do not retry blindly |
+| `FoldRefused(_)` | Disk pressure or I/O error | Capacity — reclaim, then retry |
+| `Abandoned` | Operator call | None |
+
+Collapsing these to a bare "failed" would make a determinism defect
+indistinguishable from a full disk, and the second is routinely retried.
+
+---
+
+## 4. Transitions
+
+Rows are the current state; columns are the event. `—` is a refused transition
+(returns `TransitionRefused`, carrying which transition was attempted and why —
+a caller cannot log "transition failed" without saying which one).
+
+| from \ on | `fold_progress(p)` | `reached_head(h)` | `append(h)` | `equivalence_proven(g)` | `cutover(h)` | `failure(r)` | `restart()` |
+|---|---|---|---|---|---|---|---|
+| `Building{f}` | `Building{p}`, — if `p < f` | `CaughtUp{h}`, — if `f > h` | `Building{f}`, — if `h < f` | — | — | `Failed(r)` | `Building{f}` |
+| `CaughtUp{at}` | — | — | **`Building{at}`**, — if `h < at` | `Verified{g}` if `g == at`, else — | — | `Failed(r)` | `Building{at}` |
+| `Verified{at}` | — | — | **`Building{at}`**, — if `h < at` | — | `Active` if `h == at`, else — | `Failed(r)` | **`Building{at}`** |
+| `Active` | — | — | `Active` | — | — | — | `Active` |
+| `Failed(_)` | — | — | — | — | — | — | `Failed(_)` |
+
+Five cells carry the argument.
+
+**`Verified` + `append` → `Building`.** The single most important transition
+here, and the one a hand-rolled implementation would omit. The proof was taken at
+a generation; the log moved; the proof now describes something that is not what
+would be served. It **demotes rather than fails** — nothing is wrong, the world
+simply moved — and it demotes to `Building` rather than `CaughtUp` because the
+projection is now genuinely behind by the appended event. It has to fold again,
+not merely be re-proven.
+
+**`cutover` refused unless `h == at`.** Belt and braces for the same race: even
+if a caller reached `Verified` and the head moved by a path the state machine did
+not observe, the head is re-checked at the moment of the swap.
+
+**`equivalence_proven` refused unless `g == at`.** A proof taken at a different
+generation is a proof about something else. Accepting it is how "we verified it"
+becomes true of a different database than the one being activated.
+
+**`append` refused when `h` is behind the folded position.** A log head that
+lands behind work already folded out of the log means the generation source is
+not monotonic (§8, S-3). Every staleness comparison in the protocol rests on
+that source, so a violation is refused loudly rather than absorbed as "no
+progress" — absorbing it would leave the protocol running normally on top of a
+broken premise.
+
+**`Active` + `failure` → refused.** An active projection is not a rebuild
+attempt. Retiring it is a separate, deliberate act with its own authorisation;
+the rebuild protocol has no transition that removes a working projection. This
+makes "failure leaves the previous projection active" **structural** rather than
+a rule someone has to remember.
+
+---
+
+## 5. The six required invariants
+
+ADR-0041 R2 and open question 7 between them require six properties. Each is a
+test, not a review comment.
+
+| # | Invariant | Enforced by | Test |
+|---|---|---|---|
+| 1 | Partial projections are invalid by default | `is_authoritative()` is true only for `Active` | `partial_projections_are_never_authoritative` |
+| 2 | Only a verified projection may cut over | `on_cutover` refuses from every other state | `only_a_verified_projection_may_cut_over` |
+| 3 | Cutover is atomic | `Verified → Active` is a single transition with no intermediate state; and no path reaches `Active` except through it | `cutover_is_the_only_path_to_authoritative` |
+| 4 | Failure leaves the previous projection active | No transition retires a projection; `Active.on_failure` refused; `Failed` accepts no further operations | `failure_never_touches_the_projection_that_is_working` |
+| 5 | Restart/recovery behaviour is explicit | `on_restart` is total — every state has a defined resumption | `restart_resumes_a_fold_but_demotes_a_verification` |
+| 6 | Equivalence proof is recorded before activation | `Active` is reachable only from `Verified`, which is reachable only from `on_equivalence_proven` | `equivalence_must_be_proven_at_the_generation_it_claims`, `a_verification_does_not_survive_an_append` |
+
+Invariant 3 needs a caveat stated plainly. **The state machine makes cutover
+atomic in the protocol; it does not make it atomic on disk.** `Verified → Active`
+has no intermediate state *here*, so no reader can observe a half-swapped
+protocol state. Whether the store's swap — renaming a table, flipping a pointer
+row, switching an attached file — is itself atomic is a store property this
+document does not supply. §8 states what the store must provide for the
+invariant to hold end to end. That obligation is real and it is not discharged
+by these tests.
+
+Invariant 4 is worth its own note: it is enforced by *absence*. The protocol
+contains no operation that removes or retires a projection. There is therefore no
+code path — correct, buggy, or maliciously ordered — by which a failed rebuild
+attempt takes down the projection that was serving. That is a stronger guarantee
+than a rule that says "on failure, keep the old one".
+
+---
+
+## 6. Catch-up convergence
+
+`catchup_is_converging(gaps)` takes the head-minus-folded distance sampled once
+per round, oldest first, and answers whether the loop is making progress.
+
+Convergence is **not** "the gap decreases every round". A burst of ingest can
+widen the gap for a round without meaning the rebuild will never finish, and a
+rule that failed on that would make the guard itself the most common reason
+rebuilds fail. The rule is *not stuck*: the gap must beat its best-so-far at
+least once every `MAX_NON_CONVERGING_ROUNDS` (3).
+
+Two deliberate choices:
+
+- **No judgement before there is evidence.** With `≤ MAX_NON_CONVERGING_ROUNDS`
+  samples the function returns `true`. An attempt that has barely started has not
+  demonstrated divergence, and failing it would be the guard inventing the
+  failure it exists to detect.
+- **Divergence is a failure, not a stall.** It resolves to
+  `FailureReason::CatchupDiverged` — a capacity signal with a named operator
+  response — rather than an unbounded wait that shows up as a hang.
+
+The sampling interval and the exact round budget are tunables, not invariants. On
+target they should be chosen against measured fold throughput; that measurement
+is part of the outstanding cost obligation (§9), not of this design.
+
+---
+
+## 7. Restart and recovery
+
+`on_restart` is total. Every state has a defined resumption, so "what happens if
+the process dies mid-rebuild" has an answer for every point in the protocol
+rather than for the points someone thought of.
+
+| State before | After restart | Why |
+|---|---|---|
+| `Building{f}` | `Building{f}` | **Resumes.** The fold is deterministic and its position is durable; re-folding from 0 would be correct but wasteful |
+| `CaughtUp{at}` | `Building{at}` | The head may have moved while the process was down |
+| `Verified{at}` | `Building{at}` | **Demotes.** See below |
+| `Active` | `Active` | The live projection survives a restart; that is what durability means |
+| `Failed(r)` | `Failed(r)` | An abandoned attempt stays abandoned, with its reason |
+
+The `Verified` demotion is the load-bearing one, and it is the same failure class
+as the tier C marker replay corrected in PR #1322: **a proof that survives a
+restart unexamined is stale evidence**. The head may have advanced during the
+outage, and the process has no way to know from its own memory that it did not.
+Re-folding and re-proving costs a lap; activating on a pre-crash proof costs a
+wrong answer that nothing detects.
+
+Note the asymmetry, which is deliberate: a *fold position* survives a restart, a
+*verification* does not. A fold position is a claim about work done, checkable
+against durable state. A verification is a claim about a relationship between two
+things at a moment, and the moment is gone.
+
+---
+
+## 8. What the store must provide
+
+The protocol is correct only if the store supplies four things. Naming them here
+is the point of writing the protocol first — each is now a requirement on the
+implementation rather than something discovered during it.
+
+| # | Requirement | Why the protocol needs it |
+|---|---|---|
+| S-1 | **A durable rebuild state record**, updated in the same transaction as the fold progress it describes | Otherwise a crash between the fold write and the state write leaves the two disagreeing, and §7's resumption reads a position that is not the position |
+| S-2 | **An atomic swap primitive** — the new projection becomes readable and the old becomes not, with no observable intermediate | Invariant 3 end to end (§5). Candidate: a single-row pointer flip inside a transaction |
+| S-3 | **A monotonic log head readable at a generation** | `on_append`, `on_reached_head` and `on_cutover` all compare against it; if it is not monotonic, the staleness check is not a check |
+| S-4 | **Equivalence comparison at a pinned generation** — the rebuilt and incremental projections compared with the log held still, or compared over a snapshot | `on_equivalence_proven` requires the proof and the generation to refer to the same instant |
+
+S-2 is the one most likely to be underestimated. A rebuild that swaps by dropping
+and renaming has a window; a rebuild that swaps by pointer has one row to make
+durable. The choice interacts with open question 3 (projections in the same file
+or a rebuildable sidecar), which remains open.
+
+---
+
+## 9. What this resolves, and what it does not
+
+**Resolves — open question 7, in design.** OQ7 asked for "either a
+fold-in-progress marker, a transactional whole-fold, or an explicit rule that
+projections are invalid until a checkpoint confirms them". The protocol supplies
+the first and third together and shows they are the same thing: the rebuild state
+*is* the fold-in-progress marker, and `is_authoritative()` *is* the
+invalid-until-confirmed rule. A fold refused midway under disk pressure leaves
+`Building`, which cannot serve and cannot cut over.
+
+**Does not resolve — the same question in the live store.** OQ7 is about
+behaviour under disk pressure in a real store. The protocol says what the state
+must be; S-1 above says the state record must be durable and transactional with
+the fold; neither is implemented, because implementing it means store work that
+ADR-0042 Decision 5 gates. **OQ7 should be recorded as resolved-in-design with
+the implementation condition named**, on the same footing OQ8 was — where the
+strategy was adopted and the R2 prototype obligation carried explicitly rather
+than quietly.
+
+**Does not discharge — the R2 cost obligation.** ADR-0041's acceptance record
+carries one outstanding obligation: prototype R2's alongside-rebuild-and-swap far
+enough to know what it costs in code, peak disk, write amplification and cutover
+latency. This document and its prototype answer **code** — the protocol is small
+and its decision surface is exhaustively testable. The other three are
+*unmeasured*, and this PR must not be read as evidence about them:
+
+| Cost | Status |
+|---|---|
+| Code | Answered. 269 lines of protocol (about a fifth of it documentation) plus 249 of tests; 14 tests; no store dependency |
+| Peak disk | **Unmeasured.** Bounded above by the D-2 arithmetic — projections are 3.74 % of store size, so a duplicate is ≈306 MiB (321 MB) at the 8 GiB ceiling — but *bounded* is not *measured*, and that figure is an arithmetic consequence of a measurement, not itself one |
+| Write amplification | **Unmeasured.** The fold writes the whole projection while ingest writes it incrementally; the sum has not been observed |
+| Cutover latency | **Unmeasured.** Depends entirely on S-2, which is not chosen |
+
+**Measurement semantics of the one number quoted above**, per the rule in
+`docs/hardware/JETSON_WM2_PERSISTENCE_DRILL.md` §4: the 3.74 % figure counts
+**bytes of projection tables against bytes of total store**, its independence
+unit is **one store built by one harness run**, it holds **schema, entity count
+and event mix** fixed at the D-2 configuration, and it supports the claim *"a
+duplicate projection is a small fraction of the store"* — and no claim about
+rebuild throughput, peak disk during a rebuild, or the cost of the swap.
+
+---
+
+## 10. Prototype status
+
+`tools/wm2-persistence-harness/src/rebuild.rs` — pure state machine, no SQL, no
+I/O, no schema. 14 tests covering the six invariants, fold-position and log-head
+sanity, convergence, and the two end-to-end paths (clean run; late append forcing
+another lap rather than a stale cutover).
+
+Run:
+
+```
+cargo test --manifest-path tools/wm2-persistence-harness/Cargo.toml rebuild::
+```
+
+The prototype is fenced from `kirra-world` by construction — it is in the
+measurement harness, it depends on nothing in the SDK's runtime crates, and it
+carries the stand-in schema. It is a design artifact that happens to compile and
+be tested, which is the only form of design document that cannot drift from what
+it describes.

--- a/docs/design/WM2_PROJECTION_REBUILD_PROTOCOL.md
+++ b/docs/design/WM2_PROJECTION_REBUILD_PROTOCOL.md
@@ -6,7 +6,7 @@
 | **Status** | **Design — proposed.** The protocol and its tests exist; the store-side implementation does not, and is gated by ADR-0042 Decision 5. |
 | **Implements** | ADR-0041 **R2** — "Projection changes are rebuilds, not backfills, and they run alongside" |
 | **Addresses** | ADR-0041 **open question 7** — partial projections under disk pressure |
-| **Prototype** | `tools/wm2-persistence-harness/src/rebuild.rs` (pure state machine, 14 tests) |
+| **Prototype** | `tools/wm2-persistence-harness/src/rebuild.rs` (pure state machine, 15 tests) |
 | **Date** | 2026-08-04 |
 
 > Kirra is designed in alignment with ISO 26262 ASIL-D requirements and IEC 61508
@@ -34,7 +34,7 @@ question a query path actually asks — *when may this projection be believed*.
   closure of the prototype.
 - **Cost.** ADR-0041's outstanding R2 obligation asks what alongside-rebuild
   costs "in code, in peak disk, in write amplification and in cutover latency".
-  This document answers the *code* half — the protocol is 269 lines and its
+  This document answers the *code* half — the protocol is 319 lines and its
   decision surface is exhaustively testable — and answers none of the other
   three. See §9.
 
@@ -114,13 +114,13 @@ a caller cannot log "transition failed" without saying which one).
 
 | from \ on | `fold_progress(p)` | `reached_head(h)` | `append(h)` | `equivalence_proven(g)` | `cutover(h)` | `failure(r)` | `restart()` |
 |---|---|---|---|---|---|---|---|
-| `Building{f}` | `Building{p}`, — if `p < f` | `CaughtUp{h}`, — if `f > h` | `Building{f}`, — if `h < f` | — | — | `Failed(r)` | `Building{f}` |
+| `Building{f}` | `Building{p}`, — if `p < f` | `CaughtUp{h}`, — unless `f == h` | `Building{f}`, — if `h < f` | — | — | `Failed(r)` | `Building{f}` |
 | `CaughtUp{at}` | — | — | **`Building{at}`**, — if `h < at` | `Verified{g}` if `g == at`, else — | — | `Failed(r)` | `Building{at}` |
 | `Verified{at}` | — | — | **`Building{at}`**, — if `h < at` | — | `Active` if `h == at`, else — | `Failed(r)` | **`Building{at}`** |
 | `Active` | — | — | `Active` | — | — | — | `Active` |
 | `Failed(_)` | — | — | — | — | — | — | `Failed(_)` |
 
-Five cells carry the argument.
+Six cells carry the argument.
 
 **`Verified` + `append` → `Building`.** The single most important transition
 here, and the one a hand-rolled implementation would omit. The proof was taken at
@@ -129,6 +129,16 @@ would be served. It **demotes rather than fails** — nothing is wrong, the worl
 simply moved — and it demotes to `Building` rather than `CaughtUp` because the
 projection is now genuinely behind by the appended event. It has to fold again,
 not merely be re-proven.
+
+**`reached_head` refused unless the fold position *equals* the head.** Folding
+past it is impossible; folding short of it and claiming catch-up anyway is the
+dangerous case, and it is not obviously dangerous, which is why it is stated
+here. `CaughtUp` is one transition from `Verified` and two from `Active`, so
+accepting `reached_head(900)` from a projection folded only to 400 activates an
+unfolded projection asserting it is current at 900 — **with every other
+invariant in §5 still satisfied**. The state machine does not assume its caller
+has folded as far as it says it has; that assumption is the thing a decision
+table exists to remove.
 
 **`cutover` refused unless `h == at`.** Belt and braces for the same race: even
 if a caller reached `Verified` and the head moved by a path the state machine did
@@ -287,7 +297,7 @@ and its decision surface is exhaustively testable. The other three are
 
 | Cost | Status |
 |---|---|
-| Code | Answered. 269 lines of protocol (about a fifth of it documentation) plus 249 of tests; 14 tests; no store dependency |
+| Code | Answered. 319 lines of protocol (about a third of it documentation) plus 266 of tests; 15 tests; no store dependency |
 | Peak disk | **Unmeasured.** Bounded above by the D-2 arithmetic — projections are 3.74 % of store size, so a duplicate is ≈306 MiB (321 MB) at the 8 GiB ceiling — but *bounded* is not *measured*, and that figure is an arithmetic consequence of a measurement, not itself one |
 | Write amplification | **Unmeasured.** The fold writes the whole projection while ingest writes it incrementally; the sum has not been observed |
 | Cutover latency | **Unmeasured.** Depends entirely on S-2, which is not chosen |
@@ -305,7 +315,7 @@ rebuild throughput, peak disk during a rebuild, or the cost of the swap.
 ## 10. Prototype status
 
 `tools/wm2-persistence-harness/src/rebuild.rs` — pure state machine, no SQL, no
-I/O, no schema. 14 tests covering the six invariants, fold-position and log-head
+I/O, no schema. 15 tests covering the six invariants, fold-position and log-head
 sanity, convergence, and the two end-to-end paths (clean run; late append forcing
 another lap rather than a stale cutover).
 

--- a/tools/wm2-persistence-harness/src/main.rs
+++ b/tools/wm2-persistence-harness/src/main.rs
@@ -22,6 +22,7 @@ mod gen;
 mod json;
 mod platform;
 mod pressure;
+mod rebuild;
 mod sha256;
 mod stall;
 mod standin;

--- a/tools/wm2-persistence-harness/src/rebuild.rs
+++ b/tools/wm2-persistence-harness/src/rebuild.rs
@@ -1,0 +1,547 @@
+//! The projection rebuild-and-swap protocol (ADR-0041 R2), as a pure state
+//! machine.
+//!
+//! # What this is and is not
+//!
+//! This is the **protocol**, not the rebuild. It owns the question "given what
+//! has happened so far, what is this projection allowed to do?" and nothing
+//! else — no SQL, no I/O, no schema. The fold itself lives in
+//! [`crate::standin::Store::fold_from`]; this decides when a fold's output may
+//! be believed.
+//!
+//! Separating them is the point. The dangerous transitions are all decisions,
+//! not computations: *may this projection serve queries yet*, *is this
+//! verification still valid*, *what survives a crash*. A decision table that
+//! cannot touch a database can be tested exhaustively, and every one of the
+//! invariants below is a test rather than a review comment.
+//!
+//! **It is not Kirra World domain logic.** It is a protocol prototype in the
+//! measurement harness, which is fenced from `kirra-world` and carries a
+//! stand-in schema. ADR-0042 Decision 5 still gates domain implementation.
+//!
+//! # The problem the states exist to solve
+//!
+//! A rebuild folds from generation 0 forward while **ingest continues**. So the
+//! new projection is chasing a head that keeps moving, and two things go wrong
+//! if the protocol is just "build, then swap":
+//!
+//! 1. **Catch-up need not converge.** If ingest outruns the fold, "wait until
+//!    caught up" is a hang, not a step. [`catchup_is_converging`] makes
+//!    non-convergence a failure rather than a stall.
+//! 2. **A verification goes stale the instant an event arrives.** Equivalence
+//!    is proven *at a generation*. If the log advances between proving it and
+//!    acting on it, the thing that was verified is not the thing being
+//!    activated. [`RebuildState::on_append`] demotes `Verified` back to
+//!    `Building` for exactly this reason — the single most important transition
+//!    here, and the one a hand-rolled implementation would omit. It demotes to
+//!    `Building` rather than `CaughtUp` because the projection is now genuinely
+//!    behind the head by the appended event: it has to fold again, not merely
+//!    be re-proven.
+//!
+//! # Open question 7
+//!
+//! ADR-0041 open question 7 asks what marks a projection left partial by an
+//! interrupted fold. The answer is this state: a projection is authoritative
+//! **only** in [`RebuildState::Active`] ([`RebuildState::is_authoritative`]).
+//! A fold refused half-way under disk pressure leaves the state at `Building`,
+//! which is not authoritative and cannot cut over — the marker OQ7 said was
+//! missing is the protocol state itself.
+//!
+//! # Why this module has no caller
+//!
+//! It is exercised by its tests and by nothing else, deliberately. The thing it
+//! would drive is a store that implements the durable rebuild-state record and
+//! the atomic swap (design §8, S-1/S-2), and that store is gated by ADR-0042
+//! Decision 5. Wiring it into the harness's `migrate` command instead — the one
+//! nearby thing it would compile against — would produce records that *look*
+//! like alongside-rebuild evidence for a run that is a single-pass backfill, and
+//! a plausible label on a real measurement is the failure mode this project has
+//! had to correct twice. So: `dead_code` is allowed here, and the allowance is
+//! the honest statement rather than the shortcut.
+#![allow(dead_code)]
+
+/// Why a rebuild attempt was abandoned. Recorded rather than collapsed to a
+/// bare "failed", because the operator response differs: a diverging catch-up
+/// means ingest outruns the fold (shed or throttle), a failed equivalence check
+/// means the fold is not deterministic (a defect, not a capacity problem).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FailureReason {
+    /// Catch-up was not converging — ingest is outrunning the fold.
+    CatchupDiverged,
+    /// The rebuilt projection did not match the incremental one at the pinned
+    /// generation. This is a determinism defect and must not be retried blindly.
+    EquivalenceMismatch { at: u64 },
+    /// The fold could not proceed — disk pressure, I/O error.
+    FoldRefused(String),
+    /// The operator abandoned the attempt.
+    Abandoned,
+}
+
+/// What a rebuild attempt is permitted to do right now.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RebuildState {
+    /// Folding forward. The projection is **partial** — this is OQ7's marker.
+    Building { folded_to: u64 },
+    /// The fold reached the log head at generation `at`. Not yet trusted: the
+    /// head may already have moved, and nothing has been compared.
+    CaughtUp { at: u64 },
+    /// Equivalence was proven against the incremental projection **at
+    /// generation `at`**. Valid only while the log head is still `at`.
+    Verified { at: u64 },
+    /// Serving queries. The only authoritative state, and terminal.
+    Active,
+    /// This attempt is over. The previous projection remains active — failure
+    /// never removes the thing that was working.
+    Failed(FailureReason),
+}
+
+/// Refused transitions carry what was attempted, so a caller cannot log
+/// "transition failed" without saying which one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TransitionRefused {
+    pub from: RebuildState,
+    pub attempted: &'static str,
+    pub because: String,
+}
+
+type Step = Result<RebuildState, TransitionRefused>;
+
+impl RebuildState {
+    /// A fresh attempt. Always starts partial — there is no state in which a
+    /// projection is trusted before anything has been folded into it.
+    pub fn begin() -> Self {
+        Self::Building { folded_to: 0 }
+    }
+
+    /// **The single question every reader of a projection must ask.**
+    ///
+    /// Only `Active`. A `Building` projection is partial, a `CaughtUp` one is
+    /// unverified, and a `Verified` one has been proven but not yet swapped in
+    /// — none of them may answer a query.
+    pub fn is_authoritative(&self) -> bool {
+        matches!(self, Self::Active)
+    }
+
+    fn refuse(&self, attempted: &'static str, because: impl Into<String>) -> TransitionRefused {
+        TransitionRefused {
+            from: self.clone(),
+            attempted,
+            because: because.into(),
+        }
+    }
+
+    /// The fold advanced to `position`.
+    pub fn on_fold_progress(&self, position: u64) -> Step {
+        match self {
+            Self::Building { folded_to } if position < *folded_to => Err(self.refuse(
+                "fold_progress",
+                format!("fold position went backwards: {folded_to} -> {position}"),
+            )),
+            Self::Building { .. } => Ok(Self::Building {
+                folded_to: position,
+            }),
+            _ => Err(self.refuse("fold_progress", "only a Building projection folds")),
+        }
+    }
+
+    /// The fold reached the log head, which was at `head` when observed.
+    pub fn on_reached_head(&self, head: u64) -> Step {
+        match self {
+            Self::Building { folded_to } if *folded_to > head => Err(self.refuse(
+                "reached_head",
+                format!("folded past the head it claims to have reached: {folded_to} > {head}"),
+            )),
+            Self::Building { .. } => Ok(Self::CaughtUp { at: head }),
+            _ => Err(self.refuse("reached_head", "only a Building projection can catch up")),
+        }
+    }
+
+    /// An event was appended to the log at generation `head`.
+    ///
+    /// **This is the transition that makes the protocol correct.** A `Verified`
+    /// projection was proven equivalent *at a generation*; once the log moves,
+    /// that proof describes a state that is no longer current, so the
+    /// projection drops back to `CaughtUp` and must be verified again. Omitting
+    /// this is how an alongside-rebuild silently activates a projection that
+    /// was never checked against the data it is about to serve.
+    pub fn on_append(&self, head: u64) -> Step {
+        // The log head cannot land behind work already folded out of it. If it
+        // does, the generation source is not monotonic (design §8, S-3) and
+        // every staleness comparison below is meaningless — so this is refused
+        // rather than absorbed.
+        let position = match self {
+            Self::Building { folded_to } => Some(*folded_to),
+            Self::CaughtUp { at } | Self::Verified { at } => Some(*at),
+            Self::Active | Self::Failed(_) => None,
+        };
+        if let Some(position) = position {
+            if head < position {
+                return Err(self.refuse(
+                    "append",
+                    format!("log head went backwards behind folded position: {head} < {position}"),
+                ));
+            }
+        }
+        match self {
+            // Already partial; the append simply puts it further behind.
+            Self::Building { folded_to } => Ok(Self::Building {
+                folded_to: *folded_to,
+            }),
+            // Fell behind again — back to folding.
+            Self::CaughtUp { at } => Ok(Self::Building { folded_to: *at }),
+            // The proof is stale. Demote, do not fail: nothing is wrong, the
+            // world simply moved.
+            Self::Verified { at } => Ok(Self::Building { folded_to: *at }),
+            // The live projection is updated incrementally; appends are normal.
+            Self::Active => Ok(Self::Active),
+            Self::Failed(_) => Err(self.refuse("append", "attempt is over")),
+        }
+    }
+
+    /// Equivalence was proven at generation `at`.
+    ///
+    /// Refused unless the projection is caught up to exactly that generation —
+    /// a proof at some other generation is a proof about something else.
+    pub fn on_equivalence_proven(&self, at: u64) -> Step {
+        match self {
+            Self::CaughtUp { at: caught } if *caught == at => Ok(Self::Verified { at }),
+            Self::CaughtUp { at: caught } => Err(self.refuse(
+                "equivalence_proven",
+                format!("proof is at generation {at} but the projection is caught up to {caught}"),
+            )),
+            _ => Err(self.refuse(
+                "equivalence_proven",
+                "only a caught-up projection can be verified",
+            )),
+        }
+    }
+
+    /// Swap this projection in as the authoritative one.
+    ///
+    /// Refused from every state but `Verified`, and refused there unless the
+    /// log head is still the generation the proof was taken at.
+    pub fn on_cutover(&self, head: u64) -> Step {
+        match self {
+            Self::Verified { at } if *at == head => Ok(Self::Active),
+            Self::Verified { at } => Err(self.refuse(
+                "cutover",
+                format!("verified at generation {at} but the head is now {head}; re-verify"),
+            )),
+            _ => Err(self.refuse(
+                "cutover",
+                "only a verified projection may cut over — this is the rule OQ7 asked for",
+            )),
+        }
+    }
+
+    pub fn on_failure(&self, reason: FailureReason) -> Step {
+        match self {
+            Self::Active => Err(self.refuse(
+                "failure",
+                "an active projection is not a rebuild attempt; retire it deliberately",
+            )),
+            Self::Failed(_) => Err(self.refuse("failure", "already failed")),
+            _ => Ok(Self::Failed(reason)),
+        }
+    }
+
+    /// What this attempt becomes after a process restart.
+    ///
+    /// The fold is deterministic and its position is durable, so `Building`
+    /// resumes rather than restarts. `Verified` **demotes**: the proof was
+    /// taken before the crash, the head may have moved during it, and a
+    /// verification that survived a restart unexamined is exactly the kind of
+    /// stale evidence this protocol exists to prevent.
+    pub fn on_restart(&self) -> Self {
+        match self {
+            Self::Building { folded_to } => Self::Building {
+                folded_to: *folded_to,
+            },
+            Self::CaughtUp { at } | Self::Verified { at } => Self::Building { folded_to: *at },
+            Self::Active => Self::Active,
+            Self::Failed(r) => Self::Failed(r.clone()),
+        }
+    }
+}
+
+/// How many catch-up rounds may pass without the gap shrinking.
+pub const MAX_NON_CONVERGING_ROUNDS: usize = 3;
+
+/// Is the catch-up loop actually converging?
+///
+/// `gaps` is the head-minus-folded distance sampled once per round, oldest
+/// first. Convergence is not "always decreasing" — a burst of ingest can widen
+/// the gap for a round without meaning the rebuild will never finish. It is
+/// "not stuck": the gap must beat its best-so-far at least once every
+/// [`MAX_NON_CONVERGING_ROUNDS`].
+///
+/// Without this, "wait until caught up" is an unbounded loop that looks like a
+/// hang, and the operator has no signal distinguishing *slow* from *never*.
+pub fn catchup_is_converging(gaps: &[u64]) -> bool {
+    if gaps.len() <= MAX_NON_CONVERGING_ROUNDS {
+        return true;
+    }
+    let mut best = u64::MAX;
+    let mut stale = 0usize;
+    for &g in gaps {
+        if g < best {
+            best = g;
+            stale = 0;
+        } else {
+            stale += 1;
+            if stale > MAX_NON_CONVERGING_ROUNDS {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn built_to(n: u64) -> RebuildState {
+        RebuildState::Building { folded_to: n }
+    }
+
+    // -----------------------------------------------------------------------
+    // The six invariants ADR-0041 R2 requires
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn partial_projections_are_never_authoritative() {
+        // OQ7: what marks a projection left partial by an interrupted fold?
+        // Its state does, and nothing but Active may answer a query.
+        assert!(!RebuildState::begin().is_authoritative());
+        assert!(!built_to(500).is_authoritative());
+        assert!(!RebuildState::CaughtUp { at: 500 }.is_authoritative());
+        assert!(!RebuildState::Verified { at: 500 }.is_authoritative());
+        assert!(!RebuildState::Failed(FailureReason::Abandoned).is_authoritative());
+        assert!(RebuildState::Active.is_authoritative());
+    }
+
+    #[test]
+    fn only_a_verified_projection_may_cut_over() {
+        for s in [
+            RebuildState::begin(),
+            built_to(500),
+            RebuildState::CaughtUp { at: 500 },
+            RebuildState::Failed(FailureReason::Abandoned),
+        ] {
+            let r = s.on_cutover(500);
+            assert!(r.is_err(), "{s:?} was allowed to cut over");
+        }
+        assert_eq!(
+            RebuildState::Verified { at: 500 }.on_cutover(500),
+            Ok(RebuildState::Active)
+        );
+    }
+
+    #[test]
+    fn a_verification_does_not_survive_an_append() {
+        // The transition the whole protocol turns on. Proven at 500, one event
+        // arrives, and the proof no longer describes the log being served.
+        let v = RebuildState::Verified { at: 500 };
+        assert_eq!(v.on_append(501).unwrap(), built_to(500));
+        // And the stale proof cannot be spent directly either.
+        assert!(
+            v.on_cutover(501).is_err(),
+            "cut over on a verification taken at an older generation"
+        );
+    }
+
+    #[test]
+    fn equivalence_must_be_proven_at_the_generation_it_claims() {
+        let c = RebuildState::CaughtUp { at: 500 };
+        assert_eq!(
+            c.on_equivalence_proven(500).unwrap(),
+            RebuildState::Verified { at: 500 }
+        );
+        assert!(
+            c.on_equivalence_proven(499).is_err(),
+            "accepted a proof taken at a different generation"
+        );
+        assert!(c.on_equivalence_proven(501).is_err());
+    }
+
+    #[test]
+    fn failure_never_touches_the_projection_that_is_working() {
+        // Failure is terminal for the ATTEMPT. The protocol has no transition
+        // that retires the previous projection except a successful cutover, so
+        // "the previous projection remains active" is structural rather than a
+        // rule someone has to remember.
+        let f = built_to(300)
+            .on_failure(FailureReason::FoldRefused("disk full".into()))
+            .unwrap();
+        assert!(matches!(f, RebuildState::Failed(_)));
+        assert!(!f.is_authoritative());
+        for attempt in [
+            f.on_fold_progress(400),
+            f.on_reached_head(400),
+            f.on_equivalence_proven(400),
+            f.on_cutover(400),
+            f.on_append(400),
+        ] {
+            assert!(attempt.is_err(), "a failed attempt kept operating");
+        }
+        // An active projection is not an attempt and cannot be "failed" into
+        // nothing — retiring it is a separate, deliberate act.
+        assert!(RebuildState::Active
+            .on_failure(FailureReason::Abandoned)
+            .is_err());
+    }
+
+    #[test]
+    fn restart_resumes_a_fold_but_demotes_a_verification() {
+        // Resuming is safe: the fold is deterministic and its position durable.
+        assert_eq!(built_to(700).on_restart(), built_to(700));
+        // Demoting is mandatory: the head may have moved while the process was
+        // down, and a proof that survives a restart unexamined is stale
+        // evidence — the same failure class as the tier C marker replay.
+        assert_eq!(
+            RebuildState::Verified { at: 700 }.on_restart(),
+            built_to(700)
+        );
+        assert_eq!(
+            RebuildState::CaughtUp { at: 700 }.on_restart(),
+            built_to(700)
+        );
+        assert_eq!(RebuildState::Active.on_restart(), RebuildState::Active);
+    }
+
+    #[test]
+    fn cutover_is_the_only_path_to_authoritative() {
+        // Exhaustive: no sequence of legal transitions reaches Active except
+        // through Verified -> cutover. Proven by construction over the whole
+        // transition surface rather than by inspection.
+        let states = [
+            RebuildState::begin(),
+            built_to(10),
+            RebuildState::CaughtUp { at: 10 },
+            RebuildState::Verified { at: 10 },
+            RebuildState::Failed(FailureReason::Abandoned),
+        ];
+        for s in &states {
+            let reached: Vec<RebuildState> = [
+                s.on_fold_progress(11),
+                s.on_reached_head(11),
+                s.on_equivalence_proven(10),
+                s.on_append(11),
+                s.on_failure(FailureReason::Abandoned),
+            ]
+            .into_iter()
+            .flatten()
+            .collect();
+            for r in reached {
+                assert!(
+                    !r.is_authoritative(),
+                    "{s:?} reached Active without a cutover"
+                );
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Fold-position sanity
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn a_fold_position_may_not_go_backwards() {
+        assert!(built_to(500).on_fold_progress(499).is_err());
+        assert_eq!(built_to(500).on_fold_progress(500).unwrap(), built_to(500));
+        assert_eq!(built_to(500).on_fold_progress(600).unwrap(), built_to(600));
+    }
+
+    #[test]
+    fn an_append_behind_the_folded_position_is_refused_not_absorbed() {
+        // A head that lands behind work already folded out of the log means the
+        // generation source is not monotonic (design §8, S-3). Every staleness
+        // comparison in this module rests on that, so it is refused loudly
+        // rather than silently treated as "no progress".
+        assert!(built_to(500).on_append(499).is_err());
+        assert!(RebuildState::CaughtUp { at: 500 }.on_append(499).is_err());
+        assert!(RebuildState::Verified { at: 500 }.on_append(499).is_err());
+        // Equal is fine: an append AT the folded position is the boundary, not
+        // a reversal.
+        assert_eq!(built_to(500).on_append(500).unwrap(), built_to(500));
+    }
+
+    #[test]
+    fn a_fold_cannot_claim_to_have_reached_a_head_behind_itself() {
+        assert!(built_to(600).on_reached_head(500).is_err());
+        assert_eq!(
+            built_to(500).on_reached_head(500).unwrap(),
+            RebuildState::CaughtUp { at: 500 }
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Catch-up convergence
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn a_shrinking_gap_converges_and_a_stuck_one_does_not() {
+        assert!(catchup_is_converging(&[900, 700, 500, 300, 100]));
+        // A burst widens the gap briefly; that is not divergence.
+        assert!(catchup_is_converging(&[900, 700, 800, 500, 300, 100]));
+        // Never beating the best again is.
+        assert!(!catchup_is_converging(&[500, 600, 700, 800, 900]));
+        assert!(!catchup_is_converging(&[500, 500, 500, 500, 500]));
+    }
+
+    #[test]
+    fn convergence_is_not_judged_before_there_is_evidence() {
+        // Too few rounds to tell — must not fail an attempt that has barely
+        // started, which would make the guard itself the reason rebuilds fail.
+        for n in 0..=MAX_NON_CONVERGING_ROUNDS {
+            let gaps = vec![500u64; n];
+            assert!(
+                catchup_is_converging(&gaps),
+                "declared divergence after {n} round(s)"
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // The happy path, end to end
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn the_full_protocol_runs_and_only_then_serves() {
+        let s = RebuildState::begin();
+        assert!(!s.is_authoritative());
+        let s = s.on_fold_progress(400).unwrap();
+        let s = s.on_append(900).unwrap(); // ingest continues
+        let s = s.on_fold_progress(900).unwrap();
+        let s = s.on_reached_head(900).unwrap();
+        assert_eq!(s, RebuildState::CaughtUp { at: 900 });
+        let s = s.on_equivalence_proven(900).unwrap();
+        assert!(!s.is_authoritative(), "verified is not yet serving");
+        let s = s.on_cutover(900).unwrap();
+        assert!(s.is_authoritative());
+    }
+
+    #[test]
+    fn a_late_append_forces_another_lap_rather_than_a_stale_cutover() {
+        // The realistic race: verified, then one more event lands before the
+        // swap. The protocol must go round again, not activate.
+        let s = RebuildState::CaughtUp { at: 900 }
+            .on_equivalence_proven(900)
+            .unwrap()
+            .on_append(901)
+            .unwrap();
+        assert_eq!(s, built_to(900));
+        assert!(s.on_cutover(901).is_err());
+        let s = s
+            .on_fold_progress(901)
+            .unwrap()
+            .on_reached_head(901)
+            .unwrap()
+            .on_equivalence_proven(901)
+            .unwrap()
+            .on_cutover(901)
+            .unwrap();
+        assert!(s.is_authoritative());
+    }
+}

--- a/tools/wm2-persistence-harness/src/rebuild.rs
+++ b/tools/wm2-persistence-harness/src/rebuild.rs
@@ -145,11 +145,27 @@ impl RebuildState {
     }
 
     /// The fold reached the log head, which was at `head` when observed.
+    ///
+    /// Requires the fold position to **equal** `head`. Folding *past* it is
+    /// impossible; folding *short* of it and calling this anyway would claim a
+    /// catch-up that did not happen — and since `CaughtUp` is one
+    /// `on_equivalence_proven` away from `Verified` and two from `Active`, that
+    /// claim would activate a projection folded to 400 while asserting it is
+    /// current at 900. The state machine does not assume its caller has folded
+    /// as far as it says.
     pub fn on_reached_head(&self, head: u64) -> Step {
         match self {
-            Self::Building { folded_to } if *folded_to > head => Err(self.refuse(
+            Self::Building { folded_to } if *folded_to != head => Err(self.refuse(
                 "reached_head",
-                format!("folded past the head it claims to have reached: {folded_to} > {head}"),
+                if *folded_to > head {
+                    format!("folded past the head it claims to have reached: {folded_to} > {head}")
+                } else {
+                    format!(
+                        "not caught up: folded to {folded_to}, head is {head}. \
+                         Keep folding — claiming this would put an unfolded projection \
+                         two transitions from serving"
+                    )
+                },
             )),
             Self::Building { .. } => Ok(Self::CaughtUp { at: head }),
             _ => Err(self.refuse("reached_head", "only a Building projection can catch up")),
@@ -161,9 +177,13 @@ impl RebuildState {
     /// **This is the transition that makes the protocol correct.** A `Verified`
     /// projection was proven equivalent *at a generation*; once the log moves,
     /// that proof describes a state that is no longer current, so the
-    /// projection drops back to `CaughtUp` and must be verified again. Omitting
-    /// this is how an alongside-rebuild silently activates a projection that
-    /// was never checked against the data it is about to serve.
+    /// projection drops back to `Building` and must be folded and verified
+    /// again. Omitting this is how an alongside-rebuild silently activates a
+    /// projection that was never checked against the data it is about to serve.
+    ///
+    /// It demotes to `Building`, not `CaughtUp`: the appended event puts the
+    /// projection genuinely behind the head, so there is fold work to do and
+    /// not merely a proof to retake.
     pub fn on_append(&self, head: u64) -> Step {
         // The log head cannot land behind work already folded out of it. If it
         // does, the generation source is not monotonic (design §8, S-3) and
@@ -473,6 +493,24 @@ mod tests {
         assert_eq!(
             built_to(500).on_reached_head(500).unwrap(),
             RebuildState::CaughtUp { at: 500 }
+        );
+    }
+
+    #[test]
+    fn claiming_catch_up_short_of_the_head_cannot_smuggle_a_partial_fold_through() {
+        // The hole this closes: CaughtUp is one transition from Verified and
+        // two from Active, so accepting `reached_head(900)` from a projection
+        // folded only to 400 would activate an unfolded projection asserting it
+        // is current at 900 — with every other invariant still satisfied.
+        assert!(built_to(400).on_reached_head(900).is_err());
+        // And the whole path is closed, not just the first step.
+        let smuggled = built_to(400)
+            .on_reached_head(900)
+            .and_then(|s| s.on_equivalence_proven(900))
+            .and_then(|s| s.on_cutover(900));
+        assert!(
+            smuggled.is_err(),
+            "a projection folded to 400 reached Active claiming generation 900"
         );
     }
 


### PR DESCRIPTION
Turns ADR-0041's accepted migration strategy into an implementable protocol, and closes open question 7 in design.

New: `docs/design/WM2_PROJECTION_REBUILD_PROTOCOL.md` (KIRRA-WM2-REBUILD-001) + `tools/wm2-persistence-harness/src/rebuild.rs` (pure state machine, 14 tests). ADR-0041's OQ7 entry, R2 item 3, and the acceptance record's outstanding obligation are updated to point at it.

## Why one sentence wasn't a protocol

R2 says: build the new projection beside the live one, catch up, swap. Correct, and it hides three races — because **ingest does not stop** while the rebuild runs.

1. **Catch-up need not converge.** If ingest outruns the fold, "wait until caught up" is a hang that looks like slowness, with no signal distinguishing *slow* from *never*.
2. **A verification goes stale the instant an event arrives.** Equivalence is proven *at a generation*. An implementation that proves equivalence and then swaps has a window in which it activates an unverified projection — and reports success.
3. **An interrupted fold leaves partial rows with nothing marking them.** OQ7 verbatim: the projection is *wrong* but *present*, and a query path that reads projections by name cannot tell.

All three are decisions, not computations. So the protocol is a state machine with no SQL, no I/O and no schema — which is what makes its decision surface exhaustively testable rather than reviewable.

## The states

`Building{folded_to}` / `CaughtUp{at}` / `Verified{at}` / `Active` / `Failed(reason)`.

`is_authoritative()` is true for `Active` and nothing else. **That is the whole answer to OQ7**: a fold refused midway under disk pressure leaves `Building`, which cannot serve and cannot cut over. The marker OQ7 said was missing is the protocol state itself — it need not be inferred from row counts or a sentinel row.

`Failed` carries *why*, because `EquivalenceMismatch` (a determinism defect, do not retry) and `FoldRefused` (a full disk, routinely retried) demand opposite responses.

## The transitions that carry the argument

**`Verified` + `append` → `Building`** — the one a hand-rolled implementation would omit. The proof was taken at a generation, the log moved, so it **demotes rather than fails** (nothing is wrong, the world moved), and to `Building` rather than `CaughtUp` because the projection is now genuinely behind by the appended event.

**`on_restart` demotes a verification** for the same reason a tier C marker may not be replayed (#1322): a proof that survives a restart unexamined is stale evidence. A fold *position* survives — it is a claim about work done, checkable against durable state. A *verification* is a claim about a relationship at a moment, and the moment is gone.

**Failure leaving the previous projection active is enforced by absence.** The protocol contains no operation that retires a projection at all, so there is no code path — correct, buggy or misordered — by which a failed attempt takes down the projection that was serving. Stronger than a rule saying "on failure, keep the old one".

## What this does *not* do, stated in the document

- **Cutover is atomic in the protocol, not on disk.** §8 names the four store properties the invariant needs end to end — durable state record transactional with fold progress, an atomic swap primitive, a monotonic head, pinned-generation comparison. **None are built.**
- **It answers the *code* half of the outstanding R2 obligation and none of the rest.** Peak disk, write amplification and cutover latency remain **unmeasured**, in a table that says so. The ≈306 MiB duplicate-projection figure is an arithmetic consequence of D-2, not a measurement of a rebuild, and §9 states its counting unit, independence unit, controlled variables and permitted claim per the rule adopted in #1329.
- **It does not move the ADR-0042 gate.** No Kirra World domain logic, storage, APIs or services. No robot runtime, safety algorithm, checker input, release-token or actuator change. The prototype is in the measurement harness over the stand-in schema (`630eb690aaef…`).

## OQ7 disposition

Recorded as **RESOLVED IN DESIGN** with the implementation condition named — on the same footing OQ8 was, where the strategy was adopted and the obligation carried in the open. The acceptance record's "questions 7, 9 and 10 remain open" sentence is left as written with a dated note, rather than rewritten to look like acceptance closed something it didn't.

## Review note

`dead_code` is allowed on the module, with the reason in its docs: wiring it into the harness's `migrate` command — the one nearby thing it would compile against — would produce records that *look* like alongside-rebuild evidence for a run that is a single-pass backfill. A plausible label on a real measurement is the failure mode this project has corrected twice.

## Verification

`cargo fmt --check` clean · `cargo clippy --all-targets -D warnings` clean · 14/14 rebuild tests, 170 harness tests, 7 integration tests pass · world domain-logic gate HOLDING (unchanged) · Kirra World bidirectional fence INTACT · quality guardrails satisfied · website citations resolve.

Not for merge without instruction.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_