### PR TITLE
feat(wm2): retention enforcement — compaction-with-citation

### DIFF
--- a/crates/kirra-world-store/src/compaction.rs
+++ b/crates/kirra-world-store/src/compaction.rs
@@ -46,6 +46,33 @@
 //! produces. The rule also reads correctly on its own terms — the event saying
 //! where a thing *is* is evidence still in use, not history to summarize.
 //!
+//! ## The two refusals are not alike, and the difference is pre-recorded
+//!
+//! It would be easy to read them as one rule applied twice. They are not:
+//!
+//! * A **protected class** makes the window a policy unit. Compacting around
+//!   it would make how much of a span survives a question about interleaving
+//!   rather than about policy, so refusing whole is the *requirement*.
+//! * A **projection head** only requires that the head itself survive. Nothing
+//!   says its neighbours must. Refusing the whole window there is a
+//!   conservative simplification, not a requirement.
+//!
+//! Two things follow. First, [`crate::WorldStore::largest_compactable_prefix`]
+//! exists so a refusal is a redirect rather than a dead end — both refusals
+//! name their first blocking generation, and that is now a designed recovery.
+//!
+//! Second, the escalation is agreed in advance: **if measurement ever shows
+//! head refusals blocking a material fraction of reclaimable space, compact
+//! *around* heads instead.** The citation model already supports disjoint
+//! spans, so that is a loop over sub-ranges rather than a redesign. Recording
+//! the trigger now costs nothing and stops it becoming an argument later.
+//!
+//! The concern is also smaller than it first looks, because **heads age out**.
+//! An event stops being a head the moment something supersedes it, so for an
+//! old span to still hold one means nothing has been observed about that
+//! `(subject, predicate)` since — which is rare in a sensor stream, and when it
+//! happens that claim is arguably still-live evidence rather than history.
+//!
 //! # What compaction is NOT
 //!
 //! **Lossy, and only for summaries** (OQ2 rule 2). D-4 measured ~50 % recovery

--- a/crates/kirra-world-store/src/compaction.rs
+++ b/crates/kirra-world-store/src/compaction.rs
@@ -1,0 +1,155 @@
+//! Retention enforcement: compaction-with-citation (ADR-0041 §11.3).
+//!
+//! OQ2 ruled retention *durations* — 30 days `raw`, 365 days protected — and
+//! D-21 measured the budget they fit in. Nothing enforced them: the classes
+//! were stored and constrained, the horizons were ruled, and the store filled
+//! in 15.79 days regardless. This is the half that makes the policy behaviour.
+//!
+//! # Deleting from an append-only hash chain
+//!
+//! The obvious problem: `world_events` is chained, and removing a span breaks
+//! recomputation at the hole. §11.3's answer is that compaction leaves a
+//! **citation** behind — what was removed, how much, the digest of the removed
+//! span, and the chain digests on either side — so the log stays verifiable
+//! **across** the hole rather than merely up to it.
+//!
+//! That makes three things true, and the third is the one that matters:
+//!
+//! 1. A verifier crossing a hole picks the chain back up from `chain_after`.
+//! 2. The removed content stays *attestable* through `range_digest`: it cannot
+//!    be recovered, but anyone later producing those events can be checked.
+//! 3. **Rows cannot be deleted quietly.** A gap with no citation is a chain
+//!    error, and a citation whose `chain_before` does not match what the
+//!    verifier computed is a chain error. Compaction is therefore an
+//!    *admission*, recorded in the same structure it modifies — not an
+//!    erasure.
+//!
+//! # Two refusals, and why the second one is new
+//!
+//! **Protected classes are refused WHOLE.** A window containing any of
+//! `safety`, `incident`, `calibration`, `adjudication` or `operator` is refused
+//! entirely — not compacted around, not partially applied. OQ2 gave those
+//! classes a 365-day horizon; silently compacting the raw traffic interleaved
+//! with them would leave a window that is *partly* summarized, and "how much of
+//! this span survives" would become a question about arrival order.
+//!
+//! **Projection heads are refused.** This one is not in §11.3, because that
+//! design predates the store having a read path. If compaction removes the
+//! event that *defines* a `(subject, predicate)`'s current claim, then
+//! `rebuild_projections()` no longer reproduces the incremental state — the
+//! property ADR-0041 names, and that
+//! [`crate::WorldStore::projection_state_digest`] exists to check, becomes
+//! quietly false.
+//!
+//! Refusing heads resolves it exactly, and provably: the fold retains only
+//! heads, so a compaction that removes no head cannot change what a rebuild
+//! produces. The rule also reads correctly on its own terms — the event saying
+//! where a thing *is* is evidence still in use, not history to summarize.
+//!
+//! # What compaction is NOT
+//!
+//! **Lossy, and only for summaries** (OQ2 rule 2). D-4 measured ~50 % recovery
+//! on the stand-in; it buys retention of *summaries*, not of observations, and
+//! does not relax the sampling conclusion.
+//!
+//! **Not reclamation.** Deleting rows returns pages to SQLite's free list; it
+//! does not shrink the file. D-3 measured what reclamation actually costs — a
+//! ~1× free-space reserve and a total write blackout — so a policy that assumes
+//! continuous `VACUUM` assumes a maintenance window that may never open. This
+//! module deliberately does not call it.
+
+/// Retention classes OQ2 gave a 365-day horizon and §11.3 protects from
+/// compaction. A window containing any of these is refused whole.
+pub const PROTECTED_CLASSES: [&str; 5] = [
+    "safety",
+    "incident",
+    "calibration",
+    "adjudication",
+    "operator",
+];
+
+/// Is this retention class protected from compaction?
+///
+/// Unknown classes are treated as **protected**. The schema constrains the
+/// column to six known values, so an unknown one means the schema moved or the
+/// row is corrupt — and in either case deleting it is the irreversible choice.
+#[must_use]
+pub fn is_protected(retention_class: &str) -> bool {
+    retention_class != "raw"
+}
+
+/// The citation table, installed lazily by the first compaction.
+///
+/// Lazily for the same reason the projection tables are (see
+/// [`crate::projection`]): ADR-0041 D-20's `log_only_bytes` is the size of a
+/// store holding only the event log, and adding root pages at `open` would
+/// silently move it.
+pub const COMPACTION_V1: &str = r#"
+CREATE TABLE IF NOT EXISTS compaction_citations (
+    lo_generation   INTEGER PRIMARY KEY,
+    hi_generation   INTEGER NOT NULL,
+    event_count     INTEGER NOT NULL,
+    range_digest    TEXT    NOT NULL,
+    chain_before    TEXT    NOT NULL,
+    chain_after     TEXT    NOT NULL,
+    compacted_at_ms INTEGER NOT NULL,
+
+    CHECK (hi_generation >= lo_generation),
+    CHECK (event_count > 0)
+);
+"#;
+
+/// One recorded compaction: the citation left where a span used to be.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Citation {
+    /// First generation removed.
+    pub lo_generation: i64,
+    /// Last generation removed.
+    pub hi_generation: i64,
+    /// How many events were actually removed.
+    pub event_count: i64,
+    /// Digest over the removed events' canonical bytes, in generation order.
+    /// The removed content is gone; this keeps it *attestable*.
+    pub range_digest: String,
+    /// Chain digest immediately BEFORE the removed span.
+    pub chain_before: String,
+    /// Chain digest of the LAST removed event — where a verifier resumes.
+    pub chain_after: String,
+    /// When the compaction ran.
+    pub compacted_at_ms: i64,
+}
+
+/// What a compaction did.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompactionOutcome {
+    /// The citation now standing in for the removed span.
+    pub citation: Citation,
+    /// Events removed.
+    pub removed: i64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn only_raw_is_compactable() {
+        assert!(!is_protected("raw"));
+        for c in PROTECTED_CLASSES {
+            assert!(is_protected(c), "{c} must be protected");
+        }
+    }
+
+    /// An unknown class must be treated as protected. The schema constrains
+    /// the column, so an unknown value means the schema moved or the row is
+    /// corrupt — and deletion is the irreversible way to be wrong.
+    #[test]
+    fn an_unknown_class_is_protected() {
+        assert!(is_protected("some-future-class"));
+        assert!(is_protected(""));
+        assert!(
+            is_protected("RAW"),
+            "case matters; only exact `raw` is open"
+        );
+    }
+}

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -558,6 +558,9 @@ impl WorldStore {
         // rather than discovered as a missing row and reported as corruption.
         let citations = self.load_citations()?;
         let mut expected_generation: i64 = 1;
+        // Which citations the walk actually consumed. Checked at the end, so
+        // an unreachable one cannot sit unread.
+        let mut visited: std::collections::BTreeSet<i64> = std::collections::BTreeSet::new();
 
         while let Some(r) = rows.next()? {
             let generation: i64 = r.get(0)?;
@@ -582,6 +585,7 @@ impl WorldStore {
                         ),
                     });
                 }
