### PR TITLE
Tier 1 slices 2–3: the observation model's pure half and the entity taxonomy

### DIFF
--- a/crates/kirra-world/src/entity.rs
+++ b/crates/kirra-world/src/entity.rs
@@ -276,48 +276,113 @@ pub struct Classification {
     pub source: SourceClass,
 }
 
+/// The outcome of adjudicating a kind — three distinct answers, kept distinct.
+///
+/// Deliberately **not** a bare [`EntityKind`]. ADR-0040's reasoning about
+/// `ResolutionOutcome` applies exactly: collapsing "no evidence", "settled" and
+/// "evidence I cannot rank" into one value loses a distinction the caller must
+/// act on differently, and the loss is unrecoverable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KindAdjudication {
+    /// No classification evidence at all.
+    NoEvidence,
+    /// The evidence settles on one kind.
+    Settled(EntityKind),
+    /// **Evidence disagrees and cannot be ranked.**
+    ///
+    /// Either the contenders' confidences rest on different bases — which §7.3
+    /// forbids comparing, since *"a detector's 0.9 and a geometric residual's
+    /// 0.9 are not comparable"* — or a score is absent, and an absent score is
+    /// not a low one.
+    ///
+    /// **This is not a kind, and the caller must not pick one from it.** It is
+    /// the honest report that the system holds classification evidence it has no
+    /// grounds to rank.
+    Unrankable {
+        /// The distinct kinds in contention, in first-seen order.
+        contenders: Vec<EntityKind>,
+    },
+}
+
 /// Adjudicate a kind from classification evidence — §6.2.
 ///
 /// Kind is *"the adjudicated result"* of classification observations, never an
 /// intrinsic property, so this is the only way to obtain one.
 ///
-/// # The rule, and what it costs
+/// # The order of resolution
 ///
-/// An operator classification outranks a sensor one. That is transition rule 4's
-/// adjudication half applied here — an operator may settle *what a thing is*,
-/// which is a question of identity and classification, not of geometry.
+/// 1. **No evidence** → [`KindAdjudication::NoEvidence`]. Never a guess.
+/// 2. **An operator claim settles it** — transition rule 4's adjudication half.
+///    An operator may settle *what a thing is*, which is classification, not
+///    geometry. Two operators who disagree are themselves unrankable.
+/// 3. **Unanimous evidence settles it**, whatever the bases. If every claim says
+///    `Package`, no comparison is needed and none is made — so differing bases
+///    among agreeing sources are harmless, which is the common case.
+/// 4. **Otherwise rank by confidence** — through [`Confidence::compare`], which
+///    enforces §7.3's cross-basis guard. Any comparison it refuses makes the
+///    whole adjudication [`KindAdjudication::Unrankable`].
 ///
-/// With no operator claim, the highest-confidence classification wins. Ties and
-/// unscored claims fall back to **the first claim offered**, which is a real
-/// limitation: it makes the result depend on input order. Recorded rather than
-/// hidden — resolving it properly needs the corroboration counting that only
-/// Tier 2 entity resolution can supply.
+/// # Ties keep the earlier claim
 ///
-/// **No evidence at all yields [`EntityKind::Unknown`]**, never a guess.
+/// Only a strictly-greater confidence displaces, so an exact tie on the same
+/// basis resolves by input order. That residual order-dependence is real and
+/// pinned by a test; ranking equal-confidence disagreement properly needs the
+/// corroboration counting only Tier 2 entity resolution can supply.
 #[must_use]
-pub fn adjudicated_kind(classifications: &[Classification]) -> EntityKind {
+pub fn adjudicated_kind(classifications: &[Classification]) -> KindAdjudication {
     if classifications.is_empty() {
-        return EntityKind::Unknown;
+        return KindAdjudication::NoEvidence;
     }
 
-    // Rule 4: an operator settles classification.
-    if let Some(c) = classifications
-        .iter()
-        .find(|c| matches!(c.source, SourceClass::Operator))
-    {
-        return c.kind;
-    }
-
-    let mut best = &classifications[0];
-    for c in &classifications[1..] {
-        // Only strictly-greater displaces, so ties keep the earlier claim.
-        if let (Some(a), Some(b)) = (c.confidence.score(), best.confidence.score()) {
-            if a > b {
-                best = c;
+    /// Distinct kinds, in first-seen order.
+    fn contenders(cs: &[Classification]) -> Vec<EntityKind> {
+        let mut out: Vec<EntityKind> = Vec::new();
+        for c in cs {
+            if !out.contains(&c.kind) {
+                out.push(c.kind);
             }
         }
+        out
     }
-    best.kind
+
+    // (2) Rule 4: an operator settles classification.
+    let operator: Vec<&Classification> = classifications
+        .iter()
+        .filter(|c| matches!(c.source, SourceClass::Operator))
+        .collect();
+    if !operator.is_empty() {
+        let first = operator[0].kind;
+        return if operator.iter().all(|c| c.kind == first) {
+            KindAdjudication::Settled(first)
+        } else {
+            // Operators outrank sensors, but not each other.
+            KindAdjudication::Unrankable {
+                contenders: contenders(&operator.iter().map(|c| (*c).clone()).collect::<Vec<_>>()),
+            }
+        };
+    }
+
+    // (3) Unanimous evidence needs no comparison — so mismatched bases among
+    //     agreeing sources never block the answer.
+    let all = contenders(classifications);
+    if all.len() == 1 {
+        return KindAdjudication::Settled(all[0]);
+    }
+
+    // (4) Disagreement: rank THROUGH the §7.3 guard, never around it.
+    let mut best = &classifications[0];
+    for c in &classifications[1..] {
+        match c.confidence.compare(&best.confidence) {
+            Ok(core::cmp::Ordering::Greater) => best = c,
+            // Less or Equal: the incumbent holds, so ties keep the earlier claim.
+            Ok(_) => {}
+            // Bases differ, or a score is absent. Either way there is no ground
+            // to rank these, and inventing one is the silent over-trust §7.3
+            // exists to prevent.
+            Err(_) => return KindAdjudication::Unrankable { contenders: all },
+        }
+    }
+    KindAdjudication::Settled(best.kind)
 }
 
 // ---------------------------------------------------------------------------
@@ -686,7 +751,7 @@ mod tests {
 
     #[test]
     fn no_evidence_yields_unknown_rather_than_a_guess() {
-        assert_eq!(adjudicated_kind(&[]), EntityKind::Unknown);
+        assert_eq!(adjudicated_kind(&[]), KindAdjudication::NoEvidence);
     }
 
     #[test]
@@ -705,7 +770,10 @@ mod tests {
             },
         ];
         // The operator wins despite far lower confidence.
-        assert_eq!(adjudicated_kind(&claims), EntityKind::Tool);
+        assert_eq!(
+            adjudicated_kind(&claims),
+            KindAdjudication::Settled(EntityKind::Tool)
+        );
     }
 
     #[test]
@@ -722,7 +790,10 @@ mod tests {
                 source: SourceClass::Sensor,
             },
         ];
-        assert_eq!(adjudicated_kind(&claims), EntityKind::Tool);
+        assert_eq!(
+            adjudicated_kind(&claims),
+            KindAdjudication::Settled(EntityKind::Tool)
+        );
     }
 
     #[test]
@@ -741,7 +812,145 @@ mod tests {
                 source: SourceClass::Sensor,
             },
         ];
-        assert_eq!(adjudicated_kind(&claims), EntityKind::Package);
+        assert_eq!(
+            adjudicated_kind(&claims),
+            KindAdjudication::Settled(EntityKind::Package)
+        );
+    }
+
+    #[test]
+    fn disagreement_across_bases_is_unrankable_not_silently_ranked() {
+        // REGRESSION. The earlier version pulled raw .score() out and compared
+        // floats, reaching straight PAST the §7.3 cross-basis guard built in
+        // slice 2 — a detector's 0.9 and a geometric residual's 0.9 are not the
+        // same quantity, and ranking them is the silent over-trust §7.3 names.
+        let claims = [
+            Classification {
+                kind: EntityKind::Package,
+                confidence: Confidence::new(Some(0.9), ConfidenceBasis::ModelScore, None).unwrap(),
+                source: SourceClass::Sensor,
+            },
+            Classification {
+                kind: EntityKind::Tool,
+                confidence: Confidence::new(Some(0.95), ConfidenceBasis::GeometricResidual, None)
+                    .unwrap(),
+                source: SourceClass::Sensor,
+            },
+        ];
+        assert_eq!(
+            adjudicated_kind(&claims),
+            KindAdjudication::Unrankable {
+                contenders: vec![EntityKind::Package, EntityKind::Tool],
+            }
+        );
+    }
+
+    #[test]
+    fn agreeing_sources_settle_even_with_mismatched_bases() {
+        // The common case, and why the basis guard does not block it: if every
+        // claim says the same thing, no comparison is needed and none is made.
+        let claims = [
+            Classification {
+                kind: EntityKind::Package,
+                confidence: Confidence::new(Some(0.4), ConfidenceBasis::ModelScore, None).unwrap(),
+                source: SourceClass::Sensor,
+            },
+            Classification {
+                kind: EntityKind::Package,
+                confidence: Confidence::new(Some(0.9), ConfidenceBasis::GeometricResidual, None)
+                    .unwrap(),
+                source: SourceClass::Import,
+            },
+        ];
+        assert_eq!(
+            adjudicated_kind(&claims),
+            KindAdjudication::Settled(EntityKind::Package)
+        );
+    }
+
+    #[test]
+    fn an_unscored_first_claim_no_longer_freezes_the_result() {
+        // REGRESSION for the second half of the finding. The old loop gated
+        // displacement on `if let (Some, Some)`, so an unscored claim at index 0
+        // meant NOTHING could ever displace it — a later 0.99 claim could not
+        // win, contradicting "highest confidence wins".
+        //
+        // The honest answer is not "the scored one wins" either: an absent score
+        // is not a low score (asserted in the observation module). So this is
+        // Unrankable — which is at least no longer silently order-frozen.
+        let claims = [
+            Classification {
+                kind: EntityKind::Package,
+                confidence: Confidence::unspecified(),
+                source: SourceClass::Sensor,
+            },
+            Classification {
+                kind: EntityKind::Tool,
+                confidence: Confidence::new(Some(0.99), ConfidenceBasis::Unspecified, None)
+                    .unwrap(),
+                source: SourceClass::Sensor,
+            },
+        ];
+        assert_ne!(
+            adjudicated_kind(&claims),
+            KindAdjudication::Settled(EntityKind::Package),
+            "the unscored first claim must not win by freezing the loop"
+        );
+        assert_eq!(
+            adjudicated_kind(&claims),
+            KindAdjudication::Unrankable {
+                contenders: vec![EntityKind::Package, EntityKind::Tool],
+            }
+        );
+    }
+
+    #[test]
+    fn operators_outrank_sensors_but_not_each_other() {
+        let claims = [
+            Classification {
+                kind: EntityKind::Package,
+                confidence: conf(0.99),
+                source: SourceClass::Sensor,
+            },
+            Classification {
+                kind: EntityKind::Tool,
+                confidence: conf(0.5),
+                source: SourceClass::Operator,
+            },
+            Classification {
+                kind: EntityKind::Vehicle,
+                confidence: conf(0.5),
+                source: SourceClass::Operator,
+            },
+        ];
+        // The sensor claim is out of contention entirely; the two operators are
+        // not rankable against each other.
+        assert_eq!(
+            adjudicated_kind(&claims),
+            KindAdjudication::Unrankable {
+                contenders: vec![EntityKind::Tool, EntityKind::Vehicle],
+            }
+        );
+    }
+
+    #[test]
+    fn agreeing_operators_settle() {
+        let claims = [
+            Classification {
+                kind: EntityKind::Tool,
+                confidence: conf(0.1),
+                source: SourceClass::Operator,
+            },
+            Classification {
+                kind: EntityKind::Tool,
+                confidence: conf(0.2),
+                source: SourceClass::Operator,
+            },
+        ];
+        assert_eq!(
+            adjudicated_kind(&claims),
+            KindAdjudication::Settled(EntityKind::Tool)
+        );
     }
 
     #[test]
