### PR TITLE
feat(wm2): emit every stalling repetition's duration, so the instrument can test its own prediction

### DIFF
--- a/tools/wm2-persistence-harness/src/json.rs
+++ b/tools/wm2-persistence-harness/src/json.rs
@@ -103,6 +103,16 @@ impl Obj {
         self
     }
 
+    /// A numeric array. Non-finite entries render as `null`, exactly as
+    /// [`float`](Self::float) does — a missing measurement must not arrive as a
+    /// number a consumer would then average.
+    pub fn float_array(mut self, key: &str, values: &[f64]) -> Self {
+        let items: Vec<String> = values.iter().map(|v| number(*v)).collect();
+        self.parts
+            .push(format!("\"{}\":[{}]", escape(key), items.join(",")));
+        self
+    }
+
     pub fn obj(mut self, key: &str, value: Obj) -> Self {
         self.parts
             .push(format!("\"{}\":{}", escape(key), value.render()));

--- a/tools/wm2-persistence-harness/src/json.rs
+++ b/tools/wm2-persistence-harness/src/json.rs
@@ -177,6 +177,25 @@ mod tests {
     }
 
     #[test]
+    fn a_float_array_renders_numbers_and_nulls_not_invalid_json() {
+        // Same contract as `float`, which is the point: a non-finite entry must
+        // not arrive as a number a consumer would then average, and must not
+        // break the parse for every other record in the file.
+        assert_eq!(
+            Obj::new().float_array("d", &[1.5, 30_182.4]).render(),
+            r#"{"d":[1.500000,30182.400000]}"#
+        );
+        assert_eq!(
+            Obj::new()
+                .float_array("d", &[f64::NAN, 2.0, f64::INFINITY])
+                .render(),
+            r#"{"d":[null,2.000000,null]}"#
+        );
+        // The empty case is the common one — most runs record no stall at all.
+        assert_eq!(Obj::new().float_array("d", &[]).render(), r#"{"d":[]}"#);
+    }
+
+    #[test]
     fn keys_are_escaped_too() {
         assert_eq!(Obj::new().int("a\"b", 1).render(), r#"{"a\"b":1}"#);
     }

--- a/tools/wm2-persistence-harness/src/main.rs
+++ b/tools/wm2-persistence-harness/src/main.rs
@@ -937,6 +937,11 @@ fn main() {
                 .float("stall_threshold_ms", stall::STALL_THRESHOLD_MS)
                 .float("worst_commit_ms", r.worst_commit_ms)
                 .float("median_worst_ms", r.median_worst_ms)
+                // One entry per STALLING repetition (its worst commit), ascending.
+                // A single `worst_commit_ms` cannot tell stalls clustered at a
+                // timeout bound from stalls spread below it, and those imply
+                // different mechanisms — see D-15 Refinement.
+                .float_array("stall_durations_ms", &r.stall_durations_ms)
                 .float("median_throughput_eps", r.median_throughput_eps())
                 .str("attribution", r.attribution.token())
                 .str("detail", r.attribution.detail())

--- a/tools/wm2-persistence-harness/src/stall.rs
+++ b/tools/wm2-persistence-harness/src/stall.rs
@@ -195,6 +195,24 @@ const WRITEBACK_BACKLOG_KB: u64 = 256 * 1024;
 /// Sustained temperature (milli-degrees C) suggesting thermal capping.
 const THERMAL_HOT_MC: u64 = 85_000;
 
+/// The stalling repetitions' durations, ascending, from every repetition's worst
+/// commit.
+///
+/// A free function rather than three lines inline, so a test can exercise **this
+/// code** instead of a copy of it. Both halves matter and neither is obvious
+/// from the output alone: the sort is what makes a cluster distinguishable from
+/// a spread at a glance, and the filter is what ties the array's length to
+/// `stalls_observed`.
+pub fn stall_durations_from(worst_per_run: &[f64]) -> Vec<f64> {
+    let mut out: Vec<f64> = worst_per_run
+        .iter()
+        .copied()
+        .filter(|ms| *ms >= STALL_THRESHOLD_MS)
+        .collect();
+    out.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    out
+}
+
 /// Extract the counter delta across one commit's window from a sampled series.
 ///
 /// This is the OQ9 instrument fix. `series` is the background sampler's output,
@@ -618,12 +636,15 @@ pub fn run(
     } else {
         worst_per_run[worst_per_run.len() / 2]
     };
-    // Sorted, so the shape is readable without post-processing.
-    let stall_durations_ms: Vec<f64> = worst_per_run
-        .iter()
-        .copied()
-        .filter(|ms| *ms >= STALL_THRESHOLD_MS)
-        .collect();
+    let stall_durations_ms = stall_durations_from(&worst_per_run);
+    // The array and the count are two views of the same thing; a refactor that
+    // let them disagree would read as a measurement gap rather than a
+    // bookkeeping bug, which is the expensive kind of confusion.
+    debug_assert_eq!(
+        stall_durations_ms.len(),
+        stalls,
+        "stall_durations_ms must have one entry per stalling repetition"
+    );
 
     let attribution = if worst_per_run.is_empty() {
         StallAttribution::Unattributed(
@@ -1028,17 +1049,20 @@ mod tests {
 
     #[test]
     fn the_stall_durations_are_exactly_the_repetitions_that_stalled() {
-        // The list and the count come from the same source and must not drift:
-        // a reader comparing `stalls_observed` against the array's length is
-        // entitled to find them equal, and a mismatch would look like a
-        // measurement gap rather than a bookkeeping bug.
-        let worst_per_run = [4.0, 12.5, STALL_THRESHOLD_MS, 8_496.0, 30_182.4];
-        let durations: Vec<f64> = worst_per_run
-            .iter()
-            .copied()
-            .filter(|ms| *ms >= STALL_THRESHOLD_MS)
-            .collect();
+        // Calls `stall_durations_from` — the function `run` uses — with input
+        // deliberately OUT OF ORDER. An earlier version of this test filtered a
+        // pre-sorted array itself, so it asserted "ascending" about a list that
+        // arrived ascending and would have passed even if the real code stopped
+        // sorting. A test that reimplements the logic tests the
+        // reimplementation.
+        let worst_per_run = [30_182.4, 4.0, 8_496.0, 12.5, STALL_THRESHOLD_MS];
+        let durations = stall_durations_from(&worst_per_run);
+
+        // Sorted output from unsorted input: the sort is real, not inherited.
         assert_eq!(durations, vec![STALL_THRESHOLD_MS, 8_496.0, 30_182.4]);
+        assert!(durations.windows(2).all(|w| w[0] <= w[1]));
+
+        // Length ties to what `stalls_observed` counts, by the same predicate.
         assert_eq!(
             durations.len(),
             worst_per_run
@@ -1047,11 +1071,10 @@ mod tests {
                 .count(),
             "the array length must equal stalls_observed by construction"
         );
-        // Ascending, so the shape reads without post-processing — the whole
-        // point is telling a cluster at a timeout bound from a spread below it.
-        assert!(durations.windows(2).all(|w| w[0] <= w[1]));
-        // The threshold is inclusive on both sides of the comparison.
+        // The threshold is inclusive, matching the `>=` that counts a stall.
         assert!(durations.contains(&STALL_THRESHOLD_MS));
+        assert!(stall_durations_from(&[]).is_empty());
+        assert!(stall_durations_from(&[4.0, 999.999]).is_empty());
     }
 
     #[test]

--- a/tools/wm2-persistence-harness/src/stall.rs
+++ b/tools/wm2-persistence-harness/src/stall.rs
@@ -342,6 +342,19 @@ pub struct StallResult {
     pub worst_commit_ms: f64,
     /// Median of the per-run worst commit — how bad a *typical* run gets.
     pub median_worst_ms: f64,
+    /// Every stalling repetition's worst commit, milliseconds, ascending.
+    ///
+    /// **One entry per stalling repetition, not per stall** — `bench::append`
+    /// reports a repetition's `max`, so a repetition containing two stalls
+    /// contributes only its worse one. The length therefore equals
+    /// `stalls_observed` by construction.
+    ///
+    /// Exists because a single `worst_commit_ms` cannot distinguish stalls
+    /// *clustered* at a timeout bound from stalls *distributed* below it, and
+    /// those imply different mechanisms: clustering says the bound is doing the
+    /// recovering, spread says the fault often resolves on its own (D-15
+    /// *Refinement*).
+    pub stall_durations_ms: Vec<f64>,
     pub throughput_eps: Vec<f64>,
     pub attribution: StallAttribution,
     /// Counters across the worst commit's own window — **not** across the run.
@@ -605,6 +618,12 @@ pub fn run(
     } else {
         worst_per_run[worst_per_run.len() / 2]
     };
+    // Sorted, so the shape is readable without post-processing.
+    let stall_durations_ms: Vec<f64> = worst_per_run
+        .iter()
+        .copied()
+        .filter(|ms| *ms >= STALL_THRESHOLD_MS)
+        .collect();
 
     let attribution = if worst_per_run.is_empty() {
         StallAttribution::Unattributed(
@@ -622,6 +641,7 @@ pub fn run(
         stalls_observed: stalls,
         worst_commit_ms: worst_overall,
         median_worst_ms: median_worst,
+        stall_durations_ms,
         throughput_eps: throughput,
         attribution,
         delta_at_worst: worst_windowed,
@@ -926,6 +946,7 @@ mod tests {
             median_worst_ms: 9.0,
             throughput_eps: vec![30_000.0; 20],
             attribution: attribute_stall(&win(12.0, SystemDelta::default())),
+            stall_durations_ms: Vec::new(),
             delta_at_worst: win(0.0, SystemDelta::default()),
         };
         assert!(!r.fails_the_run());
@@ -948,6 +969,7 @@ mod tests {
             median_worst_ms: 11.0,
             throughput_eps: vec![36_000.0, 35_800.0, 3_123.0, 36_200.0, 35_900.0],
             attribution: StallAttribution::Unattributed(String::new()),
+            stall_durations_ms: Vec::new(),
             delta_at_worst: win(0.0, SystemDelta::default()),
         };
         assert_eq!(r.median_throughput_eps(), 35_900.0);
@@ -964,6 +986,7 @@ mod tests {
             median_worst_ms: f64::NAN,
             throughput_eps: vec![],
             attribution: StallAttribution::Unattributed(String::new()),
+            stall_durations_ms: Vec::new(),
             delta_at_worst: win(0.0, SystemDelta::default()),
         };
         assert!(r.median_throughput_eps().is_nan());
@@ -979,6 +1002,7 @@ mod tests {
             median_worst_ms: f64::NAN,
             throughput_eps: vec![],
             attribution: StallAttribution::Unattributed(String::new()),
+            stall_durations_ms: Vec::new(),
             delta_at_worst: win(0.0, SystemDelta::default()),
         };
         assert!(r.fails_the_run());
@@ -995,10 +1019,39 @@ mod tests {
             median_worst_ms: 10.0,
             throughput_eps: vec![],
             attribution: StallAttribution::Unattributed(String::new()),
+            stall_durations_ms: Vec::new(),
             delta_at_worst: win(0.0, SystemDelta::default()),
         };
         assert_eq!(mk(1).stall_rate(), 0.05);
         assert_eq!(mk(10).stall_rate(), 0.5);
+    }
+
+    #[test]
+    fn the_stall_durations_are_exactly_the_repetitions_that_stalled() {
+        // The list and the count come from the same source and must not drift:
+        // a reader comparing `stalls_observed` against the array's length is
+        // entitled to find them equal, and a mismatch would look like a
+        // measurement gap rather than a bookkeeping bug.
+        let worst_per_run = [4.0, 12.5, STALL_THRESHOLD_MS, 8_496.0, 30_182.4];
+        let durations: Vec<f64> = worst_per_run
+            .iter()
+            .copied()
+            .filter(|ms| *ms >= STALL_THRESHOLD_MS)
+            .collect();
+        assert_eq!(durations, vec![STALL_THRESHOLD_MS, 8_496.0, 30_182.4]);
+        assert_eq!(
+            durations.len(),
+            worst_per_run
+                .iter()
+                .filter(|ms| **ms >= STALL_THRESHOLD_MS)
+                .count(),
+            "the array length must equal stalls_observed by construction"
+        );
+        // Ascending, so the shape reads without post-processing — the whole
+        // point is telling a cluster at a timeout bound from a spread below it.
+        assert!(durations.windows(2).all(|w| w[0] <= w[1]));
+        // The threshold is inclusive on both sides of the comparison.
+        assert!(durations.contains(&STALL_THRESHOLD_MS));
     }
 
     #[test]


### PR DESCRIPTION
The stall record reported `worst_commit_ms` and nothing else about the shape, so it could not distinguish stalls **clustered** at a timeout bound from stalls **spread** below it. Those imply different mechanisms — clustering says the timeout is doing the recovering, spread says the fault often resolves on its own.

That became load-bearing today. D-15 first read the 30 s stalls as timeout-*caused*; an 8 496 ms stall with the same idle-device signature and no kernel timeout entry showed the timeout is the recovery **bound** instead. The refined model predicts a distribution of sub-timeout stalls — and the instrument could not test its own prediction.

## The change

`stall_durations_ms`: one entry per stalling repetition, ascending, emitted through a new `Obj::float_array`. Non-finite entries render as `null`, matching `float`, so a missing measurement never arrives as a number a consumer would average.

## Named limitation

**One entry per stalling *repetition*, not per stall.** `bench::append` reports a repetition's `max`, so a repetition containing two stalls contributes only its worse one. The array length equals `stalls_observed` by construction, and a test pins that — a reader comparing the two is entitled to find them equal, and a mismatch would read as a measurement gap rather than a bookkeeping bug.

Emitting *every* stall would need `bench::append` to report all commits over a threshold. Not done here, and not needed for the clustering question.

## Verification

`cargo fmt --check` and `cargo clippy --all-targets -D warnings` clean · 182 unit + 7 integration tests pass · end-to-end run emits `stall_durations_ms: []` with `stalls_observed: 0`, so the length invariant holds in the empty case too.

Instrument only — no runtime, safety algorithm, checker input, release-token or actuator change. No Kirra World domain logic. Kept off #1333 so that PR's "docs and evidence only" claim stays true.

Not for merge without instruction.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_