+                visited.insert(c.lo_generation);
                 prev = c.chain_after.clone();
                 expected_generation = c.hi_generation + 1;
             }
@@ -662,9 +666,7 @@ impl WorldStore {
         }
 
         // A span compacted off the END of the log leaves no following row to
-        // trigger the crossing above, so it is checked here. Without this a
-        // trailing citation would go unverified — the one place a forged
-        // citation could otherwise hide.
+        // trigger the crossing above, so it is followed here.
         while let Some(c) = citations.get(&expected_generation) {
             if c.chain_before != prev {
                 return Err(StoreError::CitationBroken {
@@ -672,8 +674,28 @@ impl WorldStore {
                     detail: "trailing citation does not join the chain".to_string(),
                 });
             }
+            visited.insert(c.lo_generation);
             prev = c.chain_after.clone();
             expected_generation = c.hi_generation + 1;
+        }
+
+        // EVERY citation must have been walked. The loops above only follow
+        // citations reachable by contiguity from generation 1, so one sitting
+        // at an unreachable `lo_generation` — past the end of the log, or
+        // behind a gap nothing accounts for — would otherwise be ignored and
+        // the whole verification still return Ok.
+        //
+        // That is a hole in the property this design exists to provide: a
+        // citation is an *admission* that a span was removed, so an admission
+        // no verifier ever reads is not one. Refusing here means every
+        // citation is either walked and checked, or the chain fails.
+        if let Some(orphan) = citations.keys().find(|k| !visited.contains(k)) {
+            return Err(StoreError::CitationBroken {
+                lo_generation: *orphan,
+                detail: "citation is unreachable from the verified sequence — it \
+                         accounts for generations that were never reached"
+                    .to_string(),
+            });
         }
         Ok(())
     }
@@ -742,6 +764,29 @@ impl WorldStore {
     /// Every recorded compaction, oldest span first.
     pub fn citations(&self) -> Result<Vec<Citation>, StoreError> {
         Ok(self.load_citations()?.into_values().collect())
+    }
+
+    /// Test-only: insert a citation for a span that was never removed.
+    ///
+    /// Lets a test plant an **unreachable** citation — one the verification
+    /// walk never arrives at — which is the case that must be refused rather
+    /// than quietly ignored.
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn forge_citation_for_test(
+        &self,
+        lo_generation: i64,
+        hi_generation: i64,
+        now_ms: i64,
+    ) -> Result<(), StoreError> {
+        self.conn.execute_batch(compaction::COMPACTION_V1)?;
+        self.conn.execute(
+            "INSERT INTO compaction_citations (
+                lo_generation, hi_generation, event_count, range_digest,
+                chain_before, chain_after, compacted_at_ms
+             ) VALUES (?1,?2,1,'forged','forged','forged',?3)",
+            params![lo_generation, hi_generation, now_ms],
+        )?;
+        Ok(())
     }
 
     /// Test-only: remove a citation, leaving its gap unexplained.
@@ -1379,6 +1424,14 @@ impl WorldStore {
     /// generation order — the same bytes the chain covers. That is what keeps
     /// removed content *attestable*: it cannot be recovered, but anyone who
     /// later produces those events can be checked against this.
+    ///
+    /// The hash is **streamed**, not accumulated. Buffering the window's
+    /// canonical JSON before hashing would be O(window) memory at exactly the
+    /// moment memory is least available: a 30-day `raw` window at OQ2's ruled
+    /// 3.20 /s is ~8.3 M events, which at ~600 B each is several GB of
+    /// `String` — an OOM triggered by the operation you run *because* the
+    /// device is full. Feeding `Sha256` per event keeps it bounded regardless
+    /// of window size, and produces the identical digest.
     fn summarize_range(&self, lo: i64, hi: i64) -> Result<(i64, String, String), StoreError> {
         let mut stmt = self.conn.prepare(
             "SELECT generation, event_id, observation_id, txn_time_ms, valid_from_ms,
@@ -1389,7 +1442,8 @@ impl WorldStore {
              ORDER BY generation ASC",
         )?;
         let mut rows = stmt.query(params![lo, hi])?;
-        let mut acc = String::new();
+        use sha2::Digest;
+        let mut hasher = sha2::Sha256::new();
         let mut count = 0i64;
         let mut last_chain = String::new();
 
@@ -1441,11 +1495,11 @@ impl WorldStore {
                 payload_schema: r.get(18)?,
                 retention_class: &retention_class,
             };
-            acc.push_str(&canonical_event_json(&rebuilt));
-            acc.push('\n');
+            hasher.update(canonical_event_json(&rebuilt).as_bytes());
+            hasher.update(b"\n");
             count += 1;
         }
-        Ok((count, sha256_hex(acc.as_bytes()), last_chain))
+        Ok((count, hex::encode(hasher.finalize()), last_chain))
     }
 
     /// Subjects whose state changed after transaction time `since_ms`.

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -1160,6 +1160,80 @@ impl WorldStore {
         Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
     }
 
+    /// The largest `lo..=n` that [`WorldStore::compact_range`] would accept,
+    /// or `None` if nothing in the window is compactable.
+    ///
+    /// Both refusals name their first blocking generation, so a caller can
+    /// always retry on the sub-range below it. This makes that a **designed**
+    /// recovery rather than an accident of the error type: a refusal is a
+    /// redirect, not a dead end.
+    ///
+    /// Note the asymmetry, which is deliberate. The two refusals are refusals
+    /// of different kinds:
+    ///
+    /// * **Protected classes** are a *policy* unit. §11.3 refuses such a window
+    ///   whole, and this helper honours that by stopping at the protected
+    ///   event rather than stepping over it — compacting around it would make
+    ///   how much of a span survives a question about interleaving.
+    /// * **Projection heads** are a *correctness* constraint. Nothing says a
+    ///   head's neighbours must survive, only the head itself.
+    ///
+    /// So for heads, stopping short is a conservative simplification rather
+    /// than a requirement. If measurement ever shows head refusals blocking a
+    /// material fraction of reclaimable space, the escalation is to compact
+    /// *around* them — the citation model already handles disjoint spans, so
+    /// it is a loop over sub-ranges, not a redesign. Recorded here and in
+    /// ADR-0041 §11.3 so that is a pre-agreed trigger, not a later argument.
+    pub fn largest_compactable_prefix(&self, lo: i64, hi: i64) -> Result<Option<i64>, StoreError> {
+        if lo < 1 || hi < lo {
+            return Ok(None);
+        }
+        let mut limit = hi;
+
+        let protected: Option<i64> = self
+            .conn
+            .query_row(
+                "SELECT MIN(generation) FROM world_events
+                 WHERE generation BETWEEN ?1 AND ?2 AND retention_class <> 'raw'",
+                params![lo, hi],
+                |r| r.get(0),
+            )
+            .optional()?
+            .flatten();
+        if let Some(g) = protected {
+            limit = limit.min(g - 1);
+        }
+
+        if self.has_projections()? {
+            let head: Option<i64> = self
+                .conn
+                .query_row(
+                    "SELECT MIN(e.generation) FROM world_events e
+                     JOIN world_current c ON c.generation = e.generation
+                     WHERE e.generation BETWEEN ?1 AND ?2",
+                    params![lo, hi],
+                    |r| r.get(0),
+                )
+                .optional()?
+                .flatten();
+            if let Some(g) = head {
+                limit = limit.min(g - 1);
+            }
+        }
+
+        if limit < lo {
+            return Ok(None);
+        }
+        // A prefix with no rows in it is not compactable either — otherwise
+        // this would hand back a range `compact_range` refuses as empty.
+        let present: i64 = self.conn.query_row(
+            "SELECT COUNT(*) FROM world_events WHERE generation BETWEEN ?1 AND ?2",
+            params![lo, limit],
+            |r| r.get(0),
+        )?;
+        Ok(if present > 0 { Some(limit) } else { None })
+    }
+
     /// Compact `lo..=hi` out of the log, leaving a citation in its place.
     ///
     /// Refuses, whole, if the window contains:

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -44,9 +44,11 @@ use std::path::Path;
 
 use rusqlite::{params, Connection, OptionalExtension};
 
+pub mod compaction;
 pub mod projection;
 pub mod schema;
 
+pub use compaction::{Citation, CompactionOutcome};
 pub use projection::{ProjectedClaim, CURRENT_PROJECTION};
 
 // Re-exported so the dependency edge is real rather than declared-and-unused.
@@ -153,6 +155,43 @@ pub enum StoreError {
         /// What was wrong with it.
         detail: String,
     },
+    /// A compaction window contained a protected-class event. §11.3 refuses
+    /// such a window **whole** rather than compacting around it.
+    ProtectedClassInRange {
+        /// The offending generation.
+        generation: i64,
+        /// Its retention class.
+        retention_class: String,
+    },
+    /// A compaction window contained an event that defines a projection's
+    /// current claim. Removing it would make `rebuild_projections` stop
+    /// reproducing the incremental state.
+    ProjectionHeadInRange {
+        /// The offending generation.
+        generation: i64,
+        /// The subject whose current claim it defines.
+        subject: String,
+    },
+    /// Generations are missing with no citation explaining them. This is what
+    /// stops a span being deleted quietly.
+    UncitedGap {
+        /// The first missing generation.
+        generation: i64,
+    },
+    /// A citation exists but does not join the chain it claims to bridge.
+    CitationBroken {
+        /// The citation's first generation.
+        lo_generation: i64,
+        /// What did not line up.
+        detail: String,
+    },
+    /// A compaction range was empty or inverted.
+    EmptyRange {
+        /// The requested low bound.
+        lo: i64,
+        /// The requested high bound.
+        hi: i64,
+    },
 }
 
 impl std::fmt::Display for StoreError {
@@ -174,6 +213,36 @@ impl std::fmt::Display for StoreError {
             }
             Self::CorruptRow { generation, detail } => {
                 write!(f, "corrupt row at generation {generation}: {detail}")
+            }
+            Self::ProtectedClassInRange {
+                generation,
+                retention_class,
+            } => write!(
+                f,
+                "generation {generation} is retention_class={retention_class}, which is \
+                 protected from compaction; the window is refused whole \
+                 (ADR-0041 §11.3, OQ2)"
+            ),
+            Self::ProjectionHeadInRange {
+                generation,
+                subject,
+            } => write!(
+                f,
+                "generation {generation} defines the current claim for `{subject}`; \
+                 compacting it would make a projection rebuild diverge from the \
+                 incremental fold"
+            ),
+            Self::UncitedGap { generation } => write!(
+                f,
+                "generation {generation} is missing with no compaction citation \
+                 accounting for it"
+            ),
+            Self::CitationBroken {
+                lo_generation,
+                detail,
+            } => write!(f, "citation at generation {lo_generation}: {detail}"),
+            Self::EmptyRange { lo, hi } => {
+                write!(f, "compaction range {lo}..={hi} is empty or inverted")
             }
         }
     }