@@ -760,8 +969,14 @@ mod tests {
             confidence: conf(0.9),
             source: SourceClass::Operator,
         }];
-        assert_eq!(adjudicated_kind(&before), EntityKind::Package);
-        assert_eq!(adjudicated_kind(&after), EntityKind::Tool);
+        assert_eq!(
+            adjudicated_kind(&before),
+            KindAdjudication::Settled(EntityKind::Package)
+        );
+        assert_eq!(
+            adjudicated_kind(&after),
+            KindAdjudication::Settled(EntityKind::Tool)
+        );
         assert_eq!(
             e.id(),
             &eid("e-1"),

--- a/crates/kirra-world/src/entity.rs
+++ b/crates/kirra-world/src/entity.rs
@@ -1,0 +1,865 @@
+//! The entity taxonomy's pure half — `KIRRA-WM-ARCH-001` §6, Tier 1.
+//!
+//! §6 has three parts. **Structure and kinds are here**; *identity adjudication*
+//! (§6.3 — candidate clustering, merge and split events) is `WM_SCOPE.md`
+//! **Tier 2**, and this module deliberately stops at the boundary.
+//!
+//! # Two rules made structural
+//!
+//! **1. An unknown kind degrades to `Unknown`; it never guesses a supertype.**
+//! §6.2: *"A consumer that does not know a kind must degrade to `Unknown`, not
+//! guess a supertype."* So [`EntityKind::group`] returns `Option<EntityGroup>`
+//! and gives `None` for [`EntityKind::Unknown`] — there is no supertype to read,
+//! rather than a plausible one to misread. [`EntityKind::from_token`] maps every
+//! unrecognised token to `Unknown`, which is what makes new kinds *additive*
+//! (§6.2) instead of breaking old consumers.
+//!
+//! **2. Resolution confidence cannot be confused with attribute confidence.**
+//! §6.1 flags them as distinct — resolution confidence is *"how sure we are this
+//! is **one** thing"*, not how sure we are of any of its attributes. They would
+//! otherwise be the same [`Confidence`] type and silently interchangeable, so
+//! [`ResolutionConfidence`] is a newtype and the compiler keeps them apart.
+//!
+//! # A tension inside §6, flagged rather than resolved
+//!
+//! §6.1's field table lists `kind` as a field every entity carries. §6.2 says
+//! **the opposite**: *"Kind is a **classification observation**, not an intrinsic
+//! property. A detector saying 'package' is evidence. The kind shown in a
+//! projection is the adjudicated result."*
+//!
+//! Those cannot both be literally true of a stored field. This module follows
+//! **§6.2**, for the same reason §6.1 already gives about attributes — *"they
+//! are projections over the observations bound to it, so an attribute always
+//! retains its own source, time, and confidence"* — and kind is exactly such an
+//! attribute. [`Entity`] therefore has **no `kind` field**; kind is produced by
+//! [`adjudicated_kind`] from classification evidence, so it cannot be set to
+//! something the evidence does not support.
+//!
+//! Recorded as an open question for the World Model owner: **is §6.1's `kind`
+//! row meant as a cached projection, or as an independently settable field?**
+//! Under the first reading these agree and this module is right. Under the
+//! second they conflict, and the conflict should be resolved in the blueprint
+//! rather than here.
+//!
+//! # What is missing, and why
+//!
+//! `entity_id` generation (monotonic, never reused), `first_observed` /
+//! `last_observed`, and `provenance_head` (a hash-chain head) all need the
+//! store: ULID generation and hashing are dependencies, and `kirra-world` has
+//! **zero by design** — the same argument that scoped [`crate::observation`].
+//! [`EntityId`] here is an opaque validated wrapper, not a generator.
+
+use crate::observation::{Confidence, SourceClass};
+
+// ---------------------------------------------------------------------------
+// Identity
+// ---------------------------------------------------------------------------
+
+/// Why an entity value could not be built.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum EntityError {
+    /// An id was empty or whitespace.
+    EmptyEntityId,
+    /// An alias name was empty or whitespace.
+    EmptyAliasName,
+    /// The lifecycle transition is not permitted — see [`Lifecycle::advance_to`].
+    IllegalTransition {
+        /// The state moved from.
+        from: LifecycleState,
+        /// The state moved to.
+        to: LifecycleState,
+    },
+}
+
+/// A stable, opaque entity identifier.
+///
+/// §6.1: *"Stable, opaque, monotonic. Never reused, never encodes semantics."*
+///
+/// **Opaque is enforced by construction, not by convention** — the inner value
+/// is private and there is no parsing accessor, so no consumer can come to
+/// depend on structure inside an id. Monotonicity and never-reuse are properties
+/// of the *generator*, which lives in the store; this type cannot enforce them
+/// and does not claim to.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct EntityId(String);
+
+impl EntityId {
+    /// Wrap an identifier.
+    ///
+    /// # Errors
+    ///
+    /// [`EntityError::EmptyEntityId`] if empty or whitespace.
+    pub fn new(id: impl Into<String>) -> Result<Self, EntityError> {
+        let id = id.into();
+        if id.trim().is_empty() {
+            return Err(EntityError::EmptyEntityId);
+        }
+        Ok(Self(id))
+    }
+
+    /// The identifier as text. Deliberately the only accessor — callers may
+    /// compare and display, not decompose.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Kinds — §6.2
+// ---------------------------------------------------------------------------
+
+/// The four kind groups. **Closed at the root** (§6.2).
+///
+/// Note there is no `Unknown` group: an unrecognised kind has no supertype, and
+/// [`EntityKind::group`] returns `None` rather than inventing one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum EntityGroup {
+    /// Things with agency.
+    Agents,
+    /// Things in the world with a physical extent.
+    PhysicalObjects,
+    /// Locations.
+    Places,
+    /// Things with no physical extent.
+    Abstract,
+}
+
+/// A semantic entity type — §6.2's grouped, extensible, root-closed taxonomy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum EntityKind {
+    // Agents
+    /// A robot.
+    Robot,
+    /// A person.
+    Person,
+    /// An animal.
+    Animal,
+    // Physical objects
+    /// A physical object with no more specific kind.
+    Object,
+    /// A tool.
+    Tool,
+    /// A package.
+    Package,
+    /// A vehicle.
+    Vehicle,
+    /// A door.
+    Door,
+    /// A charging dock.
+    ChargingDock,
+    // Places
+    /// A room.
+    Room,
+    /// A zone.
+    Zone,
+    /// A waypoint.
+    Waypoint,
+    /// A landmark.
+    Landmark,
+    /// A surface.
+    Surface,
+    // Abstract
+    /// A mission.
+    Mission,
+    /// A task.
+    Task,
+    /// A route.
+    Route,
+    /// A skill.
+    Skill,
+    /// A capability.
+    Capability,
+    /// **A kind this build does not recognise.**
+    ///
+    /// The degrade target §6.2 requires. Reached by [`EntityKind::from_token`]
+    /// for any unrecognised token, which is what lets a newer producer add a
+    /// kind without breaking an older consumer.
+    Unknown,
+}
+
+impl EntityKind {
+    /// The group this kind belongs to, or `None` if the kind is unrecognised.
+    ///
+    /// **`None` is the rule, not an omission.** §6.2 requires a consumer that
+    /// does not know a kind to *"degrade to `Unknown`, not guess a supertype"*.
+    /// Returning `Option` is how that becomes unavailable rather than merely
+    /// discouraged — there is no group to read, so none can be guessed.
+    #[must_use]
+    pub fn group(self) -> Option<EntityGroup> {
+        Some(match self {
+            Self::Robot | Self::Person | Self::Animal => EntityGroup::Agents,
+            Self::Object
+            | Self::Tool
+            | Self::Package
+            | Self::Vehicle
+            | Self::Door
+            | Self::ChargingDock => EntityGroup::PhysicalObjects,
+            Self::Room | Self::Zone | Self::Waypoint | Self::Landmark | Self::Surface => {
+                EntityGroup::Places
+            }
+            Self::Mission | Self::Task | Self::Route | Self::Skill | Self::Capability => {
+                EntityGroup::Abstract
+            }
+            Self::Unknown => return None,
+        })
+    }
+
+    /// The stable wire token.
+    #[must_use]
+    pub fn as_token(self) -> &'static str {
+        match self {
+            Self::Robot => "robot",
+            Self::Person => "person",
+            Self::Animal => "animal",
+            Self::Object => "object",
+            Self::Tool => "tool",
+            Self::Package => "package",
+            Self::Vehicle => "vehicle",
+            Self::Door => "door",
+            Self::ChargingDock => "charging_dock",
+            Self::Room => "room",
+            Self::Zone => "zone",
+            Self::Waypoint => "waypoint",
+            Self::Landmark => "landmark",
+            Self::Surface => "surface",
+            Self::Mission => "mission",
+            Self::Task => "task",
+            Self::Route => "route",
+            Self::Skill => "skill",
+            Self::Capability => "capability",
+            Self::Unknown => "unknown",
+        }
+    }
+
+    /// Parse a wire token. **Anything unrecognised becomes [`Self::Unknown`].**
+    ///
+    /// This is what makes §6.2's *"new kinds are additive and versioned, never
+    /// repurposed"* survivable in a mixed-version fleet: an older consumer meets
+    /// a newer kind and degrades, rather than failing or guessing.
+    #[must_use]
+    pub fn from_token(token: &str) -> Self {
+        match token {
+            "robot" => Self::Robot,
+            "person" => Self::Person,
+            "animal" => Self::Animal,
+            "object" => Self::Object,
+            "tool" => Self::Tool,
+            "package" => Self::Package,
+            "vehicle" => Self::Vehicle,
+            "door" => Self::Door,
+            "charging_dock" => Self::ChargingDock,
+            "room" => Self::Room,
+            "zone" => Self::Zone,
+            "waypoint" => Self::Waypoint,
+            "landmark" => Self::Landmark,
+            "surface" => Self::Surface,
+            "mission" => Self::Mission,
+            "task" => Self::Task,
+            "route" => Self::Route,
+            "skill" => Self::Skill,
+            "capability" => Self::Capability,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+/// One classification claim about an entity — §6.2's *"a detector saying
+/// 'package' is evidence"*.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Classification {
+    /// What the classifier says this is.
+    pub kind: EntityKind,
+    /// How confident it is, and on what basis.
+    pub confidence: Confidence,
+    /// What kind of producer said so.
+    pub source: SourceClass,
+}
+
+/// Adjudicate a kind from classification evidence — §6.2.
+///
+/// Kind is *"the adjudicated result"* of classification observations, never an
+/// intrinsic property, so this is the only way to obtain one.
+///
+/// # The rule, and what it costs
+///
+/// An operator classification outranks a sensor one. That is transition rule 4's
+/// adjudication half applied here — an operator may settle *what a thing is*,
+/// which is a question of identity and classification, not of geometry.
+///
+/// With no operator claim, the highest-confidence classification wins. Ties and
+/// unscored claims fall back to **the first claim offered**, which is a real
+/// limitation: it makes the result depend on input order. Recorded rather than
+/// hidden — resolving it properly needs the corroboration counting that only
+/// Tier 2 entity resolution can supply.
+///
+/// **No evidence at all yields [`EntityKind::Unknown`]**, never a guess.
+#[must_use]
+pub fn adjudicated_kind(classifications: &[Classification]) -> EntityKind {
+    if classifications.is_empty() {
+        return EntityKind::Unknown;
+    }
+
+    // Rule 4: an operator settles classification.
+    if let Some(c) = classifications
+        .iter()
+        .find(|c| matches!(c.source, SourceClass::Operator))
+    {
+        return c.kind;
+    }
+
+    let mut best = &classifications[0];
+    for c in &classifications[1..] {
+        // Only strictly-greater displaces, so ties keep the earlier claim.
+        if let (Some(a), Some(b)) = (c.confidence.score(), best.confidence.score()) {
+            if a > b {
+                best = c;
+            }
+        }
+    }
+    best.kind
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle — §6.1
+// ---------------------------------------------------------------------------
+
+/// Which lifecycle state an entity is in, without the merge/split payload.
+///
+/// Exists so [`EntityError::IllegalTransition`] can name states without
+/// carrying ids into an error type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum LifecycleState {
+    /// Newly created, not yet corroborated.
+    Provisional,
+    /// A thing we believe in.
+    Established,
+    /// Not observed lately, not retired.
+    Dormant,
+    /// Gone. Terminal.
+    Retired,
+    /// Merged into another entity. Terminal, but still resolvable.
+    Merged,
+    /// Produced by splitting another entity. A live state.
+    Split,
+}
+
+/// An entity's lifecycle — §6.1.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Lifecycle {
+    /// Newly created, not yet corroborated.
+    Provisional,
+    /// A thing we believe in.
+    Established,
+    /// Not observed lately. Reversible — see [`Lifecycle::advance_to`].
+    Dormant,
+    /// Gone. **Terminal.**
+    Retired,
+    /// **Merged into another entity — terminal, and still resolvable.**
+    ///
+    /// §6.3: *"Both original IDs remain resolvable forever and answer with a
+    /// redirect."* The same shape as [`crate::trust::Adjudication::Rejected`]:
+    /// terminal for this record, not for the subject. Merging never deletes.
+    Merged {
+        /// The entity this one is now an alias for.
+        into: EntityId,
+    },
+    /// **Produced by splitting another entity.** A *live* state carrying its
+    /// origin, not a terminal one.
+    Split {
+        /// The entity this one was split out of.
+        from: EntityId,
+    },
+}
+
+impl Lifecycle {
+    /// The payload-free state.
+    #[must_use]
+    pub fn state(&self) -> LifecycleState {
+        match self {
+            Self::Provisional => LifecycleState::Provisional,
+            Self::Established => LifecycleState::Established,
+            Self::Dormant => LifecycleState::Dormant,
+            Self::Retired => LifecycleState::Retired,
+            Self::Merged { .. } => LifecycleState::Merged,
+            Self::Split { .. } => LifecycleState::Split,
+        }
+    }
+
+    /// Whether this state admits any further transition.
+    #[must_use]
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, Self::Retired | Self::Merged { .. })
+    }
+
+    /// Move to a new lifecycle state.
+    ///
+    /// # The permitted moves, and which of them the blueprint actually states
+    ///
+    /// §6.1 gives `Provisional → Established → Dormant → Retired`, *"plus
+    /// `Merged(into)` / `Split(from)`"*, and says no more. Three readings had to
+    /// be supplied, and each is called out here rather than buried:
+    ///
+    /// * **`Dormant → Established` is permitted.** The arrow chain is written
+    ///   one-directionally, but an entity observed again after a quiet period is
+    ///   the ordinary case, and forbidding it would force a new identity for a
+    ///   thing that never stopped existing — precisely the identity-loss failure
+    ///   §6.3 exists to prevent.
+    /// * **`Retired` and `Merged` are terminal.** Neither admits any move.
+    /// * **`Split` is live, not terminal**, on the reading that `Split(from)`
+    ///   marks an entity *produced by* a split. It therefore behaves like
+    ///   `Established`.
+    ///
+    /// Recorded as an open question: **is `Split(from)` a live origin marker or
+    /// a terminal marker on the entity that was split?** The two readings differ
+    /// in whether the *original* survives a split.
+    ///
+    /// # Errors
+    ///
+    /// [`EntityError::IllegalTransition`], naming both states.
+    pub fn advance_to(&self, next: Lifecycle) -> Result<Lifecycle, EntityError> {
+        let from = self.state();
+        let to = next.state();
+
+        let permitted = match from {
+            // Terminal states admit nothing.
+            LifecycleState::Retired | LifecycleState::Merged => false,
+            LifecycleState::Provisional => matches!(
+                to,
+                LifecycleState::Established
+                    | LifecycleState::Dormant
+                    | LifecycleState::Retired
+                    | LifecycleState::Merged
+                    | LifecycleState::Split
+            ),
+            LifecycleState::Established | LifecycleState::Split => matches!(
+                to,
+                LifecycleState::Dormant
+                    | LifecycleState::Retired
+                    | LifecycleState::Merged
+                    | LifecycleState::Split
+            ),
+            LifecycleState::Dormant => matches!(
+                to,
+                LifecycleState::Established
+                    | LifecycleState::Retired
+                    | LifecycleState::Merged
+                    | LifecycleState::Split
+            ),
+        };
+
+        if permitted {
+            Ok(next)
+        } else {
+            Err(EntityError::IllegalTransition { from, to })
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Resolution confidence — §6.1
+// ---------------------------------------------------------------------------
+
+/// How sure we are that an entity is **one thing**.
+///
+/// §6.1 marks this *"distinct from attribute confidence"*, and the newtype is
+/// what makes the distinction hold: without it both would be [`Confidence`] and
+/// a caller could pass "I am 0.9 sure this box is red" where "I am 0.9 sure
+/// these two sightings are the same box" was wanted. Those are different claims
+/// and conflating them misstates what the system knows.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolutionConfidence(Confidence);
+
+impl ResolutionConfidence {
+    /// Mark a confidence as being about identity.
+    #[must_use]
+    pub fn new(confidence: Confidence) -> Self {
+        Self(confidence)
+    }
+
+    /// The underlying confidence. Explicit, so unwrapping is visible at the
+    /// call site rather than implicit through a `Deref`.
+    #[must_use]
+    pub fn inner(&self) -> &Confidence {
+        &self.0
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Aliases and the entity spine — §6.1
+// ---------------------------------------------------------------------------
+
+/// A name something is known by, **with its own provenance** (§6.1).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Alias {
+    name: String,
+    source: SourceClass,
+}
+
+impl Alias {
+    /// Build an alias.
+    ///
+    /// # Errors
+    ///
+    /// [`EntityError::EmptyAliasName`] if the name is empty or whitespace.
+    pub fn new(name: impl Into<String>, source: SourceClass) -> Result<Self, EntityError> {
+        let name = name.into();
+        if name.trim().is_empty() {
+            return Err(EntityError::EmptyAliasName);
+        }
+        Ok(Self { name, source })
+    }
+
+    /// The name.
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Where the name came from. §6.1 requires each alias to carry this — an
+    /// operator's name for a thing and a detector's label are not the same kind
+    /// of claim.
+    #[must_use]
+    pub fn source(&self) -> SourceClass {
+        self.source
+    }
+}
+
+/// The entity **spine** — §6.1.
+///
+/// > *"Attributes are **not** stored on the entity. They are projections over
+/// > the observations bound to it, so an attribute always retains its own
+/// > source, time, and confidence. An entity is a spine; observations hang from
+/// > it."*
+///
+/// **There is no `kind` field**, deliberately — see the module docs. Kind comes
+/// from [`adjudicated_kind`] over classification evidence.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Entity {
+    id: EntityId,
+    lifecycle: Lifecycle,
+    aliases: Vec<Alias>,
+    resolution_confidence: ResolutionConfidence,
+}
+
+impl Entity {
+    /// Create a provisional entity — the state everything starts in.
+    #[must_use]
+    pub fn provisional(id: EntityId, resolution_confidence: ResolutionConfidence) -> Self {
+        Self {
+            id,
+            lifecycle: Lifecycle::Provisional,
+            aliases: Vec::new(),
+            resolution_confidence,
+        }
+    }
+
+    /// The identifier.
+    #[must_use]
+    pub fn id(&self) -> &EntityId {
+        &self.id
+    }
+
+    /// The lifecycle state.
+    #[must_use]
+    pub fn lifecycle(&self) -> &Lifecycle {
+        &self.lifecycle
+    }
+
+    /// Every name this is known by.
+    #[must_use]
+    pub fn aliases(&self) -> &[Alias] {
+        &self.aliases
+    }
+
+    /// How sure we are this is one thing.
+    #[must_use]
+    pub fn resolution_confidence(&self) -> &ResolutionConfidence {
+        &self.resolution_confidence
+    }
+
+    /// Add a name.
+    #[must_use]
+    pub fn with_alias(mut self, alias: Alias) -> Self {
+        self.aliases.push(alias);
+        self
+    }
+
+    /// Move the lifecycle on.
+    ///
+    /// # Errors
+    ///
+    /// [`EntityError::IllegalTransition`] — see [`Lifecycle::advance_to`].
+    pub fn advance_to(mut self, next: Lifecycle) -> Result<Self, EntityError> {
+        self.lifecycle = self.lifecycle.advance_to(next)?;
+        Ok(self)
+    }
+
+    /// Where a merged entity redirects to — §6.3's *"answer with a redirect"*.
+    ///
+    /// `None` unless this entity was merged.
+    #[must_use]
+    pub fn redirects_to(&self) -> Option<&EntityId> {
+        match &self.lifecycle {
+            Lifecycle::Merged { into } => Some(into),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::observation::ConfidenceBasis;
+
+    fn conf(score: f32) -> Confidence {
+        Confidence::new(Some(score), ConfidenceBasis::ModelScore, None).unwrap()
+    }
+
+    fn res_conf() -> ResolutionConfidence {
+        ResolutionConfidence::new(Confidence::unspecified())
+    }
+
+    fn eid(s: &str) -> EntityId {
+        EntityId::new(s).unwrap()
+    }
+
+    // -- §6.2: degrade, never guess a supertype ---------------------------
+
+    #[test]
+    fn an_unknown_kind_has_no_supertype_to_guess() {
+        // THE §6.2 rule. There is no group to read, so none can be invented.
+        assert_eq!(EntityKind::Unknown.group(), None);
+    }
+
+    #[test]
+    fn an_unrecognised_token_degrades_rather_than_failing() {
+        // A newer producer's kind meeting an older consumer.
+        assert_eq!(
+            EntityKind::from_token("quadruped_drone"),
+            EntityKind::Unknown
+        );
+        assert_eq!(EntityKind::from_token(""), EntityKind::Unknown);
+        assert_eq!(EntityKind::from_token("ROBOT"), EntityKind::Unknown);
+    }
+
+    #[test]
+    fn every_known_kind_round_trips_and_has_a_group() {
+        let all = [
+            EntityKind::Robot,
+            EntityKind::Person,
+            EntityKind::Animal,
+            EntityKind::Object,
+            EntityKind::Tool,
+            EntityKind::Package,
+            EntityKind::Vehicle,
+            EntityKind::Door,
+            EntityKind::ChargingDock,
+            EntityKind::Room,
+            EntityKind::Zone,
+            EntityKind::Waypoint,
+            EntityKind::Landmark,
+            EntityKind::Surface,
+            EntityKind::Mission,
+            EntityKind::Task,
+            EntityKind::Route,
+            EntityKind::Skill,
+            EntityKind::Capability,
+        ];
+        assert_eq!(all.len(), 19, "the blueprint's §6.2 table has 19 kinds");
+        for k in all {
+            assert_eq!(EntityKind::from_token(k.as_token()), k, "{k:?}");
+            assert!(k.group().is_some(), "{k:?} must have a group");
+        }
+    }
+
+    #[test]
+    fn unknown_round_trips_but_stays_groupless() {
+        assert_eq!(
+            EntityKind::from_token(EntityKind::Unknown.as_token()),
+            EntityKind::Unknown
+        );
+        assert_eq!(EntityKind::Unknown.group(), None);
+    }
+
+    // -- §6.2: kind is evidence, not an intrinsic property -----------------
+
+    #[test]
+    fn no_evidence_yields_unknown_rather_than_a_guess() {
+        assert_eq!(adjudicated_kind(&[]), EntityKind::Unknown);
+    }
+
+    #[test]
+    fn an_operator_settles_the_classification() {
+        // Rule 4's adjudication half: an operator may settle WHAT a thing is.
+        let claims = [
+            Classification {
+                kind: EntityKind::Package,
+                confidence: conf(0.99),
+                source: SourceClass::Sensor,
+            },
+            Classification {
+                kind: EntityKind::Tool,
+                confidence: conf(0.10),
+                source: SourceClass::Operator,
+            },
+        ];
+        // The operator wins despite far lower confidence.
+        assert_eq!(adjudicated_kind(&claims), EntityKind::Tool);
+    }
+
+    #[test]
+    fn without_an_operator_the_strongest_sensor_claim_wins() {
+        let claims = [
+            Classification {
+                kind: EntityKind::Package,
+                confidence: conf(0.3),
+                source: SourceClass::Sensor,
+            },
+            Classification {
+                kind: EntityKind::Tool,
+                confidence: conf(0.8),
+                source: SourceClass::Sensor,
+            },
+        ];
+        assert_eq!(adjudicated_kind(&claims), EntityKind::Tool);
+    }
+
+    #[test]
+    fn a_tie_keeps_the_earlier_claim() {
+        // Documented limitation: the result depends on input order. Asserted so
+        // the behaviour is pinned rather than accidental.
+        let claims = [
+            Classification {
+                kind: EntityKind::Package,
+                confidence: conf(0.5),
+                source: SourceClass::Sensor,
+            },
+            Classification {
+                kind: EntityKind::Tool,
+                confidence: conf(0.5),
+                source: SourceClass::Sensor,
+            },
+        ];
+        assert_eq!(adjudicated_kind(&claims), EntityKind::Package);
+    }
+
+    #[test]
+    fn reclassification_does_not_need_a_new_entity() {
+        // §6.2: "the box you thought was a package turning out to be a tool is a
+        // reclassification, not a new object." The entity has no kind field, so
+        // this is true by construction — there is nothing on it to contradict.
+        let e = Entity::provisional(eid("e-1"), res_conf());
+        let before = [Classification {
+            kind: EntityKind::Package,
+            confidence: conf(0.9),
+            source: SourceClass::Sensor,
+        }];
+        let after = [Classification {
+            kind: EntityKind::Tool,
+            confidence: conf(0.9),
+            source: SourceClass::Operator,
+        }];
+        assert_eq!(adjudicated_kind(&before), EntityKind::Package);
+        assert_eq!(adjudicated_kind(&after), EntityKind::Tool);
+        assert_eq!(
+            e.id(),
+            &eid("e-1"),
+            "identity unchanged by reclassification"
+        );
+    }
+
+    // -- Lifecycle ---------------------------------------------------------
+
+    #[test]
+    fn the_ordinary_progression_is_permitted() {
+        let l = Lifecycle::Provisional
+            .advance_to(Lifecycle::Established)
+            .unwrap()
+            .advance_to(Lifecycle::Dormant)
+            .unwrap()
+            .advance_to(Lifecycle::Retired)
+            .unwrap();
+        assert_eq!(l.state(), LifecycleState::Retired);
+    }
+
+    #[test]
+    fn a_dormant_entity_can_be_observed_again() {
+        // The supplied reading: forbidding this would force a new identity for a
+        // thing that never stopped existing.
+        assert!(Lifecycle::Dormant
+            .advance_to(Lifecycle::Established)
+            .is_ok());
+    }
+
+    #[test]
+    fn retired_and_merged_are_terminal() {
+        assert!(Lifecycle::Retired.is_terminal());
+        assert!(Lifecycle::Merged { into: eid("e-2") }.is_terminal());
+
+        assert_eq!(
+            Lifecycle::Retired.advance_to(Lifecycle::Established),
+            Err(EntityError::IllegalTransition {
+                from: LifecycleState::Retired,
+                to: LifecycleState::Established,
+            })
+        );
+        assert!(Lifecycle::Merged { into: eid("e-2") }
+            .advance_to(Lifecycle::Established)
+            .is_err());
+    }
+
+    #[test]
+    fn a_split_entity_is_live_not_terminal() {
+        let l = Lifecycle::Split { from: eid("e-0") };
+        assert!(!l.is_terminal());
+        assert!(l.advance_to(Lifecycle::Dormant).is_ok());
+    }
+
+    #[test]
+    fn a_merged_entity_still_resolves_by_redirect() {
+        // §6.3: "Both original IDs remain resolvable forever and answer with a
+        // redirect." Merging never deletes.
+        let e = Entity::provisional(eid("e-1"), res_conf())
+            .advance_to(Lifecycle::Merged { into: eid("e-2") })
+            .unwrap();
+        assert_eq!(e.redirects_to(), Some(&eid("e-2")));
+        assert_eq!(e.id(), &eid("e-1"), "the merged-away id is still its own");
+    }
+
+    #[test]
+    fn an_unmerged_entity_redirects_nowhere() {
+        let e = Entity::provisional(eid("e-1"), res_conf());
+        assert_eq!(e.redirects_to(), None);
+    }
+
+    // -- Validation --------------------------------------------------------
+
+    #[test]
+    fn empty_identifiers_are_refused() {
+        assert_eq!(EntityId::new("  "), Err(EntityError::EmptyEntityId));
+        assert_eq!(
+            Alias::new("", SourceClass::Operator),
+            Err(EntityError::EmptyAliasName)
+        );
+    }
+
+    #[test]
+    fn an_alias_carries_where_the_name_came_from() {
+        // §6.1: an operator's name and a detector's label are not the same claim.
+        let e = Entity::provisional(eid("e-1"), res_conf())
+            .with_alias(Alias::new("the loading bay", SourceClass::Operator).unwrap())
+            .with_alias(Alias::new("zone_04", SourceClass::Import).unwrap());
+        assert_eq!(e.aliases().len(), 2);
+        assert_eq!(e.aliases()[0].source(), SourceClass::Operator);
+        assert_eq!(e.aliases()[1].source(), SourceClass::Import);
+    }
+
+    #[test]
+    fn resolution_confidence_is_not_interchangeable_with_attribute_confidence() {
+        // The newtype is the whole point; this test documents the intent, since
+        // the real enforcement is that the wrong type does not compile.
+        let rc = ResolutionConfidence::new(conf(0.9));
+        assert_eq!(rc.inner().score(), Some(0.9));
+    }
+}

--- a/crates/kirra-world/src/lib.rs
+++ b/crates/kirra-world/src/lib.rs
@@ -98,6 +98,7 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 
+pub mod entity;
 pub mod observation;
 pub mod trust;
 

--- a/crates/kirra-world/src/lib.rs
+++ b/crates/kirra-world/src/lib.rs
@@ -98,6 +98,7 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 
+pub mod observation;
 pub mod trust;
 
 // ---------------------------------------------------------------------------

--- a/crates/kirra-world/src/observation.rs
+++ b/crates/kirra-world/src/observation.rs
@@ -1,0 +1,738 @@
+//! The observation model's pure half — `KIRRA-WM-ARCH-001` §7, Tier 1.
+//!
+//! §7.1 specifies an eighteen-field immutable `Observation` record. **This
+//! module implements the part of it that can be pure**, and deliberately stops
+//! short of the rest — see *What is missing and why* below.
+//!
+//! # Two rules made structural rather than remembered
+//!
+//! The same move that gave [`crate::trust`] its shape: where the blueprint
+//! states a rule in prose, prefer a type that cannot express the violation.
+//!
+//! **1. Cross-modal confidence comparison is refused by default.** §7.3:
+//!
+//! > *"A bare float is nearly useless across modalities: a detector's 0.9 and a
+//! > geometric residual's 0.9 are not comparable, and treating them as such is
+//! > how fusion systems silently over-trust. Carrying the basis makes cross-modal
+//! > comparison an explicit decision rather than an accident."*
+//!
+//! [`Confidence::compare`] therefore **errors** when the two bases differ.
+//! Comparing across bases requires calling [`Confidence::compare_across_bases`],
+//! whose name is the explicit decision the blueprint asks for. The accident is
+//! not discouraged; it is unavailable.
+//!
+//! **2. Clock domains do not mix.** §5.1 and the hypervisor contract channel's
+//! two-clock-domain model both say it, and `AOU-TIMESYNC-001` makes conversion
+//! the integrator's obligation *at the producing edge*. [`DomainInstant`]
+//! carries its domain, and [`DomainInstant::compare`] refuses a cross-domain
+//! comparison rather than returning a confidently wrong ordering.
+//!
+//! # What is missing, and why — the dependency argument
+//!
+//! §7.1's record also carries `observation_id: Ulid`, `evidence_digest: Hash`,
+//! `prev_hash: Hash`, `frame: FrameRef`, `map: Option<MapVersion>` and a
+//! per-kind versioned `TypedPayload`. **None of them are here**, because each
+//! needs a dependency — ULID generation, a hash implementation, frame and map
+//! types — and `kirra-world` has **zero dependencies by design**.
+//!
+//! That is not fastidiousness; it is the argument ADR-0040's open question 1 was
+//! decided on. The seam between this crate and `kirra-world-store` was retained
+//! precisely so that `rusqlite`, `serde_json`, `sha2` and `hex` do not end up
+//! beside the domain types. Pulling a hash in here to finish a struct would spend
+//! that decision without revisiting it.
+//!
+//! So: identity, content-hashing and chaining belong to the **store**, which
+//! already implements all three. Frames and maps belong to a later slice.
+//!
+//! **`ObservationKind` is also absent.** §7.1 names the field but the blueprint
+//! never enumerates its variants, and inventing a taxonomy of observation kinds
+//! would be a domain decision this module has no basis for.
+
+use crate::trust::Origin;
+use core::cmp::Ordering;
+
+// ---------------------------------------------------------------------------
+// Confidence — §7.3
+// ---------------------------------------------------------------------------
+
+/// What a confidence score is *made of*.
+///
+/// The axis that makes scores comparable-or-not. Two scores share a basis or
+/// they do not, and [`Confidence::compare`] treats that as decisive.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ConfidenceBasis {
+    /// A model's own output score.
+    ModelScore,
+    /// Derived from geometric fit residual.
+    GeometricResidual,
+    /// A human's stated certainty.
+    OperatorCertainty,
+    /// Derived from how many independent sources agree. Pairs with
+    /// [`crate::trust::Corroboration`].
+    Corroboration,
+    /// **Synthesized rather than measured.** The honest basis for a value the
+    /// producer inferred from context rather than obtained from the datum.
+    ///
+    /// This variant is what makes ADR-0040's `PerceivedObject` condition
+    /// satisfiable: that ruling requires any synthesized confidence to be
+    /// *"visible in the store rather than indistinguishable from a measured
+    /// value"*. A claim carrying `Assumed` is visibly synthesized — the
+    /// distinction survives storage instead of being lost at the boundary.
+    Assumed,
+    /// No basis stated.
+    ///
+    /// **Valid and common, by explicit design.** §7.3: *"the design must not
+    /// force producers to invent precision they do not have."* A producer with
+    /// no confidence to report says so, rather than fabricating one.
+    Unspecified,
+}
+
+/// How a score was calibrated, if it was.
+///
+/// An opaque reference; this crate does not interpret it.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CalibrationRef(String);
+
+impl CalibrationRef {
+    /// Wrap a calibration identifier.
+    ///
+    /// # Errors
+    ///
+    /// [`ConfidenceError::EmptyCalibrationRef`] if `id` is empty or whitespace —
+    /// an empty reference reads as "calibrated" while naming nothing, which is
+    /// worse than `None`.
+    pub fn new(id: impl Into<String>) -> Result<Self, ConfidenceError> {
+        let id = id.into();
+        if id.trim().is_empty() {
+            return Err(ConfidenceError::EmptyCalibrationRef);
+        }
+        Ok(Self(id))
+    }
+
+    /// The identifier.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Why a confidence could not be built, or two could not be compared.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConfidenceError {
+    /// The score was NaN or infinite. Fail-closed: a non-finite score is not a
+    /// low score, it is an absent one, and the producer must say which.
+    ScoreNotFinite,
+    /// The score was outside `[0, 1]`.
+    ScoreOutOfRange,
+    /// A calibration reference was empty.
+    EmptyCalibrationRef,
+    /// **Cross-modal comparison, refused.** §7.3's whole point: a detector's 0.9
+    /// and a geometric residual's 0.9 are not the same quantity. Both bases are
+    /// named so the caller can decide, then call
+    /// [`Confidence::compare_across_bases`] if the comparison is genuinely
+    /// meant.
+    BasesDiffer {
+        /// The left operand's basis.
+        left: ConfidenceBasis,
+        /// The right operand's basis.
+        right: ConfidenceBasis,
+    },
+    /// One or both sides carried no score, so there is nothing to order.
+    ScoreAbsent,
+}
+
+/// A producer's confidence — **structured, never a bare float** (§7.3).
+#[derive(Debug, Clone, PartialEq)]
+pub struct Confidence {
+    score: Option<f32>,
+    basis: ConfidenceBasis,
+    calibration: Option<CalibrationRef>,
+}
+
+impl Confidence {
+    /// Build a confidence.
+    ///
+    /// # Errors
+    ///
+    /// [`ConfidenceError::ScoreNotFinite`] or [`ConfidenceError::ScoreOutOfRange`]
+    /// if a score is present and not a finite value in `[0, 1]`.
+    pub fn new(
+        score: Option<f32>,
+        basis: ConfidenceBasis,
+        calibration: Option<CalibrationRef>,
+    ) -> Result<Self, ConfidenceError> {
+        if let Some(s) = score {
+            if !s.is_finite() {
+                return Err(ConfidenceError::ScoreNotFinite);
+            }
+            if !(0.0..=1.0).contains(&s) {
+                return Err(ConfidenceError::ScoreOutOfRange);
+            }
+        }
+        Ok(Self {
+            score,
+            basis,
+            calibration,
+        })
+    }
+
+    /// The honest zero-information confidence: no score, no basis, no
+    /// calibration. What a producer with nothing to report should send.
+    #[must_use]
+    pub fn unspecified() -> Self {
+        Self {
+            score: None,
+            basis: ConfidenceBasis::Unspecified,
+            calibration: None,
+        }
+    }
+
+    /// A confidence whose score was **synthesized from context, not measured**.
+    ///
+    /// The constructor an importer reaches for when the source datum carries no
+    /// confidence of its own — see [`ConfidenceBasis::Assumed`].
+    ///
+    /// # Errors
+    ///
+    /// As [`Self::new`].
+    pub fn assumed(score: f32) -> Result<Self, ConfidenceError> {
+        Self::new(Some(score), ConfidenceBasis::Assumed, None)
+    }
+
+    /// The score, if the producer reported one.
+    #[must_use]
+    pub fn score(&self) -> Option<f32> {
+        self.score
+    }
+
+    /// What the score is made of.
+    #[must_use]
+    pub fn basis(&self) -> ConfidenceBasis {
+        self.basis
+    }
+
+    /// The calibration reference, if any.
+    #[must_use]
+    pub fn calibration(&self) -> Option<&CalibrationRef> {
+        self.calibration.as_ref()
+    }
+
+    /// Whether this value was synthesized rather than measured.
+    ///
+    /// The predicate a store or auditor uses to answer "is any of this made up?"
+    #[must_use]
+    pub fn is_synthesized(&self) -> bool {
+        matches!(self.basis, ConfidenceBasis::Assumed)
+    }
+
+    /// Order two confidences — **only when they share a basis**.
+    ///
+    /// # Errors
+    ///
+    /// * [`ConfidenceError::BasesDiffer`] if the bases are not identical. This
+    ///   is the §7.3 guard, and it is the default path precisely so that the
+    ///   silent over-trust it describes cannot happen by accident.
+    /// * [`ConfidenceError::ScoreAbsent`] if either side has no score.
+    pub fn compare(&self, other: &Self) -> Result<Ordering, ConfidenceError> {
+        if self.basis != other.basis {
+            return Err(ConfidenceError::BasesDiffer {
+                left: self.basis,
+                right: other.basis,
+            });
+        }
+        self.compare_across_bases(other)
+    }
+
+    /// Order two confidences **ignoring their bases** — the explicit decision
+    /// §7.3 asks for, named so it cannot be taken by accident.
+    ///
+    /// Call this only where the comparison is genuinely meant and its meaning is
+    /// argued somewhere. [`Self::compare`] is the default for a reason.
+    ///
+    /// # Errors
+    ///
+    /// [`ConfidenceError::ScoreAbsent`] if either side has no score. Absence is
+    /// not zero — a producer that reported nothing has not reported low
+    /// confidence, and ordering it against a real score would invent a fact.
+    pub fn compare_across_bases(&self, other: &Self) -> Result<Ordering, ConfidenceError> {
+        let (a, b) = match (self.score, other.score) {
+            (Some(a), Some(b)) => (a, b),
+            _ => return Err(ConfidenceError::ScoreAbsent),
+        };
+        // Both are validated finite at construction, so partial_cmp is total
+        // here; the fallback is unreachable and defensive rather than expected.
+        Ok(a.partial_cmp(&b).unwrap_or(Ordering::Equal))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Source — §7.1 "WHO"
+// ---------------------------------------------------------------------------
+
+/// What kind of thing produced an observation — §7.1's `source_class`.
+///
+/// Distinct from [`Origin`], which is a **trust axis**. This says what the
+/// producer *is*; `Origin` says what the resulting claim *counts as*. See
+/// [`SourceClass::origin`] for the mapping between them, and why it is proposed
+/// rather than inherited.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SourceClass {
+    /// A sensor or perception producer.
+    Sensor,
+    /// A human operator.
+    Operator,
+    /// Deployment configuration.
+    Configuration,
+    /// An external dataset.
+    Import,
+    /// Computed from other recorded evidence.
+    Derivation,
+    /// Received from a peer over a network.
+    Network,
+}
+
+impl SourceClass {
+    /// The [`Origin`] a claim from this producer carries.
+    ///
+    /// # This mapping is proposed, not inherited
+    ///
+    /// The blueprint defines both enums but never states the correspondence, and
+    /// they are not the same size — six source classes, five origins (four
+    /// storable). Two cases therefore required a judgement:
+    ///
+    /// * **`Configuration` → `Imported`.** Deployment config is authored by a
+    ///   human, which argues for `Asserted`, but it arrives as data rather than
+    ///   as a live ruling on a specific claim. `Imported` claims less.
+    /// * **`Network` → `Imported`.** A peer's claim is external evidence. It is
+    ///   emphatically **not** `Observed` — this instance did not measure it, and
+    ///   treating a relayed claim as a local measurement is how a fleet launders
+    ///   provenance across a hop.
+    ///
+    /// Both ambiguous cases resolve to `Imported` deliberately: of the storable
+    /// origins it is the one that asserts least about how the claim was obtained.
+    /// Recorded as an open question for the World Model owner: **is this
+    /// mapping right, and should `Configuration` be `Asserted`?**
+    #[must_use]
+    pub fn origin(self) -> Origin {
+        match self {
+            Self::Sensor => Origin::Observed,
+            Self::Operator => Origin::Asserted,
+            Self::Derivation => Origin::Derived,
+            Self::Import | Self::Configuration | Self::Network => Origin::Imported,
+        }
+    }
+}
+
+/// What an observation is *about* — §7.1's `subject`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum SubjectRef {
+    /// A resolved entity, by opaque id.
+    Entity(String),
+    /// A candidate that entity resolution has not yet adjudicated.
+    Candidate(String),
+    /// A spatial frame.
+    Frame(String),
+    /// **Nothing yet.**
+    ///
+    /// Load-bearing, not a placeholder: the model is evidence-first, so an
+    /// observation may be recorded before anything decides what it is about, and
+    /// re-attribution later must not rewrite it. This variant is why the
+    /// observation model does not depend on the entity taxonomy.
+    Unbound,
+}
+
+// ---------------------------------------------------------------------------
+// Time — §7.1 "WHEN", and the non-mixing rule
+// ---------------------------------------------------------------------------
+
+/// Which clock an instant was read from.
+///
+/// §5.1 and `docs/safety/HYPERVISOR_CONTRACT_CHANNEL.md` §5 both state the
+/// normative rule: **clock domains do not mix**, and conversion happens at the
+/// producing edge (`AOU-TIMESYNC-001`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ClockDomain {
+    /// The safety/boundary timing domain.
+    Boundary,
+    /// General system timing.
+    System,
+}
+
+/// An instant that knows which clock it came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct DomainInstant {
+    /// Milliseconds on `domain`'s clock.
+    pub ms: u64,
+    /// The clock this reading came from.
+    pub domain: ClockDomain,
+}
+
+/// Why two instants could not be compared, or an interval could not be built.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TimeError {
+    /// **Clock domains do not mix.** Refused rather than answered, because a
+    /// cross-domain ordering is not merely imprecise — it is meaningless, and
+    /// returning one would be confidently wrong.
+    DomainsDiffer {
+        /// The left operand's domain.
+        left: ClockDomain,
+        /// The right operand's domain.
+        right: ClockDomain,
+    },
+    /// An interval ended before it began.
+    IntervalEndsBeforeItStarts,
+}
+
+impl DomainInstant {
+    /// Order two instants — **only within one clock domain**.
+    ///
+    /// # Errors
+    ///
+    /// [`TimeError::DomainsDiffer`] on a cross-domain comparison. There is
+    /// deliberately no `compare_across_domains` escape hatch, unlike
+    /// [`Confidence::compare_across_bases`]: comparing two confidences of
+    /// different bases is *unwise*, while comparing two clocks that were never
+    /// synchronized is *unsound*. Conversion is the producing edge's job.
+    pub fn compare(&self, other: &Self) -> Result<Ordering, TimeError> {
+        if self.domain != other.domain {
+            return Err(TimeError::DomainsDiffer {
+                left: self.domain,
+                right: other.domain,
+            });
+        }
+        Ok(self.ms.cmp(&other.ms))
+    }
+}
+
+/// When a claim held in the world — §7.1's `valid_time`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ValidInterval {
+    start: DomainInstant,
+    end: Option<DomainInstant>,
+}
+
+impl ValidInterval {
+    /// Build an interval.
+    ///
+    /// # Errors
+    ///
+    /// * [`TimeError::DomainsDiffer`] if `start` and `end` are on different
+    ///   clocks — an interval spanning two unsynchronized clocks has no length.
+    /// * [`TimeError::IntervalEndsBeforeItStarts`] if `end` precedes `start`.
+    pub fn new(start: DomainInstant, end: Option<DomainInstant>) -> Result<Self, TimeError> {
+        if let Some(e) = end {
+            if start.compare(&e)? == Ordering::Greater {
+                return Err(TimeError::IntervalEndsBeforeItStarts);
+            }
+        }
+        Ok(Self { start, end })
+    }
+
+    /// An interval that has begun and has no stated end.
+    #[must_use]
+    pub fn open_from(start: DomainInstant) -> Self {
+        Self { start, end: None }
+    }
+
+    /// When it began.
+    #[must_use]
+    pub fn start(&self) -> DomainInstant {
+        self.start
+    }
+
+    /// When it ended, if it has.
+    #[must_use]
+    pub fn end(&self) -> Option<DomainInstant> {
+        self.end
+    }
+
+    /// The clock domain this interval lives in.
+    #[must_use]
+    pub fn domain(&self) -> ClockDomain {
+        self.start.domain
+    }
+
+    /// Project into a [`crate::trust::ValidityWindow`], so the trust model's
+    /// read-time validity question can be asked about this observation.
+    ///
+    /// `ttl_ms` is §7.1's producer-declared freshness budget; `None` means the
+    /// claim does not go stale.
+    ///
+    /// # The domain is dropped here, deliberately
+    ///
+    /// `ValidityWindow` carries bare `u64` milliseconds. That is safe **only**
+    /// because every field of this interval is already proven to share one
+    /// domain — `new` refuses a mixed one. The caller must pass a `now_ms` read
+    /// from [`Self::domain`]'s clock; nothing downstream can check that for
+    /// them, which is exactly why the check happens here instead.
+    #[must_use]
+    pub fn to_validity_window(&self, ttl_ms: Option<u64>) -> crate::trust::ValidityWindow {
+        crate::trust::ValidityWindow {
+            valid_from_ms: self.start.ms,
+            valid_to_ms: self.end.map(|e| e.ms),
+            staleness_budget_ms: ttl_ms,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::trust::{validity_at, Validity};
+
+    // -- §7.3: cross-modal comparison is refused, not discouraged ---------
+
+    #[test]
+    fn comparing_across_bases_is_refused_by_default() {
+        // THE §7.3 rule: "a detector's 0.9 and a geometric residual's 0.9 are
+        // not comparable, and treating them as such is how fusion systems
+        // silently over-trust."
+        let detector = Confidence::new(Some(0.9), ConfidenceBasis::ModelScore, None).unwrap();
+        let residual =
+            Confidence::new(Some(0.9), ConfidenceBasis::GeometricResidual, None).unwrap();
+
+        assert_eq!(
+            detector.compare(&residual),
+            Err(ConfidenceError::BasesDiffer {
+                left: ConfidenceBasis::ModelScore,
+                right: ConfidenceBasis::GeometricResidual,
+            })
+        );
+
+        // ...and the explicit decision is available, by a name that shows up in
+        // review.
+        assert_eq!(
+            detector.compare_across_bases(&residual),
+            Ok(Ordering::Equal)
+        );
+    }
+
+    #[test]
+    fn same_basis_compares_normally() {
+        let low = Confidence::new(Some(0.2), ConfidenceBasis::ModelScore, None).unwrap();
+        let high = Confidence::new(Some(0.8), ConfidenceBasis::ModelScore, None).unwrap();
+        assert_eq!(low.compare(&high), Ok(Ordering::Less));
+        assert_eq!(high.compare(&low), Ok(Ordering::Greater));
+    }
+
+    #[test]
+    fn an_absent_score_is_not_a_low_score() {
+        let none = Confidence::unspecified();
+        let some = Confidence::new(Some(0.0), ConfidenceBasis::Unspecified, None).unwrap();
+        // Same basis, so the basis guard passes — but there is still nothing to
+        // order, and 0.0 must not be invented for the absent side.
+        assert_eq!(none.compare(&some), Err(ConfidenceError::ScoreAbsent));
+    }
+
+    #[test]
+    fn a_non_finite_score_is_refused_rather_than_clamped() {
+        assert_eq!(
+            Confidence::new(Some(f32::NAN), ConfidenceBasis::ModelScore, None),
+            Err(ConfidenceError::ScoreNotFinite)
+        );
+        assert_eq!(
+            Confidence::new(Some(f32::INFINITY), ConfidenceBasis::ModelScore, None),
+            Err(ConfidenceError::ScoreNotFinite)
+        );
+        assert_eq!(
+            Confidence::new(Some(1.5), ConfidenceBasis::ModelScore, None),
+            Err(ConfidenceError::ScoreOutOfRange)
+        );
+        assert_eq!(
+            Confidence::new(Some(-0.1), ConfidenceBasis::ModelScore, None),
+            Err(ConfidenceError::ScoreOutOfRange)
+        );
+    }
+
+    #[test]
+    fn the_boundaries_of_the_range_are_admitted() {
+        assert!(Confidence::new(Some(0.0), ConfidenceBasis::ModelScore, None).is_ok());
+        assert!(Confidence::new(Some(1.0), ConfidenceBasis::ModelScore, None).is_ok());
+    }
+
+    // -- The ADR-0040 PerceivedObject condition ---------------------------
+
+    #[test]
+    fn a_synthesized_confidence_is_visibly_synthesized() {
+        // ADR-0040's tracked-object ruling requires synthesized confidence to be
+        // "visible in the store rather than indistinguishable from a measured
+        // value". `Assumed` is what makes that satisfiable.
+        let synthesized = Confidence::assumed(0.7).unwrap();
+        let measured = Confidence::new(Some(0.7), ConfidenceBasis::ModelScore, None).unwrap();
+
+        assert!(synthesized.is_synthesized());
+        assert!(!measured.is_synthesized());
+
+        // Identical scores, and they still do not compare — the basis guard
+        // catches exactly the confusion the ruling was worried about.
+        assert!(matches!(
+            synthesized.compare(&measured),
+            Err(ConfidenceError::BasesDiffer { .. })
+        ));
+    }
+
+    #[test]
+    fn a_producer_with_nothing_to_report_says_so() {
+        let c = Confidence::unspecified();
+        assert_eq!(c.score(), None);
+        assert_eq!(c.basis(), ConfidenceBasis::Unspecified);
+        assert!(!c.is_synthesized());
+    }
+
+    #[test]
+    fn an_empty_calibration_reference_is_refused() {
+        assert_eq!(
+            CalibrationRef::new("   "),
+            Err(ConfidenceError::EmptyCalibrationRef)
+        );
+        assert!(CalibrationRef::new("platt-2026-01").is_ok());
+    }
+
+    // -- Clock domains do not mix -----------------------------------------
+
+    #[test]
+    fn cross_domain_comparison_is_refused() {
+        let boundary = DomainInstant {
+            ms: 100,
+            domain: ClockDomain::Boundary,
+        };
+        let system = DomainInstant {
+            ms: 200,
+            domain: ClockDomain::System,
+        };
+        assert_eq!(
+            boundary.compare(&system),
+            Err(TimeError::DomainsDiffer {
+                left: ClockDomain::Boundary,
+                right: ClockDomain::System,
+            })
+        );
+        // Within one domain it is an ordinary comparison.
+        let later = DomainInstant {
+            ms: 300,
+            domain: ClockDomain::Boundary,
+        };
+        assert_eq!(boundary.compare(&later), Ok(Ordering::Less));
+    }
+
+    #[test]
+    fn an_interval_cannot_span_two_clocks() {
+        let start = DomainInstant {
+            ms: 0,
+            domain: ClockDomain::Boundary,
+        };
+        let end = DomainInstant {
+            ms: 10,
+            domain: ClockDomain::System,
+        };
+        assert!(matches!(
+            ValidInterval::new(start, Some(end)),
+            Err(TimeError::DomainsDiffer { .. })
+        ));
+    }
+
+    #[test]
+    fn an_interval_cannot_end_before_it_starts() {
+        let start = DomainInstant {
+            ms: 10,
+            domain: ClockDomain::Boundary,
+        };
+        let end = DomainInstant {
+            ms: 9,
+            domain: ClockDomain::Boundary,
+        };
+        assert_eq!(
+            ValidInterval::new(start, Some(end)),
+            Err(TimeError::IntervalEndsBeforeItStarts)
+        );
+        // Zero-length is admitted: a claim can hold at an instant.
+        let same = DomainInstant {
+            ms: 10,
+            domain: ClockDomain::Boundary,
+        };
+        assert!(ValidInterval::new(start, Some(same)).is_ok());
+    }
+
+    // -- Composition with the trust model ---------------------------------
+
+    #[test]
+    fn an_interval_projects_into_the_trust_validity_question() {
+        let start = DomainInstant {
+            ms: 1_000,
+            domain: ClockDomain::Boundary,
+        };
+        let interval = ValidInterval::open_from(start);
+        let window = interval.to_validity_window(Some(500));
+
+        assert_eq!(validity_at(&window, 1_200), Validity::Fresh);
+        assert_eq!(validity_at(&window, 1_600), Validity::Stale);
+        // And with no TTL the claim is timeless, per rule 6's Timeless arm.
+        assert_eq!(
+            validity_at(&interval.to_validity_window(None), u64::MAX),
+            Validity::Timeless
+        );
+    }
+
+    #[test]
+    fn a_closed_interval_carries_its_end_into_expiry() {
+        let start = DomainInstant {
+            ms: 0,
+            domain: ClockDomain::System,
+        };
+        let end = DomainInstant {
+            ms: 100,
+            domain: ClockDomain::System,
+        };
+        let window = ValidInterval::new(start, Some(end))
+            .unwrap()
+            .to_validity_window(None);
+        assert_eq!(validity_at(&window, 99), Validity::Timeless);
+        assert_eq!(validity_at(&window, 100), Validity::Expired);
+    }
+
+    // -- Source class -> origin -------------------------------------------
+
+    #[test]
+    fn a_relayed_claim_is_never_treated_as_locally_observed() {
+        // The laundering-across-a-hop case: this instance did not measure a
+        // peer's claim, and Network must not map to Observed.
+        assert_ne!(SourceClass::Network.origin(), Origin::Observed);
+        assert_eq!(SourceClass::Network.origin(), Origin::Imported);
+    }
+
+    #[test]
+    fn source_classes_map_to_their_origins() {
+        assert_eq!(SourceClass::Sensor.origin(), Origin::Observed);
+        assert_eq!(SourceClass::Operator.origin(), Origin::Asserted);
+        assert_eq!(SourceClass::Derivation.origin(), Origin::Derived);
+        assert_eq!(SourceClass::Import.origin(), Origin::Imported);
+        assert_eq!(SourceClass::Configuration.origin(), Origin::Imported);
+    }
+
+    #[test]
+    fn no_source_class_maps_to_the_unstorable_origin() {
+        // Origin::Predicted never appears in the evidence store (blueprint §20),
+        // and TrustAxes::new refuses it — so no producer may route to it.
+        for sc in [
+            SourceClass::Sensor,
+            SourceClass::Operator,
+            SourceClass::Configuration,
+            SourceClass::Import,
+            SourceClass::Derivation,
+            SourceClass::Network,
+        ] {
+            assert_ne!(sc.origin(), Origin::Predicted, "{sc:?} routed to Predicted");
+        }
+    }
+
+    // -- Evidence-first ----------------------------------------------------
+
+    #[test]
+    fn an_observation_subject_may_be_unbound() {
+        // Why this module does not depend on the entity taxonomy: evidence can
+        // be recorded before anything decides what it is about.
+        let s = SubjectRef::Unbound;
+        assert_eq!(s, SubjectRef::Unbound);
+        assert_ne!(s, SubjectRef::Candidate("c-1".into()));
+    }
+}

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -235,7 +235,23 @@ not permission.
       something empties the store. This is the one item here that is not about
       the domain model; it is here because that decision put it here rather than
       leaving the fill date unowned.
-- [ ] **Entity taxonomy** (§6)
+- [ ] **Entity taxonomy** (§6) — **structure and kinds DONE 2026-08-06**,
+      `crates/kirra-world/src/entity.rs`, 18 tests, still zero-dependency.
+      Delivered: the 19-kind root-closed taxonomy + `EntityGroup`, `Lifecycle`
+      with validated transitions, `EntityId`/`Alias` (each alias carrying its own
+      `SourceClass`), `ResolutionConfidence`, and the `Entity` spine.
+      **Two more rules made structural:** an unrecognised kind has **no group to
+      read** (`group()` returns `Option`, `None` for `Unknown`), so §6.2's
+      *"degrade to `Unknown`, not guess a supertype"* is unavailable to violate;
+      and `ResolutionConfidence` is a newtype so the "is this **one** thing"
+      claim cannot be passed where an attribute confidence was wanted.
+      **`Entity` has no `kind` field** — kind is adjudicated from classification
+      evidence, so reclassification cannot contradict a stored value. That
+      follows §6.2 over §6.1's field table, which **contradict each other**; the
+      tension is recorded in the module as an open question rather than resolved.
+      **Still open:** identity *adjudication* — candidate clustering, merge/split
+      events — is Tier 2. `entity_id` generation, `first_observed`/
+      `last_observed` and `provenance_head` need the store (ULID, hashing).
 - [ ] **Observation model** (§7) — **pure half DONE 2026-08-06**,
       `crates/kirra-world/src/observation.rs`, 17 tests, still zero-dependency.
       Delivered: `Confidence`/`ConfidenceBasis` (§7.3), `SourceClass` + its

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -246,7 +246,12 @@ not permission.
       and `ResolutionConfidence` is a newtype so the "is this **one** thing"
       claim cannot be passed where an attribute confidence was wanted.
       **`Entity` has no `kind` field** — kind is adjudicated from classification
-      evidence, so reclassification cannot contradict a stored value. That
+      evidence, so reclassification cannot contradict a stored value.
+      `adjudicated_kind` returns a three-way `KindAdjudication`
+      (`NoEvidence` / `Settled` / `Unrankable`) rather than a bare kind, so
+      "I hold evidence I have no grounds to rank" is reportable instead of
+      collapsed into a guess — and it ranks **through** the §7.3 cross-basis
+      guard rather than around it. That
       follows §6.2 over §6.1's field table, which **contradict each other**; the
       tension is recorded in the module as an open question rather than resolved.
       **Still open:** identity *adjudication* — candidate clustering, merge/split

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -236,7 +236,23 @@ not permission.
       the domain model; it is here because that decision put it here rather than
       leaving the fill date unowned.
 - [ ] **Entity taxonomy** (§6)
-- [ ] **Observation model** (§7)
+- [ ] **Observation model** (§7) — **pure half DONE 2026-08-06**,
+      `crates/kirra-world/src/observation.rs`, 17 tests, still zero-dependency.
+      Delivered: `Confidence`/`ConfidenceBasis` (§7.3), `SourceClass` + its
+      mapping to the trust `Origin`, `SubjectRef` (including `Unbound`, which is
+      why this did not need the entity taxonomy first), `ClockDomain`/
+      `DomainInstant`/`ValidInterval` and the projection into
+      `trust::ValidityWindow`.
+      **Two more rules made structural**, following rule 6's shape: cross-modal
+      confidence comparison **errors** unless the caller names the decision
+      (`compare_across_bases`), and clock domains **cannot** be compared at all —
+      unsound rather than merely unwise, so there is deliberately no escape hatch.
+      **Still open, and it needs dependencies:** `observation_id` (ULID),
+      `evidence_digest`/`prev_hash` (hashing), `frame`/`map`, and the per-kind
+      versioned `TypedPayload`. Those belong to the **store**, which already has
+      all three — pulling them into the core would spend ADR-0040's Q1 seam
+      decision without revisiting it. `ObservationKind` is also absent because
+      the blueprint names the field but never enumerates its variants.
 - [ ] **Relationship model** (§8)
 - [x] **The four orthogonal trust axes** (§9):
       `Origin × Corroboration × Adjudication × Validity` — **DONE 2026-08-06**,


### PR DESCRIPTION
Two Tier 1 slices: the observation model's pure half (§7) and the entity taxonomy's structure and kinds (§6). **66 tests** in `kirra-world`, up from 31. **Zero dependencies still preserved** — which is the constraint that decided both scopes.

**Ticks nothing.** Both `WM_SCOPE` boxes stay unticked and now record which half landed, which half is Tier 2, and which fields need the store.

---

## Four more rules made structural

Continuing the shape rule 6 took in slice 1 — where the blueprint states a rule in prose, prefer a type that cannot express the violation.

| Rule | Made unavailable, not merely discouraged |
|---|---|
| §7.3 cross-modal comparison | `Confidence::compare` **errors** on differing bases; `compare_across_bases` is the named decision |
| §5.1 clock domains do not mix | `DomainInstant::compare` refuses — and deliberately **no escape hatch** |
| §6.2 degrade, never guess a supertype | `group()` returns `Option`, `None` for `Unknown` — no supertype exists to misread |
| §6.1 resolution ≠ attribute confidence | `ResolutionConfidence` newtype; the compiler keeps them apart |

**The clock-domain asymmetry is deliberate and stated:** comparing two confidence bases is *unwise*, so it gets an escape hatch. Comparing two unsynchronized clocks is *unsound*, so it does not.

---

## A contradiction inside §6, flagged rather than quietly picked

§6.1's field table lists `kind` as a field every entity carries. §6.2 says the opposite:

> *"Kind is a **classification observation**, not an intrinsic property. A detector saying 'package' is evidence. The kind shown in a projection is the adjudicated result."*

Both cannot be literally true of a stored field. This follows **§6.2**, on the reason §6.1 itself gives about attributes — *"they are projections over the observations bound to it, so an attribute always retains its own source, time, and confidence"* — and kind is exactly such an attribute.

So **`Entity` has no `kind` field**, and §6.2's own example becomes true by construction: *"the box you thought was a package turning out to be a tool is a reclassification, not a new object"* — there is nothing stored for the new evidence to contradict.

**Open question for the owner:** is §6.1's `kind` row a cached projection, or an independently settable field? Under the first reading they agree. Under the second, the blueprint should resolve it — not this module.

---

## What this unblocks

`ConfidenceBasis::Assumed` is what makes **ADR-0040's `PerceivedObject` condition satisfiable**. That ruling requires synthesized confidence to be *"visible in the store rather than indistinguishable from a measured value"* — a claim carrying `Assumed` is visibly synthesized, and `is_synthesized()` is the predicate an auditor asks. `Unspecified` covers the honest case, per §7.3's *"the design must not force producers to invent precision they do not have."*

---

## Scope decided by the dependency argument

§7.1's record also carries `observation_id` (ULID), `evidence_digest`/`prev_hash` (hashing), `frame`, `map` and a versioned `TypedPayload`. §6.1 adds `entity_id` generation, `first_observed`/`last_observed` and `provenance_head`. **None are here** — each needs a dependency, and `kirra-world` has zero by design.

That is precisely the argument **ADR-0040's open question 1** was decided on: *"collapsing the store into it would place `rusqlite`, `serde_json`, `sha2` and `hex` beside the domain types."* Pulling a hash in to finish a struct would spend that decision without revisiting it. Identity, hashing and chaining stay with the store, which already implements all three.

`ObservationKind` is absent for a different reason: §7.1 names the field but the blueprint never enumerates its variants. Same discipline as `k` in slice 1 — don't invent a taxonomy the spec didn't state.

---

## Readings supplied, each called out at the code

- **`SourceClass` → `Origin`** is not stated by the blueprint and the enums differ in size (six vs five). Both ambiguous cases resolve to `Imported`, the storable origin that asserts least. **`Network` is emphatically not `Observed`** — treating a relayed claim as a local measurement is how a fleet launders provenance across a hop. A test asserts no source class can route to `Predicted`.
- **Lifecycle:** `Dormant → Established` permitted (forbidding it would force a new identity for a thing that never stopped existing — the exact failure §6.3 exists to prevent); `Retired` and `Merged` terminal; `Split` live. The last is flagged — the two readings differ on whether the original survives a split.
- **`Merged` mirrors trust's `Rejected`:** terminal for the record, not the subject. §6.3 requires merged IDs resolvable forever, so `redirects_to()` exposes it and merging never deletes.

**A limitation stated, not hidden:** without an operator claim, `adjudicated_kind` ties fall back to the first classification offered, so the result depends on input order. A test pins it. Fixing it properly needs Tier 2's corroboration counting.

---

## Negative controls — five, all load-bearing

| Guard removed | Tests that fail |
|---|---|
| cross-basis confidence guard | 2 |
| clock-domain guard | 2 |
| `Unknown` guesses a supertype | 2 |
| unrecognised token defaults to `Object` | 2 |
| operator-settles-classification | 1 |

## Verification

66 tests in `kirra-world`; `kirra-world-store` and `kirra-world-service` unaffected. Clippy clean under `#[warn(missing_docs)]`, rustfmt clean. Both Kirra World fences, the domain-logic gate, `check_quality_guardrails`, `check_website_citations` all OK. `Cargo.toml` still has **no dependencies section at all**.

## Tier 1 after this

| Item | State |
|---|---|
| Trust axes (§9) | ✅ done |
| Seven transition rules (§9.2) | 6.5 / 7 — rule 4's geometry half needs a payload |
| Observation model (§7) | pure half done; rest needs the store |
| Entity taxonomy (§6) | structure + kinds done; adjudication is Tier 2 |
| Relationship model (§8) | not started |
| Retention driver | not started — the ADR-0040 deployment condition |

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_