### PR TITLE
fix(wm2-harness): the write counter was process-wide, so every amplification figure was contaminated

### DIFF
--- a/tools/wm2-persistence-harness/src/rebuild_cost.rs
+++ b/tools/wm2-persistence-harness/src/rebuild_cost.rs
@@ -9,8 +9,11 @@
 //! # The attribution problem, and the control that solves it
 //!
 //! A rebuild runs *while ingest continues* — that is the whole premise — and
-//! both write through the same process. `/proc/self/io` therefore cannot say
+//! both write through the same process. A write counter therefore cannot say
 //! which bytes belong to the rebuild, and neither can the database file size.
+//! (The counter is thread-scoped — see [`thread_write_bytes`] — which excludes
+//! *other* threads but still cannot separate the rebuild from the ingest that
+//! is deliberately running beside it on the same one.)
 //!
 //! So this runs **two arms with identical ingest**:
 //!
@@ -48,17 +51,44 @@ use std::time::Instant;
 /// Generous: the point is to terminate rather than to grade the hardware.
 pub const MAX_CATCHUP_ROUNDS: usize = 64;
 
-/// Process-wide bytes actually written to storage, from `/proc/self/io`.
+/// Bytes actually written to storage by **this thread**, from
+/// `/proc/thread-self/io`.
 ///
 /// `write_bytes`, not `wchar`: wchar counts bytes handed to `write()`, which
 /// includes writes absorbed by the page cache and never sent anywhere. Write
 /// amplification is a question about the device.
 ///
+/// # Why thread-scoped, and not `/proc/self/io`
+///
+/// It used to read `/proc/self/io`, which is **process-wide** — and that is
+/// unsound under any multi-threaded caller, because a counter that cannot
+/// exclude other threads cannot attribute bytes to the work being measured.
+///
+/// The failure was not theoretical. `cargo test` runs tests concurrently as
+/// threads of ONE process, so a neighbouring test writing to disk landed
+/// inside this measurement's window. Measured, same test, same machine:
+///
+/// | Condition | coarse | fine | ratio |
+/// |---|---:|---:|---:|
+/// | test run alone | 1.0× | 5.1× | 5.24 |
+/// | full suite | **8.5×** | 5.1× | **0.60** |
+///
+/// The `fine` reading is untouched and `coarse` absorbs another test's writes,
+/// which inverts the comparison. It is intermittent because it depends on
+/// which tests happen to overlap — so it presents as flake and is in fact a
+/// measurement defect.
+///
+/// Thread-scoped fixes it at the source: every byte the arms write is written
+/// on the calling thread (nothing here spawns), so this counts the work and
+/// nothing else. It also makes the *instrument* honest for any future caller
+/// that measures from more than one thread.
+///
 /// `None` off Linux, or wherever the file is unreadable — a missing counter
 /// must not arrive as zero, which would render as a flatteringly efficient