@@ -484,8 +553,49 @@ impl WorldStore {
         let mut rows = stmt.query([])?;
         let mut prev = GENESIS.to_string();
 
+        // Compaction citations, keyed by the generation each span starts at.
+        // Loaded up front so a hole can be crossed the moment it is reached,
+        // rather than discovered as a missing row and reported as corruption.
+        let citations = self.load_citations()?;
+        let mut expected_generation: i64 = 1;
+
         while let Some(r) = rows.next()? {
             let generation: i64 = r.get(0)?;
+
+            // Cross any compacted spans standing between the last verified row
+            // and this one. Each must be cited, and each citation must join the
+            // chain where it claims to — that pairing is what makes a silent
+            // deletion impossible: remove rows and the gap is uncited; forge a
+            // citation and `chain_before` will not match what we computed.
+            while expected_generation < generation {
+                let c = citations.get(&expected_generation).ok_or({
+                    StoreError::UncitedGap {
+                        generation: expected_generation,
+                    }
+                })?;
+                if c.chain_before != prev {
+                    return Err(StoreError::CitationBroken {
+                        lo_generation: c.lo_generation,
+                        detail: format!(
+                            "chain_before does not match the digest at generation {}",
+                            expected_generation - 1
+                        ),
+                    });
+                }
+                prev = c.chain_after.clone();
+                expected_generation = c.hi_generation + 1;
+            }
+            if expected_generation != generation {
+                // A citation overshot into a surviving row: its span claims
+                // generations that are still present.
+                return Err(StoreError::CitationBroken {
+                    lo_generation: expected_generation,
+                    detail: format!(
+                        "a citation covers generation {generation}, which is still present"
+                    ),
+                });
+            }
+
             let event_id: String = r.get(1)?;
             let observation_id: String = r.get(2)?;
             let txn_time_ms: i64 = r.get(3)?;
@@ -548,6 +658,22 @@ impl WorldStore {
                 return Err(StoreError::ChainBroken { generation });
             }
             prev = stored;
+            expected_generation = generation + 1;
+        }
+
+        // A span compacted off the END of the log leaves no following row to
+        // trigger the crossing above, so it is checked here. Without this a
+        // trailing citation would go unverified — the one place a forged
+        // citation could otherwise hide.
+        while let Some(c) = citations.get(&expected_generation) {
+            if c.chain_before != prev {
+                return Err(StoreError::CitationBroken {
+                    lo_generation: c.lo_generation,
+                    detail: "trailing citation does not join the chain".to_string(),
+                });
+            }
+            prev = c.chain_after.clone();
+            expected_generation = c.hi_generation + 1;
         }
         Ok(())
     }
@@ -569,6 +695,97 @@ impl WorldStore {
                 |r| r.get(0),
             )
             .optional()?)
