### PR TITLE
docs(wm): settle the tracked-object row, and stop WM_SCOPE understating Tier 0

### DIFF
--- a/docs/adr/0040-world-model-ownership-and-boundary.md
+++ b/docs/adr/0040-world-model-ownership-and-boundary.md
@@ -414,8 +414,39 @@ question from the owner's plate.
 | `robot/world_model.py` | **Exists**, 195 lines, still an opt-in TTL'd read projection. Matches "compatibility projection — retain" |
 | `crates/kirra-sidecars/src/destination.rs` | **Exists**, 1 734 lines; the `ResolveOutcome` contract the query API is meant to model is present (55 references) |
 | `crates/kirra-sidecars/src/destination_service.rs` | **Exists**, 717 lines. Matches "retain" |
-| Tracked-object inputs | Not verifiable by inspection — genuinely needs its owner |
+| Tracked-object inputs | **Checked, and the row's factual half is only half true — see below.** The *disposition* still needs its owner |
 | `places.json` / `routes.json` | **The compatibility row is right; the inventory row's path was wrong — now fixed.** The deployed files really are `places.json` / `routes.json` (set by `KIRRA_DEST_PLACES_PATH` / `KIRRA_DEST_ROUTES_PATH`), so the disposition above stands. What did not exist was `robot/testdata/places.json`: the shipped examples are `places.example.json` / `routes.example.json`, and the inventory now cites those |
+
+#### Tracked-object inputs — "already carry confidence and staleness" is true of the wrong type
+
+The row's rationale reads *"Perception observations; already carry confidence
+and staleness."* Checked against the tree, that is true of some perception
+types and **false of the one the checker actually consumes**:
+
+| Type | `confidence` | timestamp |
+|---|---|---|
+| `kirra_taj::CameraVruObservation` | **yes** | **yes** (`stamp_ms`) |
+| `kirra_taj` object-goal / intent types | **yes** | — |
+| **`kirra_core::trajectory::PerceivedObject`** | **no** | **no** |
+
+`PerceivedObject` — id, position, velocity, heading, velocity vector — is what
+the RSS and trajectory checks run on, and it carries neither. **Staleness on
+that path is a property of the *channel*, not of the object**: freshness is
+enforced by subscription policy (`KIRRA_SUBSCRIPTION_STALENESS_MS`) and by
+`AcceptedTrajectory`'s `promoted_at_ms` + `max_age_ms`, never by a field
+travelling with the datum.
+
+**Why this matters to the disposition rather than being a nitpick.** The row
+says these become import-source *observations*, and an observation in Kirra
+World must carry its own provenance and validity. If the datum has neither, the
+importer has to attach both from channel context — and "attach a confidence
+from context" is precisely how a fabricated confidence enters an evidence
+store wearing the same clothes as a measured one.
+
+So the disposition is still plausible, but it is **not free**, and whoever
+confirms this row should confirm it knowing that the import needs a stated rule
+for where confidence and validity come from on the `PerceivedObject` path.
+That rule does not exist yet.
 
 ### Open question 4 appears already dispositioned
 

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -83,9 +83,37 @@ Not code. It blocks authorized implementation by the ADRs' own words.
 | ADR-0040 ratification checklist | **4 of 5 unticked** — dependency review, compatibility inventory, deployment ownership, open questions 1 & 4 |
 | ADR-0042 Decision 5 | Recorded, but an **owner self-assessment, not an independent assurance review**, with Q2/Q4/Q5 open |
 
