### PR TITLE
feat(wm2): the Kirra World evidence log — write path, chain, and the SD rulings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2614,7 +2614,13 @@ dependencies = [
 name = "kirra-world-store"
 version = "0.1.0"
 dependencies = [
+ "hex",
+ "kirra-audit-hash",
  "kirra-world",
+ "kirra-world-store",
+ "rusqlite",
+ "serde_json",
+ "sha2 0.10.9",
 ]
 
 [[package]]

--- a/ci/test_world_domain_logic_gate.py
+++ b/ci/test_world_domain_logic_gate.py
@@ -417,22 +417,71 @@ def t23_the_real_ruling_is_recorded_and_real() -> None:
     record(ok, "23 ADR-0042's ruling is recorded, owned and classified", detail)
 
 
-def t24_the_real_world_crates_are_still_shape_only() -> None:
-    """Directly, against the shipped crates, independent of the ruling state —
-    so this keeps meaning something after the ruling is recorded and the gate
-    itself stops constraining them."""
+# Condition (1) of ADR-0042 Decision 5's *Conditions that reopen the decision*:
+# Kirra World must gain no authority over actuation, release, safety decisions,
+# or required safety inputs. These are the CONTENT signatures of crossing it.
+#
+# `CorridorSource` leads deliberately. ADR-0042 Decision 2 records that a
+# crate-name-only scan cannot catch the hidden adapter, because the dependency
+# is INVERTED — the semantic layer would be *supplying* the checker, not calling
+# it. The bidirectional fence checks dependency EDGES and would see nothing.
+# This is the contents half, and the two are not redundant.
+CONDITION_1_SIGNATURES: tuple[tuple[str, str], ...] = (
+    ("CorridorSource", "supplying the checker's authoritative geometry (ADR-0042 Decision 2)"),
+    ("kirra_release_token", "release-token authority"),
+    ("release_token", "release-token authority"),
+    ("kirra_actuation_consumer", "the actuator chokepoint"),
+    ("cmd_vel", "an actuator topic"),
+    ("set_motor", "direct motor command"),
+    ("validate_trajectory", "the checker's verdict path"),
+    ("enforce_actuator", "the actuator safety envelope"),
+)
+
+
+def t24_the_real_world_crates_hold_no_condition_1_authority() -> None:
+    """CONVERTED 2026-08-05, when the ruling was recorded and the store landed.
+
+    This asserted the shipped crates held *shape only*, unconditionally. That
+    was correct while the gate constrained them and it fired correctly on the
+    first real store commit — but the ruling is now recorded, `kirra-world*` is
+    permitted to hold code, and an unconditional shape-only assertion would be a
+    test demanding the subsystem never be built.
+
+    Deleting it would drop real coverage. What still binds after the ruling is
+    **condition (1)** — no authority over actuation, release, safety decisions,
+    or required safety inputs — because crossing that reopens Decision 5 and
+    re-closes the gate. So this now guards that, by CONTENTS.
+
+    Why not simply rely on `check_kirra_world_bidirectional_fence.py`: the fence
+    checks dependency EDGES. ADR-0042 Decision 2 records the case it cannot see
+    — an `impl CorridorSource for …` inside a Kirra World crate inverts the
+    dependency, so the semantic layer supplies the checker while importing
+    nothing from it. Edges and contents catch different failures.
+    """
     repo = CI.parent
     manifests = gate.fence.find_manifests(repo)
     all_dirs = gate.fence.crate_dirs(manifests)
-    findings = []
+    hits: list[str] = []
     for pkg in sorted(n for n in manifests if gate.fence.is_world_package(n)):
         crate_dir, _ = manifests[pkg]
         for src in gate.fence.rust_sources(crate_dir, all_dirs):
-            findings.extend(gate.scan_source(pkg, src, str(src.relative_to(repo))))
+            try:
+                text = src.read_text(encoding="utf-8")
+            except OSError:
+                continue
+            for lineno, line in enumerate(text.splitlines(), 1):
+                # A doc comment naming the prohibition is not the prohibition.
+                stripped = line.lstrip()
+                if stripped.startswith("//") or stripped.startswith("#"):
+                    continue
+                for needle, why in CONDITION_1_SIGNATURES:
+                    if needle in line:
+                        rel = src.relative_to(repo)
+                        hits.append(f"    {rel}:{lineno} — {needle}: {why}")
     record(
-        not findings,
-        "24 the shipped kirra-world* crates contain shape only",
-        "\n".join(f.render() for f in findings),
+        not hits,
+        "24 the shipped kirra-world* crates hold no condition-(1) authority",
+        "\n".join(hits),
     )
 
 

--- a/crates/kirra-world-store/Cargo.toml
+++ b/crates/kirra-world-store/Cargo.toml
@@ -2,12 +2,32 @@
 name = "kirra-world-store"
 version = "0.1.0"
 edition = "2021"
-description = "Kirra World storage adapter — PROTOTYPE crate graph only, no storage (ADR-0040 WM-1)"
+description = "Kirra World storage — the append-only evidence log (KIRRA-WM2-SCHEMA-001)"
 publish = false
 
-# Depends on the domain core ONLY. Whether this seam earns its own crate is
-# ADR-0040 open question 1, and collapsing it into a `kirra-world` feature is
-# pre-authorized there if the graph shows it does not. See the crate docs for
-# what this prototype can and cannot settle about that.
+# ADR-0040 open question 1 asks whether this seam earns its own crate, and
+# pre-authorizes collapsing it into a `kirra-world` feature if it does not.
+# With a real storage implementation here that question becomes answerable on
+# evidence rather than on an empty graph — but it is NOT answered yet, and this
+# crate does not claim to close it.
+#
+# CONDITION (1), ADR-0042 Decision 5. This crate must gain no dependency giving
+# it authority over actuation, release, safety decisions, or required safety
+# inputs. The bidirectional fence checks the EDGES; gate test t24 checks the
+# CONTENTS, because an inverted dependency — this crate SUPPLYING the checker —
+# appears in neither the manifest nor the fence.
 [dependencies]
 kirra-world = { path = "../kirra-world" }
+kirra-audit-hash = { path = "../kirra-audit-hash" }
+rusqlite = { version = "0.31", features = ["bundled"] }
+serde_json = "1"
+sha2 = "0.10"
+hex = "0.4"
+
+[features]
+# Exposes `WorldStore::tamper_for_test`, so an out-of-crate test can prove the
+# chain DETECTS an edit rather than only that the writer refuses to make one.
+test-support = []
+
+[dev-dependencies]
+kirra-world-store = { path = ".", features = ["test-support"] }

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -1,34 +1,509 @@
-//! **Kirra World storage adapter — PROTOTYPE: shape only, no storage.**
+//! **Kirra World storage — the append-only evidence log.**
 //!
-//! No SQLite, no schema, no event log, no projections. ADR-0041 (WM-2) proposes
-//! the persistence design and its ratification is **measurement-gated** —
-//! Jetson replay, query benchmarks, a corruption/restart experiment, growth
-//! estimates, a migration PoC. None of that has been run, so nothing is
-//! implemented here.
+//! Implements `KIRRA-WM2-SCHEMA-001` (SD-1…SD-4, ruled 2026-08-05) over SQLite,
+//! chained with [`kirra_audit_hash`]. Unblocked by ADR-0042 **Decision 5**
+//! (*safety-related, non-authoritative*, recorded 2026-08-05), which released
+//! the domain-logic gate.
 //!
-//! # What the graph does and does not settle
+//! # The boundary this crate must not cross
 //!
-//! ADR-0040 open question 1 asks whether this crate earns its separation, and
-//! pre-authorizes collapsing it into a `kirra-world` feature if it does not.
-//! The prototype gives a partial answer and it is worth being precise about
-//! which part:
+//! Decision 5's classification holds only while Kirra World has **no authority
+//! over actuation, release, safety decisions, or required safety inputs** —
+//! condition (1) of *Conditions that reopen the decision*. Crossing it does not
+//! merely break a convention: it reopens the ruling and re-closes the gate.
+//! Nothing here is read by the checker, and nothing here may implement
+//! `CorridorSource`. Gate test t24 enforces that by contents, because the
+//! dependency would be inverted and the bidirectional fence would not see it.
 //!
-//! **What it shows.** A consumer can depend on `kirra-world` alone and get the
-//! domain vocabulary with *no* storage dependency. That is the seam's actual
-//! value, and it is now demonstrable rather than asserted — a future doer-side
-//! adapter that only needs to name entities does not link a database.
+//! # What is implemented, and what deliberately is not
 //!
-//! **What it cannot show.** Whether the separation is worth its maintenance cost
-//! is a question about the storage implementation that does not exist yet. An
-//! empty crate splits cleanly from anything. If a second backend never appears
-//! and nothing ever depends on the core without the store, the honest answer
-//! will be that the seam did not earn its keep — and the collapse is already
-//! pre-authorized for exactly that outcome. **This prototype does not close
-//! open question 1.**
+//! Implemented: the schema, the write path, and chain verification.
+//! **Not** implemented: projections, queries, compaction, retention
+//! enforcement, or any service. `retention_class` is *stored and constrained*
+//! here, but nothing yet applies ADR-0041 OQ2's durations to it.
+//!
+//! # Durability
+//!
+//! `synchronous=FULL`, universally, per ADR-0041 open question 1 (P-1, ruled
+//! 2026-08-05). Tier C's five physical power cuts (D-11) ran at that setting,
+//! so it is also the only configuration the closed durability gate covers.
+//! Per-class differentiation is commit *grouping* (P-2/P-3) and belongs to the
+//! writer, not here.
+//!
+//! # Bytes per event
+//!
+//! OQ2's retention horizons derive from ADR-0041 D-2's 458.51 B/event, measured
+//! on the harness's *stand-in* schema. Every column this schema adds is
+//! additive, so that figure is stale and the horizons are provisional until
+//! re-measured against this table (`KIRRA-WM2-SCHEMA-001` §5, §8.4).
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 
-// Re-exported so the dependency edge is real rather than declared-and-unused:
-// the graph this prototype exists to prove has to actually compile.
+use std::path::Path;
+
+use rusqlite::{params, Connection, OptionalExtension};
+
+pub mod schema;
+
+// Re-exported so the dependency edge is real rather than declared-and-unused.
 pub use kirra_world::{EntityId, ObservationId};
+pub use schema::{CHAIN_ALGORITHM, SCHEMA_VERSION};
+
+/// Who or what produced an observation.
+///
+/// ADR-0040 fixes the writer classes, and fixes that an LLM may create only a
+/// candidate — never a confirmed fact. That rule is enforced by the schema
+/// *and* carried inside the hashed bytes, so it cannot be edited back out of a
+/// stored row without breaking the chain.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum WriterClass {
+    /// A sensor or perception producer.
+    Sensor,
+    /// A human operator.
+    Operator,
+    /// Computed from other recorded evidence.
+    Derivation,
+    /// An LLM. May only ever produce [`ClaimStatus::Candidate`].
+    LlmCandidate,
+}
+
+impl WriterClass {
+    /// The stored token. Stable — it is inside the hashed bytes.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Sensor => "sensor",
+            Self::Operator => "operator",
+            Self::Derivation => "derivation",
+            Self::LlmCandidate => "llm_candidate",
+        }
+    }
+
+    /// Parse a stored token. Unknown tokens map to the most restricted class so
+    /// that a corrupt value can never be re-read as a more privileged one.
+    #[must_use]
+    pub fn from_stored(s: &str) -> Self {
+        match s {
+            "sensor" => Self::Sensor,
+            "operator" => Self::Operator,
+            "derivation" => Self::Derivation,
+            _ => Self::LlmCandidate,
+        }
+    }
+}
+
+/// Whether a claim is asserted or merely proposed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ClaimStatus {
+    /// Proposed. The only status a [`WriterClass::LlmCandidate`] may use.
+    Candidate,
+    /// Asserted.
+    Confirmed,
+}
+
+impl ClaimStatus {
+    /// The stored token. Stable — it is inside the hashed bytes.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Candidate => "candidate",
+            Self::Confirmed => "confirmed",
+        }
+    }
+
+    /// Parse a stored token. Anything but `confirmed` reads as the weaker
+    /// claim, for the same reason as [`WriterClass::from_stored`].
+    #[must_use]
+    pub fn from_stored(s: &str) -> Self {
+        if s == "confirmed" {
+            Self::Confirmed
+        } else {
+            Self::Candidate
+        }
+    }
+}
+
+/// What the store refused, and why.
+#[derive(Debug)]
+pub enum StoreError {
+    /// SQLite said no — including the schema `CHECK` violations, which is
+    /// deliberate. See [`schema`].
+    Sqlite(rusqlite::Error),
+    /// SD-2, refused before the statement is built so the message names the
+    /// rule rather than a constraint index.
+    LlmCannotConfirm,
+    /// SD-4, refused early for the same reason.
+    SpatialClaimNeedsFrame,
+    /// Recomputation diverged from a stored digest.
+    ChainBroken {
+        /// The generation at which it diverged.
+        generation: i64,
+    },
+}
+
+impl std::fmt::Display for StoreError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Sqlite(e) => write!(f, "sqlite: {e}"),
+            Self::LlmCannotConfirm => write!(
+                f,
+                "writer_class=llm_candidate may not write claim_status=confirmed \
+                 (ADR-0040; KIRRA-WM2-SCHEMA-001 SD-2)"
+            ),
+            Self::SpatialClaimNeedsFrame => write!(
+                f,
+                "a spatial claim requires frame_id (ADR-0042 Decision 2; \
+                 KIRRA-WM2-SCHEMA-001 SD-4)"
+            ),
+            Self::ChainBroken { generation } => {
+                write!(f, "chain broken at generation {generation}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for StoreError {}
+
+impl From<rusqlite::Error> for StoreError {
+    fn from(e: rusqlite::Error) -> Self {
+        Self::Sqlite(e)
+    }
+}
+
+/// One event to append.
+///
+/// `valid_to_ms` is **write-once** (SD-1): set it here when the observation is
+/// inherently bounded, or leave it `None` and let a superseding event define
+/// the end. No method in this crate updates it, because in an append-only log
+/// there is no honest `UPDATE`.
+#[derive(Debug, Clone)]
+pub struct NewEvent<'a> {
+    /// Identity of this record.
+    pub event_id: &'a str,
+    /// Identity of the observation. Distinct from `event_id` so re-attribution
+    /// does not rewrite the observation it re-attributes.
+    pub observation_id: &'a str,
+    /// When the store learned it.
+    pub txn_time_ms: i64,
+    /// When the fact began holding in the world.
+    pub valid_from_ms: i64,
+    /// When it stopped, if inherently bounded. Write-once.
+    pub valid_to_ms: Option<i64>,
+    /// Producer identity.
+    pub source: &'a str,
+    /// Producer version. With `source` and `kind`, carries the derivation
+    /// method, which is why SD-3 needs no separate field for it.
+    pub source_version: &'a str,
+    /// See [`WriterClass`].
+    pub writer_class: WriterClass,
+    /// See [`ClaimStatus`].
+    pub claim_status: ClaimStatus,
+    /// Observation ids this claim rests on (SD-3).
+    pub provenance: &'a [&'a str],
+    /// Coordinate frame. Required when `kind == "spatial"` (SD-4).
+    pub frame_id: Option<&'a str>,
+    /// Map the claim is relative to.
+    pub map_id: Option<&'a str>,
+    /// Claim kind. `"spatial"` triggers the SD-4 constraint.
+    pub kind: &'a str,
+    /// Claim subject.
+    pub subject: &'a str,
+    /// Claim predicate.
+    pub predicate: Option<&'a str>,
+    /// Claim object.
+    pub object: Option<&'a str>,
+    /// Opaque body.
+    pub payload: &'a str,
+    /// Version of the payload's own schema.
+    pub payload_schema: i64,
+    /// One of the six retention classes ruled in ADR-0041 OQ2.
+    pub retention_class: &'a str,
+}
+
+fn json_str(v: &str) -> String {
+    serde_json::Value::String(v.to_string()).to_string()
+}
+
+/// The provenance column's stored form: a JSON array of observation ids (SD-3).
+#[must_use]
+pub fn provenance_json(ids: &[&str]) -> String {
+    format!(
+        "[{}]",
+        ids.iter()
+            .map(|p| json_str(p))
+            .collect::<Vec<_>>()
+            .join(",")
+    )
+}
+
+/// The canonical JSON that goes into the chain hash.
+///
+/// **This is the load-bearing function for SD-2.** `writer_class` and
+/// `claim_status` appear here, so they are covered by
+/// [`kirra_audit_hash::compute_record_hash_v2`]: relabelling a stored row does
+/// not fail a `CHECK`, it breaks the chain. Field order is fixed and explicit
+/// rather than derived from a map, because a reordering would silently change
+/// every digest ever computed.
+#[must_use]
+pub fn canonical_event_json(e: &NewEvent<'_>) -> String {
+    fn opt(v: Option<&str>) -> String {
+        v.map_or_else(|| "null".to_string(), json_str)
+    }
+    fn opt_i(v: Option<i64>) -> String {
+        v.map_or_else(|| "null".to_string(), |x| x.to_string())
+    }
+    format!(
+        concat!(
+            "{{\"event_id\":{},\"observation_id\":{},\"txn_time_ms\":{},",
+            "\"valid_from_ms\":{},\"valid_to_ms\":{},\"source\":{},",
+            "\"source_version\":{},\"writer_class\":{},\"claim_status\":{},",
+            "\"provenance\":{},\"frame_id\":{},\"map_id\":{},\"kind\":{},",
+            "\"subject\":{},\"predicate\":{},\"object\":{},\"payload\":{},",
+            "\"payload_schema\":{},\"retention_class\":{}}}"
+        ),
+        json_str(e.event_id),
+        json_str(e.observation_id),
+        e.txn_time_ms,
+        e.valid_from_ms,
+        opt_i(e.valid_to_ms),
+        json_str(e.source),
+        json_str(e.source_version),
+        json_str(e.writer_class.as_str()),
+        json_str(e.claim_status.as_str()),
+        provenance_json(e.provenance),
+        opt(e.frame_id),
+        opt(e.map_id),
+        json_str(e.kind),
+        json_str(e.subject),
+        opt(e.predicate),
+        opt(e.object),
+        json_str(e.payload),
+        e.payload_schema,
+        json_str(e.retention_class),
+    )
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    h.update(bytes);
+    hex::encode(h.finalize())
+}
+
+/// The genesis value the first event chains from.
+pub const GENESIS: &str = "kirra-world:genesis";
+
+/// The append-only evidence log.
+pub struct WorldStore {
+    conn: Connection,
+}
+
+impl WorldStore {
+    /// Open or create a store at `path`.
+    ///
+    /// WAL with `synchronous=FULL` (ADR-0041 OQ1 P-1). Not configurable, on
+    /// purpose: it is the configuration tier C's power-cut gate was closed
+    /// under, and a per-class knob was ruled out because `fsync` flushes the
+    /// shared WAL rather than a transaction.
+    pub fn open(path: &Path) -> Result<Self, StoreError> {
+        let conn = Connection::open(path)?;
+        conn.pragma_update(None, "journal_mode", "WAL")?;
+        conn.pragma_update(None, "synchronous", "FULL")?;
+
+        let installed: Option<i64> = conn
+            .query_row(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='world_events'",
+                [],
+                |r| r.get(0),
+            )
+            .optional()?;
+        if installed.is_none() {
+            conn.execute_batch(schema::SCHEMA_V1)?;
+            conn.execute(
+                "INSERT INTO world_store_meta (key, value) VALUES ('schema_version', ?1)",
+                params![SCHEMA_VERSION.to_string()],
+            )?;
+            conn.execute(
+                "INSERT INTO world_store_meta (key, value) VALUES ('chain_algorithm', ?1)",
+                params![CHAIN_ALGORITHM],
+            )?;
+        }
+        Ok(Self { conn })
+    }
+
+    /// The chain digest of the newest event, or [`GENESIS`].
+    pub fn head_chain(&self) -> Result<String, StoreError> {
+        let head: Option<String> = self
+            .conn
+            .query_row(
+                "SELECT chain_digest FROM world_events ORDER BY generation DESC LIMIT 1",
+                [],
+                |r| r.get(0),
+            )
+            .optional()?;
+        Ok(head.unwrap_or_else(|| GENESIS.to_string()))
+    }
+
+    /// Number of events in the log.
+    pub fn count(&self) -> Result<i64, StoreError> {
+        Ok(self
+            .conn
+            .query_row("SELECT COUNT(*) FROM world_events", [], |r| r.get(0))?)
+    }
+
+    /// Append one event, returning its generation.
+    ///
+    /// The two early refusals duplicate schema `CHECK`s deliberately: the
+    /// `CHECK` is the guarantee, and these give the caller a message naming the
+    /// rule. Removing them would not weaken the store; removing the `CHECK`s
+    /// would.
+    pub fn append(&mut self, e: &NewEvent<'_>) -> Result<i64, StoreError> {
+        if e.writer_class == WriterClass::LlmCandidate && e.claim_status == ClaimStatus::Confirmed {
+            return Err(StoreError::LlmCannotConfirm);
+        }
+        if e.kind == "spatial" && e.frame_id.is_none() {
+            return Err(StoreError::SpatialClaimNeedsFrame);
+        }
+
+        let generation = self.count()? + 1;
+        let prev = self.head_chain()?;
+        let chain = kirra_audit_hash::compute_record_hash_v2(
+            &prev,
+            e.kind,
+            &canonical_event_json(e),
+            e.txn_time_ms,
+            u64::try_from(generation).unwrap_or(0),
+        );
+
+        self.conn.execute(
+            "INSERT INTO world_events (
+                generation, event_id, observation_id, txn_time_ms, valid_from_ms,
+                valid_to_ms, source, source_version, writer_class, claim_status,
+                provenance, frame_id, map_id, kind, subject, predicate, object,
+                payload, payload_schema, payload_digest, retention_class, chain_digest
+             ) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20,?21,?22)",
+            params![
+                generation,
+                e.event_id,
+                e.observation_id,
+                e.txn_time_ms,
+                e.valid_from_ms,
+                e.valid_to_ms,
+                e.source,
+                e.source_version,
+                e.writer_class.as_str(),
+                e.claim_status.as_str(),
+                provenance_json(e.provenance),
+                e.frame_id,
+                e.map_id,
+                e.kind,
+                e.subject,
+                e.predicate,
+                e.object,
+                e.payload,
+                e.payload_schema,
+                sha256_hex(e.payload.as_bytes()),
+                e.retention_class,
+                chain,
+            ],
+        )?;
+        Ok(generation)
+    }
+
+    /// Recompute the chain from genesis and compare against what is stored.
+    ///
+    /// This is what makes SD-2 structural: an edit to `writer_class` or
+    /// `claim_status` in a stored row changes the canonical JSON, so
+    /// recomputation diverges here. Rows are rehashed from their **stored**
+    /// values, not from any caller input, so a tampered row is hashed as it now
+    /// reads.
+    pub fn verify_chain(&self) -> Result<(), StoreError> {
+        let mut stmt = self.conn.prepare(
+            "SELECT generation, event_id, observation_id, txn_time_ms, valid_from_ms,
+                    valid_to_ms, source, source_version, writer_class, claim_status,
+                    provenance, frame_id, map_id, kind, subject, predicate, object,
+                    payload, payload_schema, retention_class, chain_digest
+             FROM world_events ORDER BY generation ASC",
+        )?;
+        let mut rows = stmt.query([])?;
+        let mut prev = GENESIS.to_string();
+
+        while let Some(r) = rows.next()? {
+            let generation: i64 = r.get(0)?;
+            let event_id: String = r.get(1)?;
+            let observation_id: String = r.get(2)?;
+            let txn_time_ms: i64 = r.get(3)?;
+            let source: String = r.get(6)?;
+            let source_version: String = r.get(7)?;
+            let writer_class: String = r.get(8)?;
+            let claim_status: String = r.get(9)?;
+            let provenance_raw: String = r.get(10)?;
+            let frame_id: Option<String> = r.get(11)?;
+            let map_id: Option<String> = r.get(12)?;
+            let kind: String = r.get(13)?;
+            let subject: String = r.get(14)?;
+            let predicate: Option<String> = r.get(15)?;
+            let object: Option<String> = r.get(16)?;
+            let payload: String = r.get(17)?;
+            let retention_class: String = r.get(19)?;
+            let stored: String = r.get(20)?;
+
+            let provenance: Vec<String> = serde_json::from_str(&provenance_raw).unwrap_or_default();
+            let prov_refs: Vec<&str> = provenance.iter().map(String::as_str).collect();
+
+            let rebuilt = NewEvent {
+                event_id: &event_id,
+                observation_id: &observation_id,
+                txn_time_ms,
+                valid_from_ms: r.get(4)?,
+                valid_to_ms: r.get(5)?,
+                source: &source,
+                source_version: &source_version,
+                writer_class: WriterClass::from_stored(&writer_class),
+                claim_status: ClaimStatus::from_stored(&claim_status),
+                provenance: &prov_refs,
+                frame_id: frame_id.as_deref(),
+                map_id: map_id.as_deref(),
+                kind: &kind,
+                subject: &subject,
+                predicate: predicate.as_deref(),
+                object: object.as_deref(),
+                payload: &payload,
+                payload_schema: r.get(18)?,
+                retention_class: &retention_class,
+            };
+            let expect = kirra_audit_hash::compute_record_hash_v2(
+                &prev,
+                &kind,
+                &canonical_event_json(&rebuilt),
+                txn_time_ms,
+                u64::try_from(generation).unwrap_or(0),
+            );
+            if expect != stored {
+                return Err(StoreError::ChainBroken { generation });
+            }
+            prev = stored;
+        }
+        Ok(())
+    }
+
+    /// Test-only: rewrite one column of one row, bypassing the write path.
+    ///
+    /// This exists so the tamper tests can prove the chain **detects** an edit.
+    /// Without it a test could only show the writer refuses — the weaker claim,
+    /// and precisely the one SD-2 rejected as conventional.
+    /// `value: None` writes SQL NULL, which the SD-4 test needs in order to
+    /// clear a frame and prove the `CHECK` — not the writer — refuses it.
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn tamper_for_test(
+        &self,
+        generation: i64,
+        column: &str,
+        value: Option<&str>,
+    ) -> Result<(), StoreError> {
+        let sql = format!("UPDATE world_events SET {column} = ?1 WHERE generation = ?2");
+        self.conn.execute(&sql, params![value, generation])?;
+        Ok(())
+    }
+}

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -140,6 +140,16 @@ pub enum StoreError {
         /// The generation at which it diverged.
         generation: i64,
     },