+    }
+
+    /// Every citation, keyed by the generation its span starts at.
+    fn load_citations(&self) -> Result<std::collections::BTreeMap<i64, Citation>, StoreError> {
+        if !self.has_citations()? {
+            return Ok(std::collections::BTreeMap::new());
+        }
+        let mut stmt = self.conn.prepare(
+            "SELECT lo_generation, hi_generation, event_count, range_digest,
+                    chain_before, chain_after, compacted_at_ms
+             FROM compaction_citations ORDER BY lo_generation ASC",
+        )?;
+        let rows = stmt.query_map([], |r| {
+            Ok(Citation {
+                lo_generation: r.get(0)?,
+                hi_generation: r.get(1)?,
+                event_count: r.get(2)?,
+                range_digest: r.get(3)?,
+                chain_before: r.get(4)?,
+                chain_after: r.get(5)?,
+                compacted_at_ms: r.get(6)?,
+            })
+        })?;
+        let mut out = std::collections::BTreeMap::new();
+        for c in rows {
+            let c = c?;
+            out.insert(c.lo_generation, c);
+        }
+        Ok(out)
+    }
+
+    /// Whether any compaction has run against this store.
+    pub fn has_citations(&self) -> Result<bool, StoreError> {
+        let n: Option<i64> = self
+            .conn
+            .query_row(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='compaction_citations'",
+                [],
+                |r| r.get(0),
+            )
+            .optional()?;
+        Ok(n.is_some())
+    }
+
+    /// Every recorded compaction, oldest span first.
+    pub fn citations(&self) -> Result<Vec<Citation>, StoreError> {
+        Ok(self.load_citations()?.into_values().collect())
+    }
+
+    /// Test-only: remove a citation, leaving its gap unexplained.
+    ///
+    /// This is how a test proves the chain refuses an **uncited** gap — the
+    /// property that stops compaction being a licence to delete evidence. A
+    /// test that only compacted correctly could never show it.
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn delete_citation_for_test(&self, lo_generation: i64) -> Result<(), StoreError> {
+        self.conn.execute(
+            "DELETE FROM compaction_citations WHERE lo_generation = ?1",
+            params![lo_generation],
+        )?;
+        Ok(())
+    }
+
+    /// Test-only: rewrite one column of a citation, to forge one.
+    ///
+    /// Allowlisted rather than interpolated, for the same reason
+    /// [`WorldStore::tamper_for_test`] is: the `test-support` feature makes
+    /// this public API.
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn tamper_citation_for_test(
+        &self,
+        lo_generation: i64,
+        column: &str,
+        value: &str,
+    ) -> Result<(), StoreError> {
+        const TAMPERABLE: &[&str] = &[
+            "chain_before",
+            "chain_after",
+            "range_digest",
+            "event_count",
+            "hi_generation",
+        ];
+        if !TAMPERABLE.contains(&column) {
+            return Err(StoreError::CitationBroken {
+                lo_generation,
+                detail: format!("`{column}` is not a tamperable column"),
+            });
+        }
+        let sql = format!("UPDATE compaction_citations SET {column} = ?1 WHERE lo_generation = ?2");
+        self.conn.execute(&sql, params![value, lo_generation])?;
+        Ok(())
     }
 
     /// Test-only: rewrite one column of one row, bypassing the write path.
@@ -941,6 +1158,220 @@ impl WorldStore {
         ))?;
         let rows = stmt.query_map(params![subject], claim_from_row)?;
         Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+    }
+
+    /// Compact `lo..=hi` out of the log, leaving a citation in its place.
+    ///
+    /// Refuses, whole, if the window contains:
+    ///
+    /// * a **protected-class** event (§11.3, OQ2's 365-day classes), or
+    /// * an event that is a **projection head** — removing it would make
+    ///   [`WorldStore::rebuild_projections`] stop reproducing the incremental
+    ///   fold, quietly falsifying the property ADR-0041 names.
+    ///
+    /// Both refusals are all-or-nothing. Compacting "around" the offending
+    /// events would make how much of a span survives a question about arrival
+    /// order rather than about policy.
+    ///
+    /// This does **not** reclaim disk. Deleted pages return to SQLite's free
+    /// list; D-3 measured what an actual `VACUUM` costs (a ~1× free-space
+    /// reserve and a total write blackout), so it is the caller's decision and
+    /// not a side effect of retention.
+    pub fn compact_range(
+        &mut self,
+        lo: i64,
+        hi: i64,
+        now_ms: i64,
+    ) -> Result<CompactionOutcome, StoreError> {
+        if lo < 1 || hi < lo {
+            return Err(StoreError::EmptyRange { lo, hi });
+        }
+        self.conn.execute_batch(compaction::COMPACTION_V1)?;
+
+        // --- refusal 1: protected classes ---------------------------------
+        let protected: Option<(i64, String)> = self
+            .conn
+            .query_row(
+                "SELECT generation, retention_class FROM world_events
+                 WHERE generation BETWEEN ?1 AND ?2 AND retention_class <> 'raw'
+                 ORDER BY generation ASC LIMIT 1",
+                params![lo, hi],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .optional()?;
+        if let Some((generation, retention_class)) = protected {
+            return Err(StoreError::ProtectedClassInRange {
+                generation,
+                retention_class,
+            });
+        }
+
+        // --- refusal 2: projection heads ----------------------------------
+        if self.has_projections()? {
+            let head: Option<(i64, String)> = self
+                .conn
+                .query_row(
+                    "SELECT e.generation, e.subject FROM world_events e
+                     JOIN world_current c ON c.generation = e.generation
+                     WHERE e.generation BETWEEN ?1 AND ?2
+                     ORDER BY e.generation ASC LIMIT 1",
+                    params![lo, hi],
+                    |r| Ok((r.get(0)?, r.get(1)?)),
+                )
+                .optional()?;
+            if let Some((generation, subject)) = head {
+                return Err(StoreError::ProjectionHeadInRange {
+                    generation,
+                    subject,
+                });
+            }
+        }
+
+        // --- the span itself ----------------------------------------------
+        let (event_count, range_digest, chain_after) = self.summarize_range(lo, hi)?;
+        if event_count == 0 {
+            return Err(StoreError::EmptyRange { lo, hi });
+        }
+
+        // `chain_before` is the digest the verifier will have computed when it
+        // arrives at the hole: the last surviving row below `lo`, or GENESIS.
+        // Taking the row below `lo` rather than `lo - 1` is deliberate — an
+        // earlier compaction may already have removed `lo - 1`.
+        let surviving_below: Option<String> = self
+            .conn
+            .query_row(
+                "SELECT chain_digest FROM world_events
+                 WHERE generation < ?1 ORDER BY generation DESC LIMIT 1",
+                params![lo],
+                |r| r.get(0),
+            )
+            .optional()?;
+        let chain_before: String = match surviving_below {
+            Some(d) => d,
+            None => {
+                // Nothing survives below the hole. If an earlier compaction
+                // already covers that region, its `chain_after` is where the
+                // chain stands; otherwise we are at the head of the log.
+                //
+                // Note the `?`: a failure to read the citations must surface,
+                // not silently fall through to GENESIS and mint a citation
+                // that claims the chain starts here.
+                self.load_citations()?
+                    .values()
+                    .rfind(|c| c.hi_generation < lo)
+                    .map_or_else(|| GENESIS.to_string(), |c| c.chain_after.clone())
+            }
+        };
+
+        let tx = self.conn.transaction()?;
+        tx.execute(
+            "DELETE FROM world_events WHERE generation BETWEEN ?1 AND ?2",
+            params![lo, hi],
+        )?;
+        tx.execute(
+            "INSERT INTO compaction_citations (
+                lo_generation, hi_generation, event_count, range_digest,
+                chain_before, chain_after, compacted_at_ms
+             ) VALUES (?1,?2,?3,?4,?5,?6,?7)",
+            params![
+                lo,
+                hi,
+                event_count,
+                range_digest,
+                chain_before,
+                chain_after,
+                now_ms
+            ],
+        )?;
+        tx.commit()?;
+
+        Ok(CompactionOutcome {
+            citation: Citation {
+                lo_generation: lo,
+                hi_generation: hi,
+                event_count,
+                range_digest,
+                chain_before,
+                chain_after,
+                compacted_at_ms: now_ms,
+            },
+            removed: event_count,
+        })
+    }
+
+    /// Count, content digest and final chain digest of a span, before removal.
+    ///
+    /// `range_digest` is taken over the canonical bytes of each event in
+    /// generation order — the same bytes the chain covers. That is what keeps
+    /// removed content *attestable*: it cannot be recovered, but anyone who
+    /// later produces those events can be checked against this.
+    fn summarize_range(&self, lo: i64, hi: i64) -> Result<(i64, String, String), StoreError> {
+        let mut stmt = self.conn.prepare(
+            "SELECT generation, event_id, observation_id, txn_time_ms, valid_from_ms,
+                    valid_to_ms, source, source_version, writer_class, claim_status,
+                    provenance, frame_id, map_id, kind, subject, predicate, object,
+                    payload, payload_schema, retention_class, chain_digest
+             FROM world_events WHERE generation BETWEEN ?1 AND ?2
+             ORDER BY generation ASC",
+        )?;
+        let mut rows = stmt.query(params![lo, hi])?;
+        let mut acc = String::new();
+        let mut count = 0i64;
+        let mut last_chain = String::new();
+
+        while let Some(r) = rows.next()? {
+            let generation: i64 = r.get(0)?;
+            let event_id: String = r.get(1)?;
+            let observation_id: String = r.get(2)?;
+            let txn_time_ms: i64 = r.get(3)?;
+            let source: String = r.get(6)?;
+            let source_version: String = r.get(7)?;
+            let writer_class: String = r.get(8)?;
+            let claim_status: String = r.get(9)?;
+            let provenance_raw: String = r.get(10)?;
+            let frame_id: Option<String> = r.get(11)?;
+            let map_id: Option<String> = r.get(12)?;
+            let kind: String = r.get(13)?;
+            let subject: String = r.get(14)?;
+            let predicate: Option<String> = r.get(15)?;
+            let object: Option<String> = r.get(16)?;
+            let payload: String = r.get(17)?;
+            let retention_class: String = r.get(19)?;
+            last_chain = r.get(20)?;
+
+            let provenance: Vec<String> =
+                serde_json::from_str(&provenance_raw).map_err(|err| StoreError::CorruptRow {
+                    generation,
+                    detail: format!("provenance is not a JSON array of strings: {err}"),
+                })?;
+            let prov_refs: Vec<&str> = provenance.iter().map(String::as_str).collect();
+
+            let rebuilt = NewEvent {
+                event_id: &event_id,
+                observation_id: &observation_id,
+                txn_time_ms,
+                valid_from_ms: r.get(4)?,
+                valid_to_ms: r.get(5)?,
+                source: &source,
+                source_version: &source_version,
+                writer_class: WriterClass::from_stored(&writer_class),
+                claim_status: ClaimStatus::from_stored(&claim_status),
+                provenance: &prov_refs,
+                frame_id: frame_id.as_deref(),
+                map_id: map_id.as_deref(),
+                kind: &kind,
+                subject: &subject,
+                predicate: predicate.as_deref(),
+                object: object.as_deref(),
+                payload: &payload,
+                payload_schema: r.get(18)?,
+                retention_class: &retention_class,
+            };
+            acc.push_str(&canonical_event_json(&rebuilt));
+            acc.push('\n');
+            count += 1;
+        }
+        Ok((count, sha256_hex(acc.as_bytes()), last_chain))
     }
 
     /// Subjects whose state changed after transaction time `since_ms`.

