### PR TITLE
feat(wm2): measure R2's alongside-rebuild cost against a control arm

### DIFF
--- a/docs/adr/0041-world-model-persistence-architecture.md
+++ b/docs/adr/0041-world-model-persistence-architecture.md
@@ -729,15 +729,18 @@ reasons, which D-13 shows are avoidable.
    costs in code, in peak disk, in write amplification and in cutover latency.
    Storage is the *smallest* of those: projections are 3.74 % of total store
    size, so a duplicate is ≈306 MiB (321 MB) at the 8 GiB ceiling rather than a
-   second 8 GiB. **Partially discharged 2026-08-04 — still open.** The protocol
-   is now specified and prototyped
-   (`docs/design/WM2_PROJECTION_REBUILD_PROTOCOL.md`), which answers the *code*
-   cost and settles cutover ordering and the partial-projection state. **Peak
-   disk, write amplification and cutover latency are still unmeasured**, and
-   those are the three that need the store the design does not build.
+   second 8 GiB. **Measured 2026-08-04 — see D-16. Host-indicative; the target
+   run remains.** The protocol was specified and prototyped
+   (`docs/design/WM2_PROJECTION_REBUILD_PROTOCOL.md`), answering the *code* cost
+   and settling cutover ordering and the partial-projection state; the
+   `rebuild` harness command then measured the other three against a control arm
+   running identical ingest without the rebuild. **Write amplification is the
+   finding, and it is a dial rather than a constant: 2.7×–35.6× across a 16×
+   range of fold-chunk counts.**
 
-Items 1 and 2 are closed on target. **Item 3 is the real engineering, it is
-untouched, and it is the part that should carry a spike before anyone signs** —
+Items 1 and 2 are closed on target. **Item 3 is no longer untouched — D-16
+measures it — but it is host-indicative, so the obligation narrows rather than
+closes** —
 D-14 establishes that a migration *can* be cheap, not that the alongside-rebuild
 protocol R2 specifies has been built or costed.
 
@@ -1570,6 +1573,100 @@ mounts. It does not affect this finding — the failure is in the NVMe driver,
 below the filesystem, and the mechanism rests on kernel-log correlation — but a
 durability evidence platform configured to continue past filesystem errors is a
 gap to close before the next evidence run.
+
+### D-16 — R2's alongside rebuild costs a *dial*, not a number: write amplification 2.7×–35.6×
+
+`HOST-INDICATIVE-NOT-TARGET.` The acceptance record's outstanding obligation
+asks what alongside-rebuild-and-swap costs "in code, in peak disk, in write
+amplification and in cutover latency". The protocol answered *code*. The
+`rebuild` harness command answers the rest.
+
+**The measurement has a control**, because it has to. A rebuild runs while
+ingest continues, and both write through the same process — `/proc/self/io`
+cannot say which bytes belong to which, and neither can the file size. So two
+arms run **identical ingest**, one with the rebuild and one without, and every
+cost below is the *difference*. Without that control the numbers would be "bytes
+written while a rebuild happened to be running", which overstates the rebuild by
+the entire ingest load.
+
+Every transition is driven by the protocol's own state machine, so what is
+measured is the procedure R2 specifies rather than something resembling it.
+
+#### Write amplification is a tunable, and quoting one number for it would mislead
+
+Total ingest held constant at 16 000 events; only the fold's chunk count varies:
+
+| Fold chunks | Write amplification | Extra writes | Cutover | Catch-up laps |
+|---:|---:|---:|---:|---:|
+| 2 | **2.7×** | 3.2 MB | 1.83 ms | 1 |
+| 4 | **5.3×** | 6.3 MB | 1.60 ms | 2 |
+| 8 | **14.0×** | 16.7 MB | 1.55 ms | 3 |
+| 16 | **20.4×** | 24.0 MB | 1.61 ms | 6 |
+| 32 | **35.6×** | 42.5 MB | 1.50 ms | 12 |
+
+Amplification is **not a property of the rebuild**. It rises roughly linearly
+with how finely the fold is chunked, because each chunk commits a transaction
+that rewrites projection pages already written, and each commit adds WAL frames
+that a checkpoint later writes again. A single figure — the first run gave
+14.0× — would have described one arbitrary point on a curve spanning **13.2×**.
+
+**The engineering consequence is a trade-off, now quantified.** Coarser chunks
+cost far less I/O; finer chunks hold each fold transaction for less time. An
+implementation has to pick, and on flash the pick matters: at the ≈306 MiB
+duplicate-projection figure, a 3× rebuild is ~0.9 GB of device writes and a 35×
+rebuild is ~10.7 GB. That is a wear question, not a throughput one.
+
+#### Cutover is flat, which is what R2's availability claim needs
+
+**1.50–1.83 ms**, independent of chunking — the swap is a rename pair inside one
+transaction, so no rows move. Against a 620 ms rebuild that is **0.26 %**. The
+claim R2 rests on — the robot keeps serving throughout, and the only moment it
+cannot is the swap — is supported rather than assumed. Retiring the old tables
+(`DROP`) is measured separately at ~0.9 ms and is reclamation, not cutover.
+
+**What that figure excludes, and it is not a rounding detail.** SQLite renames
+tables but not their indexes, so a rename-pair cutover leaves the live projection
+carrying the rebuild's index names and the next cycle collides. Every resolution
+costs something — recreating indexes inside the blackout window turns the swap
+into an index rebuild, name ping-pong makes the live schema depend on cycle
+parity, and pointer-based cutover avoids it but is a different design. The
+prototype takes none of them: it runs one cycle and **refuses a second with a
+stated reason**, so 1.50–1.83 ms is the cost of a rename pair and nothing else.
+Read it as a floor. The choice is now explicit implementation work under the
+protocol's S-2 (`docs/design/WM2_PROJECTION_REBUILD_PROTOCOL.md` §8).
+
+#### Peak disk: use the free-list measure, not the file size
+
+The duplicate projection measures **2.61–2.69 %** of store size (mean 2.64 %),
+and that figure is *stable* across chunk counts (1.02× spread) because it is the
+same projection either way.
+
+Two cautions, both learned by getting them wrong first:
+
+- **`DROP TABLE` does not shrink a SQLite file.** It moves pages to the free
+  list. Measuring the retired projection by file shrinkage reports **zero**,
+  which reads as a projection that cost nothing. The figures above come from the
+  free-list delta.
+- **Peak on-disk overhead is the noisier measure** (3.46× spread across the same
+  runs) because it moves with WAL checkpoint timing. It is emitted, but the
+  projection's own size is the number to cite.
+
+**Against D-2's arithmetic.** The acceptance record derived ≈306 MiB from D-2's
+3.74 % projection overhead. This measures **2.64 %** directly — the same order,
+about 30 % lower. Neither refutes the other: D-2's figure is bytes-per-event
+overhead on its configuration, this is projection pages as a fraction of a store
+with a different entity count and event mix. They are two measurements, not one
+measurement twice.
+
+#### What this does not do
+
+**It is not a target run.** `HOST-INDICATIVE-NOT-TARGET`, so none of it is
+citable against the ratification checklist, and the amplification figure in
+particular is the one most likely to move on the Jetson's NVMe — D-15 has just
+established that device's write path has a defect. It is also over the
+**stand-in schema**, so the constants describe that schema and not a ratified
+one. The *shape* — amplification linear in chunk count, cutover flat and small,
+projection a low single-digit percentage — is what should be expected to carry.
 
 ### D-12 — design implications the measurement forces
 

--- a/docs/adr/0041-world-model-persistence-architecture.md
+++ b/docs/adr/0041-world-model-persistence-architecture.md
@@ -735,7 +735,7 @@ reasons, which D-13 shows are avoidable.
    and settling cutover ordering and the partial-projection state; the
    `rebuild` harness command then measured the other three against a control arm
    running identical ingest without the rebuild. **Write amplification is the
-   finding, and it is a dial rather than a constant: 2.7×–35.6× across a 16×
+   finding, and it is a dial rather than a constant: 2.8×–35.8× across a 16×
    range of fold-chunk counts.**
 
 Items 1 and 2 are closed on target. **Item 3 is no longer untouched — D-16
@@ -1574,7 +1574,7 @@ below the filesystem, and the mechanism rests on kernel-log correlation — but 
 durability evidence platform configured to continue past filesystem errors is a
 gap to close before the next evidence run.
 
-### D-16 — R2's alongside rebuild costs a *dial*, not a number: write amplification 2.7×–35.6×
+### D-16 — R2's alongside rebuild costs a *dial*, not a number: write amplification 2.8×–35.8×
 
 `HOST-INDICATIVE-NOT-TARGET.` The acceptance record's outstanding obligation
 asks what alongside-rebuild-and-swap costs "in code, in peak disk, in write
@@ -1592,23 +1592,39 @@ the entire ingest load.
 Every transition is driven by the protocol's own state machine, so what is
 measured is the procedure R2 specifies rather than something resembling it.
 
+**The measured window covers the alongside tables' creation**, including their
+indexes. It did not in the first version — the DDL ran before the counter
+snapshot, so the rebuild arm's window started later than the control arm's and
+the two were not symmetric. Corrected under review. The effect turned out to be
+small (amplification moved 14.0× → 14.1× at the mid configuration, which is what
+two empty tables and two empty indexes should cost), but the claim being made
+was that indexes are included, and a measurement that excludes what it names is
+wrong independently of by how much.
+
 #### Write amplification is a tunable, and quoting one number for it would mislead
 
 Total ingest held constant at 16 000 events; only the fold's chunk count varies:
 
 | Fold chunks | Write amplification | Extra writes | Cutover | Catch-up laps |
 |---:|---:|---:|---:|---:|
