### PR TITLE
docs(wm): name the layers, and raise the predictive-containment question the diagram exposed

### DIFF
--- a/docs/adr/0040-world-model-ownership-and-boundary.md
+++ b/docs/adr/0040-world-model-ownership-and-boundary.md
@@ -510,6 +510,64 @@ unblocked. This gate no longer constrains the `kirra-world*` crates."*
 ADR-0040's Proposed status is a governance position, not an enforced gate — so
 Tier 1 is not mechanically blocked either way.
 
+### Open question 6 — predictive containment
+
+Raised 2026-08-05, because a layering diagram and the blueprint currently
+disagree and nobody had noticed.
+
+> **Should predictive state remain in a separate store referenced by Kirra
+> World entity IDs, or may Kirra World host a separately fenced predictive
+> namespace?**
+
+**This does not gate ratification.** The checklist names open questions **1 and
+4** specifically; raising a sixth must not silently enlarge that gate, and this
+sentence exists so it cannot.
+
+#### What the blueprint currently says
+
+`KIRRA-WM-ARCH-001` §20 — *not* ADR-0041, which is where these rules are most
+often mis-attributed because the persistence decisions live there:
+
+> *"Predictions live in a **separate store** and reference World Model entity
+> IDs. They are never observations... A prediction may not be promoted to an
+> observation... The World Model stays deterministic. **A learned model in that
+> path would destroy replay.**"*
+
+And §9.1: `Predicted` **never appears in the evidence store**.
+
+#### The distinction the question exists to protect
+
+Two things are both "the LLM's opinion", and only one is admitted today:
+
+| | Example | Status |
+|---|---|---|
+| **LLM-originated candidate** — proposes something confirmable | *"I think that is the toolbox"* | **Already inside, already fenced** — `writer_class = llm_candidate`, refused `confirmed` by the schema (SD-2), excluded from the confirmed-only fold, reachable only by naming `candidates()` |
+| **Predictive belief** — a probability over unobserved state | *"The keys are probably still near the door"* | **Outside.** §9.1 |
+
+A diagram that nests "the cognitive layer" inside Kirra World collapses these,
+and the collapse is invisible because both are the same thing to a reader.
+
+#### The default, unless and until a ruling changes it
+
+* the prediction store is **separate**;
+* predictions **never become observations**;
+* predictions **cannot enter confirmed-only projections**;
+* predictive consumers get a **read seam, not write authority** over confirmed
+  knowledge.
+
+#### Why it is worth asking rather than assuming
+
+The "separately fenced namespace" option is not obviously wrong — the store
+already demonstrates that hostile content can live inside a structure that
+refuses to fold it, which is exactly what SD-2 and the confirmed-only fold do
+for `llm_candidate`. The argument against is §20's: a learned model *in the
+projection path* destroys replay, and replay is what the whole evidence-first
+inversion buys.
+
+Answering it means deciding whether "separately fenced" can be made as
+structural as SD-2 is — a schema-level refusal, not a convention. That is a
+ruling, not a diagram.
+
 ### One further checkbox may be tickable
 
 ADR-0039's safety-assurance item says the ruling *"must be **recorded**; it need
@@ -547,6 +605,12 @@ The one item with no technical component. Recorded here is what the decision
 4. Naming collision disposition (ADR-0039 C1/C3).
 5. Does the dashboard's "administrative write" need a distinct writer class, or
    is it an operator-calibration adapter with a different transport?
+6. **Predictive containment.** Should predictive state remain in a **separate
+   store** referenced by Kirra World entity IDs, or may Kirra World host a
+   **separately fenced predictive namespace**? See *Open question 6 —
+   predictive containment* below. **Does not gate ratification**: the checklist
+   names open questions 1 and 4 specifically, and raising this must not
+   silently enlarge that gate.
 
 ---
 

--- a/docs/adr/0040-world-model-ownership-and-boundary.md
+++ b/docs/adr/0040-world-model-ownership-and-boundary.md
@@ -608,7 +608,7 @@ The one item with no technical component. Recorded here is what the decision
 6. **Predictive containment.** Should predictive state remain in a **separate
    store** referenced by Kirra World entity IDs, or may Kirra World host a
    **separately fenced predictive namespace**? See *Open question 6 —