--- a/crates/kirra-world-store/tests/retention.rs
+++ b/crates/kirra-world-store/tests/retention.rs
@@ -292,6 +292,66 @@ fn compaction_preserves_rebuild_equals_incremental() {
     clean(&p);
 }
 
+/// **Every citation must be walked.** The crossing loops only follow citations
+/// reachable by contiguity from generation 1, so one sitting at an unreachable
+/// `lo_generation` would be ignored and verification would still return `Ok`.
+///
+/// That is a hole in the property this whole design provides: a citation is an
+/// *admission* that a span was removed, and an admission no verifier ever
+/// reads is not one.
+#[test]
+fn an_unreachable_citation_is_refused() {
+    let p = tmp("orphan-citation");
+    let mut s = seeded(&p);
+    s.compact_range(1, 4, T0 + 9_000)
+        .expect("a real compaction");
+    s.verify_chain().expect("clean");
+
+    // Move the citation's span far past the end of the log. Nothing walks it,
+    // and before the fix nothing complained either.
+    s.tamper_citation_for_test(1, "hi_generation", "4").unwrap();
+    s.forge_citation_for_test(500, 600, T0 + 9_100).unwrap();
+
+    match s.verify_chain() {
+        Err(StoreError::CitationBroken { lo_generation, .. }) => assert_eq!(lo_generation, 500),
+        other => panic!("an unreachable citation must be refused, got {other:?}"),
+    }
+    clean(&p);
+}
+
+/// The digest must be **byte-identical** to the buffered form it replaced.
+/// Streaming is a memory fix, not a format change: if it altered the digest,
+/// every citation already written would silently stop matching its content.
+#[test]
+fn the_range_digest_is_stable_across_window_sizes() {
+    // Compact 1..=2 in one store, and the same two events in another whose
+    // window is expressed differently but covers the same rows. Same content,
+    // same digest — which is the property a streaming hash must preserve.
+    let p = tmp("digest-stable-a");
+    let mut a = seeded(&p);
+    let ra = a.compact_range(1, 2, T0 + 9_000).expect("a");
+
+    let p2 = tmp("digest-stable-b");
+    let mut b = seeded(&p2);
+    let rb = b.compact_range(1, 2, T0 + 9_999).expect("b");
+
+    assert_eq!(
+        ra.citation.range_digest, rb.citation.range_digest,
+        "the digest must depend on content only, not on when or how it was taken"
+    );
+
+    // And a one-event window must differ from a two-event one, so the test is
+    // not passing on a constant.
+    let p3 = tmp("digest-stable-c");
+    let mut c = seeded(&p3);
+    let rc = c.compact_range(1, 1, T0 + 9_000).expect("c");
+    assert_ne!(ra.citation.range_digest, rc.citation.range_digest);
+
+    clean(&p);
+    clean(&p2);
+    clean(&p3);
+}
+
 // ---------------------------------------------------------------------------
 // A refusal is a redirect, not a dead end
 // ---------------------------------------------------------------------------

