### PR TITLE
docs(contracts): analyse the shared class selector as a dependent-failure question

### DIFF
--- a/docs/CONTRACT_PROFILES.md
+++ b/docs/CONTRACT_PROFILES.md
@@ -213,23 +213,31 @@ duplication is stated, cited and controlled (`contract_profiles.rs`
 the single source of truth). **The class *selector* is a different thing and is
 not analysed there**, so it is analysed here.
 
-The verifier's actuator envelope and parko's SG6 impact threshold are two
-governors intended to be **diverse** — `parko-kirra`'s `GovernorComparator`
-accumulates divergence between them and escalates the effective posture on it.
-Both take their class from the same logical value.
+**One value, two independent consumers, in two different subsystems:**
 
-**What that costs, stated precisely:**
-
-| Fault class | Diversity preserved? |
+| Consumer | What the class selects |
 |---|---|
-| Implementation fault in one governor | **Yes.** Separate code, separate enums, separate parsers, no dependency edge. The comparator sees it |
-| **Parameterization fault** — a valid-but-wrong class | **No.** Both governors move consistently to the same wrong class, agree with each other, and the comparator sees nothing |
+| Verifier service | The actuator envelope — `contract_for(class)` / `mrc_fallback_for(class)` |
+| `parko_ros2_node` | The SG6 impact threshold — `impact_cfg_for_class(class).spike_threshold_mps2` |
 
-The failure mode is therefore *not* a crash and *not* a divergence. It is two
-governors agreeing, correctly, about the wrong vehicle. `courier` on R2 hardware
-is the concrete instance already documented under #1219: it assumes 2× the
-braking (3.0 vs 1.5 m/s²), and over-estimating available brake under-estimates
-stopping distance directly.
+**No mechanism cross-checks the two selections.** In particular, parko's
+`GovernorComparator` is *not* that mechanism, and it would be easy to assume
+otherwise: it holds `primary: KirraGovernor` and `shadow: DiverseKirraGovernor`,
+so it compares two governor implementations **inside parko** against each other.
+It never observes the verifier, and the class selector feeds the SG6 impact path
+rather than either governor it compares. Its diversity argument is about
+implementation faults and is untouched by anything on this page.
+
+**The fault this leaves is a common-cause configuration fault.** A valid-but-
+wrong class parameterizes both consumers *consistently* — each receives a
+well-formed class string, each fail-closed parser accepts it, and neither
+subsystem holds anything to compare it against. The failure mode is not a crash
+and not a disagreement between components: it is the whole stack configured,
+coherently, for a vehicle that is not the one it is bolted to.
+
+`courier` on R2 hardware is the concrete instance already documented under
+#1219: it assumes 2× the braking (3.0 vs 1.5 m/s²), and over-estimating
+available brake under-estimates stopping distance directly.
 
 **This is latent, not live.** `parko_ros2_node` is not in the R2 launch graph —
 `kirra_with_robot.launch.py` starts `kirra_safety` nodes only — so on the R2

--- a/docs/CONTRACT_PROFILES.md
+++ b/docs/CONTRACT_PROFILES.md
@@ -204,6 +204,72 @@ library use that never call the startup init resolve to the frozen reference
 instance — `robotaxi` — so existing contract tests stay byte-identical; the
 fail-closed guarantee lives at the binary startup boundary.)
 
+### The selector is shared; the numbers are not. What that does and does not mean
+
+The section above records that **one env var parameterizes two binaries**. The
+per-class *numbers* are duplicated across two workspaces deliberately, and that
+duplication is stated, cited and controlled (`contract_profiles.rs`
+"CROSS-WORKSPACE DUPLICATION", `REQ: KIRRA-CLASS-PROFILES-001`, this document as
+the single source of truth). **The class *selector* is a different thing and is
+not analysed there**, so it is analysed here.
+
+The verifier's actuator envelope and parko's SG6 impact threshold are two
+governors intended to be **diverse** — `parko-kirra`'s `GovernorComparator`
+accumulates divergence between them and escalates the effective posture on it.
+Both take their class from the same logical value.
+
+**What that costs, stated precisely:**
+
+| Fault class | Diversity preserved? |
+|---|---|
+| Implementation fault in one governor | **Yes.** Separate code, separate enums, separate parsers, no dependency edge. The comparator sees it |
+| **Parameterization fault** — a valid-but-wrong class | **No.** Both governors move consistently to the same wrong class, agree with each other, and the comparator sees nothing |
+
+The failure mode is therefore *not* a crash and *not* a divergence. It is two
+governors agreeing, correctly, about the wrong vehicle. `courier` on R2 hardware
+is the concrete instance already documented under #1219: it assumes 2× the
+braking (3.0 vs 1.5 m/s²), and over-estimating available brake under-estimates
+stopping distance directly.
+
+**This is latent, not live.** `parko_ros2_node` is not in the R2 launch graph —
+`kirra_with_robot.launch.py` starts `kirra_safety` nodes only — so on the R2
+bench robot there is currently one consumer, not two. It becomes live the moment
+parko is deployed alongside the verifier.
+
+**Controls that already exist**, so this is a scoped observation and not an open
+hole:
+
+1. **Fail-closed parsing in both binaries.** The exposure is a *valid but wrong*
+   class, never a missing or typo'd one.
+2. **`preflight_autostart.sh` validates the value** in `/etc/kirra/kirra.env` and
+   WARNs when the class is parseable but not this platform's (#1219).
+3. **One runtime cross-check exists** —
+   `enforcement_decision.wheelbase_consistent` compares the interceptor's
+   configured wheelbase against the class the verifier reports and latches a
+   permanent stop on mismatch. It catches the class/platform mismatch *through
+   its geometry consequence*, which is narrower than checking the class itself,
+   but it is a real runtime detector and it is why a `courier`-on-R2
+   misconfiguration does not simply drive.
+
+**What is not controlled:** nothing asserts that the class the verifier resolved
+and the class parko resolved are the *same value*. They are supplied by
+integrator configuration, and the two binaries are launched by different units
+with different `EnvironmentFile` sources (`kirra.env` for the verifier;
+whatever the parko unit provides). A deployment that sets them inconsistently
+would run two governors parameterized for different vehicles, and neither would
+say so.
+
+**If parko is deployed alongside the verifier, the cheap mitigation is a startup
+cross-check**: have parko report its resolved class and compare it against the
+verifier's, refusing to start on mismatch — the same fail-closed discipline both
+binaries already apply to an unset value, extended to disagreement. That is not
+implemented and is recorded here as the known next step rather than as done.
+
+> Recorded 2026-08-05 during the ADR-0042 Decision 5 common-source sweep. It is
+> **out of scope for that ruling** — Decision 5 asks about Kirra World, and this
+> is verifier↔parko — but it is the same *kind* of question, so it is written
+> down where the class family is normative rather than left in a review thread.
+
 ---
 
 ## Provenance coverage (#1219 part 2) — a derived view, not a second inventory