-/// rebuild.
-pub fn process_write_bytes() -> Option<u64> {
-    let text = std::fs::read_to_string("/proc/self/io").ok()?;
+/// rebuild. Deliberately **no fallback** to `/proc/self/io`: falling back would
+/// silently restore the contaminated reading, which is worse than no reading.
+pub fn thread_write_bytes() -> Option<u64> {
+    let text = std::fs::read_to_string("/proc/thread-self/io").ok()?;
     for line in text.lines() {
         if let Some(v) = line.strip_prefix("write_bytes:") {
             return v.trim().parse().ok();
@@ -154,7 +184,7 @@ fn run_control(
     seed_n: u64,
 ) -> ArmResult {
     let mut store = seed(path, durability, seeded, entities, seed_n);
-    let before = process_write_bytes();
+    let before = thread_write_bytes();
     let mut peak = db_bytes(path);
     let t = Instant::now();
     let mut next = seeded;
@@ -168,7 +198,7 @@ fn run_control(
         peak = peak.max(db_bytes(path));
     }
     let wall_ms = t.elapsed().as_secs_f64() * 1e3;
-    let after = process_write_bytes();
+    let after = thread_write_bytes();
     ArmResult {
         wall_ms,
         write_bytes: match (before, after) {
@@ -204,7 +234,7 @@ pub fn run(
 
     let mut store = seed(path, durability, seeded, entities, seed_n);
 
-    let before = process_write_bytes();
+    let before = thread_write_bytes();
     let mut peak = db_bytes(path);
     let t = Instant::now();
 
@@ -357,7 +387,7 @@ pub fn run(
     }
 
     let wall_ms = t.elapsed().as_secs_f64() * 1e3;
-    let after = process_write_bytes();
+    let after = thread_write_bytes();
     let rebuild_arm = ArmResult {
         wall_ms,
         write_bytes: match (before, after) {
@@ -490,6 +520,56 @@ mod tests {
         }
     }
 
+    /// The counter must be **thread-scoped**, and this is the regression guard
+    /// for it — a property test rather than a comment, because the failure it
+    /// prevents does not look like a failure.
+    ///
+    /// With process-wide `/proc/self/io`, a neighbouring thread's writes land
+    /// in the measurement window, and the result is not an error but a *wrong
+    /// number*: `write_amplification` inflated by whatever else the process
+    /// happened to be doing. Under `cargo test` — which runs tests as threads
+    /// of one process — that made
+    /// `write_amplification_rises_with_chunk_count_…` fail intermittently, and
+    /// intermittently is the worst way for it to fail, because it teaches
+    /// people to re-run rather than to read.
+    ///
+    /// So: write a large, fsynced file **on another thread** and require this
+    /// thread's counter not to notice. The margin is deliberately loose
+    /// (an eighth) — the assertion is about *attribution*, not about how many
+    /// bytes reach the device, and a tight bound here would be its own flake.
+    #[test]
+    fn the_write_counter_excludes_another_threads_writes() {
+        use std::io::Write;
+
+        let Some(before) = thread_write_bytes() else {
+            eprintln!("no /proc/thread-self/io on this platform; attribution not asserted");
+            return;
+        };
+
+        const PAYLOAD: usize = 8 << 20; // 8 MiB — far above any plausible drift
+        let path = std::env::temp_dir().join(format!("wm2-attrib-{}.bin", std::process::id()));
+        let p2 = path.clone();
+        std::thread::spawn(move || {
+            let mut f = std::fs::File::create(&p2).expect("create");
+            f.write_all(&vec![0xA5u8; PAYLOAD]).expect("write");
+            f.sync_all().expect("fsync");
+        })
+        .join()
+        .expect("writer thread");
+
+        let after = thread_write_bytes().expect("counter still readable");
+        let delta = after.saturating_sub(before);
+        let _ = std::fs::remove_file(&path);
+
+        assert!(
+            delta < (PAYLOAD as u64) / 8,
+            "this thread's counter moved {delta} bytes while ANOTHER thread \
+             wrote {PAYLOAD} — the counter is not thread-scoped, so every \
+             write_amplification figure it produces is contaminated by \
+             whatever else the process is doing"
+        );
+    }
+
     #[test]
     fn write_amplification_rises_with_chunk_count_so_it_is_a_dial_not_a_constant() {
         // THE finding, pinned. Amplification is not a property of the rebuild;
@@ -525,7 +605,7 @@ mod tests {
                  coarser ({c:.1}x) — the trade-off this measurement exists to \
                  expose is not present"
             ),
-            // No /proc/self/io: the platform cannot answer, which is a
+            // No /proc/thread-self/io: the platform cannot answer, which is a
             // limitation to report rather than a test to fail.
             _ => eprintln!("write_bytes unavailable on this platform; amplification not asserted"),
         }

--- a/tools/wm2-persistence-harness/src/standin.rs
+++ b/tools/wm2-persistence-harness/src/standin.rs
@@ -1384,16 +1384,35 @@ mod tests {
         // doubles at a fixed log size; the grouped form should barely move.
         // Both ratios are measured in one process against the same machine, so
         // this asserts a relationship rather than a wall-clock budget.
+        // BEST-OF-3, and the statistic is `min` on purpose. Interference from
+        // other tests — `cargo test` runs them as threads of one process — can
+        // only ever make a timed section take LONGER, never shorter, so the
+        // minimum of repeated trials is the least-contaminated estimate
+        // available. Averaging would fold the interference in instead.
+        //
+        // This is not thresholds-are-too-tight: they stay exactly where they
+        // were (4x the entities, so >2.0 and <2.0 against predictions of ~4.0
+        // and ~1.0). It is the same class of defect as the one fixed in
+        // `rebuild_cost` — a measurement taken beside other work — except that
+        // wall-clock has no thread-scoped counter to switch to, so repetition
+        // is the only honest instrument. Measured: 2 failures in 8 full-suite
+        // runs before, 0 in 20 after.
+        const TRIALS: usize = 3;
         let time_it = |name: &str, step: &str, entities: u64| -> std::time::Duration {
-            let (mut s, path) = store(name);
-            s.append_batch(&gen::events(0, 8_000, entities, 5)).unwrap();
-            s.fold_from(0).unwrap();
-            let t = std::time::Instant::now();
-            s.migrate_to_v2_using(step).expect("migrate");
-            let d = t.elapsed();
-            drop(s);
-            let _ = std::fs::remove_file(&path);
-            d
+            (0..TRIALS)
+                .map(|i| {
+                    let (mut s, path) = store(&format!("{name}-{i}"));
+                    s.append_batch(&gen::events(0, 8_000, entities, 5)).unwrap();
+                    s.fold_from(0).unwrap();
+                    let t = std::time::Instant::now();
+                    s.migrate_to_v2_using(step).expect("migrate");
+                    let d = t.elapsed();
+                    drop(s);
+                    let _ = std::fs::remove_file(&path);
+                    d
+                })
+                .min()
+                .expect("TRIALS > 0")
         };
 
         let legacy_lo = time_it("scale-l-lo", SCHEMA_V2_STEP, 100);

--- a/tools/wm2-persistence-harness/src/standin.rs
+++ b/tools/wm2-persistence-harness/src/standin.rs
@@ -1408,7 +1408,18 @@ mod tests {
                     s.migrate_to_v2_using(step).expect("migrate");
                     let d = t.elapsed();
                     drop(s);
-                    let _ = std::fs::remove_file(&path);
+                    // Sidecars too, not just the main file. SQLite removes
+                    // `-wal`/`-shm` when the last connection closes, so on the
+                    // happy path `drop` has already done it — but each trial
+                    // now uses its OWN filename, so anything that survives
+                    // accumulates rather than being overwritten by the next
+                    // run. Matching `bench::remove_db` and `rebuild_cost::seed`
+                    // costs nothing and removes the question.
+                    for suffix in ["", "-wal", "-shm"] {
+                        let mut p = path.as_os_str().to_os_string();
+                        p.push(suffix);
+                        let _ = std::fs::remove_file(std::path::PathBuf::from(p));
+                    }
                     d
                 })
                 .min()


### PR DESCRIPTION
The **WM-2 persistence harness** lane failed on #1356 — a docs-only PR — with `write_amplification_rises_with_chunk_count`:

```
finer chunking (18.5x) did not cost materially more than coarser (16.1x)
```

It looked like flake. It is a **measurement defect**, and the numbers this instrument produces have been wrong whenever the test suite is busy.

## Root cause

`process_write_bytes()` read `/proc/self/io`, which is **process-wide**. `cargo test` runs tests concurrently as threads of **one** process, so a neighbouring test's writes land inside the measurement window. Same test, same machine:

| Condition | coarse | fine | ratio |
|---|---:|---:|---:|
| test run alone | 1.00× | 5.09× | 5.24 |
| full suite | **8.46×** | 5.10× | **0.60** ← fails |

`fine` is untouched; **`coarse` absorbs another test's writes** and inverts the comparison. It is intermittent because it depends on which tests happen to overlap — the worst way to fail, because it teaches people to re-run rather than to read.

Worth recording how nearly this was missed: my first check reported "passes 5/5 locally", but those runs used a **test filter** — which is precisely what removed the contamination. Only running the full suite reproduced it.

## Fix

Read `/proc/thread-self/io`. Every byte the arms write is written on the calling thread (nothing in the measured path spawns), so the counter measures the work and nothing else. **No fallback** to `/proc/self/io`: falling back would silently restore the contaminated reading, which is worse than no reading — and `None` already has honest handling for a platform that cannot answer.

It restores the **true** value, not merely a passing one. Full-suite runs now read **0.97× / 5.09× / ratio 5.24** — identical to the filtered baseline, four runs running.

**Negative control:** restoring `/proc/self/io` reproduces the CI failure almost exactly — coarse **16.96×** against CI's **16.1×**.

**Regression guard:** `the_write_counter_excludes_another_threads_writes` writes 8 MiB from another thread and requires this thread's counter not to notice. With the old reader it fails. The property needs a test rather than a comment, because the failure it prevents does not look like a failure — it looks like a number.

## A second, distinct flake in the same lane

Found while verifying, and fixed here because it reds the same blocking lane: `the_grouped_backfill_is_flat_in_entities_where_the_legacy_one_is_not` failed **2 of 8** full-suite runs, **0 of 8** alone.

Pre-existing, and **not** caused by the new 8 MiB test — checked by measuring the rate with that test skipped. Same class of defect (a measurement taken beside other work), but wall-clock has no thread-scoped counter to switch to, so the honest instrument is repetition: **best-of-3 taking the minimum**, because interference can only make a timed section *longer*, never shorter. Averaging would fold the interference in.

## Neither change weakens an assertion

The amplification threshold stays at `1.5×` and the backfill ratios stay at `2.0`. What changed is that the inputs are now measurements of the thing being measured. Loosening a threshold to clear a red check would have hidden this defect instead of finding it — and this instrument's output feeds ADR-0041 D-16's write-amplification finding.

## Verification

**0 failures across 20 full-suite runs**, against ~1 in 4 and 2 in 8 before. `cargo fmt` and `clippy --all-targets` clean.

## Scope note

No evidence bundle is invalidated. D-16's amplification figures were produced by the harness **binary**, which runs its measurement single-threaded — process and thread counters coincide there, so those numbers were never contaminated. The defect only bit under the concurrent test runner.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_