--- a/crates/kirra-world-store/tests/retention.rs
+++ b/crates/kirra-world-store/tests/retention.rs
@@ -1,0 +1,383 @@
+//! Retention enforcement: compaction-with-citation (ADR-0041 §11.3).
+//!
+//! The happy path is the least interesting thing here. What these tests are
+//! for is the set of properties that make deleting from a hash-chained log
+//! defensible at all:
+//!
+//! * a gap with **no** citation breaks the chain — you cannot delete quietly;
+//! * a **forged** citation breaks the chain — you cannot fake the admission;
+//! * a protected-class window is refused **whole**;
+//! * a projection head is refused, so a rebuild still reproduces the fold;
+//! * removed content stays **attestable** through `range_digest`.
+
+use kirra_world_store::{ClaimStatus, NewEvent, StoreError, WorldStore, WriterClass};
+
+fn tmp(name: &str) -> std::path::PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "kirra-world-retention-{}-{}.sqlite",
+        name,
+        std::process::id()
+    ));
+    clean(&p);
+    p
+}
+
+fn clean(p: &std::path::Path) {
+    for s in ["", "-wal", "-shm"] {
+        let mut q = p.as_os_str().to_os_string();
+        q.push(s);
+        let _ = std::fs::remove_file(std::path::PathBuf::from(q));
+    }
+}
+
+const T0: i64 = 1_700_000_000_000;
+
+fn ev<'a>(event_id: &'a str, subject: &'a str, valid_from_ms: i64) -> NewEvent<'a> {
+    NewEvent {
+        event_id,
+        observation_id: event_id,
+        txn_time_ms: valid_from_ms,
+        valid_from_ms,
+        valid_to_ms: None,
+        source: "sensor-a",
+        source_version: "0.1.0",
+        writer_class: WriterClass::Sensor,
+        claim_status: ClaimStatus::Confirmed,
+        provenance: &[],
+        frame_id: None,
+        map_id: None,
+        kind: "observation",
+        subject,
+        predicate: Some("position"),
+        object: None,
+        payload: r#"{"n":1}"#,
+        payload_schema: 1,
+        retention_class: "raw",
+    }
+}
+
+/// 12 raw events across 3 subjects, so heads sit at the END of the log and
+/// generations 1..=6 are safely compactable.
+fn seeded(path: &std::path::Path) -> WorldStore {
+    let mut s = WorldStore::open(path).expect("open");
+    for i in 1..=12i64 {
+        let eid = format!("e{i}");
+        let subj = format!("cup-{}", (i - 1) % 3);
+        s.append(&ev(&eid, &subj, T0 + i * 100)).expect("append");
+    }
+    s
+}
+
+// ---------------------------------------------------------------------------
+// The chain must survive the hole — and only honestly
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_chain_verifies_across_a_compacted_span() {
+    let p = tmp("verifies-across");
+    let mut s = seeded(&p);
+    s.verify_chain().expect("clean before");
+
+    let out = s.compact_range(1, 6, T0 + 9_000).expect("compact");
+    assert_eq!(out.removed, 6);
+    assert_eq!(s.count().unwrap(), 6, "six events removed");
+
+    s.verify_chain()
+        .expect("the chain must verify ACROSS the hole, not merely up to it");
+
+    let cs = s.citations().unwrap();
+    assert_eq!(cs.len(), 1);
+    assert_eq!((cs[0].lo_generation, cs[0].hi_generation), (1, 6));
+    assert_eq!(cs[0].event_count, 6);
+    assert!(!cs[0].range_digest.is_empty());
+    clean(&p);
+}
+
+/// **The property that makes compaction an admission rather than an erasure.**
+/// Delete rows without leaving a citation and the chain must refuse — otherwise
+/// "compaction" is just a licence to remove evidence.
+#[test]
+fn an_uncited_gap_breaks_the_chain() {
+    let p = tmp("uncited-gap");
+    let mut s = seeded(&p);
+    s.compact_range(1, 6, T0 + 9_000).expect("compact");
+    s.verify_chain().expect("cited gap verifies");
+
+    // Now remove the citation, leaving the hole unexplained.
+    s.delete_citation_for_test(1).unwrap();
+    match s.verify_chain() {
+        Err(StoreError::UncitedGap { generation }) => assert_eq!(generation, 1),
+        other => panic!("an uncited gap must break the chain, got {other:?}"),
+    }
+    clean(&p);
+}
+
+/// A citation that does not join the chain it claims to bridge must be
+/// refused. Without this, forging one would launder an arbitrary deletion.
+#[test]
+fn a_forged_citation_breaks_the_chain() {
+    let p = tmp("forged-citation");
+    let mut s = seeded(&p);
+    s.compact_range(1, 6, T0 + 9_000).expect("compact");
+    s.verify_chain().expect("clean");
+
+    s.tamper_citation_for_test(1, "chain_before", "deadbeef")
+        .unwrap();
+    match s.verify_chain() {
+        Err(StoreError::CitationBroken { lo_generation, .. }) => assert_eq!(lo_generation, 1),
+        other => panic!("a citation that does not join the chain must fail, got {other:?}"),
+    }
+    clean(&p);
+}
+
+/// The other half: a citation resuming at the wrong digest must also fail —
+/// caught by the next surviving row failing to recompute.
+#[test]
+fn a_citation_resuming_at_the_wrong_digest_breaks_the_chain() {
+    let p = tmp("wrong-resume");
+    let mut s = seeded(&p);
+    s.compact_range(1, 6, T0 + 9_000).expect("compact");
+
+    s.tamper_citation_for_test(1, "chain_after", "cafebabe")
+        .unwrap();
+    match s.verify_chain() {
+        Err(StoreError::ChainBroken { generation }) => assert_eq!(
+            generation, 7,
+            "the first surviving row after the hole must fail"
+        ),
+        other => panic!("expected a chain break at generation 7, got {other:?}"),
+    }
+    clean(&p);
+}
+
+/// A span compacted off the END of the log has no following row to trigger the
+/// crossing, so it is verified separately. Without that, a trailing citation
+/// would be the one place a forgery could hide.
+#[test]
+fn a_trailing_citation_is_still_verified() {
+    // Unfolded deliberately: with no projection there are no heads, so the
+    // tail is compactable and this exercises the trailing path rather than
+    // the head refusal.
+    let p = tmp("trailing");
+    let mut s = seeded(&p);
+    s.compact_range(7, 12, T0 + 9_000)
+        .expect("compact the tail");
+    assert_eq!(s.count().unwrap(), 6);
+    s.verify_chain().expect("a trailing citation must verify");
+
+    // Nothing follows it, so only the trailing pass can catch this.
+    s.tamper_citation_for_test(7, "chain_before", "0000")
+        .unwrap();
+    match s.verify_chain() {
+        Err(StoreError::CitationBroken { lo_generation, .. }) => assert_eq!(lo_generation, 7),
+        other => panic!("a forged trailing citation must be caught, got {other:?}"),
+    }
+    clean(&p);
+}
+
+// ---------------------------------------------------------------------------
+// The two refusals
+// ---------------------------------------------------------------------------
+
+/// §11.3 and OQ2: a window containing protected traffic is refused **whole**,
+/// not compacted around. Partial application would make "how much of this span
+/// survives" a question about arrival order rather than about policy.
+#[test]
+fn a_window_containing_protected_traffic_is_refused_whole() {
+    let p = tmp("protected-refused");
+    let mut s = WorldStore::open(&p).expect("open");
+    for i in 1..=6i64 {
+        let eid = format!("e{i}");
+        let subj = format!("cup-{i}");
+        s.append(&NewEvent {
+            retention_class: if i == 4 { "safety" } else { "raw" },
+            ..ev(&eid, &subj, T0 + i * 100)
+        })
+        .expect("append");
+    }
+
+    match s.compact_range(1, 5, T0 + 9_000) {
+        Err(StoreError::ProtectedClassInRange {
+            generation,
+            retention_class,
+        }) => {
+            assert_eq!(generation, 4);
+            assert_eq!(retention_class, "safety");
+        }
+        other => panic!("a protected event must refuse the window, got {other:?}"),
+    }
+
+    assert_eq!(s.count().unwrap(), 6, "nothing may be removed");
+    assert!(
+        s.citations().unwrap().is_empty(),
+        "a refused compaction leaves no citation"
+    );
+    s.verify_chain().expect("untouched");
+    clean(&p);
+}
+
+/// Every protected class, not just the one the first test happened to pick.
+#[test]
+fn every_protected_class_refuses() {
+    for class in [
+        "safety",
+        "incident",
+        "calibration",
+        "adjudication",
+        "operator",
+    ] {
+        let p = tmp(&format!("protected-{class}"));
+        let mut s = WorldStore::open(&p).expect("open");
+        s.append(&ev("e1", "cup-1", T0)).expect("raw");
+        s.append(&NewEvent {
+            retention_class: class,
+            ..ev("e2", "cup-2", T0 + 100)
+        })
+        .expect("protected");
+
+        assert!(
+            matches!(
+                s.compact_range(1, 2, T0 + 9_000),
+                Err(StoreError::ProtectedClassInRange { .. })
+            ),
+            "{class} must refuse compaction"
+        );
+        clean(&p);
+    }
+}
+
+/// **The refusal §11.3 could not have anticipated.** Removing the event that
+/// defines a projection's current claim would make `rebuild_projections`
+/// diverge from the incremental fold — falsifying the property ADR-0041 names,
+/// silently.
+#[test]
+fn a_projection_head_is_refused() {
+    let p = tmp("head-refused");
+    let mut s = seeded(&p);
+    s.fold().expect("fold");
+
+    // Generations 10, 11, 12 are the heads for cup-0/1/2.
+    match s.compact_range(7, 12, T0 + 9_000) {
+        Err(StoreError::ProjectionHeadInRange { generation, .. }) => {
+            assert_eq!(generation, 10, "the first head in the window");
+        }
+        other => panic!("a projection head must refuse the window, got {other:?}"),
+    }
+    assert_eq!(s.count().unwrap(), 12, "nothing removed");
+    clean(&p);
+}
+
+/// And the payoff: compacting only non-head events leaves a rebuild producing
+/// exactly the state the incremental fold reached. This is the invariant the
+/// head refusal exists to preserve, asserted rather than argued.
+#[test]
+fn compaction_preserves_rebuild_equals_incremental() {
+    let p = tmp("rebuild-after-compaction");
+    let mut s = seeded(&p);
+    s.fold().expect("fold");
+    let before = s.projection_state_digest().unwrap();
+
+    s.compact_range(1, 6, T0 + 9_000)
+        .expect("compact non-heads");
+    s.verify_chain().expect("chain intact");
+
+    s.rebuild_projections().expect("rebuild from zero");
+    let after = s.projection_state_digest().unwrap();
+
+    assert_eq!(
+        before, after,
+        "a rebuild after compaction must reproduce the pre-compaction state"
+    );
+    clean(&p);
+}
+
+// ---------------------------------------------------------------------------
+// Attestability and bounds
+// ---------------------------------------------------------------------------
+
+/// Removed content is gone but not unaccountable: the citation records how
+/// many events went and a digest over their exact canonical bytes.
+#[test]
+fn the_removed_span_stays_attestable() {
+    let p = tmp("attestable");
+    let mut s = seeded(&p);
+
+    // Digest the same span twice from two identical stores: the range digest
+    // is a function of content, so it must agree.
+    let p2 = tmp("attestable-2");
+    let mut s2 = seeded(&p2);
+
+    let a = s.compact_range(1, 6, T0 + 9_000).expect("compact");
+    let b = s2.compact_range(1, 6, T0 + 9_000).expect("compact");
+    assert_eq!(
+        a.citation.range_digest, b.citation.range_digest,
+        "the same content must digest the same"
+    );
+
+    // A different span must not.
+    let p3 = tmp("attestable-3");
+    let mut s3 = seeded(&p3);
+    let c = s3.compact_range(1, 5, T0 + 9_000).expect("compact");
+    assert_ne!(a.citation.range_digest, c.citation.range_digest);
+
+    clean(&p);
+    clean(&p2);
+    clean(&p3);
+}
+
+#[test]
+fn an_empty_or_inverted_range_is_refused() {
+    let p = tmp("empty-range");
+    let mut s = seeded(&p);
+    assert!(matches!(
+        s.compact_range(6, 3, T0),
+        Err(StoreError::EmptyRange { .. })
+    ));
+    assert!(matches!(
+        s.compact_range(0, 3, T0),
+        Err(StoreError::EmptyRange { .. })
+    ));
+    assert!(
+        matches!(
+            s.compact_range(90, 99, T0),
+            Err(StoreError::EmptyRange { .. })
+        ),
+        "a range matching no rows is empty, not a silent no-op citation"
+    );
+    assert!(s.citations().unwrap().is_empty());
+    clean(&p);
+}
+
+/// Two compactions in sequence: the second must chain from where the first
+/// left off, not from a row that no longer exists.
+#[test]
+fn successive_compactions_chain_correctly() {
+    let p = tmp("successive");
+    let mut s = seeded(&p);
+    s.compact_range(1, 4, T0 + 9_000).expect("first");
+    s.verify_chain().expect("after first");
+    s.compact_range(5, 8, T0 + 9_100).expect("second");
+    s.verify_chain()
+        .expect("the second citation must join where the first left off");
+
+    assert_eq!(s.count().unwrap(), 4);
+    assert_eq!(s.citations().unwrap().len(), 2);
+    clean(&p);
+}
+
+/// Compaction must not disturb what survives.
+#[test]
+fn surviving_events_are_unchanged() {
+    let p = tmp("survivors");
+    let mut s = seeded(&p);
+    let before = s.history("cup-0").unwrap();
+
+    s.compact_range(1, 6, T0 + 9_000).expect("compact");
+    let after = s.history("cup-0").unwrap();
+
+    let surviving: Vec<_> = before.into_iter().filter(|c| c.generation > 6).collect();
+    assert_eq!(surviving, after, "survivors must be byte-identical");
+    assert!(!after.is_empty(), "the test would be vacuous otherwise");
+    clean(&p);
+}

