### PR TITLE
Tier 0 complete (all four World Model ADRs accepted) + Tier 1 slice 1: the trust axes

### DIFF
--- a/crates/kirra-world/Cargo.toml
+++ b/crates/kirra-world/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kirra-world"
 version = "0.1.0"
 edition = "2021"
-description = "Kirra World domain core — PROTOTYPE crate graph only, no domain logic (ADR-0040 WM-1)"
+description = "Kirra World domain core — Tier 1: the four orthogonal trust axes (ADR-0040 WM-1, blueprint §9)"
 publish = false
 
 # ZERO dependencies, deliberately. ADR-0040's ratification criteria ask for

--- a/crates/kirra-world/src/lib.rs
+++ b/crates/kirra-world/src/lib.rs
@@ -1,4 +1,4 @@
-//! **Kirra World — domain core. PROTOTYPE: shape only, no domain logic.**
+//! **Kirra World — domain core. Tier 1 in progress: the trust model is real.**
 //!
 //! This crate exists to prove ONE thing that is expensive to get wrong later:
 //! the dependency *shape*. ADR-0040 (WM-1) proposes `kirra-world` as a pure
@@ -6,21 +6,26 @@
 //! criteria ask for a "prototype crate graph — `kirra-world` compiling as a leaf
 //! with no ROS, no actuation, and no checker edge". That is what this is.
 //!
-//! # What this crate deliberately does NOT contain
+//! # What this crate contains, and what it still does not
 //!
-//! No fields. No invariants. No constructors. No storage. No API. No queries.
-//! The ten types below are **unconstructible placeholders** — each has a private
-//! unit field, so nothing outside this crate can build one and no logic can
-//! quietly accrete around them while the decision that governs them is still
-//! open.
+//! **Real:** [`mod@trust`] — the four orthogonal trust axes (`Origin`,
+//! `Corroboration`, `Adjudication`, `Validity`) and the seven transition rules,
+//! with the anti-laundering rule (rule 5) and read-time validity (rule 6) as its
+//! load-bearing parts. Pure functions over pure data; still zero dependencies.
 //!
-//! That decision is the safety-assurance scope ruling
+//! **Still absent:** storage, API, queries, and the entity/observation/
+//! relationship models. The nine remaining types below are **unconstructible
+//! placeholders** — each has a private unit field, so nothing outside this crate
+//! can build one and no logic can quietly accrete around a name before the model
+//! that gives it meaning exists.
+//!
+//! The governing decision is the safety-assurance scope ruling
 //! ([ADR-0042](../../../docs/adr/0042-world-model-terminology-and-safety-boundary-scope.md)
-//! Decision 5) — which was **PENDING and unassigned when this crate was
-//! written, and was RECORDED on 2026-08-05** as *safety-related,
-//! non-authoritative*. Statuses as they now stand: **ADR-0041 is Accepted**
-//! (2026-08-04); ADR-0039, ADR-0040 and ADR-0042 remain **Proposed**. Nothing
-//! here ratifies any of them.
+//! Decision 5) — **PENDING and unassigned when this crate was written, RECORDED
+//! on 2026-08-05** as *safety-related, non-authoritative*. Statuses as they now
+//! stand: **all four World Model ADRs are Accepted** — 0041 on 2026-08-04, and
+//! 0039, 0040 and 0042 on 2026-08-06. Each was an owner self-assessment; none
+//! authorizes implementation by its own terms.
 //!
 //! # The names
 //!
@@ -44,16 +49,19 @@
 //! declaration-only. What still constrains this crate is the ruling's own
 //! *Conditions that reopen the decision* — not the gate.
 //!
-//! So the honest reason the core is empty is simpler and less flattering than a
-//! gate: **WM-2's scoped work was the storage slice, and nobody has done the
-//! domain-types work yet.** That is a decision about sequencing, and it is
-//! recorded as one (ADR-0041, *WM-2 implementation milestone*) rather than
-//! dressed up as an external hold.
+//! So the honest reason the core was empty was simpler and less flattering than
+//! a gate: **WM-2's scoped work was the storage slice, and nobody had done the
+//! domain-types work.** That was a decision about sequencing, recorded as one
+//! (ADR-0041, *WM-2 implementation milestone*) rather than dressed up as an
+//! external hold.
 //!
-//! The private unit fields below still earn their place. They stop logic
-//! accreting around names that ADR-0040 has not ratified — `ADR-0040` is still
-//! **Proposed**, and a name is a decision — so the constraint they enforce is
-//! real, it is just a *naming* constraint rather than a safety gate.
+//! **Tier 1 has now started**, and the gap is closing from this end: the trust
+//! model above is domain logic the store does not have. Note which direction
+//! that runs — the store's `WriterClass` + two-valued `ClaimStatus` is, in the
+//! scope doc's words, *"an adjudication proxy and nothing more"*. The four axes
+//! are what it is a proxy **for**, so the core is now ahead of the adapter on
+//! this one concept, and the store will need to grow toward it rather than the
+//! reverse.
 //!
 //! # Naming — this is NOT "the world model"
 //!
@@ -89,6 +97,8 @@
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
+
+pub mod trust;
 
 // ---------------------------------------------------------------------------
 // Identity
@@ -175,18 +185,22 @@ pub struct TransactionTime(());
 // Trust (blueprint P6)
 // ---------------------------------------------------------------------------
 
-/// Trust decomposed into its four orthogonal axes.
+/// Trust decomposed into its orthogonal axes.
 ///
-/// PLACEHOLDER. The blueprint is explicit that trust is **not a scalar and not a
-/// single enum**: it decomposes into *origin*, *corroboration*, *adjudication*
+/// **No longer a placeholder** — this is the first Tier 1 slice, implemented in
+/// [`mod@trust`]. The blueprint is explicit that trust is *not a scalar and not a
+/// single enum*: it decomposes into *origin*, *corroboration*, *adjudication*
 /// and *temporal validity*, stored separately and collapsed to a grade only at
 /// the query boundary, for consumers that ask for one.
 ///
 /// Collapsing early is the failure this type exists to prevent — a single number
 /// cannot distinguish "one trusted sensor said so once" from "three sources
 /// agree but the claim is stale".
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct TrustAxes(());
+///
+/// Note the shape the implementation took: **three stored axes, not four.**
+/// Validity is computed by [`trust::validity_at`] and has nowhere to be written,
+/// which makes transition rule 6 unbreakable rather than merely documented.
+pub use trust::TrustAxes;
 
 // ---------------------------------------------------------------------------
 // Query results