-| 2 | **2.7×** | 3.2 MB | 1.83 ms | 1 |
-| 4 | **5.3×** | 6.3 MB | 1.60 ms | 2 |
-| 8 | **14.0×** | 16.7 MB | 1.55 ms | 3 |
-| 16 | **20.4×** | 24.0 MB | 1.61 ms | 6 |
-| 32 | **35.6×** | 42.5 MB | 1.50 ms | 12 |
+| 2 | **2.8×** | 3.3 MB | 2.29 ms | 1 |
+| 4 | **5.3×** | 6.4 MB | 2.28 ms | 2 |
+| 8 | **14.1×** | 16.8 MB | 2.33 ms | 3 |
+| 16 | **20.5×** | 24.2 MB | 2.06 ms | 6 |
+| 32 | **35.8×** | 42.7 MB | 2.19 ms | 12 |
+
+Reproduced exactly (1.00× spread over repeated runs at identical parameters:
+`--events 40000 --entities 2000`, total ingest 16 000). The parameters are
+stated because an earlier check re-ran this sweep on the harness *defaults* —
+a different seed size and entity count — and the control arm moved 1.4×,
+which very nearly got attributed to a code change. Two sweeps that differ in
+what is held fixed are two experiments, not a before and after.
 
 Amplification is **not a property of the rebuild**. It rises roughly linearly
 with how finely the fold is chunked, because each chunk commits a transaction
 that rewrites projection pages already written, and each commit adds WAL frames
 that a checkpoint later writes again. A single figure — the first run gave
-14.0× — would have described one arbitrary point on a curve spanning **13.2×**.
+14.1× — would have described one arbitrary point on a curve spanning **12.8×**.
 
 **The engineering consequence is a trade-off, now quantified.** Coarser chunks
 cost far less I/O; finer chunks hold each fold transaction for less time. An
@@ -1618,11 +1634,21 @@ rebuild is ~10.7 GB. That is a wear question, not a throughput one.
 
 #### Cutover is flat, which is what R2's availability claim needs
 
-**1.50–1.83 ms**, independent of chunking — the swap is a rename pair inside one
-transaction, so no rows move. Against a 620 ms rebuild that is **0.26 %**. The
-claim R2 rests on — the robot keeps serving throughout, and the only moment it
-cannot is the swap — is supported rather than assumed. Retiring the old tables
-(`DROP`) is measured separately at ~0.9 ms and is reclamation, not cutover.
+**≈2.0–2.4 ms** — the swap is a rename pair inside one transaction, so no rows
+move. Against a 525–929 ms rebuild that is **≈0.3 %**. The claim R2 rests on —
+the robot keeps serving throughout, and the only moment it cannot is the swap —
+is supported rather than assumed. Retiring the old tables (`DROP`) is measured
+separately at ~0.9 ms and is reclamation, not cutover.
+
+**Quote this as "about 2 ms", not to three figures.** Unlike amplification,
+which reproduces exactly, cutover carries **1.21× run-to-run spread** at a
+fixed configuration. That is the number that licenses the word *flat*: the
+variation across a 16× range of chunk counts (2.06–2.33 ms) is no larger than
+the variation between repeats of a *single* configuration, so the measurement
+cannot distinguish chunking as an influence — which is the honest form of
+"independent of chunking". An earlier draft of this entry gave the range to
+three significant figures, which implied a precision the instrument does not
+have.
 
 **What that figure excludes, and it is not a rounding detail.** SQLite renames
 tables but not their indexes, so a rename-pair cutover leaves the live projection
@@ -1637,8 +1663,8 @@ protocol's S-2 (`docs/design/WM2_PROJECTION_REBUILD_PROTOCOL.md` §8).
 
 #### Peak disk: use the free-list measure, not the file size
 
-The duplicate projection measures **2.61–2.69 %** of store size (mean 2.64 %),
-and that figure is *stable* across chunk counts (1.02× spread) because it is the
+The duplicate projection measures **2.54–2.61 %** of store size (mean 2.58 %),
+and that figure is *stable* across chunk counts (1.03× spread) because it is the
 same projection either way.
 
 Two cautions, both learned by getting them wrong first:
@@ -1647,13 +1673,13 @@ Two cautions, both learned by getting them wrong first:
   list. Measuring the retired projection by file shrinkage reports **zero**,
   which reads as a projection that cost nothing. The figures above come from the
   free-list delta.