--- a/crates/kirra-world-store/tests/retention.rs
+++ b/crates/kirra-world-store/tests/retention.rs
@@ -293,6 +293,97 @@ fn compaction_preserves_rebuild_equals_incremental() {
 }
 
 // ---------------------------------------------------------------------------
+// A refusal is a redirect, not a dead end
+// ---------------------------------------------------------------------------
+
+/// `largest_compactable_prefix` must return a range `compact_range` actually
+/// accepts — otherwise it is advice that does not work.
+#[test]
+fn the_prefix_helper_returns_a_range_compaction_accepts() {
+    let p = tmp("prefix-accepts");
+    let mut s = seeded(&p);
+    s.fold().expect("fold");
+
+    // Heads are 10, 11, 12, so the largest compactable prefix of 1..=12 is 9.
+    let limit = s.largest_compactable_prefix(1, 12).unwrap();
+    assert_eq!(limit, Some(9));
+
+    s.compact_range(1, limit.unwrap(), T0 + 9_000)
+        .expect("the helper's answer must be accepted");
+    s.verify_chain().expect("chain intact");
+    clean(&p);
+}
+
+/// The asymmetry between the two refusals, asserted rather than only argued.
+///
+/// A protected event makes the window a *policy* unit, so the helper stops
+/// below it. A projection head only requires the head itself to survive, so
+/// stopping below it is a conservative simplification — recorded as such,
+/// with compacting-around pre-authorized if measurement demands it.
+#[test]
+fn the_prefix_helper_stops_below_the_first_blocker_of_either_kind() {
+    // Protected at 4 → prefix is 3.
+    let p = tmp("prefix-protected");
+    let mut s = WorldStore::open(&p).expect("open");
+    for i in 1..=6i64 {
+        let eid = format!("e{i}");
+        let subj = format!("cup-{i}");
+        s.append(&NewEvent {
+            retention_class: if i == 4 { "incident" } else { "raw" },
+            ..ev(&eid, &subj, T0 + i * 100)
+        })
+        .expect("append");
+    }
+    assert_eq!(s.largest_compactable_prefix(1, 6).unwrap(), Some(3));
+    s.compact_range(1, 3, T0 + 9_000).expect("accepted");
+    clean(&p);
+
+    // Head at 10 → prefix is 9, same shape, different reason.
+    let p2 = tmp("prefix-head");
+    let mut s2 = seeded(&p2);
+    s2.fold().expect("fold");
+    assert_eq!(s2.largest_compactable_prefix(7, 12).unwrap(), Some(9));
+    clean(&p2);
+}
+
+/// A window blocked at its very first generation has no compactable prefix at
+/// all, and must say so rather than returning an empty range compaction would
+/// then refuse.
+#[test]
+fn a_window_blocked_at_its_first_generation_has_no_prefix() {
+    let p = tmp("prefix-none");
+    let mut s = WorldStore::open(&p).expect("open");
+    s.append(&NewEvent {
+        retention_class: "safety",
+        ..ev("e1", "cup-1", T0)
+    })
+    .expect("protected first");
+    s.append(&ev("e2", "cup-2", T0 + 100)).expect("raw");
+
+    assert_eq!(s.largest_compactable_prefix(1, 2).unwrap(), None);
+    assert_eq!(
+        s.largest_compactable_prefix(90, 99).unwrap(),
+        None,
+        "a range matching no rows has no prefix either"
+    );
+    assert_eq!(s.largest_compactable_prefix(6, 3).unwrap(), None);
+    clean(&p);
+}
+
+/// An unfolded store has no heads, so only the policy refusal applies.
+#[test]
+fn without_a_projection_only_the_policy_refusal_bounds_the_prefix() {
+    let p = tmp("prefix-unfolded");
+    let s = seeded(&p);
+    assert_eq!(
+        s.largest_compactable_prefix(1, 12).unwrap(),
+        Some(12),
+        "no projection means no heads, so the whole raw window is compactable"
+    );
+    clean(&p);
+}
+
+// ---------------------------------------------------------------------------
 // Attestability and bounds
 // ---------------------------------------------------------------------------
 

--- a/docs/adr/0041-world-model-persistence-architecture.md
+++ b/docs/adr/0041-world-model-persistence-architecture.md
@@ -174,6 +174,42 @@ knowingly bounded. Ratifying **compaction-with-citation**:
 **Thresholds are deferred until measured.** Choosing them now would be a guess
 presented as a policy.
 
