### PR TITLE
docs(wm2): record the busy-time threshold as addressed by a control, not a recalibration

### DIFF
--- a/docs/adr/0041-world-model-persistence-architecture.md
+++ b/docs/adr/0041-world-model-persistence-architecture.md
@@ -1536,7 +1536,26 @@ Three results the predictions did not cover, recorded as observations:
    attribution the windowing fix removed, this time from a correctly-windowed
    measurement. The threshold was calibrated against 30 s stalls and does not
    obviously transfer to shorter windows, where background I/O is a larger
-   fraction of the span. **Not yet addressed.**
+   fraction of the span.
+
+   **Addressed 2026-08-04, by a control rather than a recalibration.** The
+   attribution now also asks whether the device was *at least as busy as usual*,
+   against a baseline measured on the same device in the same run with the stall
+   window's share removed. That is what `IO-DEVICE` claims, and it is
+   self-calibrating: the same metric on both sides, so window length cancels.
+   Against it the three measured stalls sit at roughly **0.02, 0.01 and 0.40** of
+   baseline — a wide margin rather than the coin flip the absolute test had
+   become. Deeper than the calibration problem: `/proc/diskstats` field 13
+   accumulates per-I/O *service time*, so the ratio has no fixed ceiling and 0.5
+   was never a probability.
+
+   **The absolute constant was NOT recalibrated, deliberately.** One short-window
+   measurement cannot re-derive it, and the known failure mode is a *false*
+   `IO-DEVICE`, so the relative arm is applied **in conjunction** — it can only
+   remove verdicts, never add them. `IO_BUSY_FRACTION = 0.5` remains an
+   uncalibrated constant that no longer decides anything on its own; where no
+   baseline can be drawn, the verdict stays reachable but is reported as
+   `NO BASELINE: absolute test only, the weaker evidence`.
 
 **`NORMAL`/b1's median throughput is bimodal across four target runs** — 5 143
 (D-10), 9 485, 9 821, 5 006 ev/s — two clusters roughly 2× apart. A median is

--- a/docs/adr/0041-world-model-persistence-architecture.md
+++ b/docs/adr/0041-world-model-persistence-architecture.md
@@ -1543,9 +1543,18 @@ Three results the predictions did not cover, recorded as observations:
 
    **Addressed 2026-08-04, by a control rather than a recalibration.** The
    attribution now also asks whether the device was *at least as busy as usual*,
-   against a baseline measured on the same device in the same run with the stall
-   window's share removed. That is what `IO-DEVICE` claims, and it is
+   compared with a baseline measured on the same device in the same run with the
+   stall window's share removed. That is what `IO-DEVICE` claims, and it is
    self-calibrating: the same metric on both sides, so window length cancels.
+
+   **So the risk described above no longer applies as stated.** Where a baseline
+   can be drawn, `IO-DEVICE` requires **both** tests — the 0.5 absolute bar
+   *and* at-or-above baseline — so clearing 0.5 is no longer sufficient, and a
+   5 s stall of the kind measured here is refused on the baseline arm at ~0.40.
+   The 0.5 bar only decides alone in the **fallback** case, where no baseline is
+   available, and there the verdict discloses that (`NO BASELINE`). The
+   paragraph above is retained as the record of why the control was added, not
+   as a live risk.
    Against it the three measured stalls sit at roughly **0.02, 0.01 and 0.40** of
    baseline — a wide margin rather than the coin flip the absolute test had
    become. Deeper than the calibration problem: `/proc/diskstats` field 13

--- a/docs/safety/ASSUMPTIONS_OF_USE.md
+++ b/docs/safety/ASSUMPTIONS_OF_USE.md
@@ -1612,11 +1612,11 @@ which the robot was still operating.
   - Neither addresses the root cause, and a lower timeout bounds the *recovery*
     of the symptom rather than preventing it.
 - **Instrument caveat that this AoU depends on — ADDRESSED 2026-08-04.** With a
-  5 s stall, device busy-time inside the measured window was **34.3 %** against
-  1–2 % for the 30 s stalls (ordinary non-stalling windows in the same runs read
-  74–100 %), against an absolute `IO-DEVICE` threshold of 50 %. Qualifying a
-  drive against a *short* timeout therefore risked a stall of this kind being
-  labelled a busy device — the false attribution the windowing fix removed.
+  5 s stall, device busy-time inside the measured window was **34.3 %**, versus
+  1–2 % for the 30 s stalls and 74–100 % for ordinary non-stalling windows in
+  the same runs — all judged by a single absolute `IO-DEVICE` threshold of 50 %.
+  Qualifying a drive at a *short* timeout therefore risked a stall of this kind
+  being labelled a busy device, the false attribution the windowing fix removed.
 
   The instrument now judges busy-time against a **baseline measured on the same
   device in the same run**, outside the stall window, and attributes `IO-DEVICE`

