### PR TITLE
docs(console): record what the ignore step does NOT fix — the cap is on deployments, not builds

### DIFF
--- a/console/vercel-ignore-build.sh
+++ b/console/vercel-ignore-build.sh
@@ -25,6 +25,41 @@
 # rebuilding produces a byte-identical result at the cost of a build slot.
 #
 # ---------------------------------------------------------------------------
+# What this script does NOT fix — measured 2026-08-05
+#
+# This works: PR checks show `Canceled by Ignored Build Step` against a
+# SUCCESS status wherever it runs. It did not stop the account hitting its
+# limit, and the paragraph above is wrong about which limit that was.
+#
+# The failures still seen on Rust-only pull requests are:
+#
+#   Resource is limited - try again in 24 hours
+#   (more than 100, code: "api-deployments-free-per-day")
+#
+# `api-DEPLOYMENTS-per-day`, not builds. It is an account-level cap on
+# deployments CREATED, and it is enforced before the build runs — so this
+# script never gets the chance to skip anything. On a rate-limited day the
+# statuses are red no matter what is written here.
+#
+# The cause is not this script and cannot be fixed by it: **seven Vercel
+# projects are connected to this one repository, every one of them with
+# console/ as its Root Directory** — observed on 2026-08-05 as
+# kirra-runtime-sdk, -1vdc, -5lt3, -f35q, -hdy4, -og6p, -tgo8. Seven
+# deployments per push exhausts a 100/day cap in well under a day of ordinary
+# work, and an ignored build still creates a deployment (Vercel lists the
+# ignored ones with inspector and preview URLs, so they are objects, not
+# no-ops) — check the account's usage page to confirm how they are counted.
+#
+# Six of those projects are redundant. Removing them is a DASHBOARD action;
+# there is no repository-side equivalent, because all seven read THIS file and
+# this vercel.json, so any switch here — `git.deploymentEnabled` included —
+# turns all seven off together rather than six.
+#
+# Recorded here rather than in a ticket because this is the file someone
+# reaches for when the statuses go red, and the honest answer is "this script
+# is working; the problem is upstream of it."
+#
+# ---------------------------------------------------------------------------
 # The fail-safe direction is BUILD, not SKIP
 #
 # Every uncertain case below exits 1. The two errors are not symmetric:

--- a/console/vercel-ignore-build.sh
+++ b/console/vercel-ignore-build.sh
@@ -15,9 +15,13 @@
 #
 # This repository is overwhelmingly Rust. A typical pull request touches
 # crates/ and nothing else, yet every push rebuilds the Next.js console —
-# once per connected Vercel project. That is how the account reached its
-# build-rate limit while the changes under review contained no console code
-# at all.
+# once per connected Vercel project. Those rebuilds are pure waste: build
+# minutes spent producing a byte-identical result while the changes under
+# review contain no console code at all.
+#
+# They are **not** what exhausts the account's daily limit, and this script
+# does not stop the red statuses that limit produces. Read "What this script
+# does NOT fix" below before concluding otherwise.
 #
 # Vercel builds this project from the console/ Root Directory, so console/ is
 # the complete set of inputs. If nothing under it changed, the previous
@@ -28,8 +32,9 @@
 # What this script does NOT fix — measured 2026-08-05
 #
 # This works: PR checks show `Canceled by Ignored Build Step` against a
-# SUCCESS status wherever it runs. It did not stop the account hitting its
-# limit, and the paragraph above is wrong about which limit that was.
+# SUCCESS status wherever it runs. It saves the build minutes described
+# above. It does not stop the account hitting its daily limit, because that
+# limit counts something else.
 #
 # The failures still seen on Rust-only pull requests are:
 #


### PR DESCRIPTION
Comment-only. The script's behaviour is byte-unchanged.

## What was wrong

`vercel-ignore-build.sh`'s *"Why this exists"* section said console rebuilds are *"how the account reached its build-rate limit"* — which reads as though this script addressed it. Measured today, that is wrong about **which limit**:

```
Resource is limited - try again in 24 hours
(more than 100, code: "api-deployments-free-per-day")
```

`api-`**`deployments`**`-per-day`. An account-level cap on deployments **created**, enforced *before* the build runs — so on a rate-limited day this script never gets the chance to skip anything, and the statuses are red regardless of what it says.

## The script itself is working

PR checks show `Canceled by Ignored Build Step` against a **success** status wherever it actually runs. Nothing here is broken.

The cause is upstream of it: **seven Vercel projects are connected to this one repository, every one with `console/` as its Root Directory** — observed 2026-08-05 as `kirra-runtime-sdk`, `-1vdc`, `-5lt3`, `-f35q`, `-hdy4`, `-og6p`, `-tgo8`. Seven deployments per push exhausts a 100/day cap well inside a day of ordinary work, and an ignored build still *creates* a deployment (Vercel lists the ignored ones with inspector and preview URLs, so they are objects rather than no-ops — the note points at the usage page to confirm how they're counted rather than asserting it).

## Why there is no repository-side fix

Six of those projects are redundant, and removing them is a **dashboard** action. There is no repo-side equivalent: all seven read *this* file and *this* `vercel.json`, so any switch here — `git.deploymentEnabled` included — turns all seven off together rather than six.

Left as a recorded caveat rather than a fix, deliberately. A repo-side change that *appeared* to address this would be worse than the red statuses, because it would stop anyone looking at the real cause.

## Why in the script rather than a ticket

This is the file someone opens when the statuses go red, and the answer they need is *"this is working; the problem is upstream of it."* A ticket is not where that person is looking.

## Verification

Both directions of the exit convention were exercised — worth doing on a file where `0` means *skip* and `1` means *build*, backwards from everything else in this repo:

| Condition | Result |
|---|---|
| `HEAD` without a `console/` change | `no changes under console/ … skipping build`, exit **0** |
| `HEAD` = this commit, which touches `console/` | `console/ changed … building`, exit **1** |

`bash -n` and `shellcheck` both clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_