-   predictive containment* below. **Does not gate ratification**: the checklist
+   predictive containment* above, in the dependency-review findings. **Does not gate ratification**: the checklist
    names open questions 1 and 4 specifically, and raising this must not
    silently enlarge that gate.
 

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -61,7 +61,7 @@ container.
 ### Predictive state is not part of Kirra World
 
 Not unless a future ruling changes `KIRRA-WM-ARCH-001` §9.1 and §20. See
-*Open question — predictive containment* in
+*Open question 6 — predictive containment* in
 [ADR-0040](../adr/0040-world-model-ownership-and-boundary.md).
 
 > **Citation note.** §9.1 (trust model) and §20 (AI prediction integration) are

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -30,6 +30,80 @@ World predicts nothing. It records.
 
 ---
 
+## 0a. What Kirra World contains — the layer vocabulary
+
+Naming the layers, because "the world model" collapses three different things
+and the collapse is what makes the safety conversation hard. **This is
+vocabulary for architecture already ratified in ADR-0041, not new
+architecture** — the log-plus-projections shape, the rebuild property and the
+no-projection-only-fact rule are all existing normative requirements. What is
+new here is only that they have names.
+
+### Kirra World contains
+
+**1. Evidence Ledger** — immutable, provenance-carrying, bitemporal events.
+*"What happened."*
+
+**2. Deterministic World Knowledge** — materialized projections derived from
+**confirmed** evidence. *"What we currently know."* Governed by the rules
+ADR-0041 and the blueprint already impose:
+
+* rebuild-from-zero must equal the incremental state;
+* **no projection-only fact** — everything traces to events;
+* a reducer or rule version change forces a rebuild;
+* validity is computed at read time, never stored.
+
+### Kirra World may expose a Cognitive Interface
+
+A **one-way read seam** for external predictive systems. A seam, not a
+container.
+
+### Predictive state is not part of Kirra World
+
+Not unless a future ruling changes `KIRRA-WM-ARCH-001` §9.1 and §20. See
+*Open question — predictive containment* in
+[ADR-0040](../adr/0040-world-model-ownership-and-boundary.md).
+
+> **Citation note.** §9.1 (trust model) and §20 (AI prediction integration) are
+> sections of the **blueprint**, `KIRRA-WM-ARCH-001`, *not* of ADR-0041. They
+> are easy to attribute to the ADR because that is where the persistence
+> decisions live; sending a reader to the wrong document over a boundary rule
+> is worth one sentence to prevent.
+
+### The distinction that must not be smoothed over
+
+Two things are both called "LLM output" and only one of them is admitted:
+
+| | Example | Status |
+|---|---|---|
+| **LLM-originated candidate** — proposes something confirmable | *"I think that is the toolbox"* | **Inside Kirra World, already fenced** — `writer_class = llm_candidate`, excluded from the confirmed-only fold, reachable only by naming `candidates()` |
+| **Predictive belief** — infers a probability over unobserved state | *"The keys are probably still near the door"* | **Outside Kirra World.** §9.1: `Predicted` never appears in the evidence store |
+
+A diagram that nests "the cognitive layer" inside Kirra World collapses these,
+and the collapse is invisible because both are "the LLM's opinion."
+
+### The precompute rider
+
+The layering invites *"maintain a projection for everything."* That is not free,
+and this project has the numbers:
+
+* **D-16** — rebuild write amplification **2.8×–35.8×**, and a *dial* rather
+  than a constant (it is a property of how finely the fold is chunked);
+* **D-21** — projections cost ~3 % storage, but that is **one** projection over
+  an entity-bounded stream; a projection per question changes the arithmetic;
+* the real hazard is that **a stale projection is worse than none, because a
+  consumer trusts it**.
+
+> **Precompute only when freshness, invalidation, rebuild cost, write
+> amplification and provenance are explicit.**
+
+Otherwise the trade is *"the LLM might be wrong"* for *"the cache is silently
+stale"* — which is harder to notice and looks like success. `robot/world_model.py`
+already encodes the defence: TTL'd fields read `UNKNOWN` when stale rather than
+returning the last value they held.
+
+---
+
 ## 1. What "done" means here
 
 Taken from the blueprint rather than invented, so this document cannot quietly