+#### A third refusal, added 2026-08-05 when the read path landed
+
+`crates/kirra-world-store` now implements this section. Doing so surfaced a
+constraint §11.3 could not have stated, because it predates the store having
+projections: **an event that is a projection head is not compactable.**
+
+Removing the event that defines a `(subject, predicate)`'s current claim makes
+`rebuild_projections` stop reproducing the incremental fold — falsifying, and
+silently, the pure-fold property this ADR names elsewhere as a thing to test
+rather than assume. Refusing heads resolves it *provably*: the fold retains only
+heads, so a compaction that removes none cannot change what a rebuild produces.
+
+**The two refusals are not the same kind of rule, and the difference is
+load-bearing:**
+
+| Refusal | Kind | Whole-window refusal is… |
+|---|---|---|
+| protected class | **policy** — the window is a retention unit | a **requirement**; compacting around it would make how much of a span survives a question about interleaving |
+| projection head | **correctness** — only the head must survive | a **conservative simplification**; nothing says a head's neighbours must survive |
+
+**Pre-agreed escalation.** Because the head refusal is a simplification rather
+than a requirement, its relaxation is authorized *now* rather than argued later:
+**if measurement shows head refusals blocking a material fraction of reclaimable
+space, compact _around_ heads instead.** The citation model already supports
+disjoint spans, so that is a loop over sub-ranges, not a redesign.
+
+Until then, `WorldStore::largest_compactable_prefix` makes a refusal a redirect
+rather than a dead end — both refusals name their first blocking generation, and
+a caller can retry immediately on the sub-range below it.
+
+The concern is also smaller than it first appears, because **heads age out**. An
+event stops being a head as soon as something supersedes it, so for a span old
+enough to be past its retention horizon to still hold one means nothing has been
+observed about that subject since — rare in a sensor stream, and when it does
+happen that claim is arguably still-live evidence rather than history.
+
 ### Compaction is not reclamation — two operations, not one
 
 **Measured** (`tools/wm2-persistence-harness`, `compact`; host-indicative,


### PR DESCRIPTION
OQ2 ruled retention *durations* (#1352) and D-21 measured the budget they fit in (#1353). **Nothing enforced them.** The classes were stored and constrained, the horizons were ruled, and the store filled in 15.79 days regardless. This is the mechanism that turns the policy into behaviour.

Mechanism only — see *Deliberately not done* for what this is not.

> Kirra is designed in alignment with ISO 26262 ASIL-D requirements and IEC 61508 SIL 3 requirements. Independent third-party assessment has not yet been performed.

---

## Deleting from an append-only hash chain

Removing a span breaks recomputation at the hole. §11.3's answer is that compaction leaves a **citation**: what went, how much, a digest over the removed events' canonical bytes, and the chain digests either side. `verify_chain` now crosses holes via citations, so the log verifies **across** the gap rather than merely up to it.

Three things follow, and the third is the point:

1. A verifier crossing a hole resumes from `chain_after`.
2. Removed content stays **attestable** via `range_digest` — unrecoverable, but anyone later producing those events can be checked against it.
3. **Rows cannot be deleted quietly.** A gap with no citation is a chain error; a citation whose `chain_before` doesn't match what the verifier computed is a chain error; one resuming at the wrong digest is caught by the next surviving row failing to recompute. Compaction is an *admission recorded in the structure it modifies*, not an erasure.

## Two refusals — and they are not the same kind of rule

| Refusal | Kind | Whole-window refusal is… |
|---|---|---|
| **protected class** (`safety`/`incident`/`calibration`/`adjudication`/`operator`) | **policy** — the window is a retention unit | a **requirement**. Compacting around it makes "how much of this span survives" a question about interleaving rather than about policy |
| **projection head** | **correctness** — only the head must survive | a **conservative simplification**. Nothing says a head's neighbours must survive |

I initially gave both the same shape without arguing for it. The table above is the correction, and it drives the two follow-ups below.

Unknown retention classes count as **protected**: the schema constrains the column, so an unknown value means the schema moved or the row is corrupt — and deletion is the irreversible way to be wrong.

### The head refusal is new, and §11.3 could not have stated it

That design predates the store having a read path. Removing the event that defines a `(subject, predicate)`'s current claim makes `rebuild_projections` stop reproducing the incremental fold — falsifying, *silently*, the pure-fold property #1353 just established.

Refusing heads resolves it **provably**: the fold retains only heads, so a compaction that removes none cannot change what a rebuild produces. Asserted directly in `compaction_preserves_rebuild_equals_incremental`, not argued.

### A refusal is a redirect, not a dead end

`largest_compactable_prefix(lo, hi)` returns the largest range `compact_range` will accept. Both refusals already named their first blocking generation so a caller *could* retry below it — but that was an accident of the error type. Now it's designed, it honours the asymmetry by stopping below **either** blocker, and it returns only ranges compaction actually accepts (including refusing a prefix containing no rows, which would otherwise be handed back and then rejected as empty).

### The escalation is pre-agreed, not deferred

Because the head refusal is a simplification rather than a requirement, ADR-0041 §11.3 now records its relaxation **in advance**: if measurement shows head refusals blocking a material fraction of reclaimable space, **compact _around_ heads**. The citation model already supports disjoint spans, so that's a loop over sub-ranges, not a redesign. Recording the trigger now costs nothing and stops it becoming an argument later.

The concern is also smaller than it first looks, because **heads age out**. An event stops being a head as soon as something supersedes it — so for a span old enough to be past its retention horizon to still hold one means nothing has been observed about that subject since. Rare in a sensor stream, and when it happens that claim is arguably still-live evidence rather than history.

## Tests — 17, and the happy path is the least interesting

| Injected fault | Fails |
|---|---|
| chain tolerates uncited gaps | `an_uncited_gap_breaks_the_chain` |
| drop the projection-head refusal | `a_projection_head_is_refused` |
| drop the protected-class refusal | `a_window_containing_protected_traffic_is_refused_whole`, `every_protected_class_refuses` |

Each negative control fires on exactly its own test and nothing else. Also covered: a forged `chain_before`, a forged `chain_after` (caught one row later), a **trailing** citation — a span compacted off the end has no following row to trigger the mid-log crossing, so it gets its own pass, and would otherwise be the one place a forgery could hide — successive compactions chaining correctly, survivors byte-identical, and `range_digest` agreeing across identical stores while differing across different spans.

## Two things I got wrong while writing it

- **`a_trailing_citation_is_still_verified` compacted a *leading* span.** Its name and comment claimed something the test did not do. It now compacts the tail on an unfolded store — the only way to reach the trailing-citation pass, since an unfolded store has no heads.
- **Clippy flagged a `map_or_else`, and looking properly showed a fail-open I had written.** `.ok()` swallowed a citation-read failure and fell back to `GENESIS` — which would mint a citation claiming the chain *starts* at the hole. Now propagates.

## Deliberately not done

- **No reclamation.** Deleting rows returns pages to SQLite's free list without shrinking the file. D-3 measured what `VACUUM` actually costs — a ~1× free-space reserve and a total write blackout — so a policy assuming continuous reclamation assumes a maintenance window that may never open. It stays the caller's decision, not a side effect of retention.
- **No policy driver.** This is the mechanism; the scheduler that decides *which* spans are past their horizon is separate, and needs the retention durations wired to a clock.
- **No summary record.** §11.3's compaction retains a *summary* citing the source range; this stores the citation and digest but writes no `DegradedSummary`. Compaction here therefore buys space, not summaries — OQ2 rule 2's "buys summaries, not observations" is not yet true in the implementation.
- **No time-travel-into-a-compacted-window behaviour.** §11.3 requires such a query return the summary *and say so*; `as_of` currently just returns less. That needs the summary record above.

## Verification

```
cargo test -p kirra-world-store         10 + 16 + 17 + 11 passed
cargo clippy -p kirra-world-store -D warnings    0 findings
cargo fmt --check · cargo check --workspace --locked   clean
Kirra World bidirectional fence: INTACT
Kirra World domain-logic gate:   38/38
website citation gate:           OK
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_