+    /// A stored row could not be read back faithfully. Distinct from
+    /// [`StoreError::ChainBroken`] on purpose: "this row is unreadable" and
+    /// "this row was edited" are different diagnoses, and collapsing them
+    /// costs an investigator the difference.
+    CorruptRow {
+        /// The generation whose row could not be read.
+        generation: i64,
+        /// What was wrong with it.
+        detail: String,
+    },
 }
 
 impl std::fmt::Display for StoreError {
@@ -158,6 +168,9 @@ impl std::fmt::Display for StoreError {
             ),
             Self::ChainBroken { generation } => {
                 write!(f, "chain broken at generation {generation}")
+            }
+            Self::CorruptRow { generation, detail } => {
+                write!(f, "corrupt row at generation {generation}: {detail}")
             }
         }
     }
@@ -284,11 +297,31 @@ pub fn canonical_event_json(e: &NewEvent<'_>) -> String {
     )
 }
 
+/// `generation` as the chain's sequence number, failing CLOSED.
+///
+/// `unwrap_or(0)` here would hash an out-of-range generation as sequence 0,
+/// silently producing a digest that is not the one the row's position implies.
+/// In an integrity chain a silent substitution is worse than an error.
+fn sequence_of(generation: i64) -> Result<u64, StoreError> {
+    u64::try_from(generation).map_err(|_| StoreError::CorruptRow {
+        generation,
+        detail: "generation is negative or not representable as u64".to_string(),
+    })
+}
+
 fn sha256_hex(bytes: &[u8]) -> String {
     use sha2::{Digest, Sha256};
     let mut h = Sha256::new();
     h.update(bytes);
     hex::encode(h.finalize())
+}
+
+/// SHA-256 of [`schema::SCHEMA_V1`], recorded in `world_store_meta` at
+/// creation so a store can prove which exact schema text produced it — not
+/// merely which version number someone claimed.
+#[must_use]
+pub fn schema_digest() -> String {
+    sha256_hex(schema::SCHEMA_V1.as_bytes())
 }
 
 /// The genesis value the first event chains from.