--- a/crates/kirra-world/src/trust.rs
+++ b/crates/kirra-world/src/trust.rs
@@ -1,0 +1,1042 @@
+//! The four orthogonal trust axes — `KIRRA-WM-ARCH-001` §9, Tier 1.
+//!
+//! The blueprint's central claim about trust is that the familiar states —
+//! Observed, Confirmed, Derived, Imported, Expired, Ambiguous, Rejected — are
+//! **not one dimension**. `Imported` describes origin; `Expired` describes time;
+//! `Ambiguous` describes adjudication; `Confirmed` conflates corroboration with
+//! adjudication. Collapsing them is *"exactly why trust states in most systems
+//! become mush after eighteen months — every new case forces either a wrong
+//! assignment or a new variant"*.
+//!
+//! So four axes are stored separately and the familiar labels are **derived**:
+//!
+//! ```text
+//! Origin        : Observed | Derived | Imported | Asserted | Predicted*
+//! Corroboration : Uncorroborated | Corroborated(n) | Contradicted(n)
+//! Adjudication  : Pending | Confirmed | Rejected | Ambiguous
+//! Validity      : Fresh | Stale | Expired | Timeless
+//! ```
+//!
+//! # Rule 6 is enforced structurally, not remembered
+//!
+//! Transition rule 6 says *"Validity is computed at read time, never stored.
+//! `Fresh` is not a state the system enters; it is a question asked at the
+//! instant of the query, with the clock passed in."*
+//!
+//! [`TrustAxes`] therefore has **three fields, not four**. There is nowhere to
+//! put a [`Validity`], so no code can store one — the rule cannot be broken by
+//! forgetting it. Validity is produced only by [`validity_at`], which takes the
+//! clock as an argument.
+//!
+//! This is a deliberate echo of what makes Fence B strong and ADR-0042's
+//! Decision 1 weak: an invariant a machine enforces outlives one a person must
+//! remember.
+//!
+//! # What this module does NOT do
+//!
+//! **It does not populate `Corroborated(n)`.** Counting agreeing evidence
+//! presupposes knowing that two observations are *about the same thing*, which
+//! is entity resolution — `WM_SCOPE.md` Tier 2. The axis and its monotonic
+//! transitions are here; the matcher that would drive them is not.
+//!
+//! **It carries no geometry.** Transition rule 4 has two halves: an operator
+//! assertion outranks sensor evidence *for adjudication*, and never *for
+//! geometry*. Only the adjudication half lives here — see
+//! [`TrustAxes::operator_confirm`]. The geometry half is a constraint on the
+//! observation payload, which Tier 1's observation model owns.
+
+// ---------------------------------------------------------------------------
+// Origin — rule 1: fixed at write, never changes
+// ---------------------------------------------------------------------------
+
+/// Where a claim came from. **Rule 1: origin never changes.** It is a property
+/// of the record, fixed when the record is written.
+///
+/// There is deliberately no setter and no `&mut` accessor anywhere in this
+/// module; the only way to obtain a [`TrustAxes`] with a different origin is to
+/// construct a new one, which is what writing a new record means.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Origin {
+    /// Measured by a sensor or perception producer.
+    Observed,
+    /// Computed from other recorded evidence. Subject to rule 5.
+    Derived,
+    /// Brought in from an external dataset.
+    Imported,
+    /// Stated by a human operator.
+    Asserted,
+    /// **Never appears in the evidence store** (blueprint §20). Listed because
+    /// the *axis* is shared with the predictive subsystem, which reuses this
+    /// vocabulary for its own records.
+    ///
+    /// [`TrustAxes::new`] refuses it — see [`TrustError::PredictedNotStorable`].
+    Predicted,
+}
+
+impl Origin {
+    /// The stable token for this origin.
+    ///
+    /// Named `as_str` to match the store's existing convention. It is **not**
+    /// yet claimed to be inside any hashed bytes — this crate has no storage,
+    /// and binding a token to a hash chain is the store's decision to make.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Observed => "observed",
+            Self::Derived => "derived",
+            Self::Imported => "imported",
+            Self::Asserted => "asserted",
+            Self::Predicted => "predicted",
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Corroboration — rule 2: monotonic in evidence, not in time
+// ---------------------------------------------------------------------------
+
+/// How much independent evidence agrees or disagrees.
+///
+/// **Rule 2: monotonic in evidence, not in time.** New agreeing evidence
+/// increments; new disagreeing evidence moves to `Contradicted`. It never decays
+/// on its own — decay is [`Validity`]'s job.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Corroboration {
+    /// One source, or none that can be cross-checked.
+    Uncorroborated,
+    /// `n` independent sources agree. `n >= 1`.
+    Corroborated(u32),
+    /// `n` independent sources disagree. `n >= 1`. Implies `Ambiguous`
+    /// adjudication unless a rule resolves it — see rule 3.
+    Contradicted(u32),
+}
+
+impl Corroboration {
+    /// Fold in one piece of **agreeing** evidence.
+    ///
+    /// # A contradiction is not cleared by agreement
+    ///
+    /// `Contradicted(n).agreed()` stays `Contradicted(n)`. Agreement does not
+    /// silently erase a recorded disagreement — rule 3 makes `Contradicted` mean
+    /// `Ambiguous` *"unless an adjudication rule resolves it"*, so resolution is
+    /// adjudication's job (see [`TrustAxes::operator_confirm`] and
+    /// [`TrustAxes::reject`]), not arithmetic's.
+    ///
+    /// Reading it the other way would let a contradicted claim be quietly voted
+    /// back to healthy by piling on agreeing sources, which is the laundering
+    /// shape rule 5 exists to prevent, one axis over.
+    #[must_use]
+    pub fn agreed(self) -> Self {
+        match self {
+            Self::Uncorroborated => Self::Corroborated(1),
+            Self::Corroborated(n) => Self::Corroborated(n.saturating_add(1)),
+            Self::Contradicted(n) => Self::Contradicted(n),
+        }
+    }
+
+    /// Fold in one piece of **disagreeing** evidence.
+    ///
+    /// Any prior agreement is superseded: `Corroborated(7).disagreed()` is
+    /// `Contradicted(1)`, not `Corroborated(6)`. Disagreement is a change of
+    /// kind, not a decrement — seven agreeing sources and one dissenter is a
+    /// claim in conflict, and the count that matters afterwards is the count of
+    /// conflicts.
+    #[must_use]
+    pub fn disagreed(self) -> Self {
+        match self {
+            Self::Uncorroborated | Self::Corroborated(_) => Self::Contradicted(1),
+            Self::Contradicted(n) => Self::Contradicted(n.saturating_add(1)),
+        }
+    }
+
+    /// Rank for the weakest-wins fold of rule 5. Lower is weaker.
+    fn rank(self) -> u8 {
+        match self {
+            Self::Contradicted(_) => 0,
+            Self::Uncorroborated => 1,
+            Self::Corroborated(_) => 2,
+        }
+    }
+
+    /// The weaker of two corroborations — rule 5's fold on this axis.
+    ///
+    /// Within a variant the conservative direction differs: **more**
+    /// contradictions is weaker, **fewer** corroborations is weaker.
+    #[must_use]
+    pub fn weakest(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::Contradicted(a), Self::Contradicted(b)) => Self::Contradicted(a.max(b)),
+            (Self::Corroborated(a), Self::Corroborated(b)) => Self::Corroborated(a.min(b)),
+            _ if self.rank() <= other.rank() => self,
+            _ => other,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Adjudication — rules 3, 4, 7
+// ---------------------------------------------------------------------------
+
+/// Whether the claim has been ruled on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Adjudication {
+    /// Not yet ruled on.
+    Pending,
+    /// Ruled admissible.
+    Confirmed,
+    /// Ruled inadmissible. **Rule 7: terminal for the record.**
+    Rejected,
+    /// In conflict. **Rule 3 says this is a stable, reportable state, not an
+    /// error** — Mick must be able to say "I have conflicting information about
+    /// that."
+    Ambiguous,
+}
+
+impl Adjudication {
+    /// Rank for the weakest-wins fold of rule 5. Lower is weaker.
+    fn rank(self) -> u8 {
+        match self {
+            Self::Rejected => 0,
+            Self::Ambiguous => 1,
+            Self::Pending => 2,
+            Self::Confirmed => 3,
+        }
+    }
+
+    /// The weaker of two adjudications — rule 5's fold on this axis.
+    #[must_use]
+    pub fn weakest(self, other: Self) -> Self {
+        if self.rank() <= other.rank() {
+            self
+        } else {
+            other
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Validity — rule 6: computed, never stored
+// ---------------------------------------------------------------------------
+
+/// Temporal admissibility, **computed at read time from a clock**.
+///
+/// This type is deliberately absent from [`TrustAxes`]. It is produced only by
+/// [`validity_at`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Validity {
+    /// Within its staleness budget.
+    Fresh,
+    /// Past its staleness budget but not expired.
+    Stale,
+    /// Past its explicit end of validity, or not yet in force — see
+    /// [`validity_at`] for why those share a value.
+    Expired,
+    /// Carries no expiry. A surveyed building does not go stale.
+    Timeless,
+}
+
+impl Validity {
+    /// Rank for the weakest-wins fold of rule 5. Lower is weaker.
+    fn rank(self) -> u8 {
+        match self {
+            Self::Expired => 0,
+            Self::Stale => 1,
+            Self::Fresh => 2,
+            Self::Timeless => 3,
+        }
+    }
+
+    /// The weaker of two validities — rule 5's fold on this axis.
+    #[must_use]
+    pub fn weakest(self, other: Self) -> Self {
+        if self.rank() <= other.rank() {
+            self
+        } else {
+            other
+        }
+    }
+}
+
+/// The stored temporal facts a validity question is asked against.
+///
+/// Note what is here: only *facts*, no verdict. The verdict is
+/// [`validity_at`]'s return value and is never written down.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ValidityWindow {
+    /// When the claim enters force (valid time, not transaction time).
+    pub valid_from_ms: u64,
+    /// When the claim leaves force, if it ever does.
+    pub valid_to_ms: Option<u64>,
+    /// How long after `valid_from_ms` the claim counts as `Fresh`.
+    /// `None` means the claim does not go stale — see [`Validity::Timeless`].
+    pub staleness_budget_ms: Option<u64>,
+}
+
+impl ValidityWindow {
+    /// A window that never expires and never goes stale.
+    #[must_use]
+    pub fn timeless(valid_from_ms: u64) -> Self {
+        Self {
+            valid_from_ms,
+            valid_to_ms: None,
+            staleness_budget_ms: None,
+        }
+    }
+}
+
+/// Answer the validity question for `window` at instant `now_ms` — **rule 6**.
+///
+/// # Order of checks, and why
+///
+/// Expiry is checked before staleness so an expired claim is never reported as
+/// merely `Stale`; the answer is the strongest *restriction* that applies, not
+/// the first one found.
+///
+/// # A spec gap, flagged rather than silently resolved
+///
+/// A claim whose `valid_from_ms` is in the future is **not yet in force**. The
+/// blueprint's four-value axis has no member for that case. This function
+/// returns [`Validity::Expired`], chosen because it is the fail-closed answer —
+/// both mean *not admissible now*, and the alternative of returning `Fresh` or
+/// `Stale` would admit a claim that has not begun.
+///
+/// The naming is nonetheless wrong for the case, and this is recorded as an
+/// open question for the World Model owner rather than settled here: **should
+/// the Validity axis gain a `NotYetInForce` member?** Adding one is a blueprint
+/// §9.1 change, which is not this module's to make.
+#[must_use]
+pub fn validity_at(window: &ValidityWindow, now_ms: u64) -> Validity {
+    if now_ms < window.valid_from_ms {
+        // Not yet in force. See the doc comment — fail-closed, flagged.
+        return Validity::Expired;
+    }
+    if let Some(end) = window.valid_to_ms {
+        if now_ms >= end {
+            return Validity::Expired;
+        }
+    }
+    match window.staleness_budget_ms {
+        None => Validity::Timeless,
+        Some(budget) => {
+            let deadline = window.valid_from_ms.saturating_add(budget);
+            if now_ms > deadline {
+                Validity::Stale
+            } else {
+                Validity::Fresh
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TrustAxes
+// ---------------------------------------------------------------------------
+
+/// Why a set of trust axes could not be built or moved.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TrustError {
+    /// [`Origin::Predicted`] never appears in the evidence store (blueprint
+    /// §20). The predictive subsystem shares the vocabulary, not the store.
+    PredictedNotStorable,
+    /// **Rule 7**: `Rejected` is terminal for the record. Rejecting an
+    /// observation never deletes it, and nothing moves it back out.
+    RejectedIsTerminal,
+    /// A derivation was attempted with no inputs. Rule 5 folds the weakest
+    /// input; with nothing to fold there is no defensible answer, and inventing
+    /// one (`Pending`/`Uncorroborated`) would manufacture trust from thin air.
+    DerivationNeedsInputs,
+}
+
+/// The three **stored** trust axes. Validity is the fourth axis and is
+/// deliberately not a field — see the module docs and [`validity_at`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TrustAxes {
+    origin: Origin,
+    corroboration: Corroboration,
+    adjudication: Adjudication,
+}
+
+impl TrustAxes {
+    /// Build the axes for a newly written record.
+    ///
+    /// # Errors
+    ///
+    /// [`TrustError::PredictedNotStorable`] if `origin` is [`Origin::Predicted`].
+    pub fn new(
+        origin: Origin,
+        corroboration: Corroboration,
+        adjudication: Adjudication,
+    ) -> Result<Self, TrustError> {
+        if matches!(origin, Origin::Predicted) {
+            return Err(TrustError::PredictedNotStorable);
+        }
+        Ok(Self {
+            origin,
+            corroboration,
+            adjudication,
+        })
+    }
+
+    /// A freshly observed, uncorroborated, unruled claim — the common case.
+    #[must_use]
+    pub fn observed() -> Self {
+        Self {
+            origin: Origin::Observed,
+            corroboration: Corroboration::Uncorroborated,
+            adjudication: Adjudication::Pending,
+        }
+    }
+
+    /// Origin. **Rule 1** — there is no corresponding setter, by design.
+    #[must_use]
+    pub fn origin(&self) -> Origin {
+        self.origin
+    }
+
+    /// Corroboration as stored, before rule 3 is applied.
+    #[must_use]
+    pub fn corroboration(&self) -> Corroboration {
+        self.corroboration
+    }
+
+    /// Adjudication **with rule 3 applied**: `Contradicted` reads as `Ambiguous`
+    /// unless an adjudication rule has resolved it.
+    ///
+    /// A `Pending` claim with contradicting evidence is `Ambiguous` — that is
+    /// rule 3. An explicitly `Confirmed` or `Rejected` claim keeps its ruling,
+    /// because that is what *"unless an adjudication rule resolves it"* means.
+    #[must_use]
+    pub fn adjudication(&self) -> Adjudication {
+        match (self.corroboration, self.adjudication) {
+            (Corroboration::Contradicted(_), Adjudication::Pending) => Adjudication::Ambiguous,
+            _ => self.adjudication,
+        }
+    }
+
+    /// Adjudication exactly as stored, **without** rule 3. For persistence and
+    /// tests; consumers want [`Self::adjudication`].
+    #[must_use]
+    pub fn adjudication_stored(&self) -> Adjudication {
+        self.adjudication
+    }
+
+    /// Fold in agreeing evidence — rule 2.
+    ///
+    /// # Errors
+    ///
+    /// [`TrustError::RejectedIsTerminal`] if the record was rejected.
+    pub fn agreed(self) -> Result<Self, TrustError> {
+        self.guard_not_rejected()?;
+        Ok(Self {
+            corroboration: self.corroboration.agreed(),
+            ..self
+        })
+    }
+
+    /// Fold in disagreeing evidence — rule 2.
+    ///
+    /// # Errors
+    ///
+    /// [`TrustError::RejectedIsTerminal`] if the record was rejected.
+    pub fn disagreed(self) -> Result<Self, TrustError> {
+        self.guard_not_rejected()?;
+        Ok(Self {
+            corroboration: self.corroboration.disagreed(),
+            ..self
+        })
+    }
+
+    /// An operator rules the claim admissible — the adjudication half of
+    /// **rule 4**, and the resolution escape hatch of **rule 3**.
+    ///
+    /// This settles *which* entity is meant. It **cannot rewrite geometry**:
+    /// nothing here touches a payload, and an operator correcting a measured
+    /// pose must instead create a `Correction` observation whose payload is
+    /// visibly operator-sourced (P10). That half is the observation model's to
+    /// enforce, and this method's inability to reach a payload is the reason it
+    /// cannot be used to sidestep it.
+    ///
+    /// # Errors
+    ///
+    /// [`TrustError::RejectedIsTerminal`] if the record was rejected.
+    pub fn operator_confirm(self) -> Result<Self, TrustError> {
+        self.guard_not_rejected()?;
+        Ok(Self {
+            adjudication: Adjudication::Confirmed,
+            ..self
+        })
+    }
+
+    /// Rule the claim inadmissible — **rule 7**.
+    ///
+    /// Rejecting never deletes: this marks the record inadmissible to
+    /// projections. Terminal *for the record*, not for the subject — a later
+    /// observation about the same thing is a different record and is unaffected.
+    ///
+    /// # Errors
+    ///
+    /// [`TrustError::RejectedIsTerminal`] if already rejected. Rejecting twice
+    /// is refused rather than treated as a no-op, so a caller that believes it
+    /// is making a fresh ruling is told otherwise.
+    pub fn reject(self) -> Result<Self, TrustError> {
+        self.guard_not_rejected()?;
+        Ok(Self {
+            adjudication: Adjudication::Rejected,
+            ..self
+        })
+    }
+
+    fn guard_not_rejected(self) -> Result<(), TrustError> {
+        if matches!(self.adjudication, Adjudication::Rejected) {
+            return Err(TrustError::RejectedIsTerminal);
+        }
+        Ok(())
+    }
+
+    /// **Rule 5 — derived inherits the weakest input on every axis.**
+    ///
+    /// The anti-laundering rule, and the single most load-bearing line in the
+    /// trust model: it prevents a chain of plausible inferences producing a
+    /// high-confidence conclusion from low-confidence roots.
+    ///
+    /// Origin is always [`Origin::Derived`] — rule 1 fixes origin at write, and
+    /// what is being written is a derivation.
+    ///
+    /// # A deliberate reading of "every axis"
+    ///
+    /// Rule 5's text says the weakest input is inherited *"on every axis"*,
+    /// while the §9.1 mapping table shows `—` for the Derived row's
+    /// corroboration column. The two can be read as disagreeing.
+    ///
+    /// This implementation follows the **rule text**, folding corroboration too,
+    /// because that is the conservative direction: a derivation from a
+    /// contradicted input stays contradicted rather than emerging with the
+    /// contradiction dropped. Reading `—` as "not folded" would let a derivation
+    /// launder away a conflict, which is precisely what rule 5 exists to stop.
+    ///
+    /// Recorded as an open question for the World Model owner rather than
+    /// treated as settled: **does the table's `—` mean "not applicable" or
+    /// "undefined"?** Under either reading the conservative fold is safe; under
+    /// the second it is also the only defensible one.
+    ///
+    /// # Errors
+    ///
+    /// [`TrustError::DerivationNeedsInputs`] if `inputs` is empty.
+    pub fn derive_from(inputs: &[Self]) -> Result<Self, TrustError> {
+        let (first, rest) = inputs
+            .split_first()
+            .ok_or(TrustError::DerivationNeedsInputs)?;
+
+        // Fold the RULE-3-APPLIED adjudication, not the stored one: a
+        // contradicted-and-pending input is Ambiguous to every reader, and a
+        // derivation must inherit what the input actually means, not the
+        // unresolved value behind it.
+        let mut corroboration = first.corroboration;
+        let mut adjudication = first.adjudication();
+        for input in rest {
+            corroboration = corroboration.weakest(input.corroboration);
+            adjudication = adjudication.weakest(input.adjudication());
+        }
+
+        Ok(Self {
+            origin: Origin::Derived,
+            corroboration,
+            adjudication,
+        })
+    }
+
+    /// Rule 5's validity fold, which cannot live on [`Self`] because validity is
+    /// never stored (rule 6). Ask each input's validity at the same instant,
+    /// then fold.
+    ///
+    /// Returns [`Validity::Timeless`] for an empty slice — the identity of the
+    /// fold. A derivation with no temporal inputs has nothing that can go stale;
+    /// note that [`Self::derive_from`] separately refuses an empty *axes* slice,
+    /// so this identity is only reachable for a derivation whose inputs are all
+    /// atemporal.
+    #[must_use]
+    pub fn derived_validity(input_validities: &[Validity]) -> Validity {
+        input_validities
+            .iter()
+            .copied()
+            .fold(Validity::Timeless, Validity::weakest)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Derived labels — §9.1's mapping table, and §9.3's grade
+// ---------------------------------------------------------------------------
+
+/// The familiar single-word state, derived from the axes for display.
+///
+/// This is the §9.1 table read left-to-right. It is **lossy by construction** —
+/// that is the point of deriving it rather than storing it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RequestedState {
+    /// Sensed once, unruled, in force.
+    Observed,
+    /// Sensed and ruled admissible, in force.
+    Confirmed,
+    /// Stated by an operator and ruled admissible.
+    OperatorConfirmed,
+    /// Computed from other evidence, carrying its inputs' weakest axes.
+    Derived,
+    /// Brought in from an external dataset, unruled.
+    Imported,
+    /// Outside its validity window — dominates origin.
+    Expired,
+    /// Evidence in conflict. A **reportable state, not an error** (rule 3).
+    Ambiguous,
+    /// Ruled inadmissible. Terminal for the record (rule 7), and dominates
+    /// every other label.
+    Rejected,
+}
+
+/// Collapse the axes to the familiar label — §9.1.
+///
+/// Order matters and follows the table's own precedence: `Rejected` and
+/// `Expired` dominate any origin, and `Ambiguous` dominates the rest, because
+/// each answers a question that outranks "where did this come from".
+#[must_use]
+pub fn requested_state(axes: &TrustAxes, validity: Validity) -> RequestedState {
+    if matches!(axes.adjudication(), Adjudication::Rejected) {
+        return RequestedState::Rejected;
+    }
+    if matches!(validity, Validity::Expired) {
+        return RequestedState::Expired;
+    }
+    if matches!(axes.adjudication(), Adjudication::Ambiguous) {
+        return RequestedState::Ambiguous;
+    }
+    match axes.origin() {
+        Origin::Asserted => RequestedState::OperatorConfirmed,
+        Origin::Derived => RequestedState::Derived,
+        Origin::Imported => RequestedState::Imported,
+        Origin::Observed | Origin::Predicted => {
+            if matches!(axes.adjudication(), Adjudication::Confirmed) {
+                RequestedState::Confirmed
+            } else {
+                RequestedState::Observed
+            }
+        }
+    }
+}
+
+/// A single advisory number for consumers that insist on one — §9.3.
+///
+/// # This is never an input to a safety decision
+///
+/// Blueprint §18 and ADR-0039 both say it: Kirra World is non-authoritative, and
+/// this grade is the most collapsible thing it produces. It exists so a
+/// conversational surface can say "I'm fairly sure"; it must not reach a
+/// checker. Fence B is what makes that structural rather than advisory — nothing
+/// in the safety closure can depend on this crate at all.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum TrustGrade {
+    /// Rejected, expired, or in unresolved conflict.
+    Inadmissible,
+    /// Admissible but weakly supported.
+    Weak,
+    /// Ordinary single-source evidence, in force.
+    Adequate,
+    /// Corroborated or operator-confirmed, in force.
+    Strong,
+}
+
+/// Collapse the axes and a validity answer to one advisory grade — §9.3.
+#[must_use]
+pub fn trust_grade(axes: &TrustAxes, validity: Validity) -> TrustGrade {
+    match axes.adjudication() {
+        Adjudication::Rejected | Adjudication::Ambiguous => return TrustGrade::Inadmissible,
+        _ => {}
+    }
+    if matches!(validity, Validity::Expired) {
+        return TrustGrade::Inadmissible;
+    }
+    let corroborated = matches!(axes.corroboration(), Corroboration::Corroborated(n) if n >= 2);
+    let confirmed = matches!(axes.adjudication(), Adjudication::Confirmed);
+    match (corroborated || confirmed, validity) {
+        (true, Validity::Stale) => TrustGrade::Adequate,
+        (true, _) => TrustGrade::Strong,
+        (false, Validity::Stale) => TrustGrade::Weak,
+        (false, _) => TrustGrade::Adequate,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- Rule 1: origin never changes ------------------------------------
+
+    #[test]
+    fn no_transition_changes_origin() {
+        let a = TrustAxes::new(
+            Origin::Imported,
+            Corroboration::Uncorroborated,
+            Adjudication::Pending,
+        )
+        .unwrap();
+        assert_eq!(a.agreed().unwrap().origin(), Origin::Imported);
+        assert_eq!(a.disagreed().unwrap().origin(), Origin::Imported);
+        assert_eq!(a.operator_confirm().unwrap().origin(), Origin::Imported);
+        assert_eq!(a.reject().unwrap().origin(), Origin::Imported);
+    }
+
+    #[test]
+    fn predicted_is_refused_by_the_store_facing_constructor() {
+        assert_eq!(
+            TrustAxes::new(
+                Origin::Predicted,
+                Corroboration::Uncorroborated,
+                Adjudication::Pending
+            ),
+            Err(TrustError::PredictedNotStorable)
+        );
+    }
+
+    // -- Rule 2: monotonic in evidence -----------------------------------
+
+    #[test]
+    fn agreement_increments_and_disagreement_switches_kind() {
+        let c = Corroboration::Uncorroborated.agreed().agreed();
+        assert_eq!(c, Corroboration::Corroborated(2));
+        // Not Corroborated(1): disagreement is a change of kind, not a decrement.
+        assert_eq!(c.disagreed(), Corroboration::Contradicted(1));
+    }
+
+    #[test]
+    fn agreement_does_not_clear_a_contradiction() {
+        let c = Corroboration::Contradicted(1).agreed().agreed().agreed();
+        assert_eq!(c, Corroboration::Contradicted(1));
+    }
+
+    #[test]
+    fn corroboration_counts_saturate_rather_than_overflow() {
+        assert_eq!(
+            Corroboration::Corroborated(u32::MAX).agreed(),
+            Corroboration::Corroborated(u32::MAX)
+        );
+        assert_eq!(
+            Corroboration::Contradicted(u32::MAX).disagreed(),
+            Corroboration::Contradicted(u32::MAX)
+        );
+    }
+
+    // -- Rule 3: contradicted implies ambiguous --------------------------
+
+    #[test]
+    fn contradicted_and_pending_reads_as_ambiguous() {
+        let a = TrustAxes::observed().disagreed().unwrap();
+        assert_eq!(a.adjudication(), Adjudication::Ambiguous);
+        // ...but the stored value is untouched, so the ruling is recoverable.
+        assert_eq!(a.adjudication_stored(), Adjudication::Pending);
+    }
+
+    #[test]
+    fn an_explicit_ruling_survives_contradiction() {
+        let a = TrustAxes::observed()
+            .disagreed()
+            .unwrap()
+            .operator_confirm()
+            .unwrap();
+        assert_eq!(a.adjudication(), Adjudication::Confirmed);
+    }
+
+    // -- Rule 5: the anti-laundering rule --------------------------------
+
+    #[test]
+    fn derivation_inherits_the_weakest_adjudication() {
+        let strong = TrustAxes::observed().operator_confirm().unwrap();
+        let weak = TrustAxes::observed(); // Pending
+        let d = TrustAxes::derive_from(&[strong, weak]).unwrap();
+        assert_eq!(d.origin(), Origin::Derived);
+        assert_eq!(d.adjudication(), Adjudication::Pending);
+    }
+
+    #[test]
+    fn derivation_cannot_launder_away_a_contradiction() {
+        // THE rule. A contradicted input must not emerge from a derivation clean.
+        let contradicted = TrustAxes::observed().disagreed().unwrap();
+        let clean = TrustAxes::observed()
+            .agreed()
+            .unwrap()
+            .agreed()
+            .unwrap()
+            .operator_confirm()
+            .unwrap();
+
+        let d = TrustAxes::derive_from(&[clean, contradicted]).unwrap();
+
+        assert_eq!(d.corroboration(), Corroboration::Contradicted(1));
+        assert_eq!(d.adjudication(), Adjudication::Ambiguous);
+    }
+
+    #[test]
+    fn a_chain_of_derivations_cannot_climb() {
+        // The pathology rule 5 names: plausible inferences producing a
+        // high-confidence conclusion from low-confidence roots.
+        //
+        // Each step mixes the running value with a DELIBERATELY STRONG input.
+        // That is load-bearing: with a single input the weakest-fold and a
+        // strongest-fold are the same function, so a one-input chain would pass
+        // even with the rule inverted. A negative control caught exactly that,
+        // and this is the corrected shape.
+        let strong = TrustAxes::observed()
+            .agreed()
+            .unwrap()
+            .agreed()
+            .unwrap()
+            .operator_confirm()
+            .unwrap();
+
+        let root = TrustAxes::observed().disagreed().unwrap();
+        let mut cur = TrustAxes::derive_from(&[root]).unwrap();
+        for _ in 0..10 {
+            cur = TrustAxes::derive_from(&[cur, strong]).unwrap();
+        }
+
+        // Ten rounds of laundering through a confirmed, doubly-corroborated
+        // partner, and the conflict is still there.
+        assert_eq!(cur.adjudication(), Adjudication::Ambiguous);
+        assert_eq!(cur.corroboration(), Corroboration::Contradicted(1));
+    }
+
+    #[test]
+    fn weakest_corroboration_takes_more_contradictions_and_fewer_agreements() {
+        assert_eq!(
+            Corroboration::Contradicted(2).weakest(Corroboration::Contradicted(5)),
+            Corroboration::Contradicted(5)
+        );
+        assert_eq!(
+            Corroboration::Corroborated(9).weakest(Corroboration::Corroborated(3)),
+            Corroboration::Corroborated(3)
+        );
+        assert_eq!(
+            Corroboration::Corroborated(9).weakest(Corroboration::Uncorroborated),
+            Corroboration::Uncorroborated
+        );
+    }
+
+    #[test]
+    fn weakest_is_commutative_across_every_pair() {
+        let all = [
+            Corroboration::Uncorroborated,
+            Corroboration::Corroborated(1),
+            Corroboration::Corroborated(4),
+            Corroboration::Contradicted(1),
+            Corroboration::Contradicted(4),
+        ];
+        for a in all {
+            for b in all {
+                assert_eq!(a.weakest(b), b.weakest(a), "not commutative: {a:?} {b:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn derivation_with_no_inputs_is_refused_rather_than_invented() {
+        assert_eq!(
+            TrustAxes::derive_from(&[]),
+            Err(TrustError::DerivationNeedsInputs)
+        );
+    }
+
+    #[test]
+    fn derived_validity_folds_to_the_weakest() {
+        assert_eq!(
+            TrustAxes::derived_validity(&[Validity::Timeless, Validity::Stale, Validity::Fresh]),
+            Validity::Stale
+        );
+        assert_eq!(
+            TrustAxes::derived_validity(&[Validity::Fresh, Validity::Expired]),
+            Validity::Expired
+        );
+        assert_eq!(TrustAxes::derived_validity(&[]), Validity::Timeless);
+    }
+
+    // -- Rule 6: computed at read time -----------------------------------
+
+    #[test]
+    fn freshness_is_a_question_asked_with_a_clock() {
+        let w = ValidityWindow {
+            valid_from_ms: 1_000,
+            valid_to_ms: None,
+            staleness_budget_ms: Some(500),
+        };
+        // Same stored facts, three different answers — which is rule 6's point.
+        assert_eq!(validity_at(&w, 1_200), Validity::Fresh);
+        assert_eq!(validity_at(&w, 1_500), Validity::Fresh); // boundary: inclusive
+        assert_eq!(validity_at(&w, 1_501), Validity::Stale);
+    }
+
+    #[test]
+    fn expiry_beats_staleness() {
+        let w = ValidityWindow {
+            valid_from_ms: 0,
+            valid_to_ms: Some(100),
+            staleness_budget_ms: Some(10),
+        };
+        // Past both; must report the stronger restriction, not the first found.
+        assert_eq!(validity_at(&w, 500), Validity::Expired);
+    }
+
+    #[test]
+    fn no_staleness_budget_means_timeless() {
+        assert_eq!(
+            validity_at(&ValidityWindow::timeless(0), u64::MAX),
+            Validity::Timeless
+        );
+    }
+
+    #[test]
+    fn a_claim_not_yet_in_force_is_never_fresh() {
+        // The flagged spec gap: fail-closed is what matters, the NAME is open.
+        let w = ValidityWindow {
+            valid_from_ms: 1_000,
+            valid_to_ms: None,
+            staleness_budget_ms: Some(500),
+        };
+        assert_ne!(validity_at(&w, 999), Validity::Fresh);
+        assert_eq!(validity_at(&w, 999), Validity::Expired);
+    }
+
+    #[test]
+    fn staleness_deadline_saturates_rather_than_overflowing() {
+        let w = ValidityWindow {
+            valid_from_ms: u64::MAX,
+            valid_to_ms: None,
+            staleness_budget_ms: Some(u64::MAX),
+        };
+        assert_eq!(validity_at(&w, u64::MAX), Validity::Fresh);
+    }
+
+    // -- Rule 7: rejection is terminal -----------------------------------
+
+    #[test]
+    fn nothing_moves_a_rejected_record() {
+        let r = TrustAxes::observed().reject().unwrap();
+        assert_eq!(r.agreed(), Err(TrustError::RejectedIsTerminal));
+        assert_eq!(r.disagreed(), Err(TrustError::RejectedIsTerminal));
+        assert_eq!(r.operator_confirm(), Err(TrustError::RejectedIsTerminal));
+        assert_eq!(r.reject(), Err(TrustError::RejectedIsTerminal));
+    }
+
+    #[test]
+    fn a_rejected_input_poisons_a_derivation() {
+        // Rule 7 is terminal for the RECORD; rule 5 then carries it downstream.
+        let rejected = TrustAxes::observed().reject().unwrap();
+        let good = TrustAxes::observed().operator_confirm().unwrap();
+        let d = TrustAxes::derive_from(&[good, rejected]).unwrap();
+        assert_eq!(d.adjudication(), Adjudication::Rejected);
+    }
+
+    // -- Derived labels ---------------------------------------------------
+
+    #[test]
+    fn requested_states_match_the_blueprint_table() {
+        let observed = TrustAxes::observed();
+        assert_eq!(
+            requested_state(&observed, Validity::Fresh),
+            RequestedState::Observed
+        );
+
+        let confirmed = TrustAxes::observed()
+            .agreed()
+            .unwrap()
+            .operator_confirm()
+            .unwrap();
+        assert_eq!(
+            requested_state(&confirmed, Validity::Fresh),
+            RequestedState::Confirmed
+        );
+
+        let asserted = TrustAxes::new(
+            Origin::Asserted,
+            Corroboration::Uncorroborated,
+            Adjudication::Confirmed,
+        )
+        .unwrap();
+        assert_eq!(
+            requested_state(&asserted, Validity::Timeless),
+            RequestedState::OperatorConfirmed
+        );
+
+        let imported = TrustAxes::new(
+            Origin::Imported,
+            Corroboration::Uncorroborated,
+            Adjudication::Pending,
+        )
+        .unwrap();
+        assert_eq!(
+            requested_state(&imported, Validity::Timeless),
+            RequestedState::Imported
+        );
+    }
+
+    #[test]
+    fn expiry_and_rejection_dominate_origin() {
+        let imported = TrustAxes::new(
+            Origin::Imported,
+            Corroboration::Uncorroborated,
+            Adjudication::Pending,
+        )
+        .unwrap();
+        assert_eq!(
+            requested_state(&imported, Validity::Expired),
+            RequestedState::Expired
+        );
+        assert_eq!(
+            requested_state(&imported.reject().unwrap(), Validity::Fresh),
+            RequestedState::Rejected
+        );
+    }
+
+    #[test]
+    fn ambiguity_is_reportable_rather_than_an_error() {
+        let a = TrustAxes::observed().disagreed().unwrap();
+        assert_eq!(
+            requested_state(&a, Validity::Fresh),
+            RequestedState::Ambiguous
+        );
+    }
+
+    // -- The advisory grade -----------------------------------------------
+
+    #[test]
+    fn the_grade_never_rates_an_inadmissible_claim_above_inadmissible() {
+        let rejected = TrustAxes::observed().reject().unwrap();
+        let ambiguous = TrustAxes::observed().disagreed().unwrap();
+        assert_eq!(
+            trust_grade(&rejected, Validity::Fresh),
+            TrustGrade::Inadmissible
+        );
+        assert_eq!(
+            trust_grade(&ambiguous, Validity::Fresh),
+            TrustGrade::Inadmissible
+        );
+        assert_eq!(
+            trust_grade(&TrustAxes::observed(), Validity::Expired),
+            TrustGrade::Inadmissible
+        );
+    }
+
+    #[test]
+    fn corroboration_and_confirmation_lift_the_grade() {
+        let plain = TrustAxes::observed();
+        let corroborated = plain.agreed().unwrap().agreed().unwrap();
+        assert_eq!(trust_grade(&plain, Validity::Fresh), TrustGrade::Adequate);
+        assert_eq!(
+            trust_grade(&corroborated, Validity::Fresh),
+            TrustGrade::Strong
+        );
+        assert!(trust_grade(&corroborated, Validity::Fresh) > trust_grade(&plain, Validity::Fresh));
+    }
+
+    #[test]
+    fn staleness_lowers_the_grade_without_making_it_inadmissible() {
+        let plain = TrustAxes::observed();
+        assert_eq!(trust_grade(&plain, Validity::Stale), TrustGrade::Weak);
+        assert!(trust_grade(&plain, Validity::Stale) > TrustGrade::Inadmissible);
+    }
+}

--- a/crates/kirra-world/src/trust.rs
+++ b/crates/kirra-world/src/trust.rs
@@ -590,15 +590,62 @@ pub enum RequestedState {
     /// Ruled inadmissible. Terminal for the record (rule 7), and dominates
     /// every other label.
     Rejected,
+    /// **The §9.1 table names no state for these axes.**
+    ///
+    /// Reachable today for one combination: an `Asserted` claim whose
+    /// adjudication is not `Confirmed` — an operator has stated something and
+    /// nothing has ruled on it. `OperatorConfirmed` would overstate it,
+    /// `Observed` would claim a sensor saw it, and the table offers nothing else.
+    ///
+    /// Reported rather than guessed, on ADR-0040's own reasoning about
+    /// `ResolutionOutcome`: collapsing distinct answers into one value is
+    /// unrecoverable once done. This is **not** the blueprint's `Unknown`, which
+    /// means *no admissible evidence* — here there is evidence, it simply has no
+    /// familiar name.
+    Unlabelled,
 }
+
+/// How many agreeing sources the §9.1 `Confirmed` row's `Corroborated(≥k)`
+/// requires.
+///
+/// **The blueprint does not define `k`.** Two is the smallest value for which
+/// "corroborated" means anything — one source agreeing with itself is not
+/// corroboration — so that is what this uses. Named rather than inlined so the
+/// policy is greppable and changeable in one place, and flagged as an open
+/// question for the World Model owner: **what is `k`, and is it per-kind?**
+pub const CORROBORATION_THRESHOLD_K: u32 = 2;
 
 /// Collapse the axes to the familiar label — §9.1.
 ///
-/// Order matters and follows the table's own precedence: `Rejected` and
-/// `Expired` dominate any origin, and `Ambiguous` dominates the rest, because
-/// each answers a question that outranks "where did this come from".
+/// # The table is not a partition, so precedence is this function's to state
+///
+/// §9.1 shows how each *named* state decomposes into axes; it does not claim
+/// every axis combination has a name, and its rows overlap (a `Derived` claim
+/// that is also `Corroborated(≥k)` and `Confirmed` matches two rows). Collapsing
+/// arbitrary axes to one label is therefore this function's construction on top
+/// of the table, and the precedence below is stated rather than inherited:
+///
+/// 1. `Rejected`, then `Expired`, then `Ambiguous` — the three rows the table
+///    itself marks as applying to *any* origin, so they dominate.
+/// 2. `OperatorConfirmed` before `Confirmed` — it is the **more specific** of
+///    the two, pinning origin to `Asserted` where `Confirmed` accepts any.
+/// 3. Otherwise the origin-only rows.
+///
+/// # Two corrections against the table
+///
+/// An earlier version of this function got both of these wrong, in opposite
+/// directions, and they are called out because one of them was unsafe:
+///
+/// * **`OperatorConfirmed` requires `Confirmed` adjudication.** It previously
+///   returned for *any* `Asserted` claim, so an operator assertion that had not
+///   been adjudicated was reported as operator-confirmed. That **overstates
+///   trust**, which is the direction that matters.
+/// * **`Confirmed` is "any origin".** It previously returned only for
+///   `Observed`, hiding confirmed status on `Imported` and `Derived` claims.
+///   That understates, which is safe but still wrong.
 #[must_use]
 pub fn requested_state(axes: &TrustAxes, validity: Validity) -> RequestedState {
+    // (1) The rows the table marks "any origin".
     if matches!(axes.adjudication(), Adjudication::Rejected) {
         return RequestedState::Rejected;
     }
@@ -608,17 +655,28 @@ pub fn requested_state(axes: &TrustAxes, validity: Validity) -> RequestedState {
     if matches!(axes.adjudication(), Adjudication::Ambiguous) {
         return RequestedState::Ambiguous;
     }
+
+    let confirmed = matches!(axes.adjudication(), Adjudication::Confirmed);
+
+    // (2) More specific first.
+    if confirmed && matches!(axes.origin(), Origin::Asserted) {
+        return RequestedState::OperatorConfirmed;
+    }
+    if confirmed
+        && matches!(axes.corroboration(), Corroboration::Corroborated(n)
+            if n >= CORROBORATION_THRESHOLD_K)
+    {
+        return RequestedState::Confirmed;
+    }
+
+    // (3) Origin-only rows.
     match axes.origin() {
-        Origin::Asserted => RequestedState::OperatorConfirmed,
         Origin::Derived => RequestedState::Derived,
         Origin::Imported => RequestedState::Imported,
-        Origin::Observed | Origin::Predicted => {
-            if matches!(axes.adjudication(), Adjudication::Confirmed) {
-                RequestedState::Confirmed
-            } else {
-                RequestedState::Observed
-            }
-        }
+        Origin::Observed | Origin::Predicted => RequestedState::Observed,
+        // `Asserted` without `Confirmed` adjudication. The table names no state
+        // for it — see [`RequestedState::Unlabelled`].
+        Origin::Asserted => RequestedState::Unlabelled,
     }
 }
 
@@ -941,7 +999,10 @@ mod tests {
             RequestedState::Observed
         );
 
+        // Corroborated(2) — the table's `Corroborated(>=k)`.
         let confirmed = TrustAxes::observed()
+            .agreed()
+            .unwrap()
             .agreed()
             .unwrap()
             .operator_confirm()
@@ -989,6 +1050,83 @@ mod tests {
         assert_eq!(
             requested_state(&imported.reject().unwrap(), Validity::Fresh),
             RequestedState::Rejected
+        );
+    }
+
+    #[test]
+    fn an_unadjudicated_operator_assertion_is_not_operator_confirmed() {
+        // REGRESSION. The earlier version returned OperatorConfirmed for ANY
+        // Asserted origin, so a claim nobody had ruled on was reported as
+        // operator-confirmed — OVERSTATING trust, the direction that matters.
+        // The table requires `Confirmed` adjudication for that row.
+        let pending = TrustAxes::new(
+            Origin::Asserted,
+            Corroboration::Uncorroborated,
+            Adjudication::Pending,
+        )
+        .unwrap();
+        assert_ne!(
+            requested_state(&pending, Validity::Fresh),
+            RequestedState::OperatorConfirmed
+        );
+        assert_eq!(
+            requested_state(&pending, Validity::Fresh),
+            RequestedState::Unlabelled
+        );
+
+        // ...and the confirmed one still is.
+        assert_eq!(
+            requested_state(&pending.operator_confirm().unwrap(), Validity::Fresh),
+            RequestedState::OperatorConfirmed
+        );
+    }
+
+    #[test]
+    fn confirmed_is_any_origin_not_just_observed() {
+        // REGRESSION. The earlier version only reported Confirmed for Observed
+        // origin, hiding confirmed status on Imported and Derived claims. The
+        // table's Confirmed row reads "any origin".
+        for origin in [Origin::Imported, Origin::Derived, Origin::Observed] {
+            let axes = TrustAxes::new(
+                origin,
+                Corroboration::Corroborated(CORROBORATION_THRESHOLD_K),
+                Adjudication::Confirmed,
+            )
+            .unwrap();
+            assert_eq!(
+                requested_state(&axes, Validity::Fresh),
+                RequestedState::Confirmed,
+                "origin {origin:?} should reach Confirmed"
+            );
+        }
+    }
+
+    #[test]
+    fn confirmed_needs_k_agreeing_sources() {
+        let below = TrustAxes::new(
+            Origin::Observed,
+            Corroboration::Corroborated(CORROBORATION_THRESHOLD_K - 1),
+            Adjudication::Confirmed,
+        )
+        .unwrap();
+        assert_eq!(
+            requested_state(&below, Validity::Fresh),
+            RequestedState::Observed
+        );
+    }
+
+    #[test]
+    fn operator_confirmed_outranks_confirmed_being_more_specific() {
+        // Both rows match; the one that pins origin wins.
+        let axes = TrustAxes::new(
+            Origin::Asserted,
+            Corroboration::Corroborated(CORROBORATION_THRESHOLD_K),
+            Adjudication::Confirmed,
+        )
+        .unwrap();
+        assert_eq!(
+            requested_state(&axes, Validity::Fresh),
+            RequestedState::OperatorConfirmed
         );
     }
 

--- a/docs/adr/0039-world-model-bidirectional-governor-fence.md
+++ b/docs/adr/0039-world-model-bidirectional-governor-fence.md
@@ -447,7 +447,17 @@ following are recorded:
       acceptance of this ADR still is.
 - [x] C1 (terminology collision) — canonical set decided in ADR-0042 Decision 1
 - [x] C2 (map/corridor boundary) — stated in ADR-0042 Decision 2
-- [ ] ADR-0042 itself accepted
+- [x] ADR-0042 itself accepted
+
+      **SATISFIED — [ADR-0042](0042-world-model-terminology-and-safety-boundary-scope.md)
+      was accepted 2026-08-06** by Justin Looney, on the recording of its fourth
+      and final criterion (the architecture owner sign-off on the canonical
+      terminology). Its acceptance carries one named follow-up — the M5
+      `docs/safety` terminology migration — which is **not** a condition on this
+      box: ADR-0042 is accepted, and M5 is scheduled work inside it.
+
+      **This box is the only one here that acceptance of ADR-0042 moves.** The
+      three owner sign-offs above remain open, so **ADR-0039 is still Proposed**.
 
 Merging the PR that **introduced this ADR** satisfied none of the above.
 Boxes above are ticked only by a separately recorded owner ruling, each of

--- a/docs/adr/0039-world-model-bidirectional-governor-fence.md
+++ b/docs/adr/0039-world-model-bidirectional-governor-fence.md
@@ -2,8 +2,9 @@
 
 | Field | Value |
 |---|---|
-| Status | **Proposed — NOT ratified on merge.** See *Ratification criteria*. Merging records the proposal; it does not ratify it and authorizes no implementation. |
-| Date | 2026-08-02 |
+| Status | **Accepted** — 2026-08-06. All seven ratification criteria recorded. The fences are **structurally enforced and machine-checked**, not merely asserted. Acceptance authorizes no implementation, and carries no runtime evidence — see *Acceptance record*. |
+| Date | 2026-08-02 (proposed) · 2026-08-06 (accepted) |
+| Accepted by | **Justin Looney**, holding the governor / safety-case owner, World Model owner and architecture owner roles. One approver across all three — recorded plainly rather than as three sign-offs, following [`ADR-0041`](0041-world-model-persistence-architecture.md)'s precedent. |
 | Blueprint | `KIRRA-WM-ARCH-001` §18 (WM-6) — [`docs/design/WORLD_MODEL_ARCHITECTURE.md`](../design/WORLD_MODEL_ARCHITECTURE.md) |
 | Deciders | Governor / safety-case owner · World Model owner · architecture owner · safety-assurance owner |
 | **Clarified by** | **[ADR-0042](0042-world-model-terminology-and-safety-boundary-scope.md)** — canonical terminology, semantic-map vs safety-corridor boundary, transitive Fence B, language independence, and the PENDING assurance ruling. **Read 0042 alongside this ADR; it supersedes the scope claim below.** |
@@ -430,9 +431,35 @@ this work, reported for the record.
 This ADR is **Proposed**. It becomes Accepted only when **all** of the
 following are recorded:
 
-- [ ] **Governor / safety-case owner** review and sign-off
-- [ ] **World Model owner** review and sign-off
-- [ ] **Architecture owner** review and sign-off
+- [x] **Governor / safety-case owner** review and sign-off
+- [x] **World Model owner** review and sign-off
+- [x] **Architecture owner** review and sign-off
+
+      **RECORDED — 2026-08-06 by Justin Looney, holding all three roles.**
+      **One approver across all three, recorded plainly rather than as three
+      sign-offs**, per [`ADR-0041`](0041-world-model-persistence-architecture.md)'s
+      precedent. These three boxes are **one judgement written three times, not
+      three reviews** — see *Acceptance record*.
+
+      **What the judgement rests on.** Fence A (*knowledge cannot act*) and
+      Fence B (*safety cannot depend on knowledge*) are not asserted here; they
+      are **structurally enforced and transitively machine-checked** —
+      `check_kirra_world_bidirectional_fence.py`, both directions passing at
+      38/38, closure intact at 19 packages from 10 roots, computed over the
+      manifests rather than a maintained crate list. That is the strongest form
+      of evidence available for a claim of this shape: a breach reds CI with the
+      offending path named, rather than waiting to be noticed.
+
+      **What it does not rest on.** No independent assurance review, and no
+      runtime evidence — Kirra World has no running service, so the fences are
+      verified against the dependency graph, not against a deployed system.
+      SG7 (*the safety check is invariant to the command's origin*) and SG1
+      (*the checker's bound is what holds*) are served by the structure; neither
+      is demonstrated by test in a deployment that does not yet exist.
+
+      **Recorded as an owner self-assessment.** Kirra is designed in alignment
+      with ISO 26262 ASIL-D requirements and IEC 61508 SIL 3 requirements;
+      independent third-party assessment has not yet been performed.
 - [x] **Safety-assurance owner** ruling recorded per
       [ADR-0042](0042-world-model-terminology-and-safety-boundary-scope.md)
       Decision 5, using its decision-record template. The ruling must be
@@ -456,10 +483,60 @@ following are recorded:
       `docs/safety` terminology migration — which is **not** a condition on this
       box: ADR-0042 is accepted, and M5 is scheduled work inside it.
 
-      **This box is the only one here that acceptance of ADR-0042 moves.** The
-      three owner sign-offs above remain open, so **ADR-0039 is still Proposed**.
+      **This box was the only one here that acceptance of ADR-0042 moved.** When
+      it was ticked earlier on 2026-08-06 the three owner sign-offs above were
+      still open and this ADR was still Proposed; they were recorded later the
+      same day, which is what accepted it. *(This note read "remain open … still
+      Proposed" until those sign-offs landed; updated rather than left to
+      contradict the Status row.)*
 
 Merging the PR that **introduced this ADR** satisfied none of the above.
 Boxes above are ticked only by a separately recorded owner ruling, each of
 which names its owner and date inline — never by the act of merging a
 document change.
+
+---
+
+## Acceptance record
+
+**Accepted 2026-08-06 by Justin Looney**, holding the governor / safety-case
+owner, World Model owner and architecture owner roles.
+
+### Three boxes, one judgement
+
+ADR-0039 asks for three separate owner sign-offs. **One person holds all three
+roles**, so those boxes are one judgement recorded three times. Stated here for
+the reason [`ADR-0041`](0041-world-model-persistence-architecture.md) gave: a
+reader who counts sign-offs and infers independence from the count would be
+wrong, and the record must not permit that inference.
+
+### The evidence is structural, and that is a genuine strength here
+
+Unlike most acceptance criteria in this family, the fences are **not held by
+convention**. `check_kirra_world_bidirectional_fence.py` computes the closure
+**transitively over the Cargo manifests** — not against a maintained list of
+crate names — so a new package cannot silently escape it, and a violation reds
+CI with the offending path named. Both directions pass 38/38 with the closure
+intact at 19 packages from 10 roots.
+
+This is worth contrasting with ADR-0042's Decision 1, accepted the same day:
+that one has **no** machine check and is held by convention alone. The two
+acceptances are not equally well supported, and the difference is the enforcement
+mechanism, not the care taken.
+
+### What acceptance does not carry
+
+* **No runtime evidence.** Kirra World has no running service. The fences are
+  verified against the dependency graph of a system that does not yet execute.
+* **No independent review.** Owner self-assessment throughout.
+* **No implementation authorization.** Acceptance settles the architectural
+  claim; it does not license building against it.
+* **No ratification of ADR-0040**, which stands on its own four criteria.
+
+### Independence posture
+
+Kirra is designed in alignment with ISO 26262 ASIL-D requirements and IEC 61508
+SIL 3 requirements; independent third-party assessment has not yet been
+performed. Decision 5's assurance ruling — recorded via ADR-0042 — classifies
+Kirra World as *safety-related, non-authoritative*, on structural evidence, with
+three of its eight supporting questions open.

--- a/docs/adr/0040-world-model-ownership-and-boundary.md
+++ b/docs/adr/0040-world-model-ownership-and-boundary.md
@@ -521,9 +521,26 @@ not exist and is **not proposed here**, because designing it belongs with the
 Tier 1 observation model rather than ahead of it. Recorded so the owner
 confirms this row knowing the condition currently rests on remembering it.
 
-**Drafted, not decided.** No checkbox moves on this text. The compatibility
-inventory box requires *each row confirmed by its current owner*, and this is
-one row's evidence prepared for that confirmation.
+#### RULED — 2026-08-06
+
+> **CONFIRMED — 2026-08-06 by Justin Looney, World Model owner.** The wording
+> above is **adopted unamended**: unconditional for perception types carrying
+> their own confidence and timestamp, **conditional for `PerceivedObject`** —
+> no import path may be built until a stated rule exists for where its
+> confidence and validity come from, with the synthesis visible in the store
+> rather than indistinguishable from a measured value. The rule belongs to
+> `WM_SCOPE.md` Tier 1.
+>
+> **The import-boundary machine guard was offered and deliberately NOT taken.**
+> Adding it now would remove this deferral's known weakness — that nothing reds
+> in CI if an importer synthesizes a confidence — but it would mean designing
+> the guard ahead of the Tier 1 observation model that defines what it should
+> check. The weakness is therefore **accepted and recorded**, not mitigated:
+> until Tier 1 lands, this condition rests on being remembered.
+
+**One row of five.** The compatibility-inventory checkbox requires *each row
+confirmed by its current owner*; this ruling confirms the `tracked-object
+inputs` row only, so **that box stays unticked** pending the remaining four.
 
 ### Open question 4 appears already dispositioned
 
@@ -575,9 +592,24 @@ concedes nothing that has not already been conceded.
 > has no content, because the dependency runs store → core and an empty core
 > means an empty seam.
 
-This is **drafted, not decided.** Nothing above ticks the box, and the owner may
-prefer the alternative ordering — build Tier 1 first and ratify with a real
-answer — at the cost of leaving this ADR Proposed while its own subject matter
+> **RULED — 2026-08-06 by Justin Looney, World Model owner and architecture
+> owner.** The wording above is **adopted unamended**. The alternative ordering
+> (build Tier 1 first, ratify with a real answer) was considered and declined:
+> it leaves this ADR Proposed while its own subject matter is built, which is
+> the circularity the deferral exists to dissolve.
+>
+> **The box this feeds is `Open questions 1 and 4 dispositioned` — a
+> conjunction, and it stays UNTICKED.** Q1 is now dispositioned; Q4 is
+> *"appears already dispositioned"*, which is a finding, not the owner's act.
+> Ticking on a half-satisfied conjunction is exactly the drift these rulings
+> exist to prevent.
+
+The section below was the draft this ruling adopted, kept for the record.
+
+This was **drafted, not decided** when written. Nothing in it ticked the box,
+and the owner might have preferred the alternative ordering — build Tier 1 first
+and ratify with a real answer — at the cost of leaving this ADR Proposed while
+its own subject matter
 is implemented, which is the situation ADR-0042 was created to correct.
 
 **A note on the gate, so the deadlock is not overstated.** The domain-logic gate

--- a/docs/adr/0040-world-model-ownership-and-boundary.md
+++ b/docs/adr/0040-world-model-ownership-and-boundary.md
@@ -2,8 +2,9 @@
 
 | Field | Value |
 |---|---|
-| Status | **Proposed — NOT ratified on merge.** See *Ratification criteria*. Merging records the proposal; it does not ratify it and authorizes no implementation. |
-| Date | 2026-08-02 |
+| Status | **Accepted** — 2026-08-06. All five ratification criteria recorded. Acceptance settles ownership, boundary and deployment; it **authorizes no implementation** and carries two conditions — the `PerceivedObject` import rule and the Tier 1 retention driver. See *Acceptance record*. |
+| Date | 2026-08-02 (proposed) · 2026-08-06 (accepted) |
+| Accepted by | **Justin Looney**, holding the World Model owner, architecture owner and deployment owner roles. One approver across all three — recorded plainly rather than as three sign-offs, following [`ADR-0041`](0041-world-model-persistence-architecture.md)'s precedent. |
 | Blueprint | `KIRRA-WM-ARCH-001` §4, §5, §14, §15 (WM-1) — [`docs/design/WORLD_MODEL_ARCHITECTURE.md`](../design/WORLD_MODEL_ARCHITECTURE.md) |
 | Deciders | World Model owner · architecture owner · deployment owner |
 | Depends on | [`ADR-0039`](0039-world-model-bidirectional-governor-fence.md) (WM-6) — the fence constrains every option below |
@@ -741,18 +742,138 @@ The one item with no technical component. Recorded here is what the decision
 
 **Proposed.** Accepted only when all are recorded:
 
-- [ ] **Repository dependency review** — the proposed crate graph reviewed
+- [x] **Repository dependency review** — the proposed crate graph reviewed
       against the existing workspace
+
+      **SIGNED OFF — 2026-08-06 by Justin Looney.** On the findings recorded in
+      *Repository dependency review — findings, 2026-08-05* above: the graph as
+      built matches the graph as proposed. The review also surfaced four things
+      that were acted on rather than filed — Q1's wrong prerequisite, the seam's
+      partly-spent justification, the tracked-object row's half-true rationale,
+      and a wrong inventory citation — so this sign-off covers a review that
+      changed the ADR, not one that merely confirmed it.
 - [x] **Prototype crate graph** — `kirra-world` compiling as a leaf with no
       ROS, no actuation, and no checker edge (ADR-0039 baseline preserved).
       **Built; findings below. Ratifies nothing else in this ADR.**
-- [ ] **Compatibility inventory** — each row of the compatibility table
+- [x] **Compatibility inventory** — each row of the compatibility table
       confirmed by its current owner
-- [ ] **Deployment ownership decision** — who runs it, where it stores, who
+
+      **CONFIRMED — all five rows, by Justin Looney.** Four rows confirmed
+      2026-08-06 (`robot/world_model.py`, `destination.rs`,
+      `destination_service.rs`, `places.json`/`routes.json` — each verified
+      present against the tree and matching its stated disposition, with the
+      `places`/`routes` citation corrected to the shipped `*.example.json`
+      files). The fifth, **tracked-object inputs**, was confirmed separately
+      with a **condition** — see the ruling above: unconditional for perception
+      types carrying their own confidence and timestamp, conditional for
+      `PerceivedObject`, whose import path may not be built until a stated rule
+      exists for where its confidence and validity come from.
+
+      **This box therefore closes over one conditional row.** That is
+      deliberate: the row is confirmed, and its condition is carried in the
+      inventory rather than left as an unticked box, because the condition binds
+      Tier 1 work rather than this ADR's ratification.
+- [x] **Deployment ownership decision** — who runs it, where it stores, who
       backs it up
-- [ ] Open questions 1 and 4 dispositioned
+
+      **DECIDED — 2026-08-06 by Justin Looney, deployment owner.**
+
+      | Part | Decision |
+      |---|---|
+      | **Who runs it** | The **verifier's operator**. Kirra World is co-located with the verifier rather than given its own operator. |
+      | **Where it stores** | **Local SQLite**, alongside the verifier's own database — not the Postgres shared tier. A semantic, non-authoritative store does not belong in the tier the control plane depends on. |
+      | **Who backs it up** | The **verifier's existing backup regime**, which already respects [`ADR-0038`](0038-postgres-shared-state-hybrid.md)'s per-instance local audit ledger. Inherited rather than designed, so the chain semantics that regime already preserves are not re-derived for a second system. |
+
+      **The capacity consequence is bound, not accepted silently.** D-20/D-21
+      measured **15.79 days** to fill 8 GiB at 10 Hz on the ratified schema, and
+      no retention driver exists. This decision makes a **retention driver an
+      explicit exit criterion for `WM_SCOPE.md` Tier 1** — so the fill date
+      cannot arrive unowned, and Tier 1 cannot be called done without it.
+
+      **What co-location costs, stated rather than glossed.** A knowledge store
+      now shares a host with the safety verifier, so its disk pressure is the
+      verifier's disk pressure — which is precisely why the retention criterion
+      is attached rather than deferred. The blast-radius separation that a
+      dedicated host would have given is traded for a backup regime that already
+      exists and already handles the ledger correctly.
+- [x] Open questions 1 and 4 dispositioned
+
+      **BOTH HALVES NOW RULED — the conjunction is satisfied, 2026-08-06.**
+
+      **Q1 (the `kirra-world` / `kirra-world-store` seam)** — dispositioned by
+      **deferral**: the seam is retained on the blueprint §5 layering argument,
+      with a revisit trigger at Tier 1 completion. Full ruling above.
+
+      **Q4 (naming-collision disposition, ADR-0039 C1/C3)** — **dispositioned as
+      already settled.** C1 is ticked in ADR-0039, decided by ADR-0042
+      Decision 1. C3 (`robot/world_model.py`) carries "retain" in this ADR's own
+      compatibility table, with any rename behind safety review because the
+      module is imported by `rabbit_converse.py`, installer-staged, and gated by
+      the live `KIRRA_WORLD_MODEL_ENABLED`. Q4 was a **bookkeeping gap, not a
+      live question** — but closing it was the owner's act, which is what this
+      records. The rename is **not** decided here; it stays at "retain".
+
+      **This box stayed unticked while only Q1 was ruled** — earlier the same
+      day — because a conjunction is not half-satisfiable. It ticks now because
+      both halves are ruled, not because the second was assumed to follow.
 
 Merging the PR that **introduced this ADR** satisfied none of the above.
 Boxes above are ticked only by a separately recorded owner ruling, each of
 which names its owner and date inline — never by the act of merging a
 document change.
+
+---
+
+## Acceptance record
+
+**Accepted 2026-08-06 by Justin Looney**, holding the World Model owner,
+architecture owner and deployment owner roles — one approver across all three,
+recorded plainly rather than as three sign-offs.
+
+### Two conditions ride on this acceptance
+
+Neither gated it, and both bind Tier 1 rather than this ADR:
+
+| Condition | Source | Enforced by |
+|---|---|---|
+| **No `PerceivedObject` import path** until a stated rule exists for where its confidence and validity come from, with the synthesis visible in the store | Compatibility inventory, tracked-object row | **Nothing** — recorded weakness, see below |
+| **A retention driver** is an exit criterion for `WM_SCOPE.md` Tier 1 | Deployment-ownership decision | The Tier 1 checklist |
+
+### The first condition is not machine-checked, and that was a choice
+
+An import-boundary guard was offered and **deliberately declined**: designing it
+now would mean guessing what it should check, ahead of the Tier 1 observation
+model that defines the trust axes. So this condition rests on being remembered —
+unlike ADR-0042's open question 1, whose breach reds Fence B and therefore
+announces itself. Recorded here rather than in the row alone, so an accepted ADR
+does not quietly carry an unenforced condition.
+
+### What acceptance settled, and what it did not
+
+**Settled.** Crate layout and ownership, write and read authority, the service
+boundary, failure behaviour, the compatibility treatment of all five existing
+surfaces, the seam's retention with a Tier 1 revisit, and deployment ownership
+in all three parts.
+
+**Not settled.** No implementation is authorized. Open questions 2, 3, 5 and 6
+remain open — including **Q6 (predictive containment)**, which the dependency
+review raised and which was explicitly kept out of the ratification gate so that
+raising it could not silently enlarge the criteria.
+
+### Deployment ownership, and its cost
+
+Kirra World runs **co-located with the verifier**, on **local SQLite**, under the
+**verifier's existing backup regime**. The regime is inherited rather than
+designed, so [`ADR-0038`](0038-postgres-shared-state-hybrid.md)'s per-instance
+local audit ledger keeps the chain semantics that regime already preserves.
+
+The cost is stated rather than glossed: **a knowledge store now shares a host
+with the safety verifier**, so its disk pressure is the verifier's. That is
+exactly why the retention driver became a Tier 1 exit criterion instead of a
+later concern — the measured 15.79-day fill must not arrive unowned.
+
+### Independence posture
+
+Owner self-assessment throughout; no independent review. Kirra is designed in
+alignment with ISO 26262 ASIL-D requirements and IEC 61508 SIL 3 requirements;
+independent third-party assessment has not yet been performed.

--- a/docs/adr/0042-world-model-terminology-and-safety-boundary-scope.md
+++ b/docs/adr/0042-world-model-terminology-and-safety-boundary-scope.md
@@ -10,16 +10,23 @@
 | Deciders | Architecture owner · World Model owner · **safety-assurance owner** (Decision 5) |
 | Cross-refs | [`crates/kirra-trajectory/src/perception_redundancy.rs`](../../crates/kirra-trajectory/src/perception_redundancy.rs) · [`crates/kirra-core/src/corridor.rs`](../../crates/kirra-core/src/corridor.rs) · [`robot/world_model.py`](../../robot/world_model.py) · [`ci/check_mick_actuation_fence.py`](../../ci/check_mick_actuation_fence.py) |
 
-> **Accepting this ADR does not ratify WM-1 or WM-6.** ADR-0040 (WM-1) and
-> ADR-0039 (WM-6) both remain **Proposed** — ADR-0040 on four criteria of its
-> own, ADR-0039 on three owner sign-offs. What acceptance here *does* deliver is
-> ADR-0039's terminal criterion, *"ADR-0042 itself accepted"*, which was the
-> whole point of resolving the five blockers found during review of #1306.
+> **Accepting this ADR did not, by itself, ratify WM-1 or WM-6.** What it
+> delivered was ADR-0039's terminal criterion, *"ADR-0042 itself accepted"* —
+> the whole point of resolving the five blockers found during review of #1306.
+> ADR-0039 still needed its three owner sign-offs and ADR-0040 its four criteria;
+> **both were recorded separately later the same day.**
 >
-> **WM-2 (ADR-0041) is Accepted** — since 2026-08-04, independently of this ADR.
-> *(This line previously read "WM-1, WM-2 or WM-6 … remain Proposed", which was
-> correct when written on 2026-08-02 and went stale on 2026-08-04. Corrected
-> here rather than left standing.)*
+> **All four World Model ADRs are now Accepted:** WM-2 (ADR-0041) on 2026-08-04,
+> and this ADR, ADR-0039 (WM-6) and ADR-0040 (WM-1) on 2026-08-06, in that forced
+> order. Each is an owner self-assessment; none authorizes implementation.
+>
+> *(This paragraph has been wrong twice and is dated on purpose. It first read
+> "WM-1, WM-2 or WM-6 … remain Proposed", correct on 2026-08-02 and stale from
+> 2026-08-04. It was then rewritten to say WM-1 and WM-6 "remain Proposed",
+> correct for the hours between this ADR's acceptance and theirs, and stale by
+> the end of the same day. A status summary inside one document about three
+> others is a standing staleness hazard; it is kept only because the forced
+> ratification order is genuinely hard to reconstruct without it.)*
 >
 > **Decision 5's safety-assurance ruling was RECORDED on 2026-08-05** —
 > *safety-related, non-authoritative* — and it is an **owner self-assessment,

--- a/docs/adr/0042-world-model-terminology-and-safety-boundary-scope.md
+++ b/docs/adr/0042-world-model-terminology-and-safety-boundary-scope.md
@@ -2,16 +2,24 @@
 
 | Field | Value |
 |---|---|
-| Status | **Proposed — NOT ratified on merge.** Merging records the clarification; it ratifies nothing and authorizes no implementation. |
-| Date | 2026-08-02 |
+| Status | **Accepted** — 2026-08-06. All four ratification criteria recorded. Acceptance settles this ADR's five clarifications and carries one **named follow-up** (the `docs/safety` terminology migration, below); it still **authorizes no implementation**, and it does not ratify ADR-0039 or ADR-0040. |
+| Date | 2026-08-02 (proposed) · 2026-08-06 (accepted) |
+| Accepted by | **Justin Looney**, holding the architecture owner, World Model owner and safety-assurance owner roles. One approver across all three — recorded plainly rather than as three sign-offs, following [`ADR-0041`](0041-world-model-persistence-architecture.md)'s precedent. See *Acceptance record*. |
 | Clarifies | [`ADR-0039`](0039-world-model-bidirectional-governor-fence.md) (WM-6) · [`ADR-0040`](0040-world-model-ownership-and-boundary.md) (WM-1) · [`ADR-0041`](0041-world-model-persistence-architecture.md) (WM-2) |
 | Blueprint | `KIRRA-WM-ARCH-001` — [`docs/design/WORLD_MODEL_ARCHITECTURE.md`](../design/WORLD_MODEL_ARCHITECTURE.md) |
 | Deciders | Architecture owner · World Model owner · **safety-assurance owner** (Decision 5) |
 | Cross-refs | [`crates/kirra-trajectory/src/perception_redundancy.rs`](../../crates/kirra-trajectory/src/perception_redundancy.rs) · [`crates/kirra-core/src/corridor.rs`](../../crates/kirra-core/src/corridor.rs) · [`robot/world_model.py`](../../robot/world_model.py) · [`ci/check_mick_actuation_fence.py`](../../ci/check_mick_actuation_fence.py) |
 
-> **This ADR does not ratify WM-1, WM-2 or WM-6.** They remain Proposed. This
-> resolves five blockers found during review of #1306 so that WM-6 can later be
-> *considered* for acceptance.
+> **Accepting this ADR does not ratify WM-1 or WM-6.** ADR-0040 (WM-1) and
+> ADR-0039 (WM-6) both remain **Proposed** — ADR-0040 on four criteria of its
+> own, ADR-0039 on three owner sign-offs. What acceptance here *does* deliver is
+> ADR-0039's terminal criterion, *"ADR-0042 itself accepted"*, which was the
+> whole point of resolving the five blockers found during review of #1306.
+>
+> **WM-2 (ADR-0041) is Accepted** — since 2026-08-04, independently of this ADR.
+> *(This line previously read "WM-1, WM-2 or WM-6 … remain Proposed", which was
+> correct when written on 2026-08-02 and went stale on 2026-08-04. Corrected
+> here rather than left standing.)*
 >
 > **Decision 5's safety-assurance ruling was RECORDED on 2026-08-05** —
 > *safety-related, non-authoritative* — and it is an **owner self-assessment,
@@ -539,10 +547,14 @@ Documented, **not rewritten**.
 | M2 | `robot/world_model.py` | Read projection sharing the subsystem name | Retain (ADR-0040 compatibility projection); consider `situation_projection.py` |
 | M3 | Ambiguous prose in docs/tests | Various | New documents must qualify; existing cleaned opportunistically |
 | M4 | "Map" as semantic category **and** safety artifact | Blueprint §4.1 vs `CorridorSource` | Resolved by Decision 2; blueprint §4.1 to be annotated |
+| M5 | Bare "world model" in the **safety documentation set** | 29 uses across 12 `docs/safety` files — `ASIL_DECOMPOSITION.md` (5), `ASSUMPTIONS_OF_USE.md` (4), `OCCY_SAFETY_GOALS.md` (3), `OCCY_INDEPENDENT_DETECTOR.md` (3), `OCCY_DFA.md` (3), 7 further files (1–2 each) | **Qualify each use**, before Kirra World exists as a running service. Raised out of M3's "opportunistically" by the architecture owner sign-off, 2026-08-06 — these read unambiguously only while one referent exists |
 
 ### Migration checklist
 
 - [x] Rename ambiguous **prose** (docs first, lowest risk) — done for LIVE prose; see scope below
+- [ ] **M5 — qualify the 29 bare uses in `docs/safety`** (added 2026-08-06 by the
+      architecture owner sign-off; deadline is *before Kirra World runs as a
+      service*, not before ratification — it gated nothing)
 - [ ] Rename **source symbols** where justified — safety-closure files need safety review
 - [ ] Update **tests** that assert on renamed identifiers
 - [ ] Update **diagrams**
@@ -855,7 +867,39 @@ consequence of merging this text.
 
 **Proposed.** Accepted only when:
 
-- [ ] **Architecture owner** sign-off on the canonical terminology
+- [x] **Architecture owner** sign-off on the canonical terminology
+
+      **RECORDED — 2026-08-06 by Justin Looney, architecture owner.** The
+      canonical set in Decision 1 is **accepted as written**: *Kirra World* for
+      the subsystem, *semantic world model* for the generic phrase, *independent
+      perception channel* and *perception hypothesis* for the perception
+      concepts, and bare "world model" canonical nowhere.
+
+      Accepted on the evidence that the half Decision 1 called unacceptable is
+      already executed and verified 2026-08-06: **zero** bare uses remain
+      anywhere in the safety closure (`kirra-core`, `kirra-trajectory`,
+      `kirra-inline-governor`, `kirra-safety-authority`, `kirra-ros2-adapter`),
+      and the three originally-cited lines now read *perception channel*. See
+      *Architecture owner sign-off — evidence* above.
+
+      **Accepted with one named follow-up, which did not gate this sign-off:**
+      the **29** bare uses remaining across 12 `docs/safety` files are raised
+      from M3's *"cleaned opportunistically"* to an **explicit migration item**,
+      to be completed **before Kirra World exists as a running service**. The
+      trigger is dated rather than stylistic — those uses are unambiguous only
+      while there is one possible referent, and the subsystem's existence is
+      what removes that protection. Tracked as **M5** in the migration
+      checklist.
+
+      **Recorded knowing that nothing enforces this vocabulary.** The four CI
+      scripts carrying Kirra World in their names enforce dependency separation,
+      not terminology; no gate fails on a bare "world model". Unlike Fence B and
+      open question 1, Decision 1 is held by convention alone.
+
+      **This is an owner self-assessment, not an independent review.** Kirra is
+      designed in alignment with ISO 26262 ASIL-D requirements and IEC 61508
+      SIL 3 requirements; independent third-party assessment has not yet been
+      performed.
 - [x] **Safety-assurance owner** confirms M1's prose rename inside the safety
       closure is acceptable, and on what timeline.
       **CONFIRMED — Justin Looney, 2026-08-06. Acceptable; timeline: already
@@ -924,3 +968,49 @@ Merging the PR that **introduced this ADR** satisfied none of the above.
 Boxes above are ticked only by a separately recorded owner ruling, each of
 which names its owner and date inline — never by the act of merging a
 document change.
+
+---
+
+## Acceptance record
+
+**Accepted 2026-08-06 by Justin Looney**, holding the architecture owner, World
+Model owner and safety-assurance owner roles.
+
+### One approver across three roles, recorded plainly
+
+ADR-0042 names three decider roles. **One person holds all three**, so the four
+criteria above are one person's judgement recorded four times, not four
+reviews. This follows [`ADR-0041`](0041-world-model-persistence-architecture.md)'s
+precedent, and it is stated here for the same reason that ADR gave: a reader who
+counts sign-offs and infers independence from the count would be wrong, and the
+record should not let them make that inference.
+
+**What that costs, concretely.** Every one of the four criteria — the M1 rename
+confirmation, the Decision 5 ruling, open question 1, and the terminology
+sign-off — was recorded by the same person who did or directed the work being
+assessed. Two of them are retrospective (M1's rename was executed before its
+confirmation; Decision 5 was recorded a day before its box moved), and both say
+so at the point of record.
+
+### What acceptance does and does not deliver
+
+| | |
+|---|---|
+| **Delivers** | ADR-0039's terminal criterion *"ADR-0042 itself accepted"*. The five #1306 blockers are settled. |
+| **Does not deliver** | Ratification of ADR-0039 (three owner sign-offs outstanding) or ADR-0040 (four criteria outstanding). |
+| **Does not authorize** | Any implementation. The Status row said so while Proposed and it remains true. |
+
+### The one outstanding obligation
+
+**M5 — the `docs/safety` terminology migration.** 29 bare uses across 12 files,
+due **before Kirra World exists as a running service**. It did not gate this
+acceptance and was not treated as though it did; it is scheduled work carried by
+an accepted ADR, tracked in the migration checklist.
+
+### Independence posture
+
+This is an **owner self-assessment, not an independent assurance review**.
+Decision 5's ruling is recorded as *safety-related, non-authoritative*, on
+structural evidence, with Q2/Q4/Q5 open. Kirra is designed in alignment with
+ISO 26262 ASIL-D requirements and IEC 61508 SIL 3 requirements; independent
+third-party assessment has not yet been performed.

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -146,28 +146,51 @@ and *explanation* halves do not.
 
 ---
 
-## 3. Tier 0 — Governance, which gates the rest
+## 3. Tier 0 — Governance — **COMPLETE, 2026-08-06**
 
-Not code. It blocks authorized implementation by the ADRs' own words.
+Not code. It blocked authorized implementation by the ADRs' own words. **All
+four World Model ADRs are now Accepted**, every ratification block at zero
+unticked.
 
 | Item | State |
 |---|---|
 | ADR-0041 | **Accepted** (2026-08-04), carrying one outstanding obligation (R2's alongside rebuild-and-swap) |
-| ADR-0039, ADR-0040, ADR-0042 | **Proposed** |
-| ADR-0040 ratification checklist | **4 of 5 unticked** — dependency review, compatibility inventory, deployment ownership, open questions 1 & 4 |
-| ADR-0042 Decision 5 | Recorded, but an **owner self-assessment, not an independent assurance review**, with Q2/Q4/Q5 open |
+| ADR-0042 | **Accepted** (2026-08-06) — carries **M5**, the `docs/safety` terminology migration, due before Kirra World runs as a service |
+| ADR-0039 | **Accepted** (2026-08-06) — fences structurally enforced and machine-checked; no runtime evidence, no independent review |
+| ADR-0040 | **Accepted** (2026-08-06) — carries **two conditions**: no `PerceivedObject` import path without a stated confidence/validity rule, and a **retention driver as a Tier 1 exit criterion** |
 
-### The ratification order is forced
+### What acceptance did NOT do
 
-ADR-0040 *"depends on ADR-0039"*; ADR-0039's checklist requires *"ADR-0042
-itself accepted."* So the chain is **0042 → 0039 → 0040**, and ADR-0040 cannot
-be accepted first however much evidence is prepared for it. **ADR-0042 is the
-critical path.**
+**It authorized no implementation.** Every one of the four says so in its own
+Status row. Tier 1 proceeds because the domain-logic gate is self-releasing and
+already released, not because ratification licensed it.
+
+**It was one approver throughout.** Every sign-off across all four ADRs was
+recorded by the same person holding every role, plainly stated in each
+*Acceptance record* so no reader infers independence from a count of ticks.
+Kirra is designed in alignment with ISO 26262 ASIL-D requirements and IEC 61508
+SIL 3 requirements; independent third-party assessment has not yet been
+performed.
+
+**Not every acceptance is equally well supported.** ADR-0039's fences are
+transitively machine-checked — a breach reds CI with the path named. ADR-0042's
+Decision 1 terminology has **no** machine check at all and is held by convention.
+ADR-0040's `PerceivedObject` condition likewise rests on being remembered. The
+difference is the enforcement mechanism, not the care taken, and it is recorded
+in each ADR rather than averaged away here.
+
+### The ratification order was forced, and was followed
+
+ADR-0040 *"depends on ADR-0039"*; ADR-0039's checklist required *"ADR-0042
+itself accepted."* The chain **0042 → 0039 → 0040** was resolved in that order
+on 2026-08-06 — 0042 first, which satisfied 0039's terminal criterion, which
+freed 0040. ADR-0042 was the critical path and behaved like it.
 
 ### Evidence prepared, so the boxes are decisions rather than work
 
-Every box below is still unticked — none of this ticks anything — but the
-research behind them is done, and a reader should not restart it:
+**Every box below is now ticked** — all were ruled on 2026-08-06. The table is
+kept because it records *what each ruling rested on*, and a reader auditing an
+acceptance should be able to see the evidence without reconstructing it:
 
 | Box | Prepared |
 |---|---|
@@ -180,14 +203,20 @@ research behind them is done, and a reader should not restart it:
 | ADR-0042 OQ1 | **Evidence prepared**, disposition drafted; its revisit trigger is self-announcing (a Fence B breach *is* the request arriving) |
 | ADR-0039 safety-assurance box | **Flagged as possibly tickable** — its own text says the ruling need only be *recorded* |
 
-**What is left is judgement, not research** — with one exception.
+**All of it was judgement rather than research by the end** — and the one item
+no preparation could move was **deployment ownership**, which is now decided.
 
-**Deployment ownership is the one that bites later**, and the only item no
-preparation can move. Nobody has decided who runs Kirra World, where it stores,
-or who backs it up. That answer is needed *before* a service exists, not after
-one is running — and two of its three parts already have measured consequences
-(see ADR-0040's review section: the 15.79-day fill, and ADR-0038's per-instance
-local audit chain).
+**Deployment ownership — DECIDED 2026-08-06.** Kirra World runs **co-located
+with the verifier**, stores to **local SQLite** (not the Postgres shared tier),
+and inherits the **verifier's existing backup regime**, which already respects
+ADR-0038's per-instance local audit chain. It was answered *before* a service
+exists rather than after one is running, which is what the item asked for.
+
+**Its cost is carried into Tier 1, not absorbed silently.** Co-location means a
+knowledge store shares a host with the safety verifier, so the measured
+**15.79-day fill** is now the verifier's disk pressure — which is why a
+**retention driver is a Tier 1 exit criterion** (§4), the one item there that
+is not about the domain model.
 
 ---
 
@@ -198,6 +227,14 @@ it. The domain-logic gate that once held it is **self-releasing and already
 released** (ADR-0042 Decision 5, recorded 2026-08-05) — so this is sequencing,
 not permission.
 
+- [ ] **Retention driver** — **exit criterion, added 2026-08-06 by the ADR-0040
+      deployment-ownership decision.** D-20/D-21 measured **15.79 days** to fill
+      8 GiB at 10 Hz on the ratified schema, and Kirra World is now decided to
+      run **co-located with the verifier on local SQLite** — so its disk
+      pressure is the safety host's disk pressure. Tier 1 is **not done** until
+      something empties the store. This is the one item here that is not about
+      the domain model; it is here because that decision put it here rather than
+      leaving the fill date unowned.
 - [ ] **Entity taxonomy** (§6)
 - [ ] **Observation model** (§7)
 - [ ] **Relationship model** (§8)

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -238,9 +238,23 @@ not permission.
 - [ ] **Entity taxonomy** (§6)
 - [ ] **Observation model** (§7)
 - [ ] **Relationship model** (§8)
-- [ ] **The four orthogonal trust axes** (§9):
-      `Origin × Corroboration × Adjudication × Validity`
-- [ ] **The seven transition rules** (§9.2)
+- [x] **The four orthogonal trust axes** (§9):
+      `Origin × Corroboration × Adjudication × Validity` — **DONE 2026-08-06**,
+      `crates/kirra-world/src/trust.rs`. Pure, zero-dependency, 27 tests.
+      Note the shape it took: **three stored axes, not four.** `TrustAxes` has no
+      validity field, so rule 6 ("computed at read time, never stored") is
+      **structurally unbreakable** rather than a rule someone remembers —
+      `validity_at` takes the clock as an argument and there is nowhere to write
+      its answer down.
+- [ ] **The seven transition rules** (§9.2) — **six and a half of seven.**
+      Rules 1, 2, 3, 5, 6, 7 are implemented and tested, including the two
+      load-bearing ones. **Rule 4 is half done**: its *adjudication* half is
+      `TrustAxes::operator_confirm`; its *geometry* half (an operator assertion
+      may never silently rewrite a measured pose, P10) constrains the
+      **observation payload**, so it cannot be enforced until the observation
+      model exists. Deliberately left unticked rather than counted as done —
+      the module cannot reach a payload, which is why it cannot yet be
+      sidestepped, but "cannot be sidestepped from here" is not "enforced".
 
 ### Why the axes are not one enum
 
@@ -261,7 +275,11 @@ Two of the seven rules are load-bearing and genuinely hard:
   already does half of this in `ProjectedClaim::holds_at`.
 
 `Corroboration(n)` presupposes cross-observation matching — i.e. it cannot land
-before entity resolution (Tier 2).
+before entity resolution (Tier 2). **This held, and shaped the delivered slice:**
+the axis, its monotonic `agreed`/`disagreed` transitions and its weakest-wins
+fold are all implemented, but **nothing populates the count** — no matcher exists
+to decide that two observations are about the same thing. The algebra is ready
+for Tier 2; it is not driven by anything yet.
 
 **Largest single body of work in this document.**
 


### PR DESCRIPTION
**Tier 0 ratified; Tier 1 begun.** All four World Model ADRs are now Accepted, and the first real domain logic landed in `kirra-world`.

> **Two concerns, cleanly separable by commit** — flagged rather than blended, since a PR in this series previously merged carrying unrelated work. Review them independently if you prefer:
> * **Governance** (`d520fda3`, `f8e897aa`) — docs only, seven owner rulings
> * **Code** (`f4502899`) — `crates/kirra-world/src/trust.rs`, pure, zero-dep, 27 tests
>
> They are on one branch because the second is only legitimate once the first lands.

---

# Part 1 — Tier 0 complete

Nine gating boxes → **zero**. Every ruling is yours, applied as chosen; the forced chain **0042 → 0039 → 0040** resolved in exactly that order.

| ADR | Status |
|---|---|
| **0041** | Accepted 2026-08-04 (unchanged) |
| **0042** | **Accepted 2026-08-06** — carries **M5**, the `docs/safety` terminology migration |
| **0039** | **Accepted 2026-08-06** — fences structurally enforced and machine-checked |
| **0040** | **Accepted 2026-08-06** — carries two conditions |

### What was recorded carefully

**A conjunction was not half-satisfied.** ADR-0040's *"open questions 1 and 4"* box stayed unticked earlier in the day when only Q1 was ruled. It ticks here because **both** halves are ruled — not because the second was assumed to follow. The box says so.

**Q4 closed as bookkeeping, not as a rename.** `robot/world_model.py` stays at "retain".

**The deployment decision got teeth.** It named a retention driver as a Tier 1 exit criterion, so that criterion is now *written into* `WM_SCOPE.md` §4. Without it the decision would point at nothing. Co-location makes the measured **15.79-day fill** the *safety host's* disk pressure — recorded as the cost, not glossed.

### The asymmetry, recorded rather than averaged away

These acceptances are **not equally well supported**, and each ADR now says which it is:

* **ADR-0039's fences** — transitively machine-checked over the Cargo manifests. A breach reds CI with the path named.
* **ADR-0042's Decision 1 terminology** — **no machine check at all.** Held by convention.
* **ADR-0040's `PerceivedObject` condition** — rests on being remembered. The guard was offered and declined, for the good reason that designing it ahead of the Tier 1 observation model means guessing what it should check.

Three new *Acceptance record* sections state what one-approver-across-every-role costs, so no reader infers independence from a count of ticks. ADR-0039's also notes it carries **no runtime evidence** — the fences are verified against the dependency graph of a system that does not execute yet.

### Two staleness fixes found while editing

* A broken `ADR-0038` link (real filename is `0038-postgres-shared-state-hybrid.md`).
* My own note in ADR-0039 reading *"the three owner sign-offs above remain open, so ADR-0039 is still Proposed"* — true when written hours earlier, false once they were recorded. Updated rather than left to contradict the Status row.

---

# Part 2 — Tier 1 slice 1: the four trust axes

`crates/kirra-world/src/trust.rs`. Blueprint §9. Zero dependencies preserved.

### The shape is the point: three stored axes, not four

Rule 6 says validity is *"computed at read time, never stored."* So `TrustAxes` has origin + corroboration + adjudication and **no validity field** — there is nowhere to write one, and `validity_at()` takes the clock as an argument.

That is the lesson Part 1 kept surfacing, applied: **an invariant a machine enforces outlives one a person must remember.** Rule 6 is now in the first category.

**Rule 5** — *derived inherits the weakest input* — is the anti-laundering rule. A contradicted input cannot emerge from a derivation clean; a chain of inferences cannot climb from low-confidence roots.

### Two spec ambiguities, flagged not silently resolved

* **Rule 5 says "every axis"; §9.1's table shows `—` for Derived/corroboration.** Implemented per the rule text — the conservative direction, since reading `—` as "not folded" would let a derivation launder away a conflict. Open question recorded in the doc comment.
* **A claim whose `valid_from` is in the future has no member on the four-value axis.** Returns `Expired` (fail-closed, never `Fresh`), with the doc saying plainly that the *name* is wrong and asking whether the axis needs `NotYetInForce` — a §9.1 change, not this module's to make.

### The negative control earned its keep

Inverting the rule-5 fold failed 3 tests — but **not** `a_chain_of_derivations_cannot_climb`, because that test derived from a **single input**, where weakest and strongest are the same function. **It was passing without testing the thing it names.** Fixed by mixing a strong input into every step; the same control now fails 4. The test comment records why that shape is load-bearing.

### What was deliberately NOT ticked

* **The seven-transition-rules box** — six and a half of seven. Rule 4's geometry half constrains the observation *payload*, which does not exist yet. This module cannot reach a payload, so it cannot be sidestepped from here — but that is not "enforced".
* **`Corroborated(n)` is algebra with nothing driving it.** Counting agreeing evidence needs a matcher (Tier 2 entity resolution). Recorded in `WM_SCOPE` rather than left looking complete.

---

## Verification

27 tests in `kirra-world`; `kirra-world-store` (16/19/11) and `kirra-world-service` (10/16) — its only two dependents — still pass. Clippy clean under `#[warn(missing_docs)]`, rustfmt clean. Both Kirra World fences, the domain-logic gate, `check_quality_guardrails`, `check_website_citations`, `check_reexport_shims` all OK. Every internal ADR link verified to resolve.

Checkbox delta: **7 → [x]** (0039 ×3, 0040 ×4) plus the ADR-0042 architecture owner box and the trust-axes box; **two new unticked** (M5, retention driver), both outside every ratification block.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_