### PR DESCRIPTION
Two files, docs only. **Ticks nothing** — ADR-0040 unticked 4 → 4, WM_SCOPE 14 → 14.

From an architectural framing that turned out to be two-thirds already-ratified and one-third a live contradiction. Both halves are recorded as what they actually are.

## 1. The layer vocabulary — `WM_SCOPE.md` §0a

**Evidence Ledger** → **Deterministic World Knowledge** → a **Cognitive Interface** that is a *seam, not a container*.

Filed explicitly as **vocabulary for existing architecture, not new architecture.** Log-plus-projections, rebuild-from-zero-equals-incremental, no-projection-only-fact and reducer-version-forces-rebuild are all already normative in ADR-0041 and the blueprint. What is new is only that they have names. Filing it as a redesign would misrepresent both the work and the decision record.

### The precompute rider

The layering actively invites *"maintain a projection for everything."* This project has the numbers against doing that naively:

- **D-16** — rebuild write amplification **2.8×–35.8×**, and a *dial* rather than a constant;
- **D-21** — ~3 % storage, but for **one** projection over an entity-bounded stream;
- the real hazard — **a stale projection is worse than none, because a consumer trusts it.**

> Precompute only when freshness, invalidation, rebuild cost, write amplification and provenance are explicit.

Otherwise the trade is *"the LLM might be wrong"* for *"the cache is silently stale"* — harder to notice, and it looks like success. `robot/world_model.py` already encodes the defence: TTL'd fields read `UNKNOWN` rather than returning what they last held.

## 2. Open Question 6 — predictive containment (ADR-0040)

> **Should predictive state remain in a separate store referenced by Kirra World entity IDs, or may Kirra World host a separately fenced predictive namespace?**

A layering diagram put the cognitive layer **inside** Kirra World. The blueprint says otherwise, and the disagreement was unnoticed:

- **§20** — *"Predictions live in a **separate store**... never observations... A learned model in that path would destroy replay."*
- **§9.1** — `Predicted` **never appears in the evidence store.**

### The distinction it exists to protect

| | Example | Status |
|---|---|---|
| **LLM-originated candidate** | *"I think that is the toolbox"* | **Already inside, already fenced** — `writer_class = llm_candidate`, refused `confirmed` by the schema (SD-2), excluded from the confirmed-only fold, reachable only by naming `candidates()` |
| **Predictive belief** | *"The keys are probably still near the door"* | **Outside**, per §9.1 |

Both read as "the LLM's opinion," which is exactly why a diagram collapses them invisibly.

### Default preserved, explicitly

Separate store · predictions never become observations · predictions cannot enter confirmed-only projections · predictive consumers get a **read seam, not write authority**.

### Two things added beyond the question as posed

- **"Does not gate ratification"**, stated in the ADR. The checklist names open questions **1 and 4** specifically, so a sixth does not enlarge it — but that is only obvious to someone who has read the checklist recently, and the sentence prevents Tier 0 being read as having grown.
- **Why the question is genuinely open**, not rhetorical. The "separately fenced namespace" option is not obviously wrong: the store already demonstrates that inadmissible content can live inside a structure that refuses to fold it, which is what SD-2 does for `llm_candidate`. Answering it means deciding whether "separately fenced" can be made as **structural** as SD-2 is — a schema-level refusal, not a convention.

## Citation correction

**§9.1 and §20 are blueprint sections (`KIRRA-WM-ARCH-001`), not ADR-0041.** Easy to mis-attribute because the persistence decisions *do* live in the ADR. Noted in both documents so a reader is not sent to the wrong file over a boundary rule.

## Deliberately excluded

Cross-domain claims. The principle may generalize, but each vertical has to prove what is deterministic, what is inferred, and what authority follows from each — and this repository does not assert across a boundary it has not measured.

## Verification

`check_website_citations`, both Kirra World fences (**38/38** each, closure intact at 19 packages from 10 roots), the domain-logic gate, `check_quality_guardrails`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_