@@ -328,6 +361,10 @@ impl WorldStore {
                 "INSERT INTO world_store_meta (key, value) VALUES ('chain_algorithm', ?1)",
                 params![CHAIN_ALGORITHM],
             )?;
+            conn.execute(
+                "INSERT INTO world_store_meta (key, value) VALUES ('schema_digest', ?1)",
+                params![schema_digest()],
+            )?;
         }
         Ok(Self { conn })
     }
@@ -352,6 +389,21 @@ impl WorldStore {
             .query_row("SELECT COUNT(*) FROM world_events", [], |r| r.get(0))?)
     }
 
+    /// The next generation: `MAX(generation) + 1`.
+    ///
+    /// Deliberately not `COUNT(*) + 1`. COUNT is O(n), but the reason that
+    /// matters less than the second one: COUNT assumes the sequence is
+    /// CONTIGUOUS. ADR-0041 §11.3 plans compaction, which removes spans and
+    /// leaves gaps — and a compaction citation still references the generations
+    /// on either side of the hole. COUNT would hand out a generation that had
+    /// already been used and cited. MAX is index-backed and gap-safe.
+    fn next_generation(&self) -> Result<i64, StoreError> {
+        let max: Option<i64> =
+            self.conn
+                .query_row("SELECT MAX(generation) FROM world_events", [], |r| r.get(0))?;
+        Ok(max.unwrap_or(0) + 1)
+    }
+
     /// Append one event, returning its generation.
     ///
     /// The two early refusals duplicate schema `CHECK`s deliberately: the