-- **Peak on-disk overhead is the noisier measure** (3.46× spread across the same
+- **Peak on-disk overhead is the noisier measure** (3.52× spread across the same
   runs) because it moves with WAL checkpoint timing. It is emitted, but the
   projection's own size is the number to cite.
 
 **Against D-2's arithmetic.** The acceptance record derived ≈306 MiB from D-2's
-3.74 % projection overhead. This measures **2.64 %** directly — the same order,
-about 30 % lower. Neither refutes the other: D-2's figure is bytes-per-event
+3.74 % projection overhead. This measures **2.58 %** directly — the same order,
+about 31 % lower. Neither refutes the other: D-2's figure is bytes-per-event
 overhead on its configuration, this is projection pages as a fraction of a store
 with a different entity count and event mix. They are two measurements, not one
 measurement twice.

--- a/docs/design/WM2_PROJECTION_REBUILD_PROTOCOL.md
+++ b/docs/design/WM2_PROJECTION_REBUILD_PROTOCOL.md
@@ -267,6 +267,27 @@ and renaming has a window; a rebuild that swaps by pointer has one row to make
 durable. The choice interacts with open question 3 (projections in the same file
 or a rebuildable sidecar), which remains open.
 
+**S-2, concretely: rename-based cutover does not carry index names, and the
+prototype found this the hard way.** SQLite's `ALTER TABLE … RENAME TO` renames
+the table and leaves its indexes under their existing names. So a swap
+implemented as a rename pair leaves the now-live projection carrying the
+rebuild's index names, and the *next* rebuild collides on `CREATE INDEX`. The
+resolutions are all real cost or real risk:
+
+- rename indexes at cutover — SQLite has no `ALTER INDEX`, so this means dropping
+  and recreating them **inside the blackout window**, turning a rows-don't-move
+  swap into an index rebuild;
+- alternate name pairs (ping-pong between two index name sets) — cheap, but the
+  live schema's index names now depend on cycle parity;
+- pointer-based cutover (S-2's other candidate) — sidesteps it entirely, which is
+  a point in its favour that was not visible before prototyping.
+
+The measurement in ADR-0041 D-16 takes **none** of these: it does one cycle and
+then refuses a second with a stated reason. That keeps the cutover figure honest
+about what it measured (a rename pair, no index work) rather than baking in one
+arbitrary resolution and quoting its cost as *the* cost. **Choosing among the
+three is implementation work S-2 now explicitly carries.**
+
 ---
 
 ## 9. What this resolves, and what it does not

--- a/tools/wm2-persistence-harness/src/main.rs
+++ b/tools/wm2-persistence-harness/src/main.rs
@@ -35,6 +35,31 @@ use standin::Durability;
 use std::io::Write;
 use std::path::PathBuf;
 
+/// Every command this binary implements. The gate that makes an unknown
+/// command fail closed rather than produce an evidence stamp over no
+/// measurements — see the check in `parse`.
+///
+/// Adding a command means adding it here. The `every_dispatched_command_is_in
+/// _the_known_list` test greps this file's dispatch guards and fails if one is
+/// missing, so the list cannot silently fall behind the code.
+const KNOWN_COMMANDS: &[&str] = &[
+    "platform",
+    "append",
+    "replay",
+    "query",
+    "growth",
+    "migrate",
+    "crash",
+    "compact",
+    "pressure",
+    "sweep",
+    "stall",
+    "rebuild",
+    "all",
+    "powercut",
+    "crash-child",
+];
+
 const USAGE: &str = "\
 wm2-persistence-harness — ADR-0041 (WM-2) measurement harness
 
@@ -171,11 +196,43 @@ struct Args {
     assert_target: bool,
 }
 
+/// Refuse a command this binary does not implement.
+///
+/// Pure so it can be tested — `parse_args` reads `std::env::args()` directly
+/// and the fail-open this guards against is not otherwise reachable from a
+/// test.
+fn validate_command(cmd: &str) -> Result<(), String> {
+    if KNOWN_COMMANDS.contains(&cmd) {
+        return Ok(());
+    }
+    Err(format!(
+        "unknown command `{cmd}`\n\nThis binary may PREDATE it. Check `git log --oneline -1` \
+         against the commit you expect, and rebuild — an out-of-date binary is the likeliest \
+         cause.\n\n{USAGE}"
+    ))
+}
+
 fn parse_args() -> Result<Args, String> {
     let raw: Vec<String> = std::env::args().skip(1).collect();
     if raw.is_empty() || raw[0] == "-h" || raw[0] == "--help" {
         return Err(USAGE.to_string());
     }
+
+    // Fail closed on a command this binary does not implement.
+    //
+    // Dispatch is a chain of `if command == "..."` guards with no final else,
+    // so an unrecognized command used to match nothing, fall through every
+    // measurement, and still reach the epilogue — printing
+    // `evidence status : JETSON-TARGET-MEASURED` and `Done.` having measured
+    // NOTHING. Observed for real: an older binary on the target was handed
+    // `rebuild`, a command it predates, and reported a citable run.
+    //
+    // That is the worst failure this harness can have. Every other guard here
+    // exists to stop a number describing the wrong experiment; this one
+    // produced a citability stamp with no experiment at all, and the operator
+    // had no way to tell from the output. An unknown OPTION already failed
+    // closed with usage — only the command itself was fail-open.
+    validate_command(&raw[0])?;
 
     let mut default_db = std::env::temp_dir();
     default_db.push("wm2-persistence-harness.sqlite");
@@ -1267,5 +1324,65 @@ mod tests {
         assert_eq!(durabilities(&a).len(), 3);
         a.durability = Some(Durability::Full);
         assert_eq!(durabilities(&a), vec![Durability::Full]);
+    }
+
+    #[test]
+    fn an_unknown_command_fails_closed_instead_of_stamping_a_citable_run() {
+        // The defect this guards: dispatch is a chain of `if command == "..."`
+        // guards with no final else, so an unrecognized command matched
+        // nothing, fell through every measurement, and still reached the
+        // epilogue printing `evidence status : JETSON-TARGET-MEASURED` and
+        // `Done.` — a citability stamp over ZERO measurements.
+        //
+        // Observed on the target: a binary predating the `rebuild` command was
+        // handed `rebuild` and reported a citable run. An unknown OPTION
+        // already failed closed; only the command was fail-open.
+        let err = validate_command("rebuild-typo").expect_err("must refuse");
+        assert!(
+            err.contains("unknown command `rebuild-typo`"),
+            "refusal must name the command: {err}"
+        );
+        assert!(
+            err.contains("PREDATE"),
+            "an out-of-date binary is the likeliest cause and the message must say so: {err}"
+        );
+        // Every real command still passes, or this guard would break the tool.
+        for c in KNOWN_COMMANDS {
+            assert!(validate_command(c).is_ok(), "{c} must be accepted");
+        }
+    }
+
+    #[test]
+    fn every_dispatched_command_is_in_the_known_list() {
+        // KNOWN_COMMANDS is what makes an unknown command fail closed, so a
+        // command added to dispatch but not to the list would be refused at
+        // the door. Read the dispatch guards out of this file rather than
+        // trusting the two to be kept in step by hand.
+        let src = include_str!("main.rs");
+        let mut dispatched: Vec<String> = Vec::new();
+        for pat in [r#"args.command == ""#, r#"run(""#] {
+            let mut rest = src;
+            while let Some(i) = rest.find(pat) {
+                rest = &rest[i + pat.len()..];
+                if let Some(end) = rest.find('"') {
+                    let name = &rest[..end];
+                    if !name.is_empty() && !name.contains(' ') {
+                        dispatched.push(name.to_string());
+                    }
+                }
+            }
+        }
+        assert!(
+            dispatched.len() > 5,
+            "found only {dispatched:?} — the scrape stopped matching dispatch, \
+             so this test is no longer checking anything"
+        );
+        for name in &dispatched {
+            assert!(
+                KNOWN_COMMANDS.contains(&name.as_str()),
+                "`{name}` is dispatched but missing from KNOWN_COMMANDS, so it would be \
+                 refused as unknown before ever reaching its guard"
+            );
+        }
     }
 }

--- a/tools/wm2-persistence-harness/src/main.rs
+++ b/tools/wm2-persistence-harness/src/main.rs
@@ -23,6 +23,7 @@ mod json;
 mod platform;
 mod pressure;
 mod rebuild;
+mod rebuild_cost;
 mod sha256;
 mod stall;
 mod standin;
@@ -54,6 +55,9 @@ COMMANDS:
                 against ADR-0041's own reopening condition (drill §9)
     stall       Repeat one append configuration and hunt the ~29 s write stall,
                 sampling system counters across it (ADR-0041 open question 9)
+    rebuild     Cost ADR-0041 R2's alongside-rebuild-and-swap: peak disk, write
+                amplification and cutover latency, against a control arm running
+                the same ingest WITHOUT the rebuild (the acceptance obligation)
     all         Every command above, into one result stream
 
   Tier C (manual, needs a power switch — see the drill §8):
@@ -90,6 +94,11 @@ OPTIONS:
                              Both are emitted with a `migration_sql` field, so a
                              record can never be mistaken for the other
     --stall-repeats <n>      Repetitions for `stall` (default: 20)
+    --rebuild-rounds <n>     Ingest/fold rounds for `rebuild` (default: 8). Each
+                             round appends --rebuild-ingest events and folds a
+                             chunk, so the head MOVES under the fold — which is
+                             the condition R2's protocol exists to handle
+    --rebuild-ingest <n>     Events appended per round (default: 2000)
     --assert-target          Operator asserts this is target hardware under
                              representative storage, power and thermal conditions
 
@@ -154,6 +163,8 @@ struct Args {
     events_per_entity: u64,
     sweep_family: String,
     stall_repeats: usize,
+    rebuild_rounds: usize,
+    rebuild_ingest: u64,
     migration_sql: MigrationSql,
     /// Positional word after the command, used only by `powercut arm|verify`.
     subcommand: Option<String>,
@@ -188,6 +199,8 @@ fn parse_args() -> Result<Args, String> {
         events_per_entity: 100,
         sweep_family: "graph".into(),
         stall_repeats: 20,
+        rebuild_rounds: 8,
+        rebuild_ingest: 2_000,
         migration_sql: MigrationSql::Legacy,
         subcommand: None,
         assert_target: false,
@@ -239,6 +252,8 @@ fn parse_args() -> Result<Args, String> {
             "--crash-run-ms" => a.crash_run_ms = parse_num(&value(flag)?, flag)?,
             "--trial" => a.trial = parse_num(&value(flag)?, flag)?,
             "--stall-repeats" => a.stall_repeats = parse_num(&value(flag)?, flag)? as usize,
+            "--rebuild-rounds" => a.rebuild_rounds = parse_num(&value(flag)?, flag)? as usize,
+            "--rebuild-ingest" => a.rebuild_ingest = parse_num(&value(flag)?, flag)?,
             "--events-per-entity" => a.events_per_entity = parse_num(&value(flag)?, flag)?,
             "--sweep-family" => {
                 let v = value(flag)?;
@@ -908,6 +923,76 @@ fn main() {
         );
     }
 
+    if args.command == "rebuild" {
+        let d = args.durability.unwrap_or(Durability::Full);
+        // The control arm needs its own file: same ingest, same seed, no
+        // rebuild. Sitting beside the working DB so both land on one device.
+        let mut control_db = args.db.clone();
+        let name = control_db
+            .file_name()
+            .map(|s| format!("control-{}", s.to_string_lossy()))
+            .unwrap_or_else(|| "control.sqlite".into());
+        control_db.set_file_name(name);
+
+        let r = rebuild_cost::run(
+            &args.db,
+            &control_db,
+            d,
+            args.events,
+            args.entities,
+            args.rebuild_rounds,
+            args.rebuild_ingest,
+            args.seed,
+        );
+        sink.emit(
+            stamp(&class, &facts, &args)
+                .str("record", "rebuild")
+                .str("durability", d.pragma())
+                .int("seeded_events", r.seeded_events)
+                .int("ingested_during", r.ingested_during)
+                .int("rounds", r.rounds as u64)
+                .int("entities", r.entities)
+                // Gate: numbers from an attempt that never reached Active
+                // describe something other than an alongside rebuild.
+                .int("completed", u64::from(r.completed()))
+                .str("final_state", &r.final_state)
+                .int("equivalence_proven", u64::from(r.equivalence_proven))
+                .int("converged", u64::from(r.converged))
+                .int("catchup_rounds", r.catchup_rounds as u64)
+                .opt_str("failure", r.failure.as_deref())
+                // The three costs the acceptance record asks for.
+                .float("cutover_ms", r.cutover_ms)
+                .float("retire_ms", r.retire_ms)
+                .int("peak_overhead_bytes", r.peak_overhead_bytes)
+                .float("peak_overhead_ratio", r.peak_overhead_ratio)
+                .int("projection_bytes", r.projection_bytes)
+                .float(
+                    "extra_write_bytes",
+                    r.extra_write_bytes.map_or(f64::NAN, |v| v as f64),
+                )
+                .float(
+                    "write_amplification",
+                    r.write_amplification.unwrap_or(f64::NAN),
+                )
+                // Both arms, so the difference above can be checked rather than
+                // taken on trust.
+                .float("control_wall_ms", r.control.wall_ms)
+                .float("rebuild_wall_ms", r.rebuild.wall_ms)
+                .float(
+                    "control_write_bytes",
+                    r.control.write_bytes.map_or(f64::NAN, |v| v as f64),
+                )
+                .float(
+                    "rebuild_write_bytes",
+                    r.rebuild.write_bytes.map_or(f64::NAN, |v| v as f64),
+                )
+                .int("control_peak_db_bytes", r.control.peak_db_bytes)
+                .int("rebuild_peak_db_bytes", r.rebuild.peak_db_bytes)
+                .int("control_final_db_bytes", r.control.final_db_bytes)
+                .int("rebuild_final_db_bytes", r.rebuild.final_db_bytes),
+        );
+    }
+
     if args.command == "stall" {
         // Deliberately NOT part of `all`: it is a targeted investigation of one
         // configuration, and folding it into the standard run would multiply
@@ -1134,6 +1219,8 @@ mod tests {
             events_per_entity: 100,
             sweep_family: "graph".into(),
             stall_repeats: 20,
+            rebuild_rounds: 8,
+            rebuild_ingest: 2_000,
             migration_sql: MigrationSql::Legacy,
             subcommand: None,
             assert_target: false,
@@ -1171,6 +1258,8 @@ mod tests {
             events_per_entity: 100,
             sweep_family: "graph".into(),
             stall_repeats: 20,
+            rebuild_rounds: 8,
+            rebuild_ingest: 2_000,
             migration_sql: MigrationSql::Legacy,
             subcommand: None,
             assert_target: false,

--- a/tools/wm2-persistence-harness/src/rebuild_cost.rs
+++ b/tools/wm2-persistence-harness/src/rebuild_cost.rs
@@ -1,0 +1,634 @@
+//! What ADR-0041 R2's alongside-rebuild-and-swap actually costs.
+//!
+//! The acceptance record carries one outstanding obligation: prototype R2 "far
+//! enough to know what it costs in code, in peak disk, in write amplification
+//! and in cutover latency". The **code** half was answered by the protocol
+//! (`docs/design/WM2_PROJECTION_REBUILD_PROTOCOL.md`). This measures the other
+//! three.
+//!
+//! # The attribution problem, and the control that solves it
+//!
+//! A rebuild runs *while ingest continues* — that is the whole premise — and
+//! both write through the same process. `/proc/self/io` therefore cannot say
+//! which bytes belong to the rebuild, and neither can the database file size.
+//!
+//! So this runs **two arms with identical ingest**:
+//!
+//! | Arm | Does |
+//! |---|---|
+//! | **control** | seeds a store, then ingests and maintains the live projection |
+//! | **rebuild** | the same, *plus* the alongside fold, the equivalence check and the swap |
+//!
+//! Every reported cost is the **difference**. Without the control the numbers
+//! would be "bytes written while a rebuild happened to be running", which is not
+//! the cost of the rebuild and would overstate it by the whole ingest load.
+//!
+//! # Ingest is interleaved, not threaded
+//!
+//! Deterministically: append a round, fold a chunk, append a round, fold a
+//! chunk. A background thread would make the two arms do *different* amounts of
+//! ingest depending on scheduling, and then the difference between them would
+//! carry that noise rather than the rebuild's cost. Interleaving keeps the arms
+//! identical by construction and still moves the head under the fold, which is
+//! the condition the protocol exists for.
+//!
+//! # The protocol drives it
+//!
+//! Every transition goes through [`crate::rebuild::RebuildState`], so what is
+//! measured is the procedure ADR-0041 specifies rather than a copy of it that
+//! happens to resemble it. That module had no caller before this one.
+
+use crate::bench::db_bytes;
+use crate::rebuild::{catchup_is_converging, FailureReason, RebuildState};
+use crate::standin::{Durability, Store};
+use std::path::Path;
+use std::time::Instant;
+
+/// How many catch-up laps to allow before declaring the fold cannot keep up.
+/// Generous: the point is to terminate rather than to grade the hardware.
+pub const MAX_CATCHUP_ROUNDS: usize = 64;
+
+/// Process-wide bytes actually written to storage, from `/proc/self/io`.
+///
+/// `write_bytes`, not `wchar`: wchar counts bytes handed to `write()`, which
+/// includes writes absorbed by the page cache and never sent anywhere. Write
+/// amplification is a question about the device.
+///
+/// `None` off Linux, or wherever the file is unreadable — a missing counter
+/// must not arrive as zero, which would render as a flatteringly efficient
+/// rebuild.
+pub fn process_write_bytes() -> Option<u64> {
+    let text = std::fs::read_to_string("/proc/self/io").ok()?;
+    for line in text.lines() {
+        if let Some(v) = line.strip_prefix("write_bytes:") {
+            return v.trim().parse().ok();
+        }
+    }
+    None
+}
+
+/// One arm's observations.
+#[derive(Debug, Clone)]
+pub struct ArmResult {
+    pub wall_ms: f64,
+    pub write_bytes: Option<u64>,
+    pub peak_db_bytes: u64,
+    /// Size once the arm has settled. Kept alongside the peak because SQLite
+    /// does not shrink on `DROP`, so "final" and "peak" answer different
+    /// questions and reporting only one invites the wrong reading.
+    pub final_db_bytes: u64,
+}
+
+/// The answer to the outstanding R2 obligation, or as much of it as a stand-in
+/// schema can give.
+#[derive(Debug, Clone)]
+pub struct RebuildCost {
+    pub seeded_events: u64,
+    pub ingested_during: u64,
+    pub rounds: usize,
+    pub entities: u64,
+
+    pub control: ArmResult,
+    pub rebuild: ArmResult,
+
+    /// Bytes the rebuild wrote, over and above the same ingest without it.
+    pub extra_write_bytes: Option<u64>,
+    /// Extra bytes written per byte the second projection occupies on disk.
+    /// The question "how much I/O does a duplicate projection cost" in one
+    /// number — 1.0 would mean it wrote itself exactly once.
+    pub write_amplification: Option<f64>,
+    /// Bytes of on-disk footprint the second projection added at its peak.
+    pub peak_overhead_bytes: u64,
+    /// That overhead as a fraction of the control arm's peak store size.
+    pub peak_overhead_ratio: f64,
+    /// The projection's own size, from the growth the cutover's DROP reclaims.
+    pub projection_bytes: u64,
+
+    /// The swap itself: the window in which the live projection is neither the
+    /// old one nor the new one.
+    pub cutover_ms: f64,
+    /// Dropping what the cutover retired. Reclamation, not cutover.
+    pub retire_ms: f64,
+
+    pub catchup_rounds: usize,
+    pub converged: bool,
+    pub equivalence_proven: bool,
+    /// `Active` on success. Anything else means the protocol refused and the
+    /// numbers above describe an attempt that did not complete.
+    pub final_state: String,
+    pub failure: Option<String>,
+}
+
+impl RebuildCost {
+    /// Did the run actually produce what it claims to have costed?
+    ///
+    /// A cost measured over an attempt that never reached `Active` is the cost
+    /// of *something else*, so this gates whether the numbers may be cited.
+    pub fn completed(&self) -> bool {
+        self.final_state == "Active" && self.equivalence_proven && self.failure.is_none()
+    }
+}
+
+fn seed(path: &Path, durability: Durability, events: u64, entities: u64, seed_n: u64) -> Store {
+    let _ = std::fs::remove_file(path);
+    for s in ["-wal", "-shm"] {
+        let mut p = path.as_os_str().to_os_string();
+        p.push(s);
+        let _ = std::fs::remove_file(std::path::PathBuf::from(p));
+    }
+    let mut store = Store::open(path, durability).expect("open");
+    let all = crate::gen::events(0, events, entities, seed_n);
+    store.append_batch(&all).expect("seed append");
+    store.fold_from(0).expect("seed fold");
+    store
+}
+
+/// The control arm: the same ingest, without any rebuild.
+fn run_control(
+    path: &Path,
+    durability: Durability,
+    seeded: u64,
+    entities: u64,
+    rounds: usize,
+    per_round: u64,
+    seed_n: u64,
+) -> ArmResult {
+    let mut store = seed(path, durability, seeded, entities, seed_n);
+    let before = process_write_bytes();
+    let mut peak = db_bytes(path);
+    let t = Instant::now();
+    let mut next = seeded;
+    for _ in 0..rounds {
+        let batch = crate::gen::events(next, per_round, entities, seed_n);
+        store.append_batch(&batch).expect("ingest");
+        // The live projection keeps being maintained — the robot is still
+        // serving it. Both arms pay this, so it cancels in the difference.
+        store.fold_from(next).expect("live fold");
+        next += per_round;
+        peak = peak.max(db_bytes(path));
+    }
+    let wall_ms = t.elapsed().as_secs_f64() * 1e3;
+    let after = process_write_bytes();
+    ArmResult {
+        wall_ms,
+        write_bytes: match (before, after) {
+            (Some(b), Some(a)) => a.checked_sub(b),
+            _ => None,
+        },
+        peak_db_bytes: peak.max(db_bytes(path)),
+        final_db_bytes: db_bytes(path),
+    }
+}
+
+/// Run the alongside rebuild, driven by the protocol, and cost it.
+#[allow(clippy::too_many_arguments)]
+pub fn run(
+    path: &Path,
+    control_path: &Path,
+    durability: Durability,
+    seeded: u64,
+    entities: u64,
+    rounds: usize,
+    per_round: u64,
+    seed_n: u64,
+) -> RebuildCost {
+    let control = run_control(
+        control_path,
+        durability,
+        seeded,
+        entities,
+        rounds,
+        per_round,
+        seed_n,
+    );
+
+    let mut store = seed(path, durability, seeded, entities, seed_n);
+    store
+        .create_rebuild_projection()
+        .expect("create alongside projection");
+
+    let before = process_write_bytes();
+    let mut peak = db_bytes(path);
+    let t = Instant::now();
+
+    let mut state = RebuildState::begin();
+    let mut folded_to = 0u64;
+    let mut next = seeded;
+    let mut failure: Option<String> = None;
+
+    // Interleave: ingest a round, then fold a chunk. The head moves under the
+    // fold, which is the condition the protocol exists to handle.
+    for _ in 0..rounds {
+        let batch = crate::gen::events(next, per_round, entities, seed_n);
+        store.append_batch(&batch).expect("ingest");
+        store.fold_from(next).expect("live fold");
+        next += per_round;
+        let head = store.max_generation().expect("head");
+        state = match state.on_append(head) {
+            Ok(s) => s,
+            Err(e) => {
+                failure = Some(format!("{e:?}"));
+                break;
+            }
+        };
+
+        // One chunk per round, sized so the fold outpaces ingest — otherwise
+        // catch-up cannot converge and the run measures a divergence instead.
+        let chunk_to = (folded_to + per_round * 2).min(head);
+        store
+            .fold_rebuild_range(folded_to, chunk_to)
+            .expect("rebuild fold");
+        folded_to = chunk_to;
+        state = match state.on_fold_progress(folded_to) {
+            Ok(s) => s,
+            Err(e) => {
+                failure = Some(format!("{e:?}"));
+                break;
+            }
+        };
+        peak = peak.max(db_bytes(path));
+    }
+
+    // Catch up. Ingest has stopped here, which models a rebuild that outpaces
+    // its inflow; a rebuild that cannot is the `CatchupDiverged` case and the
+    // convergence guard below is what turns it into a result rather than a hang.
+    let mut gaps: Vec<u64> = Vec::new();
+    let mut catchup_rounds = 0usize;
+    let mut converged = true;
+    while failure.is_none() {
+        let head = store.max_generation().expect("head");
+        if folded_to >= head {
+            break;
+        }
+        gaps.push(head - folded_to);
+        if !catchup_is_converging(&gaps) || catchup_rounds >= MAX_CATCHUP_ROUNDS {
+            converged = false;
+            state = state
+                .on_failure(FailureReason::CatchupDiverged)
+                .unwrap_or(state);
+            failure = Some("catch-up did not converge".into());
+            break;
+        }
+        let chunk_to = (folded_to + per_round * 4).min(head);
+        store
+            .fold_rebuild_range(folded_to, chunk_to)
+            .expect("rebuild fold");
+        folded_to = chunk_to;
+        state = match state.on_fold_progress(folded_to) {
+            Ok(s) => s,
+            Err(e) => {
+                failure = Some(format!("{e:?}"));
+                break;
+            }
+        };
+        catchup_rounds += 1;
+        peak = peak.max(db_bytes(path));
+    }
+
+    let head = store.max_generation().expect("head");
+    let mut equivalence_proven = false;
+    let mut cutover_ms = f64::NAN;
+    let mut retire_ms = f64::NAN;
+    let mut projection_bytes = 0u64;
+
+    if failure.is_none() {
+        state = match state.on_reached_head(head) {
+            Ok(s) => s,
+            Err(e) => {
+                failure = Some(format!("{e:?}"));
+                state
+            }
+        };
+    }
+
+    if failure.is_none() {
+        // Equivalence: the rebuilt projection must equal the incrementally
+        // maintained one. Compared by the identical digest, so a difference is
+        // about the data and not about how it was measured.
+        let live = store.projection_digest().expect("live digest");
+        let rebuilt = store.rebuild_projection_digest().expect("rebuild digest");
+        if live == rebuilt {
+            equivalence_proven = true;
+            state = match state.on_equivalence_proven(head) {
+                Ok(s) => s,
+                Err(e) => {
+                    failure = Some(format!("{e:?}"));
+                    state
+                }
+            };
+        } else {
+            state = state
+                .on_failure(FailureReason::EquivalenceMismatch { at: head })
+                .unwrap_or(state);
+            failure = Some(format!(
+                "equivalence mismatch at generation {head}: live {live} != rebuilt {rebuilt}"
+            ));
+        }
+    }
+
+    if failure.is_none() {
+        let before_swap = db_bytes(path);
+        let c = Instant::now();
+        store.swap_rebuild_projection().expect("cutover");
+        cutover_ms = c.elapsed().as_secs_f64() * 1e3;
+        state = match state.on_cutover(head) {
+            Ok(s) => s,
+            Err(e) => {
+                failure = Some(format!("{e:?}"));
+                state
+            }
+        };
+        peak = peak.max(db_bytes(path));
+
+        // Measured on the FREE LIST, not on file size: `DROP TABLE` does not
+        // shrink a SQLite file, so a before/after on bytes-on-disk reports zero
+        // and reads as a projection that cost nothing.
+        let free_before = store.free_bytes().unwrap_or(0);
+        let r = Instant::now();
+        store.drop_retired_projection().expect("retire");
+        retire_ms = r.elapsed().as_secs_f64() * 1e3;
+        projection_bytes = store.free_bytes().unwrap_or(0).saturating_sub(free_before);
+        let _ = before_swap;
+    }
+
+    let wall_ms = t.elapsed().as_secs_f64() * 1e3;
+    let after = process_write_bytes();
+    let rebuild_arm = ArmResult {
+        wall_ms,
+        write_bytes: match (before, after) {
+            (Some(b), Some(a)) => a.checked_sub(b),
+            _ => None,
+        },
+        peak_db_bytes: peak.max(db_bytes(path)),
+        final_db_bytes: db_bytes(path),
+    };
+
+    let extra_write_bytes = match (control.write_bytes, rebuild_arm.write_bytes) {
+        (Some(c), Some(r)) => r.checked_sub(c),
+        _ => None,
+    };
+    let write_amplification = match (extra_write_bytes, projection_bytes) {
+        (Some(e), p) if p > 0 => Some(e as f64 / p as f64),
+        _ => None,
+    };
+    let peak_overhead_bytes = rebuild_arm
+        .peak_db_bytes
+        .saturating_sub(control.peak_db_bytes);
+    let peak_overhead_ratio = if control.peak_db_bytes > 0 {
+        peak_overhead_bytes as f64 / control.peak_db_bytes as f64
+    } else {
+        f64::NAN
+    };
+
+    RebuildCost {
+        seeded_events: seeded,
+        ingested_during: rounds as u64 * per_round,
+        rounds,
+        entities,
+        control,
+        rebuild: rebuild_arm,
+        extra_write_bytes,
+        write_amplification,
+        peak_overhead_bytes,
+        peak_overhead_ratio,
+        projection_bytes,
+        cutover_ms,
+        retire_ms,
+        catchup_rounds,
+        converged,
+        equivalence_proven,
+        final_state: format!("{state:?}")
+            .split(&[' ', '('][..])
+            .next()
+            .unwrap_or("?")
+            .to_string(),
+        failure,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp(name: &str) -> std::path::PathBuf {
+        let mut p = std::env::temp_dir();
+        p.push(format!(
+            "wm2-rebuild-cost-{name}-{}.sqlite",
+            std::process::id()
+        ));
+        p
+    }
+
+    #[test]
+    fn the_rebuild_completes_and_the_protocol_says_so() {
+        let (a, b) = (temp("run-a"), temp("run-b"));
+        let r = run(&a, &b, Durability::Off, 2_000, 100, 4, 250, 7);
+        assert!(
+            r.completed(),
+            "state={} equivalence={} failure={:?}",
+            r.final_state,
+            r.equivalence_proven,
+            r.failure
+        );
+        assert_eq!(r.final_state, "Active");
+        assert!(r.converged);
+        // The equivalence check is the load-bearing one: an alongside rebuild
+        // that does not reproduce the live projection has measured the cost of
+        // building something wrong.
+        assert!(r.equivalence_proven);
+        for p in [&a, &b] {
+            let _ = std::fs::remove_file(p);
+        }
+    }
+
+    #[test]
+    fn the_cutover_is_much_cheaper_than_the_fold_that_precedes_it() {
+        // The claim R2 rests on: the robot keeps serving throughout, and the
+        // only moment it cannot is the swap. That is only true if the swap is
+        // small next to the rebuild — a rename pair moves no rows, so it should
+        // be orders below the wall time, not merely under it.
+        let (a, b) = (temp("cut-a"), temp("cut-b"));
+        let r = run(&a, &b, Durability::Off, 4_000, 200, 4, 500, 11);
+        assert!(r.completed(), "{:?}", r.failure);
+        assert!(
+            r.cutover_ms < r.rebuild.wall_ms / 10.0,
+            "cutover {:.3} ms is not small against a {:.1} ms rebuild",
+            r.cutover_ms,
+            r.rebuild.wall_ms
+        );
+        assert!(r.cutover_ms >= 0.0 && r.cutover_ms.is_finite());
+        for p in [&a, &b] {
+            let _ = std::fs::remove_file(p);
+        }
+    }
+
+    #[test]
+    fn the_second_projection_costs_real_bytes() {
+        // Peak overhead must be positive and must be a fraction of the store,
+        // not a multiple — the D-2 arithmetic says a duplicate projection is
+        // ~3.7 % of total size, and a measurement wildly off that would mean
+        // this is building something other than a projection.
+        let (a, b) = (temp("bytes-a"), temp("bytes-b"));
+        let r = run(&a, &b, Durability::Off, 4_000, 200, 4, 500, 13);
+        assert!(r.completed(), "{:?}", r.failure);
+        assert!(
+            r.projection_bytes > 0,
+            "the retired projection reclaimed no space, so nothing was measured"
+        );
+        assert!(
+            r.peak_overhead_ratio < 1.0,
+            "peak overhead {:.2}x the store — that is a second store, not a second projection",
+            r.peak_overhead_ratio
+        );
+        for p in [&a, &b] {
+            let _ = std::fs::remove_file(p);
+        }
+    }
+
+    #[test]
+    fn write_amplification_rises_with_chunk_count_so_it_is_a_dial_not_a_constant() {
+        // THE finding, pinned. Amplification is not a property of the rebuild;
+        // it is a property of how finely the fold is chunked, because each
+        // chunk commits a transaction that rewrites projection pages already
+        // written. Measured on target-shaped data it spans 2.7x to 35.6x across
+        // a 16x range of chunk counts — so quoting a single number for it would
+        // describe one arbitrary point on a curve.
+        //
+        // Total ingest is held CONSTANT and only the chunking varies, or the
+        // comparison would confound the two.
+        let total = 4_000u64;
+        let (a1, b1) = (temp("amp-coarse-a"), temp("amp-coarse-b"));
+        let (a2, b2) = (temp("amp-fine-a"), temp("amp-fine-b"));
+        let coarse = run(&a1, &b1, Durability::Off, 8_000, 400, 2, total / 2, 3);
+        let fine = run(&a2, &b2, Durability::Off, 8_000, 400, 16, total / 16, 3);
+        assert!(coarse.completed() && fine.completed());
+
+        // The projection is the same one either way — if this moved, the two
+        // runs built different things and the amplification comparison would be
+        // between different denominators.
+        let ratio = fine.projection_bytes as f64 / coarse.projection_bytes as f64;
+        assert!(
+            (0.8..1.25).contains(&ratio),
+            "projection size moved {ratio:.2}x between chunk counts; \
+             the amplification numbers do not share a denominator"
+        );
+
+        match (coarse.write_amplification, fine.write_amplification) {
+            (Some(c), Some(f)) => assert!(
+                f > c * 1.5,
+                "finer chunking ({f:.1}x) did not cost materially more than \
+                 coarser ({c:.1}x) — the trade-off this measurement exists to \
+                 expose is not present"
+            ),
+            // No /proc/self/io: the platform cannot answer, which is a
+            // limitation to report rather than a test to fail.
+            _ => eprintln!("write_bytes unavailable on this platform; amplification not asserted"),
+        }
+        for p in [&a1, &b1, &a2, &b2] {
+            let _ = std::fs::remove_file(p);
+        }
+    }
+
+    #[test]
+    fn the_cutover_does_not_depend_on_how_the_fold_was_chunked() {
+        // The swap is a schema operation — no rows move — so it should be flat
+        // against chunking. If it were not, R2's availability claim would
+        // depend on a tuning parameter, which is the sort of coupling worth
+        // knowing about before it is relied on.
+        let (a1, b1) = (temp("cut-coarse-a"), temp("cut-coarse-b"));
+        let (a2, b2) = (temp("cut-fine-a"), temp("cut-fine-b"));
+        let coarse = run(&a1, &b1, Durability::Off, 8_000, 400, 2, 2_000, 5);
+        let fine = run(&a2, &b2, Durability::Off, 8_000, 400, 16, 250, 5);
+        assert!(coarse.completed() && fine.completed());
+        assert!(
+            coarse.cutover_ms < 100.0 && fine.cutover_ms < 100.0,
+            "cutover is not a schema-speed operation: {:.1} / {:.1} ms",
+            coarse.cutover_ms,
+            fine.cutover_ms
+        );
+        for p in [&a1, &b1, &a2, &b2] {
+            let _ = std::fs::remove_file(p);
+        }
+    }
+
+    #[test]
+    fn a_missing_write_counter_is_none_not_zero() {
+        // Zero would render as a rebuild that wrote nothing at all, which is
+        // the most flattering possible answer from an absent measurement.
+        let r = RebuildCost {
+            seeded_events: 0,
+            ingested_during: 0,
+            rounds: 0,
+            entities: 0,
+            control: ArmResult {
+                wall_ms: 0.0,
+                write_bytes: None,
+                peak_db_bytes: 0,
+                final_db_bytes: 0,
+            },
+            rebuild: ArmResult {
+                wall_ms: 0.0,
+                write_bytes: Some(10),
+                peak_db_bytes: 0,
+                final_db_bytes: 0,
+            },
+            extra_write_bytes: None,
+            write_amplification: None,
+            peak_overhead_bytes: 0,
+            peak_overhead_ratio: 0.0,
+            projection_bytes: 0,
+            cutover_ms: 0.0,
+            retire_ms: 0.0,
+            catchup_rounds: 0,
+            converged: true,
+            equivalence_proven: true,
+            final_state: "Active".into(),
+            failure: None,
+        };
+        assert!(r.extra_write_bytes.is_none());
+        assert!(r.write_amplification.is_none());
+    }
+
+    #[test]
+    fn an_incomplete_attempt_may_not_be_cited() {
+        let mut r = RebuildCost {
+            seeded_events: 0,
+            ingested_during: 0,
+            rounds: 0,
+            entities: 0,
+            control: ArmResult {
+                wall_ms: 0.0,
+                write_bytes: None,
+                peak_db_bytes: 0,
+                final_db_bytes: 0,
+            },
+            rebuild: ArmResult {
+                wall_ms: 0.0,
+                write_bytes: None,
+                peak_db_bytes: 0,
+                final_db_bytes: 0,
+            },
+            extra_write_bytes: None,
+            write_amplification: None,
+            peak_overhead_bytes: 0,
+            peak_overhead_ratio: 0.0,
+            projection_bytes: 0,
+            cutover_ms: 0.0,
+            retire_ms: 0.0,
+            catchup_rounds: 0,
+            converged: true,
+            equivalence_proven: true,
+            final_state: "Active".into(),
+            failure: None,
+        };
+        assert!(r.completed());
+        r.final_state = "Building".into();
+        assert!(!r.completed(), "a rebuild that never cut over was citable");
+        r.final_state = "Active".into();
+        r.equivalence_proven = false;
+        assert!(!r.completed(), "an unproven rebuild was citable");
+        r.equivalence_proven = true;
+        r.failure = Some("x".into());
+        assert!(!r.completed());
+    }
+}

--- a/tools/wm2-persistence-harness/src/rebuild_cost.rs
+++ b/tools/wm2-persistence-harness/src/rebuild_cost.rs
@@ -203,13 +203,20 @@ pub fn run(
     );
 
     let mut store = seed(path, durability, seeded, entities, seed_n);
-    store
-        .create_rebuild_projection()
-        .expect("create alongside projection");
 
     let before = process_write_bytes();
     let mut peak = db_bytes(path);
     let t = Instant::now();
+
+    // Creating the alongside tables and their indexes is part of the rebuild's
+    // cost, so it belongs INSIDE the measured window. It sat outside until
+    // review caught it, which undercounted `extra_write_bytes` and wall time by
+    // the DDL — small next to the fold, but the claim being made is that the
+    // measurement includes the indexes, and a claim that excludes what it names
+    // is the defect regardless of magnitude.
+    store
+        .create_rebuild_projection()
+        .expect("create alongside projection");
 
     let mut state = RebuildState::begin();
     let mut folded_to = 0u64;
@@ -327,7 +334,6 @@ pub fn run(
     }
 
     if failure.is_none() {
-        let before_swap = db_bytes(path);
         let c = Instant::now();
         store.swap_rebuild_projection().expect("cutover");
         cutover_ms = c.elapsed().as_secs_f64() * 1e3;
@@ -348,7 +354,6 @@ pub fn run(
         store.drop_retired_projection().expect("retire");
         retire_ms = r.elapsed().as_secs_f64() * 1e3;
         projection_bytes = store.free_bytes().unwrap_or(0).saturating_sub(free_before);
-        let _ = before_swap;
     }
 
     let wall_ms = t.elapsed().as_secs_f64() * 1e3;

--- a/tools/wm2-persistence-harness/src/standin.rs
+++ b/tools/wm2-persistence-harness/src/standin.rs
@@ -705,7 +705,11 @@ impl Store {
     pub fn create_rebuild_projection(&mut self) -> rusqlite::Result<()> {
         if self.rebuild_index_names_are_live()? {
             return Err(rusqlite::Error::SqliteFailure(
-                rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_MISUSE),
+                // SQLITE_ERROR, not SQLITE_MISUSE: the caller did nothing
+                // invalid at the API level. This is a state-based refusal, and
+                // MISUSE would read in a log as though the caller had done
+                // something unsafe.
+                rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_ERROR),
                 Some(
                     "a cutover has already happened on this store: the live projection carries \
                      the _rebuild index names, so a second rebuild cycle cannot create them. \
@@ -815,15 +819,25 @@ impl Store {
     /// NOT dropped here: reclaiming them is separate work with its own cost, and
     /// folding it into the swap would overstate the window in which readers are
     /// blocked. See [`Store::drop_retired_projection`].
+    /// Driven through rusqlite's transaction API rather than a hand-written
+    /// `BEGIN IMMEDIATE … COMMIT` batch. With the batch form, a statement that
+    /// errors mid-way leaves the transaction OPEN on the connection — the
+    /// `COMMIT` is never reached and nothing rolls it back, so the store stays
+    /// locked and every later operation inherits a failed cutover's
+    /// transaction. The RAII guard rolls back on drop, which is the behaviour
+    /// invariant 4 assumes: a failed swap leaves the previous projection
+    /// active and untouched.
     pub fn swap_rebuild_projection(&mut self) -> rusqlite::Result<()> {
-        self.conn.execute_batch(
-            "BEGIN IMMEDIATE;
-             ALTER TABLE entities_projection      RENAME TO entities_projection_retired;
+        let tx = self
+            .conn
+            .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+        tx.execute_batch(
+            "ALTER TABLE entities_projection      RENAME TO entities_projection_retired;
              ALTER TABLE relationships_projection RENAME TO relationships_projection_retired;
              ALTER TABLE entities_projection_rebuild      RENAME TO entities_projection;
-             ALTER TABLE relationships_projection_rebuild RENAME TO relationships_projection;
-             COMMIT;",
-        )
+             ALTER TABLE relationships_projection_rebuild RENAME TO relationships_projection;",
+        )?;
+        tx.commit()
     }
 
     /// Drop what the cutover retired. Reclamation, measured on its own.

--- a/tools/wm2-persistence-harness/src/standin.rs
+++ b/tools/wm2-persistence-harness/src/standin.rs
@@ -683,6 +683,182 @@ impl Store {
         Ok(applied as u64)
     }
 
+    /// Create the alongside projection tables an R2 rebuild folds into.
+    ///
+    /// Mirrors the live tables, indexes included — an index is real bytes and
+    /// real writes, and a rebuild measured without them would understate both
+    /// of the costs ADR-0041 asks about.
+    ///
+    /// **One cycle per store.** SQLite's `ALTER TABLE ... RENAME TO` does not
+    /// rename a table's indexes, so after [`Store::swap_rebuild_projection`] the
+    /// now-live tables still carry the `_rebuild` index names. A second cycle
+    /// would collide on `CREATE INDEX`. This refuses first, with a reason,
+    /// rather than surfacing SQLite's "index already exists" — and it does NOT
+    /// resolve the collision by dropping the offending index, because that
+    /// index is now serving the live projection.
+    ///
+    /// Renaming indexes back at cutover is possible only by dropping and
+    /// recreating them, which is an index rebuild inside the blackout window —
+    /// real cost, and an implementation decision the production store has to
+    /// make rather than one this prototype should make for it by measuring one
+    /// arbitrary choice. Recorded as such in the protocol's store requirements.
+    pub fn create_rebuild_projection(&mut self) -> rusqlite::Result<()> {
+        if self.rebuild_index_names_are_live()? {
+            return Err(rusqlite::Error::SqliteFailure(
+                rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_MISUSE),
+                Some(
+                    "a cutover has already happened on this store: the live projection carries \
+                     the _rebuild index names, so a second rebuild cycle cannot create them. \
+                     Cutover index renaming is unresolved — see create_rebuild_projection."
+                        .to_string(),
+                ),
+            ));
+        }
+        self.conn.execute_batch(
+            "DROP TABLE IF EXISTS entities_projection_rebuild;
+             DROP TABLE IF EXISTS relationships_projection_rebuild;
+             CREATE TABLE entities_projection_rebuild (
+                 entity_id     TEXT PRIMARY KEY,
+                 kind          TEXT    NOT NULL,
+                 place_ref     TEXT    NOT NULL,
+                 valid_from_ms INTEGER NOT NULL,
+                 generation    INTEGER NOT NULL
+             );
+             CREATE INDEX idx_entities_place_rebuild
+                 ON entities_projection_rebuild (place_ref, kind);
+             CREATE TABLE relationships_projection_rebuild (
+                 subject    TEXT    NOT NULL,
+                 predicate  TEXT    NOT NULL,
+                 object     TEXT    NOT NULL,
+                 generation INTEGER NOT NULL,
+                 PRIMARY KEY (subject, predicate, object)
+             );
+             CREATE INDEX idx_rel_object_rebuild
+                 ON relationships_projection_rebuild (object, predicate);",
+        )
+    }
+
+    /// Whether a `_rebuild`-named index is attached to a table that is NOT a
+    /// `_rebuild` table — i.e. whether a cutover has already run here.
+    fn rebuild_index_names_are_live(&self) -> rusqlite::Result<bool> {
+        let n: i64 = self.conn.query_row(
+            "SELECT COUNT(*) FROM sqlite_master
+              WHERE type = 'index'
+                AND name IN ('idx_entities_place_rebuild', 'idx_rel_object_rebuild')
+                AND tbl_name NOT LIKE '%\\_rebuild' ESCAPE '\\'",
+            [],
+            |r| r.get(0),
+        )?;
+        Ok(n > 0)
+    }
+
+    /// Fold `[from_generation, to_generation)` into the alongside projection.
+    ///
+    /// A RANGE rather than a tail, because a rebuild that folds the whole log
+    /// in one statement never lets ingest interleave — and interleaving is the
+    /// entire reason ADR-0041 R2 needs a protocol rather than a copy.
+    pub fn fold_rebuild_range(&mut self, from: u64, to: u64) -> rusqlite::Result<u64> {
+        let tx = self.conn.transaction()?;
+        {
+            tx.execute(
+                "INSERT INTO entities_projection_rebuild
+                     (entity_id, kind, place_ref, valid_from_ms, generation)
+                 SELECT subject, 'entity', substr(payload, 1, 10), valid_from_ms, generation
+                   FROM world_events
+                  WHERE kind = 'observation' AND generation >= ?1 AND generation < ?2
+                  ORDER BY valid_from_ms ASC, generation ASC
+                 ON CONFLICT(entity_id) DO UPDATE SET
+                    place_ref     = excluded.place_ref,
+                    valid_from_ms = excluded.valid_from_ms,
+                    generation    = excluded.generation
+                  WHERE (excluded.valid_from_ms, excluded.generation)
+                        > (entities_projection_rebuild.valid_from_ms,
+                           entities_projection_rebuild.generation)",
+                params![from as i64, to as i64],
+            )?;
+            tx.execute(
+                "INSERT INTO relationships_projection_rebuild
+                     (subject, predicate, object, generation)
+                 SELECT subject, predicate, object, generation FROM world_events
+                  WHERE kind = 'relationship' AND generation >= ?1 AND generation < ?2
+                    AND predicate IS NOT NULL AND object IS NOT NULL
+                  ORDER BY generation ASC
+                 ON CONFLICT(subject, predicate, object) DO UPDATE SET
+                    generation = excluded.generation
+                  WHERE excluded.generation > relationships_projection_rebuild.generation",
+                params![from as i64, to as i64],
+            )?;
+        }
+        let applied: i64 = tx.query_row(
+            "SELECT COUNT(*) FROM world_events WHERE generation >= ?1 AND generation < ?2",
+            params![from as i64, to as i64],
+            |r| r.get(0),
+        )?;
+        tx.commit()?;
+        Ok(applied as u64)
+    }
+
+    /// The same digest as [`Store::projection_digest`], over the alongside
+    /// tables — literally the same code, so equivalence cannot fail for
+    /// reasons of serialization.
+    pub fn rebuild_projection_digest(&self) -> rusqlite::Result<String> {
+        self.projection_digest_of(
+            "entities_projection_rebuild",
+            "relationships_projection_rebuild",
+        )
+    }
+
+    /// The cutover: the alongside projection becomes the live one, atomically.
+    ///
+    /// A rename pair inside one transaction — no rows move, so this is a schema
+    /// operation and the blackout is meant to be short. The retired tables are
+    /// NOT dropped here: reclaiming them is separate work with its own cost, and
+    /// folding it into the swap would overstate the window in which readers are
+    /// blocked. See [`Store::drop_retired_projection`].
+    pub fn swap_rebuild_projection(&mut self) -> rusqlite::Result<()> {
+        self.conn.execute_batch(
+            "BEGIN IMMEDIATE;
+             ALTER TABLE entities_projection      RENAME TO entities_projection_retired;
+             ALTER TABLE relationships_projection RENAME TO relationships_projection_retired;
+             ALTER TABLE entities_projection_rebuild      RENAME TO entities_projection;
+             ALTER TABLE relationships_projection_rebuild RENAME TO relationships_projection;
+             COMMIT;",
+        )
+    }
+
+    /// Drop what the cutover retired. Reclamation, measured on its own.
+    pub fn drop_retired_projection(&mut self) -> rusqlite::Result<()> {
+        self.conn.execute_batch(
+            "DROP TABLE IF EXISTS entities_projection_retired;
+             DROP TABLE IF EXISTS relationships_projection_retired;",
+        )
+    }
+
+    /// Bytes currently on the free list.
+    ///
+    /// `DROP TABLE` does not shrink a SQLite file — it moves the table's pages
+    /// to the free list, to be reused. So the file size is unchanged and the
+    /// growth in THIS is what the dropped table actually occupied. Measuring
+    /// the retired projection by file shrinkage reports zero, which reads as
+    /// "the projection was free".
+    pub fn free_bytes(&self) -> rusqlite::Result<u64> {
+        let pages: i64 = self
+            .conn
+            .query_row("PRAGMA freelist_count", [], |r| r.get(0))?;
+        let page_size: i64 = self.conn.query_row("PRAGMA page_size", [], |r| r.get(0))?;
+        Ok((pages.max(0) * page_size.max(0)) as u64)
+    }
+
+    /// Highest generation in the log, or 0 when empty.
+    pub fn max_generation(&self) -> rusqlite::Result<u64> {
+        let g: i64 = self.conn.query_row(
+            "SELECT COALESCE(MAX(generation), -1) FROM world_events",
+            [],
+            |r| r.get(0),
+        )?;
+        Ok((g + 1).max(0) as u64)
+    }
+
     pub fn clear_projections(&mut self) -> rusqlite::Result<()> {
         self.conn
             .execute_batch("DELETE FROM entities_projection; DELETE FROM relationships_projection;")
@@ -694,11 +870,34 @@ impl Store {
     /// digest that depends on SQLite's storage order and compare unequal for
     /// reasons that have nothing to do with the fold.
     pub fn projection_digest(&self) -> rusqlite::Result<String> {
+        self.projection_digest_of("entities_projection", "relationships_projection")
+    }
+
+    /// The digest of a projection pair, whichever tables hold it.
+    ///
+    /// Parameterised rather than duplicated because the R2 rebuild has to
+    /// compare the alongside projection against the live one, and a comparison
+    /// implemented twice compares the implementations. A hand-written second
+    /// copy of this function disagreed with the original on both the field
+    /// separators and whether `generation` is included — and reported a
+    /// perfectly correct rebuild as a mismatch.
+    ///
+    /// Table names are formatted in rather than bound: SQLite cannot bind an
+    /// identifier, and these are internal literals, never operator input.
+    ///
+    /// Note what is NOT hashed: `generation`. Two folds that reach the same
+    /// projection state by different routes are the same state, and the
+    /// generation that last touched a row is bookkeeping about how it got there.
+    fn projection_digest_of(
+        &self,
+        entities_table: &str,
+        relationships_table: &str,
+    ) -> rusqlite::Result<String> {
         let mut buf = Vec::new();
-        let mut stmt = self.conn.prepare(
-            "SELECT entity_id, kind, place_ref, valid_from_ms, generation \
-             FROM entities_projection ORDER BY entity_id",
-        )?;
+        let mut stmt = self.conn.prepare(&format!(
+            "SELECT entity_id, kind, place_ref, valid_from_ms \
+             FROM {entities_table} ORDER BY entity_id"
+        ))?;
         let mut rows = stmt.query([])?;
         while let Some(r) = rows.next()? {
             buf.extend_from_slice(r.get::<_, String>(0)?.as_bytes());
@@ -710,10 +909,10 @@ impl Store {
             buf.extend_from_slice(r.get::<_, i64>(3)?.to_string().as_bytes());
             buf.push(0x1e);
         }
-        let mut stmt = self.conn.prepare(
-            "SELECT subject, predicate, object FROM relationships_projection \
-             ORDER BY subject, predicate, object",
-        )?;
+        let mut stmt = self.conn.prepare(&format!(
+            "SELECT subject, predicate, object FROM {relationships_table} \
+             ORDER BY subject, predicate, object"
+        ))?;
         let mut rows = stmt.query([])?;
         while let Some(r) = rows.next()? {
             for i in 0..3 {
@@ -1211,5 +1410,55 @@ mod tests {
             gr < lr,
             "grouped ({gr:.2}) must scale better than legacy ({lr:.2})"
         );
+    }
+
+    #[test]
+    fn a_rebuild_cycle_reaches_an_equivalent_projection_and_a_second_cycle_refuses() {
+        let (mut s, path) = store("rebuild-cycle");
+        s.append_batch(&gen::events(0, 200, 12, 3)).unwrap();
+        s.fold_from(0).unwrap();
+        let live = s.projection_digest().unwrap();
+
+        // One full cycle, folded in two chunks so the range path is exercised
+        // rather than a single whole-log statement.
+        s.create_rebuild_projection().unwrap();
+        let head = s.max_generation().unwrap();
+        s.fold_rebuild_range(0, head / 2).unwrap();
+        s.fold_rebuild_range(head / 2, head).unwrap();
+        assert_eq!(
+            s.rebuild_projection_digest().unwrap(),
+            live,
+            "an alongside fold of the same log must reach the same projection; \
+             if this diverges the equivalence check in rebuild_cost is measuring \
+             two different serializations, not two different states"
+        );
+
+        s.swap_rebuild_projection().unwrap();
+        assert_eq!(
+            s.projection_digest().unwrap(),
+            live,
+            "the cutover must leave the live projection holding the rebuilt state"
+        );
+        s.drop_retired_projection().unwrap();
+
+        // The trap this guard exists for: ALTER TABLE RENAME left the _rebuild
+        // index names attached to the now-live tables, so CREATE INDEX would
+        // collide. It must refuse with a reason, not with SQLite's message, and
+        // it must not "fix" it by dropping an index the live projection uses.
+        let err = s.create_rebuild_projection().expect_err(
+            "a second cycle must refuse: the live tables carry the _rebuild index names",
+        );
+        assert!(
+            format!("{err}").contains("cutover has already happened"),
+            "refusal must name the reason, got: {err}"
+        );
+        assert_eq!(
+            s.projection_digest().unwrap(),
+            live,
+            "a refused second cycle must leave the live projection untouched"
+        );
+
+        drop(s);
+        let _ = std::fs::remove_file(&path);
     }
 }


### PR DESCRIPTION
Closes the last open item in ADR-0041's acceptance record: what the R2 alongside-rebuild-and-swap migration costs **"in code, in peak disk, in write amplification and in cutover latency"**. The protocol PR (#1330) answered *code*. This measures the other three.

## The measurement needs a control, and that is the design

A rebuild runs while ingest continues, and both write through the same process. `/proc/self/io` cannot say which bytes belong to which, and neither can the file size.

So **two arms run identical ingest** — one with the rebuild, one without — and every cost below is the *difference*. Without that control the numbers would be "bytes written while a rebuild happened to be running", which overstates the rebuild by the entire ingest load.

Every transition is driven by the protocol's own `RebuildState` machine, so what is measured is the procedure R2 specifies rather than something resembling it.

## Finding: write amplification is a dial, not a constant

Total ingest held constant at 16 000 events; only the fold's chunk count varies.

| Fold chunks | Write amplification | Extra writes | Cutover | Catch-up laps |
|---:|---:|---:|---:|---:|
| 2 | **2.7×** | 3.2 MB | 1.83 ms | 1 |
| 4 | **5.3×** | 6.3 MB | 1.60 ms | 2 |
| 8 | **14.0×** | 16.7 MB | 1.55 ms | 3 |
| 16 | **20.4×** | 24.0 MB | 1.61 ms | 6 |
| 32 | **35.6×** | 42.5 MB | 1.50 ms | 12 |

Amplification rises roughly linearly with fold granularity — each chunk commits a transaction that rewrites projection pages already written, and adds WAL frames a checkpoint later writes again. **The first run gave 14.0×.** Quoting that would have described one arbitrary point on a curve spanning 13.2×.

The engineering consequence is a trade-off, now quantified: coarser chunks cost far less I/O, finer chunks hold each fold transaction for less time. At the ≈306 MiB duplicate-projection figure that is ~0.9 GB of device writes at 3× versus ~10.7 GB at 35× — a **wear** question, not a throughput one.

## Cutover is flat, which is what R2's availability claim needs

**1.50–1.83 ms**, independent of chunking — a rename pair in one transaction, no rows move. Against a 620 ms rebuild that is **0.26 %**. Retiring the old tables is measured separately (~0.9 ms) as reclamation, not cutover.

**What that excludes, and it is not a rounding detail.** SQLite renames tables but not their indexes, so a rename-pair cutover leaves the live projection carrying the rebuild's index names and the next cycle collides on `CREATE INDEX`. Every resolution costs something real — recreating indexes *inside the blackout window* turns the swap into an index rebuild; name ping-pong makes the live schema depend on cycle parity; pointer-based cutover avoids it but is a different design (a point in its favour that was not visible before prototyping).

This takes **none** of them: one cycle, then a refusal with a stated reason. So 1.50–1.83 ms is the cost of a rename pair and nothing else — **read it as a floor**. Choosing among the three is now explicit implementation work under the protocol's S-2.

## Three traps, all found by getting them wrong first

- **`DROP TABLE` does not shrink a SQLite file** — it moves pages to the free list. Measuring the retired projection by file shrinkage reports **zero**, which reads as a projection that cost nothing. The figures come from the free-list delta.
- **A hand-written second copy of the projection digest disagreed with the original** on both the field separators and whether `generation` is hashed, and reported a perfectly correct rebuild as a mismatch. There is now one parameterised implementation, so equivalence cannot fail for reasons of serialization.
- **Peak on-disk overhead is the noisier measure** (3.46× spread across runs where the projection itself varies 1.02×) because it moves with WAL checkpoint timing. Emitted, but the projection's own size — **2.61–2.69 %** of store — is the number to cite.

Against D-2's arithmetic: the acceptance record derived ≈306 MiB from a 3.74 % projection overhead; this measures **2.64 %** directly. Same order, ~30 % lower, and neither refutes the other — different entity counts and event mixes, two measurements rather than one measurement twice.

## What this does not do

**It is not a target run.** `HOST-INDICATIVE-NOT-TARGET`, so none of it is citable against the ratification checklist, and it is over the **stand-in schema**. The amplification figure in particular is the one most likely to move on the Jetson — #1333/D-15 has just established that device's write path has a defect. The R2 obligation **narrows rather than closes**: it now reads *"Measured 2026-08-04 — see D-16. Host-indicative; the target run remains."*

## Verification

`cargo fmt --check` and `cargo clippy --all-targets` clean · **191** unit + 7 integration tests pass · quality-guardrail, website-citation and world-domain-logic gates pass (38/38).

The new store-level test drives a full cycle — fold in two chunks, digest equivalence against the incremental projection, cutover, retire — and then asserts the second cycle refuses *with its reason* and leaves the live projection untouched.

## Scope

No robot runtime behaviour, safety algorithm, checker input, release-token logic or actuator behaviour is touched. No Kirra World domain logic, storage, API or service is implemented — this measures the substrate. ADR-0042's pending safety-assurance ruling is unchanged.

Not for merge without instruction.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_