### PR DESCRIPTION
Surfaced by the ADR-0042 Decision 5 common-source sweep, and **explicitly out of scope for that ruling** — Decision 5 asks about Kirra World, this is verifier↔parko. Written where the class family is normative rather than left in a review thread.

> **This description was corrected after review.** The first version claimed parko's `GovernorComparator` accumulated divergence between the verifier's envelope and parko's SG6 threshold, and framed the finding as a defeat of that diversity. That was a factual error about a safety mechanism — see *The finding* below for what is actually true.

## What was already handled, and isn't the finding

`contract_profiles.rs` carries a **"CROSS-WORKSPACE DUPLICATION (stated, not hidden)"** block: the per-class *numbers* live in two workspaces with no dependency edge, the copy is deliberate and cited, `docs/CONTRACT_PROFILES.md` is the single source of truth, and it carries `REQ: KIRRA-CLASS-PROFILES-001`.

**The class *selector* is a different thing and is not analysed anywhere.** That's what this adds.

## The finding

One value, two independent consumers, in two different subsystems:

| Consumer | What the class selects |
|---|---|
| Verifier service | The actuator envelope — `contract_for(class)` / `mrc_fallback_for(class)` |
| `parko_ros2_node` | The SG6 impact threshold — `impact_cfg_for_class(class).spike_threshold_mps2` |

**No mechanism cross-checks the two selections**, and `GovernorComparator` is *not* that mechanism — it holds `primary: KirraGovernor` and `shadow: DiverseKirraGovernor`, comparing two governor implementations **inside parko**. It never observes the verifier, and the class selector feeds the SG6 impact path rather than either governor it compares. The section says this explicitly, because that assumption is exactly what produced the error above and a reader would make it too.

**The fault is a common-cause *configuration* fault.** A valid-but-wrong class parameterizes both consumers *consistently* — each fail-closed parser accepts a well-formed string, and neither subsystem holds anything to compare it against. The failure mode is not a crash and not a disagreement between components: it is the stack configured, coherently, for a vehicle it isn't bolted to.

`courier` on R2 hardware is the concrete instance already documented under #1219: it assumes 2× the braking (3.0 vs 1.5 m/s²), and over-estimating available brake under-estimates stopping distance directly.

## Latent, not live

`parko_ros2_node` is **not in the R2 launch graph** — `kirra_with_robot.launch.py` starts `kirra_safety` nodes only — so the bench robot runs one consumer today, not two. It becomes live the moment parko is deployed alongside the verifier. I had this wrong before checking the launch file, and the section says so plainly rather than implying an active exposure.

## Controls that already exist

Listed so this reads as a scoped observation, not an open hole:

1. **Fail-closed parsing in both binaries** — the exposure is a *valid but wrong* class, never a missing or typo'd one.
2. **`preflight_autostart.sh`** validates the value in `/etc/kirra/kirra.env` and WARNs when the class is parseable but not this platform's (#1219).
3. **`enforcement_decision.wheelbase_consistent`** is a real runtime detector — it compares the interceptor's configured wheelbase against the class the verifier reports and latches a permanent stop on mismatch. It catches the mismatch *through its geometry consequence*, which is narrower than checking the class, but it is why a `courier`-on-R2 misconfiguration does not simply drive.

## What is not controlled, stated

Nothing asserts that the class the verifier resolved and the class parko resolved are the **same value**. They come from integrator configuration, and the two binaries are launched by different units with different `EnvironmentFile` sources.

The cheap mitigation — a startup cross-check refusing to start on disagreement, extending the fail-closed discipline both binaries already apply to an unset value — is recorded as **the known next step, not as done**.

## Verification

```
quality-guardrail gate:    PASS
website-citation gate:     PASS
safety-constants gate:     PASS
prohibited-claim sweep:    clean
```

Documentation only — no code, runtime behaviour, safety algorithm, checker input, release-token logic or actuator behaviour.