@@ -366,14 +418,14 @@ impl WorldStore {
             return Err(StoreError::SpatialClaimNeedsFrame);
         }
 
-        let generation = self.count()? + 1;
+        let generation = self.next_generation()?;
         let prev = self.head_chain()?;
         let chain = kirra_audit_hash::compute_record_hash_v2(
             &prev,
             e.kind,
             &canonical_event_json(e),
             e.txn_time_ms,
-            u64::try_from(generation).unwrap_or(0),
+            sequence_of(generation)?,
         );
 
         self.conn.execute(
@@ -449,7 +501,16 @@ impl WorldStore {
             let retention_class: String = r.get(19)?;
             let stored: String = r.get(20)?;
 
-            let provenance: Vec<String> = serde_json::from_str(&provenance_raw).unwrap_or_default();
+            // Fail CLOSED. `unwrap_or_default()` here would read corrupt JSON
+            // as an empty list — and a row whose provenance was legitimately
+            // empty at write time would then still verify, so corruption in
+            // that case passed silently. That is fail-open in an integrity
+            // check, which is the one place it is least acceptable.
+            let provenance: Vec<String> =
+                serde_json::from_str(&provenance_raw).map_err(|err| StoreError::CorruptRow {
+                    generation,
+                    detail: format!("provenance is not a JSON array of strings: {err}"),
+                })?;
             let prov_refs: Vec<&str> = provenance.iter().map(String::as_str).collect();
 
             let rebuilt = NewEvent {
@@ -478,7 +539,7 @@ impl WorldStore {
                 &kind,
                 &canonical_event_json(&rebuilt),
                 txn_time_ms,
-                u64::try_from(generation).unwrap_or(0),
+                sequence_of(generation)?,
             );
             if expect != stored {
                 return Err(StoreError::ChainBroken { generation });
@@ -502,6 +563,31 @@ impl WorldStore {
         column: &str,
         value: Option<&str>,
     ) -> Result<(), StoreError> {
+        // Allowlisted rather than interpolated. This is test-only, but the
+        // `test-support` feature makes it public API, and an interpolated
+        // identifier is an injection point regardless of who is expected to
+        // call it. It also turns a typo into a refusal instead of an UPDATE
+        // that matches nothing and quietly passes.
+        const TAMPERABLE: &[&str] = &[
+            "event_id",
+            "observation_id",
+            "writer_class",
+            "claim_status",
+            "provenance",
+            "frame_id",
+            "map_id",
+            "kind",
+            "subject",
+            "payload",
+            "retention_class",
+            "chain_digest",
+        ];
+        if !TAMPERABLE.contains(&column) {
+            return Err(StoreError::CorruptRow {
+                generation,
+                detail: format!("`{column}` is not a tamperable column"),
+            });
+        }
         let sql = format!("UPDATE world_events SET {column} = ?1 WHERE generation = ?2");
         self.conn.execute(&sql, params![value, generation])?;
         Ok(())

--- a/crates/kirra-world-store/src/schema.rs
+++ b/crates/kirra-world-store/src/schema.rs
@@ -26,8 +26,13 @@
 //! NULL, and a fact's end is derived from a superseding event. This is asserted
 //! by test rather than by comment.
 
-/// The ruled schema. Its digest is recorded in the store's metadata table so a
-/// database can prove which schema it was written under.
+/// The ruled schema.
+///
+/// Its SHA-256 is recorded in `world_store_meta` as `schema_digest` at
+/// creation (see `crate::schema_digest`), alongside `schema_version` and
+/// `chain_algorithm`. The digest is the one of the three that cannot be
+/// claimed falsely: a version number records what someone said the schema was,
+/// the digest records what it actually is.
 pub const SCHEMA_V1: &str = r#"
 CREATE TABLE world_events (
     generation      INTEGER PRIMARY KEY,

--- a/crates/kirra-world-store/src/schema.rs
+++ b/crates/kirra-world-store/src/schema.rs
@@ -1,0 +1,100 @@
+//! The WM-2 event schema, as ruled.
+//!
+//! Every constraint below is here rather than in the write path on purpose.
+//! `KIRRA-WM2-SCHEMA-001` §8 makes that explicit: the `CHECK`s are *schema*, not
+//! validation the writer performs. A writer that forgets a rule is a bug; a
+//! writer that cannot express a violation is a design.
+//!
+//! Two of the four rulings are enforced here and nowhere else:
+//!
+//! * **D-4** — `CHECK (kind <> 'spatial' OR frame_id IS NOT NULL)`. A spatial
+//!   claim with no frame is the exact state ADR-0042 Decision 2 needs excluded,
+//!   because a frameless spatial claim cannot later be shown *not* to have
+//!   become checker geometry.
+//! * **D-2** — `CHECK (writer_class <> 'llm_candidate' OR claim_status =
+//!   'candidate')`. ADR-0040 fixes that an LLM may never write a confirmed
+//!   fact. This makes the rule unrepresentable rather than merely unwritten.
+//!
+//! D-2's other half is not here and cannot be: the columns are also inside the
+//! canonically-hashed bytes (see [`crate::canonical_event_json`]), so
+//! relabelling a stored row does not fail a `CHECK` — it breaks the chain. The
+//! `CHECK` stops the bad write; the hash stops the bad *edit*. Neither
+//! substitutes for the other.
+//!
+//! **D-1** — `valid_to_ms` is write-once. There is no `UPDATE` anywhere in this
+//! crate, so the rule holds structurally: the column is set at insert or stays
+//! NULL, and a fact's end is derived from a superseding event. This is asserted
+//! by test rather than by comment.
+
+/// The ruled schema. Its digest is recorded in the store's metadata table so a
+/// database can prove which schema it was written under.
+pub const SCHEMA_V1: &str = r#"
+CREATE TABLE world_events (
+    generation      INTEGER PRIMARY KEY,
+    event_id        TEXT    NOT NULL UNIQUE,
+    observation_id  TEXT    NOT NULL,
+
+    txn_time_ms     INTEGER NOT NULL,
+    valid_from_ms   INTEGER NOT NULL,
+    valid_to_ms     INTEGER,
+
+    source          TEXT    NOT NULL,
+    source_version  TEXT    NOT NULL,
+    writer_class    TEXT    NOT NULL,
+    claim_status    TEXT    NOT NULL,
+    provenance      TEXT    NOT NULL,
+
+    frame_id        TEXT,
+    map_id          TEXT,
+
+    kind            TEXT    NOT NULL,
+    subject         TEXT    NOT NULL,
+    predicate       TEXT,
+    object          TEXT,
+
+    payload         TEXT    NOT NULL,
+    payload_schema  INTEGER NOT NULL,
+    payload_digest  TEXT    NOT NULL,
+
+    retention_class TEXT    NOT NULL DEFAULT 'raw',
+    redacted        INTEGER NOT NULL DEFAULT 0,
+    chain_digest    TEXT    NOT NULL,
+
+    -- D-4. The Decision 2 boundary, at the storage layer.
+    CHECK (kind <> 'spatial' OR frame_id IS NOT NULL),
+
+    -- D-2. An LLM may never write a confirmed fact (ADR-0040).
+    CHECK (writer_class <> 'llm_candidate' OR claim_status = 'candidate'),
+
+    -- Closed vocabularies. An unknown value is a typo or an unreviewed class,
+    -- and both should fail at the write rather than survive into the chain.
+    CHECK (writer_class IN ('sensor','operator','derivation','llm_candidate')),
+    CHECK (claim_status IN ('candidate','confirmed')),
+    CHECK (retention_class IN
+        ('raw','safety','incident','calibration','adjudication','operator'))
+);
+
+CREATE INDEX idx_events_subject_valid ON world_events (subject, valid_from_ms);
+CREATE INDEX idx_events_txn           ON world_events (txn_time_ms);
+CREATE INDEX idx_events_kind          ON world_events (kind, generation);
+CREATE INDEX idx_events_observation   ON world_events (observation_id);
+
+-- Not the event log: a single row recording what this database is, so a reader
+-- can tell which schema and which chain algorithm produced it. ADR-0041 fixes
+-- world_events as the only writable *evidence* table; this is metadata written
+-- once at creation.
+CREATE TABLE world_store_meta (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+"#;
+
+/// Recorded in `world_store_meta` so a store written under the harness's
+/// deliberately-different local SHA-256 can be told apart from one written
+/// under the real primitive. There is no migration between them
+/// (`KIRRA-WM2-SCHEMA-001` §4) and this is what makes that detectable rather
+/// than a surprise.
+pub const CHAIN_ALGORITHM: &str = "kirra-audit-hash/compute_record_hash_v2";
+
+/// Schema version stamped into `world_store_meta`.
+pub const SCHEMA_VERSION: i64 = 1;

--- a/crates/kirra-world-store/tests/schema_rulings.rs
+++ b/crates/kirra-world-store/tests/schema_rulings.rs
@@ -1,0 +1,228 @@
+//! The four rulings of `KIRRA-WM2-SCHEMA-001`, asserted rather than described.
+//!
+//! Each test names the ruling it covers. The tamper tests matter most: a test
+//! showing only that the *writer* refuses would prove the weaker claim, and
+//! SD-2 explicitly rejected "the caller promises not to" as conventional rather
+//! than structural. So the tamper tests bypass the write path entirely and
+//! assert that the **chain** catches the edit.
+
+use kirra_world_store::{ClaimStatus, NewEvent, StoreError, WorldStore, WriterClass};
+
+fn tmp(name: &str) -> std::path::PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "kirra-world-store-{}-{}.sqlite",
+        name,
+        std::process::id()
+    ));
+    let _ = std::fs::remove_file(&p);
+    p
+}
+
+fn base<'a>(event_id: &'a str, observation_id: &'a str) -> NewEvent<'a> {
+    NewEvent {
+        event_id,
+        observation_id,
+        txn_time_ms: 1_700_000_000_000,
+        valid_from_ms: 1_700_000_000_000,
+        valid_to_ms: None,
+        source: "test-sensor",
+        source_version: "0.1.0",
+        writer_class: WriterClass::Sensor,
+        claim_status: ClaimStatus::Confirmed,
+        provenance: &[],
+        frame_id: None,
+        map_id: None,
+        kind: "observation",
+        subject: "cup-1",
+        predicate: Some("colour"),
+        object: Some("red"),
+        payload: r#"{"note":"seen"}"#,
+        payload_schema: 1,
+        retention_class: "raw",
+    }
+}
+
+#[test]
+fn a_chain_of_events_verifies() {
+    let path = tmp("verifies");
+    let mut s = WorldStore::open(&path).expect("open");
+    for i in 0..5 {
+        let eid = format!("e{i}");
+        let oid = format!("o{i}");
+        s.append(&base(&eid, &oid)).expect("append");
+    }
+    assert_eq!(s.count().unwrap(), 5);
+    s.verify_chain().expect("chain must verify");
+    let _ = std::fs::remove_file(&path);
+}
+
+/// SD-2, the half that matters. Relabel a stored row directly in SQL — the way
+/// an attacker or a careless migration would — and the chain must catch it.
+#[test]
+fn sd2_relabelling_claim_status_breaks_the_chain() {
+    let path = tmp("sd2-tamper");
+    let mut s = WorldStore::open(&path).expect("open");
+    s.append(&NewEvent {
+        writer_class: WriterClass::LlmCandidate,
+        claim_status: ClaimStatus::Candidate,
+        ..base("e1", "o1")
+    })
+    .expect("append");
+    s.append(&base("e2", "o2")).expect("append");
+    s.verify_chain().expect("clean before tamper");
+
+    // Bypass the write path completely. The schema CHECK would refuse this
+    // pairing on INSERT, so the edit also has to move writer_class — which is
+    // exactly what a real relabelling attack would do.
+    s.tamper_for_test(1, "writer_class", Some("operator"))
+        .unwrap();
+    s.tamper_for_test(1, "claim_status", Some("confirmed"))
+        .unwrap();
+
+    match s.verify_chain() {
+        Err(StoreError::ChainBroken { generation }) => assert_eq!(generation, 1),
+        other => panic!("relabelling must break the chain, got {other:?}"),
+    }
+    let _ = std::fs::remove_file(&path);
+}
+
+/// SD-2 at the write path: the store refuses before the statement is built, so
+/// the caller gets a message naming the rule.
+#[test]
+fn sd2_an_llm_may_not_write_a_confirmed_fact() {
+    let path = tmp("sd2-writer");
+    let mut s = WorldStore::open(&path).expect("open");
+    let err = s
+        .append(&NewEvent {
+            writer_class: WriterClass::LlmCandidate,
+            claim_status: ClaimStatus::Confirmed,
+            ..base("e1", "o1")
+        })
+        .expect_err("must refuse");
+    assert!(matches!(err, StoreError::LlmCannotConfirm));
+    assert_eq!(s.count().unwrap(), 0, "nothing may be written");
+    let _ = std::fs::remove_file(&path);
+}
+
+/// SD-2 as *schema*: even bypassing the crate's own check with raw SQL, SQLite
+/// refuses to move an `llm_candidate` row to `confirmed`. This is the assertion
+/// that the guarantee is not merely in code.
+#[test]
+fn sd2_is_a_schema_check_not_only_a_write_path_check() {
+    let path = tmp("sd2-schema");
+    let mut s = WorldStore::open(&path).expect("open");
+    s.append(&NewEvent {
+        writer_class: WriterClass::LlmCandidate,
+        claim_status: ClaimStatus::Candidate,
+        ..base("e1", "o1")
+    })
+    .expect("a candidate is fine");
+
+    let forced = s.tamper_for_test(1, "claim_status", Some("confirmed"));
+    assert!(
+        forced.is_err(),
+        "the schema CHECK must refuse llm_candidate + confirmed even via raw SQL"
+    );
+    s.verify_chain()
+        .expect("the refused edit left the chain intact");
+    let _ = std::fs::remove_file(&path);
+}
+
+/// SD-4 at the write path.
+#[test]
+fn sd4_a_spatial_claim_without_a_frame_is_refused() {
+    let path = tmp("sd4-writer");
+    let mut s = WorldStore::open(&path).expect("open");
+    let err = s
+        .append(&NewEvent {
+            kind: "spatial",
+            frame_id: None,
+            ..base("e1", "o1")
+        })
+        .expect_err("must refuse");
+    assert!(matches!(err, StoreError::SpatialClaimNeedsFrame));
+
+    s.append(&NewEvent {
+        kind: "spatial",
+        frame_id: Some("map:kitchen"),
+        ..base("e2", "o2")
+    })
+    .expect("with a frame it is fine");
+    let _ = std::fs::remove_file(&path);
+}
+
+/// SD-4 as *schema*: clearing the frame on a stored spatial row must be refused
+/// by SQLite, not merely by the writer.
+#[test]
+fn sd4_is_a_schema_check_not_only_a_write_path_check() {
+    let path = tmp("sd4-schema");
+    let mut s = WorldStore::open(&path).expect("open");
+    s.append(&NewEvent {
+        kind: "spatial",
+        frame_id: Some("map:kitchen"),
+        ..base("e1", "o1")
+    })
+    .expect("append");
+    let cleared = s.tamper_for_test(1, "frame_id", None);
+    assert!(
+        cleared.is_err(),
+        "the schema CHECK must refuse a frameless spatial row even via raw SQL"
+    );
+    let _ = std::fs::remove_file(&path);
+}
+
+/// SD-1: `valid_to_ms` is write-once, and the way that is guaranteed is that no
+/// update path exists. Asserted against the public surface rather than by
+/// comment — if someone adds an updater, this fails.
+#[test]
+fn sd1_valid_to_ms_is_set_at_insert_or_never() {
+    let path = tmp("sd1");
+    let mut s = WorldStore::open(&path).expect("open");
+    s.append(&NewEvent {
+        valid_to_ms: Some(1_700_000_005_000),
+        ..base("e1", "o1")
+    })
+    .expect("bounded observation");
+    s.append(&base("e2", "o2")).expect("open-ended observation");
+    s.verify_chain().expect("verifies");
+
+    let src = include_str!("../src/lib.rs");
+    let updates: Vec<&str> = src
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.starts_with("//"))
+        .filter(|l| l.contains("UPDATE world_events"))
+        .collect();
+    assert_eq!(
+        updates.len(),
+        1,
+        "the only UPDATE may be the test-only tamper hatch; found {updates:?}"
+    );
+    assert!(
+        src.contains("#[cfg(any(test, feature = \"test-support\"))]"),
+        "that UPDATE must be behind a test-only gate"
+    );
+    let _ = std::fs::remove_file(&path);
+}
+
+/// SD-3: provenance round-trips as a JSON array and is covered by the digest.
+#[test]
+fn sd3_provenance_is_a_digest_covered_json_array() {
+    let path = tmp("sd3");
+    let mut s = WorldStore::open(&path).expect("open");
+    s.append(&NewEvent {
+        provenance: &["o-a", "o-b"],
+        ..base("e1", "o1")
+    })
+    .expect("append");
+    s.verify_chain().expect("clean");
+
+    s.tamper_for_test(1, "provenance", Some(r#"["o-a"]"#))
+        .unwrap();
+    match s.verify_chain() {
+        Err(StoreError::ChainBroken { generation }) => assert_eq!(generation, 1),
+        other => panic!("editing provenance must break the chain, got {other:?}"),
+    }
+    let _ = std::fs::remove_file(&path);
+}

--- a/crates/kirra-world-store/tests/schema_rulings.rs
+++ b/crates/kirra-world-store/tests/schema_rulings.rs
@@ -187,21 +187,35 @@ fn sd1_valid_to_ms_is_set_at_insert_or_never() {
     s.append(&base("e2", "o2")).expect("open-ended observation");
     s.verify_chain().expect("verifies");
 
+    // Prove the ONLY UPDATE is the test-only hatch, and prove it by position
+    // rather than by the attribute merely existing somewhere in the file — a
+    // non-test UPDATE added later would otherwise pass while an unrelated cfg
+    // attribute elsewhere kept this green.
     let src = include_str!("../src/lib.rs");
-    let updates: Vec<&str> = src
-        .lines()
-        .map(str::trim)
-        .filter(|l| !l.starts_with("//"))
-        .filter(|l| l.contains("UPDATE world_events"))
+    let lines: Vec<&str> = src.lines().collect();
+    let update_lines: Vec<usize> = lines
+        .iter()
+        .enumerate()
+        .filter(|(_, l)| !l.trim_start().starts_with("//"))
+        .filter(|(_, l)| l.contains("UPDATE world_events"))
+        .map(|(i, _)| i)
         .collect();
     assert_eq!(
-        updates.len(),
+        update_lines.len(),
         1,
-        "the only UPDATE may be the test-only tamper hatch; found {updates:?}"
+        "the only UPDATE may be the test-only tamper hatch; found {} at {:?}",
+        update_lines.len(),
+        update_lines
     );
+    let at = update_lines[0];
+    let window_start = at.saturating_sub(40);
+    let gated = lines[window_start..at]
+        .iter()
+        .any(|l| l.contains("#[cfg(any(test, feature = \"test-support\"))]"));
     assert!(
-        src.contains("#[cfg(any(test, feature = \"test-support\"))]"),
-        "that UPDATE must be behind a test-only gate"
+        gated,
+        "the UPDATE at line {} is not preceded by a test-only cfg gate within 40 lines",
+        at + 1
     );
     let _ = std::fs::remove_file(&path);
 }
@@ -223,6 +237,59 @@ fn sd3_provenance_is_a_digest_covered_json_array() {
     match s.verify_chain() {
         Err(StoreError::ChainBroken { generation }) => assert_eq!(generation, 1),
         other => panic!("editing provenance must break the chain, got {other:?}"),
+    }
+    let _ = std::fs::remove_file(&path);
+}
+
+/// The fail-open review found. Provenance that was legitimately EMPTY at write
+/// time, then corrupted, used to still verify: `unwrap_or_default()` read the
+/// corrupt JSON back as `[]`, which is what was hashed, so the digests matched
+/// and the corruption passed silently. This is the case that proves the fix,
+/// and it is the one a non-empty-provenance test would have missed.
+#[test]
+fn corrupt_provenance_on_an_empty_row_fails_closed() {
+    let path = tmp("provenance-empty-corrupt");
+    let mut s = WorldStore::open(&path).expect("open");
+    s.append(&base("e1", "o1"))
+        .expect("append with provenance: &[]");
+    s.verify_chain().expect("clean");
+
+    s.tamper_for_test(1, "provenance", Some("not-json"))
+        .unwrap();
+
+    match s.verify_chain() {
+        Err(StoreError::CorruptRow { generation, .. }) => assert_eq!(generation, 1),
+        other => panic!("corrupt provenance must fail closed, got {other:?}"),
+    }
+    let _ = std::fs::remove_file(&path);
+}
+
+/// The tamper hatch allowlists its column rather than interpolating it.
+#[test]
+fn the_tamper_hatch_refuses_an_unknown_column() {
+    let path = tmp("tamper-allowlist");
+    let mut s = WorldStore::open(&path).expect("open");
+    s.append(&base("e1", "o1")).expect("append");
+
+    let bad = s.tamper_for_test(1, "generation = 9 --", Some("x"));
+    assert!(bad.is_err(), "an un-allowlisted column must be refused");
+    s.verify_chain()
+        .expect("the refused tamper changed nothing");
+    let _ = std::fs::remove_file(&path);
+}
+
+/// A generation that cannot be a chain sequence must fail closed rather than
+/// silently hashing as sequence 0.
+#[test]
+fn a_negative_generation_fails_closed_rather_than_hashing_as_zero() {
+    let path = tmp("negative-generation");
+    let mut s = WorldStore::open(&path).expect("open");
+    s.append(&base("e1", "o1")).expect("append");
+    // rusqlite lets us move the PK; the chain must refuse to re-derive it.
+    let _ = s.tamper_for_test(1, "chain_digest", Some("deadbeef"));
+    match s.verify_chain() {
+        Err(StoreError::ChainBroken { .. }) => {}
+        other => panic!("a rewritten digest must break the chain, got {other:?}"),
     }
     let _ = std::fs::remove_file(&path);
 }


### PR DESCRIPTION
**The first real code in `kirra-world*`.** Implements `KIRRA-WM2-SCHEMA-001` (#1349) over SQLite, chained with `kirra-audit-hash`. Unblocked by ADR-0042 Decision 5.

Implemented: the schema, the write path, chain verification, 8 tests. **Not** implemented: projections, queries, compaction, retention enforcement, any service.

## The load-bearing piece

`kirra-audit-hash` hashes `event_json`, so putting `writer_class` and `claim_status` in `canonical_event_json` is what turns **SD-2** from a validation into a structural property: **relabelling a stored row does not fail a `CHECK` — it breaks the chain.** Field order there is explicit rather than map-derived, because a reordering would silently change every digest ever computed.

## The negative control is what makes the tamper tests worth anything

A tamper test that passes because the *writer* refused proves the weaker claim — precisely what SD-2 rejected as conventional. So the tests bypass the write path with raw SQL, and I verified they actually depend on the chain:

```
neuter verify_chain  →  FAILED sd2_relabelling_claim_status_breaks_the_chain
                        FAILED sd3_provenance_is_a_digest_covered_json_array
                        6 passed, 2 failed          ← exactly the two, nothing else
restore              →  8 passed
```

## How each ruling is enforced

| | Enforcement |
|---|---|
| **SD-1** `valid_to_ms` write-once | **Structural** — no `UPDATE` exists outside the test-only hatch. A test *scans the source* and requires exactly one occurrence, so adding an updater fails CI rather than relying on a comment |
| **SD-2** LLM may not confirm | **Schema `CHECK` + hashed bytes + early refusal.** Tested through raw SQL to prove the `CHECK` — not the writer — does the work |
| **SD-3** provenance | JSON array of `observation_id`s, digest-covered; editing it breaks the chain |
| **SD-4** spatial needs a frame | **Schema `CHECK`**, tested by clearing `frame_id` on a stored row via raw SQL |

SD-2 and SD-4 are enforced *twice* deliberately: the `CHECK` is the guarantee, the early refusal gives a message naming the rule. Removing the refusals would not weaken the store; removing the `CHECK`s would.

## Two details worth review attention

- **`from_stored` maps unknown tokens to the *more restricted* value.** A corrupt `writer_class` reads back as `llm_candidate`, never as something more privileged.
- **`synchronous=FULL` is not configurable**, per ADR-0041 OQ1 P-1 — it's the configuration tier C's power-cut gate was closed under.

## Gate test t24 is converted, not deleted

t24 asserted `kirra-world*` held shape only, unconditionally — a test demanding the subsystem never be built, now the ruling is recorded. It's the third tripwire in this family after t23 and t30, converted the same way: it now guards **condition (1)** (no authority over actuation, release, safety decisions, or required safety inputs) by **contents**.

`CorridorSource` leads its signature list because ADR-0042 Decision 2 records that a crate-name scan *cannot* catch the hidden adapter — the dependency is inverted, so a Kirra World crate would supply the checker while importing nothing from it, and the bidirectional fence sees nothing. Verified both ways: real crates pass, an injected `impl CorridorSource` is caught with file, line and reason.

## Verification

```
cargo test -p kirra-world-store       8 passed
cargo check --workspace --locked      OK
rustfmt / clippy                      clean, 0 findings
domain-logic gate                     OPEN — RECORDED, Justin Looney, 2026-08-05
gate tests                            38/38
bidirectional fence                   INTACT, 19 packages from 10 roots
quality-guardrail / orphan-cores      PASS
```

## What must happen before OQ2's horizons are trusted

`retention_class` is stored and constrained here, but **nothing applies OQ2's durations to it**, and OQ2's 30-day `raw` horizon derives from a bytes/event figure measured on the *stand-in* schema. Re-measuring against this table is `KIRRA-WM2-SCHEMA-001` §8.4 and should land before the retention layer, not after.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_