--- a/docs/safety/ASSUMPTIONS_OF_USE.md
+++ b/docs/safety/ASSUMPTIONS_OF_USE.md
@@ -1611,15 +1611,29 @@ which the robot was still operating.
     the filesystem fails closed on detected corruption.
   - Neither addresses the root cause, and a lower timeout bounds the *recovery*
     of the symptom rather than preventing it.
-- **Instrument caveat that this AoU depends on.** With a 5 s stall, device
-  busy-time inside the measured window was **34.3 %** against 1–2 % for the 30 s
-  stalls (ordinary non-stalling windows in the same runs read 74–100 %), and the
-  harness attributes `IO-DEVICE` above 50 %. Qualifying a drive
-  against a *short* timeout therefore risks a stall of this kind being labelled
-  a busy device — the false attribution the windowing fix removed. Until that
-  threshold is re-derived for short windows, read `UNATTRIBUTED` at a low
-  timeout as weaker evidence than the same verdict at a long one. See D-15
-  *Mitigation measured*.
+- **Instrument caveat that this AoU depends on — ADDRESSED 2026-08-04.** With a
+  5 s stall, device busy-time inside the measured window was **34.3 %** against
+  1–2 % for the 30 s stalls (ordinary non-stalling windows in the same runs read
+  74–100 %), against an absolute `IO-DEVICE` threshold of 50 %. Qualifying a
+  drive against a *short* timeout therefore risked a stall of this kind being
+  labelled a busy device — the false attribution the windowing fix removed.
+
+  The instrument now judges busy-time against a **baseline measured on the same
+  device in the same run**, outside the stall window, and attributes `IO-DEVICE`
+  only if the device was at least as busy as usual. Same metric on both sides,
+  so window length cancels and the comparison transfers across timeout values.
+  The three measured stalls sit at ≈0.02, 0.01 and 0.40 of baseline.
+
+  **What is still weaker, and why this bullet is not deleted.** The absolute
+  threshold was *not* recalibrated — one short-window measurement cannot
+  re-derive it — so it is applied in conjunction with the baseline test, where
+  it can only remove verdicts. Where no baseline can be drawn (no counter, or
+  too little of the run outside the stall), the `IO-DEVICE` verdict stays
+  reachable — refusing outright would lose real findings on systems that cannot
+  supply a control — but rests on the uncalibrated constant alone and discloses
+  it. **Read an `IO-DEVICE` attribution carrying `NO BASELINE` as weaker
+  evidence than one carrying a baseline; it is the case this bullet was
+  originally written about.** See D-15 *Mitigation measured*.
 - **Scope is coverage, not durability.** Every timed-out command had completed —
   nothing was lost or retried, and D-11's five power cuts are unaffected. This
   is an availability and memory-completeness assumption.


### PR DESCRIPTION
The follow-up #1335 promised. D-15 observation 3 and `AOU-WM2-STORAGE-COMPLETION-001`'s instrument caveat both recorded `IO_BUSY_FRACTION` as a live risk and **"Not yet addressed"**. #1335 addressed it. These are the lines that follow.

## Kept honest about what did *not* happen

The absolute constant was **not** recalibrated — one short-window measurement cannot re-derive it, and `/proc/diskstats` field 13 accumulates per-I/O *service time*, so 0.5 was never a probability to begin with. What changed is that it no longer decides anything on its own: the baseline arm applies **in conjunction**, so it can only remove verdicts, never add them.

Both entries say so explicitly rather than reading as closed.

## The AoU bullet narrows rather than disappears

Where no baseline can be drawn, the `IO-DEVICE` verdict stays reachable — refusing outright would lose real findings on systems that cannot supply a control — but rests on the uncalibrated constant alone and discloses it. So the caveat now points at exactly the case it was originally written about, instead of at every short-window measurement.

## One correction made while writing it

The first draft said to read **`UNATTRIBUTED`** carrying `NO BASELINE` as weaker evidence. That is backwards: `NO BASELINE` rides an **`IO-DEVICE`** attribution — it is the *positive* verdict that discloses its missing control, which is the direction that matters, since a false `IO-DEVICE` is the failure mode this whole line of work exists to prevent.

Caught by checking `stall.rs` on merged `main` rather than trusting #1335's own description. Worth naming, given #1329's rule that a reported number must state the claim it is allowed to support — the same applies to a verdict.

## Verification

Quality-guardrail, website-citation and world-domain-logic gates pass (38/38). Documentation only — no code, no runtime behaviour, no safety algorithm, checker input, release-token logic or actuator behaviour. ADR-0042's pending ruling is unchanged.

Not for merge without instruction.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_