-**Deployment ownership is the one that bites later.** Nobody has decided who
-runs Kirra World, where it stores, or who backs it up. That answer is needed
-*before* a service exists, not after one is running.
+### The ratification order is forced
+
+ADR-0040 *"depends on ADR-0039"*; ADR-0039's checklist requires *"ADR-0042
+itself accepted."* So the chain is **0042 → 0039 → 0040**, and ADR-0040 cannot
+be accepted first however much evidence is prepared for it. **ADR-0042 is the
+critical path.**
+
+### Evidence prepared, so the boxes are decisions rather than work
+
+Every box below is still unticked — none of this ticks anything — but the
+research behind them is done, and a reader should not restart it:
+
+| Box | Prepared |
+|---|---|
+| ADR-0040 dependency review | **Written** — ADR-0040 *Repository dependency review — findings* |
+| ADR-0040 compatibility inventory | **All five rows checked** against the tree; one citation error found and fixed; the `tracked-object inputs` row's factual claim corrected. Dispositions still need their owners |
+| ADR-0040 Q1 | **Circular as stated**; a deferral disposition is drafted for accept/amend/reject |
+| ADR-0040 Q4 | **Appears already dispositioned** — C1 in ADR-0039 via ADR-0042 Decision 1, C3 in ADR-0040's own compatibility table |
+| ADR-0042 Decision 5 template | **Already satisfied** — recorded 2026-08-05; the ADR requires it *recorded*, not favourable |
+| ADR-0042 M1 rename | **Already executed** — `61dbf57f`; the box confirms a completed change |
+| ADR-0042 OQ1 | **Evidence prepared**, disposition drafted; its revisit trigger is self-announcing (a Fence B breach *is* the request arriving) |
+| ADR-0039 safety-assurance box | **Flagged as possibly tickable** — its own text says the ruling need only be *recorded* |
+
+**What is left is judgement, not research** — with one exception.
+
+**Deployment ownership is the one that bites later**, and the only item no
+preparation can move. Nobody has decided who runs Kirra World, where it stores,
+or who backs it up. That answer is needed *before* a service exists, not after
+one is running — and two of its three parts already have measured consequences
+(see ADR-0040's review section: the 15.79-day fill, and ADR-0038's per-instance
+local audit chain).
 
 ---
 


### PR DESCRIPTION
The last two preparable Tier 0 items. Two files, docs only. **Ticks nothing** — ADR-0040 unticked 4 → 4, WM_SCOPE 14 → 14.

## 1. The tracked-object row — I wrote it off too quickly

In #1360 I marked this compatibility row *"not verifiable by inspection — genuinely needs its owner."* That was half wrong. The **disposition** needs its owner; the **factual claim** — *"Perception observations; already carry confidence and staleness"* — is checkable. Checked, it is **true of the wrong type**:

| Type | `confidence` | timestamp |
|---|---|---|
| `kirra_taj::CameraVruObservation` | **yes** | **yes** (`stamp_ms`) |
| `kirra_taj` object-goal / intent types | **yes** | — |
| **`kirra_core::trajectory::PerceivedObject`** | **no** | **no** |

`PerceivedObject` — id, position, velocity, heading, velocity vector — is what the RSS and trajectory checks actually run on, and it carries neither. **Staleness on that path is a property of the channel, not of the object:** freshness comes from subscription policy (`KIRRA_SUBSCRIPTION_STALENESS_MS`) and from `AcceptedTrajectory`'s `promoted_at_ms` + `max_age_ms`, never from a field travelling with the datum.

### Why this is not a nitpick

The row's disposition turns these into import-source **observations**, and an observation in Kirra World must carry its own provenance and validity. If the datum has neither, the importer has to attach both from channel context — and *"attach a confidence from context"* is precisely how a fabricated confidence enters an evidence store wearing the same clothes as a measured one.

The disposition stays plausible. It is **not free**, and whoever confirms this row should do so knowing the import needs a stated rule for where confidence and validity come from on the `PerceivedObject` path. **That rule does not exist yet.**

## 2. WM_SCOPE was understating Tier 0

It still said four boxes unticked — true — without recording that the research behind them is done. A reader would have restarted finished work.

Now carries:

- **The forced ratification order** — 0042 → 0039 → 0040, so ADR-0040 cannot be accepted first however much evidence is prepared for it.
- **A prepared-evidence table**: dependency review written; all five compatibility rows checked; Q1 and OQ1 drafted; Q4 apparently already dispositioned; ADR-0042's Decision 5 box already satisfied and its M1 rename already executed (`61dbf57f`); ADR-0039's safety-assurance box flagged as possibly tickable.
- **What is left is judgement, not research** — with **deployment ownership** named as the one item no preparation can move.

## A process note

This commit was held back deliberately rather than pushed when written. #1362 was open on the same branch and its published body asserted *"one file, 69 insertions, zero deletions"* — pushing this onto it would have made that verification claim false, and repeated the accretion problem flagged on #1360. It waited for #1362 to merge, then landed on a branch restarted from the new `main`.

## Verification

`check_website_citations`, the Kirra World bidirectional fence (closure intact at 19 packages from 10 roots), `check_quality_guardrails` — all re-run against the **post-merge** `main`, not the tree the commit was written on.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_