### PR TITLE
fix(wm2): window the stall counters on the stalling commit, and withdraw D-10's IO-DEVICE attribution

### DIFF
--- a/docs/adr/0041-world-model-persistence-architecture.md
+++ b/docs/adr/0041-world-model-persistence-architecture.md
@@ -479,9 +479,26 @@ source; they are not migrated destructively (ADR-0040).
    in 120 repetitions, crossing both fsyncing modes and both batch sizes.
    Classified **intermittent and block-device/environment-correlated**. Thermal
    is *ruled out by measurement* (hottest zone 59.6 °C against an 85 °C
-   threshold). What remains unknown is the mechanism: one `IO-DEVICE`
-   attribution held loosely, one `UNATTRIBUTED`, PSI unavailable on this kernel,
-   and no SMART data. See the follow-ups in *Design implications*.
+   threshold). What remains unknown is the mechanism: **both attributions are
+   now `UNATTRIBUTED` or withdrawn**, PSI unavailable on this kernel, and no
+   SMART data. See the follow-ups in *Design implications*.
+
+   **Instrument fixed 2026-08-04; the mechanism question is unchanged and the
+   re-measurement is outstanding.** `attribute_stall` was comparing a
+   *whole-repetition* `disk_io_ms` against a *single-commit* `stall_ms` — a
+   denominator mismatch that clears the "block layer busy" bar from ordinary
+   background I/O alone. The `IO-DEVICE` attribution on `NORMAL`/batch=1 is
+   therefore **withdrawn** (D-10, boxed note): it is not weak evidence, it is
+   not evidence. `stall.rs` now samples a timestamped series at
+   `SAMPLE_INTERVAL_MS` and deltas across the slowest commit's own window, and
+   refuses to attribute when the sampled span is materially wider than the
+   stall — so the defect cannot recur silently. **What this does NOT do:** it
+   measures nothing new. The stall counts, latencies, throughput medians and
+   thermal reading in D-10 stand; the mechanism is exactly as unknown as before,
+   minus one attribution that looked like progress and was not. **Next step:**
+   re-run the six configurations on target with the fixed instrument, and
+   pursue PSI availability (the kernel lacks `/proc/pressure`) since without it
+   one of the two I/O signals is absent regardless of windowing.
 10. **Graph and temporal query placement (D-1, D-9).** Neither may sit on a
    deadline path, and the sweep sharpens by how much. At 100 000 entities the
    graph family is 159 ms p99 (1.6× a 10 Hz period) and the temporal family is
@@ -1149,6 +1166,30 @@ unavailable on this kernel** (`psi_io_stall_us` is `None` in every record), so
 one of the two I/O signals was simply absent. And **the counter delta is taken
 across a whole repetition while the stall is a single commit**, which can
 over-state I/O evidence.
+
+> **The second limit is now fixed in the instrument, and the `IO-DEVICE`
+> attribution above is WITHDRAWN — 2026-08-04.**
+>
+> The limitation was worse than "can over-state". `attribute_stall` tested
+> `disk_io_ms >= stall_ms * 0.5` with `disk_io_ms` accumulated over the whole
+> repetition and `stall_ms` a single commit — a **denominator mismatch**. A
+> repetition with a few seconds of ordinary device busy-time clears that bar for
+> any stall in this range *regardless of whether the device did anything during
+> the stall itself*. So `IO-DEVICE` on `NORMAL`/batch=1 is not a weakly-supported
+> finding; it is a number the pre-fix instrument would have produced from an idle
+> device, and it carries no information about the mechanism.
+>
+> `stall.rs` now samples a timestamped series at 20 ms and computes the delta
+> across **the slowest commit's own window** (`bench::CommitWindow`), and
+> attribution **refuses** when the sampled span is materially wider than the
+> stall it claims to describe. The stall counts, worst-commit latencies,
+> throughput medians and the thermal reading in the table are unaffected — they
+> never depended on the window. Only the attribution column does.
+>
+> **This is an instrument correction, not a new measurement.** Nothing here says
+> the device was idle during that stall; it says the run cannot tell. Re-running
+> the six configurations on target with the fixed instrument is the open work —
+> see open question 9.
 
 **The stall-robust medians resolve the corrupted benchmark row** — and expose
 something else. `NORMAL`/batch=64 reads 19 351 ev/s across 20 runs against the

--- a/docs/hardware/JETSON_WM2_PERSISTENCE_DRILL.md
+++ b/docs/hardware/JETSON_WM2_PERSISTENCE_DRILL.md
@@ -674,9 +674,31 @@ and would multiply every routine drill.
 - **`median_throughput_eps`**, a median across repetitions. One pathological run
   cannot move it, so throughput and stall rate become two separate facts rather
   than the single contaminated one the original benchmark produced.
-- **Concurrent system counters**, sampled across each run: PSI `full` I/O stall,
-  `/proc/diskstats` busy-milliseconds, peak dirty+writeback, hottest thermal
-  zone.
+- **Concurrent system counters**, sampled across **the stalling commit**: PSI
+  `full` I/O stall, `/proc/diskstats` busy-milliseconds, peak dirty+writeback,
+  hottest thermal zone.
+
+### The counters describe one commit, not the run — check that they do
+
+A background sampler records these every 20 ms with a timestamp, and the delta
+is taken across the window of the **single slowest commit**. Three fields on the
+record say how well that window resolved, and they should be read before the
+attribution:
+
+| Field | Read it as |
+|---|---|
+| `counter_window_ms` | the span the counters actually cover. For a real stall this should be within a few tens of ms of `worst_commit_ms` |
+| `counter_window_samples` | how many 20 ms samples fell in the window. A 1 s stall should yield ~50 |
+| `counter_window_usable` | `1` if the window is tight enough to attribute from; `0` and the attribution will be `UNATTRIBUTED` on instrument grounds |
+
+**Why this is called out.** Before 2026-08-04 the delta was taken across the
+whole repetition and compared against a single commit's duration. A repetition
+with a few seconds of ordinary device busy-time satisfies "block layer busy for
+most of the stall" no matter what the device did during the stall, so the
+instrument could report `IO-DEVICE` from an idle disk — and did, once, in D-10.
+That attribution is withdrawn. If you see `counter_window_usable: 0` on a run
+with a real stall, the counters are not describing it and the verdict is about
+the instrument, not the device; the detail string says so explicitly.
 
 ### Attribution is deliberately reluctant
 
@@ -746,7 +768,7 @@ retyping of one.
 | Tier A / B | `crash` → `outcome` + `detail` |
 | Tier C | the trials ledger, plus `tier_c_trials_recorded` / `tier_c_trials_required` |
 | **Scale sweep** (§9) | `sweep_point` rows + the `sweep_summary` `verdict` / `supports_option_a` |
-| **The ~29 s stall** (§9a) | `stall` → `stall_rate`, `median_throughput_eps`, `attribution`, and the four system-counter fields |
+| **The ~29 s stall** (§9a) | `stall` → `stall_rate`, `median_throughput_eps`, `attribution`, the four system-counter fields, and the three `counter_window_*` fields that say what span those counters cover |
 
 Three of those deserve to be read rather than filed:
 

--- a/tools/wm2-persistence-harness/src/bench.rs
+++ b/tools/wm2-persistence-harness/src/bench.rs
@@ -104,7 +104,15 @@ pub fn db_bytes(path: &Path) -> u64 {
 // Append
 // ---------------------------------------------------------------------------
 
-/// When one commit happened, as milliseconds from the start of the append loop.
+/// When one commit happened, in milliseconds from a stated origin.
+///
+/// The origin is the caller's if one is supplied to [`append_from`], otherwise
+/// the start of the append loop. **Which origin matters more than it looks.**
+/// These offsets exist to be looked up in a concurrently-sampled series, and two
+/// `Instant::now()` calls taken at different moments are two different
+/// coordinate systems — a lookup across them lands on the wrong span entirely,
+/// not merely a slightly shifted one. `append` does event generation and a hash
+/// calibration before its loop, so that gap is seconds, not microseconds.
 ///
 /// Exists so a stall can be correlated with system counters sampled *across it*
 /// rather than across the whole run. Without a window, the only honest thing to
@@ -152,6 +160,27 @@ pub fn append(
     batch: usize,
     seed: u64,
 ) -> Result<AppendResult, String> {
+    append_from(path, durability, events, entities, batch, seed, None)
+}
+
+/// [`append`], with [`CommitWindow`] offsets measured from a caller-supplied
+/// origin.
+///
+/// Pass `Some(origin)` when something else is sampling concurrently and needs
+/// its timestamps to share a coordinate system with the commit windows — see
+/// [`crate::stall::run`], which starts its sampler at that origin. `None`
+/// measures from the start of the append loop, which is right for every caller
+/// that is not correlating against an external series.
+#[allow(clippy::too_many_arguments)]
+pub fn append_from(
+    path: &Path,
+    durability: Durability,
+    events: u64,
+    entities: u64,
+    batch: usize,
+    seed: u64,
+    origin: Option<Instant>,
+) -> Result<AppendResult, String> {
     remove_db(path);
     let mut store = Store::open(path, durability).map_err(|e| e.to_string())?;
     let all = gen::events(0, events, entities, seed);
@@ -169,14 +198,14 @@ pub fn append(
     let mut durations = Vec::with_capacity(all.len() / batch.max(1) + 1);
     let mut slowest: Option<(Duration, CommitWindow)> = None;
     let wall = Instant::now();
+    // The origin the windows are reported against. Defaults to the loop start;
+    // a concurrent sampler supplies its own so the two agree.
+    let window_origin = origin.unwrap_or(wall);
     for chunk in all.chunks(batch.max(1)) {
         let t = Instant::now();
         store.append_batch(chunk).map_err(|e| e.to_string())?;
         let took = t.elapsed();
-        // Offsets from the loop start, not absolute time: the sampler in
-        // `stall` measures against the same origin, and two clocks would make
-        // the correlation meaningless.
-        let start_ms = t.duration_since(wall).as_secs_f64() * 1e3;
+        let start_ms = t.duration_since(window_origin).as_secs_f64() * 1e3;
         if slowest.as_ref().is_none_or(|(d, _)| took > *d) {
             slowest = Some((
                 took,
@@ -726,6 +755,43 @@ mod tests {
         assert!(
             w.end_ms <= a.timing.total_ms + 1.0,
             "window ends past the whole append loop"
+        );
+        remove_db(&p);
+    }
+
+    #[test]
+    fn commit_windows_are_measured_from_the_supplied_origin() {
+        // The correlation in `stall` is only sound if the commit windows and the
+        // sampler share one origin. `append` does event generation and a hash
+        // calibration before its loop, so an unshared origin is off by that much
+        // — seconds, not microseconds — and a lookup lands on an unrelated span
+        // of the series while still looking like a measurement.
+        //
+        // The sleep stands in for that setup gap: with the origin honoured the
+        // offset must include it; with the loop start used instead it would not.
+        let p = temp("append-origin");
+        let origin = Instant::now();
+        std::thread::sleep(Duration::from_millis(60));
+        let a = append_from(&p, Durability::Off, 2_000, 100, 16, 4, Some(origin)).unwrap();
+        let w = a.slowest_commit.expect("commits ran");
+        assert!(
+            w.start_ms >= 60.0,
+            "window start {:.1} ms ignores the supplied origin",
+            w.start_ms
+        );
+        // And the default still measures from the loop start, so every other
+        // caller is unaffected. The invariant there is containment in the loop,
+        // NOT an upper bound in milliseconds: the slowest commit may fall
+        // anywhere in the run, so "start_ms is small" would be a coincidence
+        // dressed as an assertion.
+        let b = append(&p, Durability::Off, 2_000, 100, 16, 4).unwrap();
+        let bw = b.slowest_commit.expect("commits ran");
+        assert!(
+            bw.start_ms >= 0.0 && bw.end_ms <= b.timing.total_ms + 1.0,
+            "default-origin window [{:.1}, {:.1}] ms escapes its own {:.1} ms loop",
+            bw.start_ms,
+            bw.end_ms,
+            b.timing.total_ms
         );
         remove_db(&p);
     }

--- a/tools/wm2-persistence-harness/src/bench.rs
+++ b/tools/wm2-persistence-harness/src/bench.rs
@@ -104,6 +104,25 @@ pub fn db_bytes(path: &Path) -> u64 {
 // Append
 // ---------------------------------------------------------------------------
 
+/// When one commit happened, as milliseconds from the start of the append loop.
+///
+/// Exists so a stall can be correlated with system counters sampled *across it*
+/// rather than across the whole run. Without a window, the only honest thing to
+/// say about a concurrent counter is that it accumulated somewhere during the
+/// run — see [`crate::stall`], where reading a whole-run counter against a
+/// one-commit duration was a real defect (ADR-0041 open question 9).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CommitWindow {
+    pub start_ms: f64,
+    pub end_ms: f64,
+}
+
+impl CommitWindow {
+    pub fn duration_ms(&self) -> f64 {
+        self.end_ms - self.start_ms
+    }
+}
+
 pub struct AppendResult {
     pub timing: Timing,
     pub durability: Durability,
@@ -111,6 +130,11 @@ pub struct AppendResult {
     pub events: u64,
     pub events_per_second: f64,
     pub hash_share_percent: f64,
+    /// The window of the single slowest commit. `None` only when no commit ran.
+    ///
+    /// This is the slowest by the same measurement that produces
+    /// `timing.max_us`, so the two always describe the same commit.
+    pub slowest_commit: Option<CommitWindow>,
 }
 
 /// Append `events` in transactions of `batch` events each, timing every commit.
@@ -143,11 +167,26 @@ pub fn append(
     };
 
     let mut durations = Vec::with_capacity(all.len() / batch.max(1) + 1);
+    let mut slowest: Option<(Duration, CommitWindow)> = None;
     let wall = Instant::now();
     for chunk in all.chunks(batch.max(1)) {
         let t = Instant::now();
         store.append_batch(chunk).map_err(|e| e.to_string())?;
-        durations.push(t.elapsed());
+        let took = t.elapsed();
+        // Offsets from the loop start, not absolute time: the sampler in
+        // `stall` measures against the same origin, and two clocks would make
+        // the correlation meaningless.
+        let start_ms = t.duration_since(wall).as_secs_f64() * 1e3;
+        if slowest.as_ref().is_none_or(|(d, _)| took > *d) {
+            slowest = Some((
+                took,
+                CommitWindow {
+                    start_ms,
+                    end_ms: start_ms + took.as_secs_f64() * 1e3,
+                },
+            ));
+        }
+        durations.push(took);
     }
     let wall = wall.elapsed().as_secs_f64();
 
@@ -168,6 +207,7 @@ pub fn append(
         } else {
             f64::NAN
         },
+        slowest_commit: slowest.map(|(_, w)| w),
         timing,
     })
 }
@@ -662,6 +702,31 @@ mod tests {
         assert_eq!(a.events, 2_000);
         assert!(a.timing.samples == 2_000, "batch=1 should time every event");
         assert!(a.hash_share_percent.is_finite() && a.hash_share_percent >= 0.0);
+        remove_db(&p);
+    }
+
+    #[test]
+    fn the_slowest_commit_window_describes_the_same_commit_as_max_us() {
+        // The stall attribution correlates system counters against this window,
+        // so a window that named a DIFFERENT commit than `max_us` would put the
+        // counters on the wrong two seconds and report confidently from them.
+        // Cheap to assert here, and the alternative is unfalsifiable on target.
+        let p = temp("append-window");
+        let a = append(&p, Durability::Off, 2_000, 100, 16, 4).unwrap();
+        let w = a
+            .slowest_commit
+            .expect("commits ran, so there is a slowest");
+        assert!(
+            (w.duration_ms() - a.timing.max_us / 1e3).abs() < 1e-6,
+            "window {:.6} ms != max_us {:.6} ms — they name different commits",
+            w.duration_ms(),
+            a.timing.max_us / 1e3
+        );
+        assert!(w.start_ms >= 0.0 && w.end_ms >= w.start_ms);
+        assert!(
+            w.end_ms <= a.timing.total_ms + 1.0,
+            "window ends past the whole append loop"
+        );
         remove_db(&p);
     }
 

--- a/tools/wm2-persistence-harness/src/main.rs
+++ b/tools/wm2-persistence-harness/src/main.rs
@@ -940,25 +940,41 @@ fn main() {
                 .float("median_throughput_eps", r.median_throughput_eps())
                 .str("attribution", r.attribution.token())
                 .str("detail", r.attribution.detail())
+                // The counter fields below are deltas across the WORST COMMIT'S
+                // OWN WINDOW, not across the run. `counter_window_ms` and
+                // `counter_window_samples` state what span produced them, so a
+                // reader never has to assume — the OQ9 instrument fix.
+                .float("counter_window_ms", r.delta_at_worst.covered_ms)
+                .int("counter_window_samples", r.delta_at_worst.samples as u64)
+                .int(
+                    "counter_window_usable",
+                    u64::from(r.delta_at_worst.window_is_usable()),
+                )
                 .float(
                     "psi_io_stall_us",
                     r.delta_at_worst
+                        .delta
                         .psi_io_stall_us
                         .map_or(f64::NAN, |v| v as f64),
                 )
                 .float(
                     "disk_io_ms",
-                    r.delta_at_worst.disk_io_ms.map_or(f64::NAN, |v| v as f64),
+                    r.delta_at_worst
+                        .delta
+                        .disk_io_ms
+                        .map_or(f64::NAN, |v| v as f64),
                 )
                 .float(
                     "peak_dirty_writeback_kb",
                     r.delta_at_worst
+                        .delta
                         .peak_dirty_writeback_kb
                         .map_or(f64::NAN, |v| v as f64),
                 )
                 .float(
                     "thermal_max_mc",
                     r.delta_at_worst
+                        .delta
                         .thermal_max_mc
                         .map_or(f64::NAN, |v| v as f64),
                 ),

--- a/tools/wm2-persistence-harness/src/stall.rs
+++ b/tools/wm2-persistence-harness/src/stall.rs
@@ -105,9 +105,18 @@ pub struct WindowedDelta {
 
 impl WindowedDelta {
     /// Is this delta actually about the stall it names?
+    ///
+    /// Bounded on BOTH sides. Too wide and the counters describe more than the
+    /// stall (the original defect). Too narrow and they describe only part of
+    /// it, which is just as wrong and less obvious — a window covering 17 % of a
+    /// commit is not "a slightly conservative measurement", it is a different
+    /// measurement. [`delta_over_window`] already guarantees containment by
+    /// construction; this repeats it so a hand-built `WindowedDelta` cannot
+    /// claim to be usable without it.
     pub fn window_is_usable(&self) -> bool {
         self.samples >= MIN_WINDOW_SAMPLES
             && self.covered_ms > 0.0
+            && self.covered_ms >= self.stall_ms
             && self.covered_ms <= self.stall_ms * MAX_WINDOW_OVERSHOOT
     }
 }
@@ -212,14 +221,14 @@ pub fn delta_over_window(
     if series.len() < 2 || !start_ms.is_finite() || !end_ms.is_finite() || end_ms < start_ms {
         return None;
     }
-    let lo = series
-        .iter()
-        .rposition(|s| s.at_ms <= start_ms)
-        .unwrap_or(0);
-    let hi = series
-        .iter()
-        .position(|s| s.at_ms >= end_ms)
-        .unwrap_or(series.len() - 1);
+    // Both brackets must EXIST. Falling back to the first/last sample when one
+    // is missing produces a window that does not contain the commit — e.g. a
+    // series ending at 1 000 ms against a commit spanning 900-1 500 ms yields a
+    // 100 ms window for a 600 ms stall, covering 17 % of it while looking like a
+    // measurement. That is the same defect as the whole-run delta with the
+    // inequality pointing the other way, so it fails closed too.
+    let lo = series.iter().rposition(|s| s.at_ms <= start_ms)?;
+    let hi = series.iter().position(|s| s.at_ms >= end_ms)?;
     if hi <= lo {
         return None;
     }
@@ -523,20 +532,20 @@ pub fn run(
     };
 
     for i in 0..repeats {
-        // The sampler stamps against the same origin the append loop measures
-        // from, so `CommitWindow` offsets and `StampedSample::at_ms` are
-        // directly comparable. `bench::append` does setup (event generation,
-        // the hash calibration) before its loop starts, so the two origins are
-        // not identical — the sampler starts earlier. That is the safe
-        // direction: the series covers more than the loop, never less, so a
-        // window is always bracketable.
+        // ONE origin, shared by the sampler and the commit windows. Two
+        // `Instant::now()` calls would be two coordinate systems: `append` does
+        // event generation and a hash calibration before its loop, so the gap
+        // between them is seconds, and a window looked up across that gap lands
+        // on an unrelated span of the series rather than a slightly shifted one.
+        // That would leave the counters as wrong as the whole-run delta this
+        // module exists to replace, while looking correct.
+        let origin = std::time::Instant::now();
         let series = std::sync::Arc::new(std::sync::Mutex::new(Vec::<StampedSample>::new()));
         let running = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
         let sampler = {
             use std::sync::atomic::Ordering;
             let series = std::sync::Arc::clone(&series);
             let running = std::sync::Arc::clone(&running);
-            let origin = std::time::Instant::now();
             std::thread::spawn(move || {
                 while running.load(Ordering::Relaxed) {
                     let at_ms = origin.elapsed().as_secs_f64() * 1e3;
@@ -549,7 +558,15 @@ pub fn run(
             })
         };
 
-        let r = crate::bench::append(path, durability, events, entities, batch, seed + i as u64);
+        let r = crate::bench::append_from(
+            path,
+            durability,
+            events,
+            entities,
+            batch,
+            seed + i as u64,
+            Some(origin),
+        );
 
         running.store(false, std::sync::atomic::Ordering::Relaxed);
         let _ = sampler.join();
@@ -820,6 +837,34 @@ mod tests {
             w.is_none() || !w.unwrap().window_is_usable(),
             "a window past the end of the series was treated as measured"
         );
+    }
+
+    #[test]
+    fn a_window_that_covers_only_part_of_the_commit_is_refused() {
+        // The mirror image of the original defect, and the easier one to miss:
+        // the series ends at 1 000 ms but the commit runs 900-1 500 ms. The
+        // first version fell back to the last sample, producing a 100 ms window
+        // for a 600 ms stall — 17 % coverage — which passed the "not too wide"
+        // guard and was attributed from.
+        let s = series(1_000, 0.0, 1_000.0);
+        assert!(
+            delta_over_window(&s, 900.0, 1_500.0).is_none(),
+            "a commit running past the end of the series was windowed anyway"
+        );
+        // Same on the left: a commit starting before the first sample.
+        let late: Vec<StampedSample> = s.iter().filter(|x| x.at_ms >= 500.0).cloned().collect();
+        assert!(
+            delta_over_window(&late, 100.0, 700.0).is_none(),
+            "a commit starting before the series was windowed anyway"
+        );
+        // And the guard holds even if such a delta is built by hand.
+        let truncated = WindowedDelta {
+            delta: d(None, Some(100), Some(1_024), None),
+            stall_ms: 600.0,
+            covered_ms: 100.0,
+            samples: 6,
+        };
+        assert!(!truncated.window_is_usable());
     }
 
     #[test]

--- a/tools/wm2-persistence-harness/src/stall.rs
+++ b/tools/wm2-persistence-harness/src/stall.rs
@@ -73,6 +73,69 @@ pub struct SystemDelta {
     pub thermal_max_mc: Option<u64>,
 }
 
+/// A [`SystemDelta`] **together with the window it was measured over**.
+///
+/// # Why the window is not optional
+///
+/// Attribution asks "was the block layer busy for most of *the stall*". That
+/// question only has an answer if the counters were accumulated across the
+/// stall. The first version of this module sampled once before the whole append
+/// run and once after, then compared that whole-run `disk_io_ms` against a
+/// single commit's duration — a **denominator mismatch**. A 60 s run with 5 s of
+/// ordinary device busy-time satisfies `5000 >= 1200 * 0.5` for a 1.2 s stall,
+/// so it reported `IO-DEVICE` even when the device was idle for the entire
+/// stall. That is how D-10 got "one `IO-DEVICE` attribution held loosely".
+///
+/// Carrying the window in the type makes the mistake hard to repeat: nothing
+/// can be attributed without stating what span the counters cover, and
+/// [`attribute_stall`] refuses outright when the span is materially wider than
+/// the stall it claims to describe.
+#[derive(Debug, Clone, PartialEq)]
+pub struct WindowedDelta {
+    pub delta: SystemDelta,
+    /// The stall being explained, milliseconds.
+    pub stall_ms: f64,
+    /// The span the counters actually cover, milliseconds. Ideally ≈ `stall_ms`;
+    /// it is bounded by the sampler's cadence, so it is never exactly equal.
+    pub covered_ms: f64,
+    /// How many samples fell in the window. Below [`MIN_WINDOW_SAMPLES`] the
+    /// window is not resolved well enough to attribute anything.
+    pub samples: usize,
+}
+
+impl WindowedDelta {
+    /// Is this delta actually about the stall it names?
+    pub fn window_is_usable(&self) -> bool {
+        self.samples >= MIN_WINDOW_SAMPLES
+            && self.covered_ms > 0.0
+            && self.covered_ms <= self.stall_ms * MAX_WINDOW_OVERSHOOT
+    }
+}
+
+/// How much wider than the stall the sampled window may be before the counters
+/// stop being about the stall.
+///
+/// Not 1.0: the sampler ticks every [`SAMPLE_INTERVAL_MS`], so the bracketing
+/// samples always sit slightly outside the commit. 1.5× leaves room for that at
+/// the [`STALL_THRESHOLD_MS`] floor (where the overshoot is at most ~4 %) while
+/// still rejecting a whole-run window by orders of magnitude.
+pub const MAX_WINDOW_OVERSHOOT: f64 = 1.5;
+
+/// Fewer samples than this and the window is a guess, not a measurement.
+pub const MIN_WINDOW_SAMPLES: usize = 3;
+
+/// Background sampler cadence. At [`STALL_THRESHOLD_MS`] this yields ~50
+/// samples across the shortest event that counts as a stall.
+pub const SAMPLE_INTERVAL_MS: u64 = 20;
+
+/// One sample, stamped against the same origin the append loop measures from.
+#[derive(Debug, Clone, PartialEq)]
+pub struct StampedSample {
+    /// Milliseconds from the start of the append loop.
+    pub at_ms: f64,
+    pub sample: SystemSample,
+}
+
 /// What the evidence supports. Deliberately coarse: these are *directions to
 /// look*, not root causes.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -123,17 +186,89 @@ const WRITEBACK_BACKLOG_KB: u64 = 256 * 1024;
 /// Sustained temperature (milli-degrees C) suggesting thermal capping.
 const THERMAL_HOT_MC: u64 = 85_000;
 
-/// Attribute one stall from its duration and the system delta across it.
+/// Extract the counter delta across one commit's window from a sampled series.
+///
+/// This is the OQ9 instrument fix. `series` is the background sampler's output,
+/// oldest first; `start_ms`/`end_ms` bound the commit being explained. The
+/// bracketing samples are the last one at or before `start_ms` and the first one
+/// at or after `end_ms`, so the window always *contains* the commit rather than
+/// clipping it.
+///
+/// Returns `None` when the series cannot resolve the window at all — no
+/// bracketing pair. That is a fail-closed answer: a caller with `None` has
+/// nothing to attribute, which is correct, whereas a caller handed a
+/// whole-series delta would attribute confidently and wrongly.
+///
+/// `peak_dirty_writeback_kb` is a peak *within the window*, not across the run,
+/// for the same reason.
+pub fn delta_over_window(
+    series: &[StampedSample],
+    start_ms: f64,
+    end_ms: f64,
+) -> Option<WindowedDelta> {
+    // Non-finite bounds are rejected explicitly rather than left to comparison:
+    // a NaN bound makes every `<=` false, which would silently select index 0
+    // for both ends and produce a zero-width "measurement".
+    if series.len() < 2 || !start_ms.is_finite() || !end_ms.is_finite() || end_ms < start_ms {
+        return None;
+    }
+    let lo = series
+        .iter()
+        .rposition(|s| s.at_ms <= start_ms)
+        .unwrap_or(0);
+    let hi = series
+        .iter()
+        .position(|s| s.at_ms >= end_ms)
+        .unwrap_or(series.len() - 1);
+    if hi <= lo {
+        return None;
+    }
+    let (a, b) = (&series[lo], &series[hi]);
+    let peak = series[lo..=hi]
+        .iter()
+        .filter_map(|s| match (s.sample.dirty_kb, s.sample.writeback_kb) {
+            (Some(d), Some(w)) => Some(d + w),
+            _ => None,
+        })
+        .max();
+    Some(WindowedDelta {
+        delta: delta(&a.sample, &b.sample, peak),
+        stall_ms: end_ms - start_ms,
+        covered_ms: b.at_ms - a.at_ms,
+        samples: hi - lo + 1,
+    })
+}
+
+/// Attribute one stall from the counters measured **across it**.
 ///
 /// The ordering matters. Device-side I/O is checked before writeback because a
 /// writeback flush *also* drives the block layer busy, so "disk busy" alone
 /// cannot distinguish them — the discriminator is whether a large dirty backlog
 /// was present. Thermal is checked last and only in the absence of I/O
 /// evidence, because a hot SoC during heavy I/O is a consequence, not a cause.
-pub fn attribute_stall(stall_ms: f64, d: &SystemDelta) -> StallAttribution {
+///
+/// Before any of that, the window is checked. Counters covering materially more
+/// than the stall cannot answer "was the device busy *during the stall*", and
+/// this returns `Unattributed` rather than the answer they superficially
+/// support. See [`WindowedDelta`] for the defect this closes.
+pub fn attribute_stall(w: &WindowedDelta) -> StallAttribution {
+    let stall_ms = w.stall_ms;
+    let d = &w.delta;
     if stall_ms < STALL_THRESHOLD_MS {
         return StallAttribution::NoStall(format!(
             "worst commit {stall_ms:.1} ms is below the {STALL_THRESHOLD_MS:.0} ms threshold"
+        ));
+    }
+
+    if !w.window_is_usable() {
+        return StallAttribution::Unattributed(format!(
+            "a {stall_ms:.0} ms stall whose counters cover {:.0} ms across {} sample(s) — the \
+             window does not describe the stall, so nothing may be attributed from it \
+             (need >= {MIN_WINDOW_SAMPLES} samples and <= {MAX_WINDOW_OVERSHOOT:.1}x the stall). \
+             This is an INSTRUMENT limitation, not a finding about the device: reading \
+             whole-run counters against a one-commit duration is the defect that produced \
+             D-10's loosely-held IO-DEVICE attribution.",
+            w.covered_ms, w.samples
         ));
     }
 
@@ -200,7 +335,10 @@ pub struct StallResult {
     pub median_worst_ms: f64,
     pub throughput_eps: Vec<f64>,
     pub attribution: StallAttribution,
-    pub delta_at_worst: SystemDelta,
+    /// Counters across the worst commit's own window — **not** across the run.
+    /// `covered_ms` and `samples` are emitted alongside so a reader can see how
+    /// well the window was resolved rather than trusting it.
+    pub delta_at_worst: WindowedDelta,
 }
 
 impl StallResult {
@@ -377,23 +515,36 @@ pub fn run(
     let mut throughput: Vec<f64> = Vec::new();
     let mut stalls = 0usize;
     let mut worst_overall = 0.0f64;
-    let mut worst_delta = SystemDelta::default();
+    let mut worst_windowed = WindowedDelta {
+        delta: SystemDelta::default(),
+        stall_ms: 0.0,
+        covered_ms: 0.0,
+        samples: 0,
+    };
 
     for i in 0..repeats {
-        let before = sample_system();
-        let peak_dw = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+        // The sampler stamps against the same origin the append loop measures
+        // from, so `CommitWindow` offsets and `StampedSample::at_ms` are
+        // directly comparable. `bench::append` does setup (event generation,
+        // the hash calibration) before its loop starts, so the two origins are
+        // not identical — the sampler starts earlier. That is the safe
+        // direction: the series covers more than the loop, never less, so a
+        // window is always bracketable.
+        let series = std::sync::Arc::new(std::sync::Mutex::new(Vec::<StampedSample>::new()));
         let running = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
         let sampler = {
             use std::sync::atomic::Ordering;
-            let peak_dw = std::sync::Arc::clone(&peak_dw);
+            let series = std::sync::Arc::clone(&series);
             let running = std::sync::Arc::clone(&running);
+            let origin = std::time::Instant::now();
             std::thread::spawn(move || {
                 while running.load(Ordering::Relaxed) {
-                    let s = sample_system();
-                    if let (Some(d), Some(w)) = (s.dirty_kb, s.writeback_kb) {
-                        peak_dw.fetch_max(d + w, Ordering::Relaxed);
+                    let at_ms = origin.elapsed().as_secs_f64() * 1e3;
+                    let sample = sample_system();
+                    if let Ok(mut v) = series.lock() {
+                        v.push(StampedSample { at_ms, sample });
                     }
-                    std::thread::sleep(std::time::Duration::from_millis(20));
+                    std::thread::sleep(std::time::Duration::from_millis(SAMPLE_INTERVAL_MS));
                 }
             })
         };
@@ -402,7 +553,7 @@ pub fn run(
 
         running.store(false, std::sync::atomic::Ordering::Relaxed);
         let _ = sampler.join();
-        let after = sample_system();
+        let samples = series.lock().map(|v| v.clone()).unwrap_or_default();
 
         let Ok(r) = r else { continue };
         let max_ms = r.timing.max_us / 1e3;
@@ -413,8 +564,21 @@ pub fn run(
         }
         if max_ms > worst_overall {
             worst_overall = max_ms;
-            let peak = peak_dw.load(std::sync::atomic::Ordering::Relaxed);
-            worst_delta = delta(&before, &after, (peak > 0).then_some(peak));
+            // Windowed on the slowest commit only. If the window cannot be
+            // resolved, carry a delta that declares that — never a whole-run
+            // one, which would attribute confidently from the wrong span.
+            let slowest = r.slowest_commit;
+            worst_windowed = slowest
+                .and_then(|w| delta_over_window(&samples, w.start_ms, w.end_ms))
+                .unwrap_or(WindowedDelta {
+                    delta: SystemDelta::default(),
+                    // The commit's own duration, taken from the window bench
+                    // measured, so the refusal message quotes the same number
+                    // the timing does.
+                    stall_ms: slowest.map_or(max_ms, |w| w.duration_ms()),
+                    covered_ms: 0.0,
+                    samples: 0,
+                });
         }
     }
 
@@ -432,7 +596,7 @@ pub fn run(
                 .into(),
         )
     } else {
-        attribute_stall(worst_overall, &worst_delta)
+        attribute_stall(&worst_windowed)
     };
 
     StallResult {
@@ -443,13 +607,25 @@ pub fn run(
         median_worst_ms: median_worst,
         throughput_eps: throughput,
         attribution,
-        delta_at_worst: worst_delta,
+        delta_at_worst: worst_windowed,
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A delta over a window that IS the stall — the good case. Tests about
+    /// attribution logic should not have to think about the window; tests about
+    /// the window say so explicitly by building a `WindowedDelta` directly.
+    fn win(stall_ms: f64, d: SystemDelta) -> WindowedDelta {
+        WindowedDelta {
+            delta: d,
+            stall_ms,
+            covered_ms: stall_ms * 1.02,
+            samples: (stall_ms / SAMPLE_INTERVAL_MS as f64) as usize + 2,
+        }
+    }
 
     fn d(psi: Option<u64>, disk: Option<u64>, dw: Option<u64>, temp: Option<u64>) -> SystemDelta {
         SystemDelta {
@@ -462,27 +638,27 @@ mod tests {
 
     #[test]
     fn below_threshold_is_no_stall() {
-        let a = attribute_stall(8.75, &SystemDelta::default());
+        let a = attribute_stall(&win(8.75, SystemDelta::default()));
         assert_eq!(a.token(), "NO-STALL");
     }
 
     #[test]
     fn the_measured_29_second_event_is_over_the_threshold() {
         // The event this module exists for: 29 271.78 ms.
-        let a = attribute_stall(29_271.78, &SystemDelta::default());
+        let a = attribute_stall(&win(29_271.78, SystemDelta::default()));
         assert_ne!(a.token(), "NO-STALL");
     }
 
     #[test]
     fn no_counters_at_all_is_unattributed_not_a_guess() {
-        let a = attribute_stall(29_271.78, &SystemDelta::default());
+        let a = attribute_stall(&win(29_271.78, SystemDelta::default()));
         assert_eq!(a.token(), "UNATTRIBUTED", "{}", a.detail());
     }
 
     #[test]
     fn busy_block_layer_without_a_backlog_points_at_the_device() {
         // 20 s of disk-busy inside a 29 s stall, small dirty set.
-        let a = attribute_stall(29_000.0, &d(None, Some(20_000), Some(1_024), None));
+        let a = attribute_stall(&win(29_000.0, d(None, Some(20_000), Some(1_024), None)));
         assert_eq!(a.token(), "IO-DEVICE", "{}", a.detail());
         assert!(a.detail().contains("SMART"), "must say what it cannot read");
     }
@@ -490,19 +666,25 @@ mod tests {
     #[test]
     fn busy_block_layer_with_a_backlog_points_at_writeback_instead() {
         // Same disk-busy evidence, but a 1 GB dirty backlog explains it.
-        let a = attribute_stall(29_000.0, &d(None, Some(20_000), Some(1_024 * 1_024), None));
+        let a = attribute_stall(&win(
+            29_000.0,
+            d(None, Some(20_000), Some(1_024 * 1_024), None),
+        ));
         assert_eq!(a.token(), "WRITEBACK-BACKLOG", "{}", a.detail());
     }
 
     #[test]
     fn psi_alone_is_enough_io_evidence() {
-        let a = attribute_stall(29_000.0, &d(Some(20_000_000), None, Some(1_024), None));
+        let a = attribute_stall(&win(29_000.0, d(Some(20_000_000), None, Some(1_024), None)));
         assert_eq!(a.token(), "IO-DEVICE", "{}", a.detail());
     }
 
     #[test]
     fn heat_with_an_idle_block_layer_points_at_thermal() {
-        let a = attribute_stall(29_000.0, &d(Some(10), Some(5), Some(1_024), Some(96_000)));
+        let a = attribute_stall(&win(
+            29_000.0,
+            d(Some(10), Some(5), Some(1_024), Some(96_000)),
+        ));
         assert_eq!(a.token(), "THERMAL", "{}", a.detail());
     }
 
@@ -510,15 +692,164 @@ mod tests {
     fn heat_during_heavy_io_is_not_blamed_on_thermal() {
         // A hot SoC during sustained I/O is a consequence, not a cause.
         // Blaming thermal here would send the investigation the wrong way.
-        let a = attribute_stall(29_000.0, &d(None, Some(25_000), Some(1_024), Some(96_000)));
+        let a = attribute_stall(&win(
+            29_000.0,
+            d(None, Some(25_000), Some(1_024), Some(96_000)),
+        ));
         assert_eq!(a.token(), "IO-DEVICE", "{}", a.detail());
     }
 
     #[test]
     fn a_briefly_busy_disk_does_not_explain_a_long_stall() {
         // 100 ms of disk activity inside a 29 s stall explains nothing.
-        let a = attribute_stall(29_000.0, &d(None, Some(100), Some(1_024), None));
+        let a = attribute_stall(&win(29_000.0, d(None, Some(100), Some(1_024), None)));
         assert_eq!(a.token(), "UNATTRIBUTED", "{}", a.detail());
+    }
+
+    // -----------------------------------------------------------------------
+    // OQ9 instrument fix — the window must be about the stall
+    // -----------------------------------------------------------------------
+
+    /// Samples every 20 ms from 0, with the counters advancing only inside
+    /// `[busy_from, busy_to)`. Everything outside that span is a quiet device.
+    fn series(span_ms: u64, busy_from: f64, busy_to: f64) -> Vec<StampedSample> {
+        let mut v = Vec::new();
+        let (mut disk, mut psi) = (0u64, 0u64);
+        let mut t = 0u64;
+        while t <= span_ms {
+            let at = t as f64;
+            if at >= busy_from && at < busy_to {
+                disk += SAMPLE_INTERVAL_MS; // fully busy
+                psi += SAMPLE_INTERVAL_MS * 1_000;
+            }
+            v.push(StampedSample {
+                at_ms: at,
+                sample: SystemSample {
+                    psi_io_total_us: Some(psi),
+                    disk_io_ms: Some(disk),
+                    dirty_kb: Some(1_024),
+                    writeback_kb: Some(0),
+                    thermal_max_mc: Some(50_000),
+                },
+            });
+            t += SAMPLE_INTERVAL_MS;
+        }
+        v
+    }
+
+    #[test]
+    fn whole_run_counters_can_no_longer_be_attributed_to_one_commit() {
+        // THE DEFECT, pinned. A 60 s run with 20 s of ordinary device busy-time
+        // and a 2 s stall. Under the old instrument the whole-run disk_io_ms
+        // (20 000) was compared against the stall (2 000 x 0.5 = 1 000) and
+        // cleared the bar easily -> a confident IO-DEVICE verdict, regardless of
+        // whether the device did anything at all during those 2 seconds.
+        let whole_run = WindowedDelta {
+            delta: d(Some(20_000_000), Some(20_000), Some(1_024), None),
+            stall_ms: 2_000.0,
+            covered_ms: 60_000.0,
+            samples: 3_000,
+        };
+        assert!(!whole_run.window_is_usable());
+        let a = attribute_stall(&whole_run);
+        assert_eq!(
+            a.token(),
+            "UNATTRIBUTED",
+            "a whole-run window was attributed to a single commit: {}",
+            a.detail()
+        );
+        assert!(
+            a.detail().contains("INSTRUMENT"),
+            "the refusal must say it is an instrument limit, not a device finding: {}",
+            a.detail()
+        );
+    }
+
+    #[test]
+    fn a_device_idle_through_the_stall_is_not_blamed_for_it() {
+        // The same run, now windowed properly: the device was busy from 0-20 s
+        // and the stall ran 40 000-42 000 ms, with the device idle throughout.
+        // The old instrument called this IO-DEVICE. It must not.
+        let s = series(60_000, 0.0, 20_000.0);
+        let w = delta_over_window(&s, 40_000.0, 42_000.0).expect("window is resolvable");
+        assert!(w.window_is_usable(), "{w:?}");
+        assert_eq!(
+            w.delta.disk_io_ms,
+            Some(0),
+            "device was idle in this window"
+        );
+        assert_eq!(attribute_stall(&w).token(), "UNATTRIBUTED");
+    }
+
+    #[test]
+    fn a_device_busy_through_the_stall_still_is() {
+        // The fix must not simply suppress attribution. Same shape, but the
+        // busy span now covers the stall.
+        let s = series(60_000, 39_000.0, 43_000.0);
+        let w = delta_over_window(&s, 40_000.0, 42_000.0).expect("window is resolvable");
+        assert!(w.window_is_usable());
+        assert_eq!(attribute_stall(&w).token(), "IO-DEVICE");
+    }
+
+    #[test]
+    fn the_window_brackets_the_commit_rather_than_clipping_it() {
+        // Bounds land between samples: the chosen pair must sit outside, so the
+        // commit is fully contained. Clipping would undercount the very
+        // counters the attribution turns on.
+        let s = series(1_000, 0.0, 0.0);
+        let w = delta_over_window(&s, 205.0, 315.0).expect("resolvable");
+        assert!(
+            w.covered_ms >= 110.0,
+            "window {} ms does not contain the 110 ms commit",
+            w.covered_ms
+        );
+        assert!(w.covered_ms <= 110.0 + 2.0 * SAMPLE_INTERVAL_MS as f64);
+    }
+
+    #[test]
+    fn an_unresolvable_window_returns_none_rather_than_the_whole_series() {
+        // Fail closed. Returning the whole-series delta here is exactly the old
+        // behaviour, so `None` is the load-bearing answer.
+        assert!(delta_over_window(&[], 0.0, 100.0).is_none());
+        assert!(delta_over_window(&series(100, 0.0, 0.0)[..1], 0.0, 100.0).is_none());
+        // A commit entirely after the last sample has no bracketing pair on the
+        // right, and must not silently reuse the final sample as both ends.
+        let s = series(100, 0.0, 0.0);
+        let w = delta_over_window(&s, 5_000.0, 5_100.0);
+        assert!(
+            w.is_none() || !w.unwrap().window_is_usable(),
+            "a window past the end of the series was treated as measured"
+        );
+    }
+
+    #[test]
+    fn too_few_samples_is_not_a_measurement() {
+        let thin = WindowedDelta {
+            delta: d(None, Some(20_000), Some(1_024), None),
+            stall_ms: 29_000.0,
+            covered_ms: 29_000.0,
+            samples: MIN_WINDOW_SAMPLES - 1,
+        };
+        assert!(!thin.window_is_usable());
+        assert_eq!(attribute_stall(&thin).token(), "UNATTRIBUTED");
+    }
+
+    #[test]
+    fn the_peak_backlog_is_taken_inside_the_window_only() {
+        // A backlog spike elsewhere in the run must not turn this stall into
+        // WRITEBACK-BACKLOG — same denominator error, different counter.
+        let mut s = series(60_000, 39_000.0, 43_000.0);
+        for x in s.iter_mut() {
+            if x.at_ms < 10_000.0 {
+                x.sample.dirty_kb = Some(4 * 1_024 * 1_024); // huge, far from the stall
+            }
+        }
+        let w = delta_over_window(&s, 40_000.0, 42_000.0).expect("resolvable");
+        assert!(
+            w.delta.peak_dirty_writeback_kb.unwrap_or(0) < WRITEBACK_BACKLOG_KB,
+            "a backlog outside the window leaked into it"
+        );
+        assert_eq!(attribute_stall(&w).token(), "IO-DEVICE");
     }
 
     #[test]
@@ -549,8 +880,8 @@ mod tests {
             worst_commit_ms: 12.0,
             median_worst_ms: 9.0,
             throughput_eps: vec![30_000.0; 20],
-            attribution: attribute_stall(12.0, &SystemDelta::default()),
-            delta_at_worst: SystemDelta::default(),
+            attribution: attribute_stall(&win(12.0, SystemDelta::default())),
+            delta_at_worst: win(0.0, SystemDelta::default()),
         };
         assert!(!r.fails_the_run());
         assert_eq!(r.stall_rate(), 0.0);
@@ -572,7 +903,7 @@ mod tests {
             median_worst_ms: 11.0,
             throughput_eps: vec![36_000.0, 35_800.0, 3_123.0, 36_200.0, 35_900.0],
             attribution: StallAttribution::Unattributed(String::new()),
-            delta_at_worst: SystemDelta::default(),
+            delta_at_worst: win(0.0, SystemDelta::default()),
         };
         assert_eq!(r.median_throughput_eps(), 35_900.0);
         assert_eq!(r.stall_rate(), 0.2);
@@ -588,7 +919,7 @@ mod tests {
             median_worst_ms: f64::NAN,
             throughput_eps: vec![],
             attribution: StallAttribution::Unattributed(String::new()),
-            delta_at_worst: SystemDelta::default(),
+            delta_at_worst: win(0.0, SystemDelta::default()),
         };
         assert!(r.median_throughput_eps().is_nan());
     }
@@ -603,7 +934,7 @@ mod tests {
             median_worst_ms: f64::NAN,
             throughput_eps: vec![],
             attribution: StallAttribution::Unattributed(String::new()),
-            delta_at_worst: SystemDelta::default(),
+            delta_at_worst: win(0.0, SystemDelta::default()),
         };
         assert!(r.fails_the_run());
         assert!(r.stall_rate().is_nan());
@@ -619,7 +950,7 @@ mod tests {
             median_worst_ms: 10.0,
             throughput_eps: vec![],
             attribution: StallAttribution::Unattributed(String::new()),
-            delta_at_worst: SystemDelta::default(),
+            delta_at_worst: win(0.0, SystemDelta::default()),
         };
         assert_eq!(mk(1).stall_rate(), 0.05);
         assert_eq!(mk(10).stall_rate(), 0.5);


### PR DESCRIPTION
The OQ9 instrument fix. It also forces a correction to D-10.

## The defect

`attribute_stall` tested:

```rust
let io_busy = d.disk_io_ms.map(|ms| ms as f64 >= stall_ms * IO_BUSY_FRACTION);
```

`disk_io_ms` came from a single before/after sample pair around the **whole repetition**. `stall_ms` is a **single commit**. A denominator mismatch — a 60 s run with 20 s of ordinary device busy-time satisfies `20000 >= 2000 * 0.5` for a 2 s stall *no matter what the device did during those two seconds*. **The instrument could report `IO-DEVICE` from an idle disk.**

## The correction to D-10

D-10 recorded this as a limitation — "the counter delta is taken across a whole repetition while the stall is a single commit, which can over-state I/O evidence". It is worse than over-statement, so **the `IO-DEVICE` attribution on `NORMAL`/batch=1 is withdrawn**, not downgraded. It is not weak evidence; it is not evidence.

Everything else in D-10 stands, because none of it depended on the window: the 3-in-120 stall rate, the worst-commit latencies, the throughput medians that resolved the corrupted `NORMAL`/batch=64 row, and the 59.6 °C thermal reading that ruled thermal out. Only the attribution column moves.

## The fix

- **`bench::append`** reports `slowest_commit: Option<CommitWindow>` — offsets, from the same origin the loop times against, of the commit that produced `timing.max_us`.
- **`stall::run`** samples a timestamped series every `SAMPLE_INTERVAL_MS` and deltas across the slowest commit's window only. The dirty/writeback peak is taken inside the window too — same denominator error, different counter.
- **`attribute_stall` takes a `WindowedDelta`**, which carries the span the counters cover. Nothing can be attributed without declaring that span, and attribution **refuses** when the span is materially wider than the stall — naming itself an *instrument* limitation rather than a device finding. That is what stops the defect recurring silently rather than merely fixing today's call site.
- **`delta_over_window` fails closed**: no bracketing sample pair returns `None`, not a whole-series delta. Returning the series is exactly the old behaviour.
- The record emits `counter_window_ms` / `counter_window_samples` / `counter_window_usable`, so a reader sees what span produced the counters instead of assuming — the measurement-semantics rule applied to this record.

## Tests

Seven new, including the two that carry the argument:

- `whole_run_counters_can_no_longer_be_attributed_to_one_commit` — the defect, pinned, with the shape that used to produce a confident `IO-DEVICE`.
- `a_device_idle_through_the_stall_is_not_blamed_for_it` and `a_device_busy_through_the_stall_still_is` — the fix must not just suppress attribution, so both directions are asserted over the same synthetic series.

Plus bracketing-not-clipping, fail-closed windows, too-few-samples, backlog-peak containment, and a `bench` coherence check that the window and `max_us` name the same commit.

## What this does not do

**It measures nothing new.** The mechanism behind OQ9 is exactly as unknown as before, minus one attribution that looked like progress. Re-running the six configurations on target with the fixed instrument is the outstanding work, and PSI remains unavailable on that kernel regardless of windowing — one of the two I/O signals is absent either way.

No robot runtime, safety algorithm, checker input, release-token or actuator change. No Kirra World domain logic. ADR-0042 Decision 5 untouched.

## Verification

`cargo fmt --check` clean · `cargo clippy --all-targets -D warnings` clean · 179 unit + 7 integration tests pass · end-to-end `stall` run emits the new window fields · domain-logic gate HOLDING · bidirectional fence INTACT · quality guardrails satisfied · citations resolve.

Not for merge without instruction.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_