### PR TITLE
Rule 4's geometry half — the transition rules close at 7/7

### DIFF
--- a/crates/kirra-world/src/lib.rs
+++ b/crates/kirra-world/src/lib.rs
@@ -15,7 +15,8 @@
 //!   rules, with the anti-laundering rule (5) and read-time validity (6) as the
 //!   load-bearing parts.
 //! * [`mod@observation`] (§7, pure half) — structured `Confidence`, source
-//!   classes, clock domains that cannot be mixed.
+//!   classes, clock domains that cannot be mixed, and payload provenance that
+//!   an operator correction cannot launder (P10).
 //! * [`mod@entity`] (§6, structure and kinds) — the root-closed taxonomy,
 //!   lifecycle, and kind as adjudicated evidence rather than a stored field.
 //! * [`mod@relationship`] (§8) — directed, typed, time-bounded relations;

--- a/crates/kirra-world/src/observation.rs
+++ b/crates/kirra-world/src/observation.rs
@@ -4,7 +4,7 @@
 //! module implements the part of it that can be pure**, and deliberately stops
 //! short of the rest — see *What is missing and why* below.
 //!
-//! # Two rules made structural rather than remembered
+//! # Three rules made structural rather than remembered
 //!
 //! The same move that gave [`crate::trust`] its shape: where the blueprint
 //! states a rule in prose, prefer a type that cannot express the violation.
@@ -27,11 +27,27 @@
 //! carries its domain, and [`DomainInstant::compare`] refuses a cross-domain
 //! comparison rather than returning a confidently wrong ordering.
 //!
+//! **3. Language never supplies geometry (P10).** §9.2's transition rule 4 has
+//! two halves; the *adjudication* half is [`crate::trust::TrustAxes::operator_confirm`]
+//! and the *geometry* half is here. An operator correcting a pose builds a
+//! [`Payload::correction`] — an associated function that never receives the
+//! payload it corrects, and whose [`PayloadSource::Correction`] variant has no
+//! source-class field to inherit. So the corrected record is unreachable from
+//! the operation, and the correction cannot present as sensed.
+//!
+//! Worth noting where the enforcement point landed: **rule 4's geometry half
+//! turned out not to need geometry.** The rule asks that an operator's payload
+//! be *"visibly distinct from a sensed one"* — a claim about provenance, which
+//! a crate with no pose type can keep in full. The `Payload` body is a type
+//! parameter precisely so that stays true.
+//!
 //! # What is missing, and why — the dependency argument
 //!
 //! §7.1's record also carries `observation_id: Ulid`, `evidence_digest: Hash`,
 //! `prev_hash: Hash`, `frame: FrameRef`, `map: Option<MapVersion>` and a
-//! per-kind versioned `TypedPayload`. **None of them are here**, because each
+//! per-kind versioned `TypedPayload` **body** — [`Payload`] carries that body's
+//! provenance but leaves the body itself a type parameter. **None of them are
+//! here**, because each
 //! needs a dependency — ULID generation, a hash implementation, frame and map
 //! types — and `kirra-world` has **zero dependencies by design**.
 //!
@@ -475,6 +491,195 @@ impl ValidInterval {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Payload provenance — §9.2 rule 4's geometry half, and P10
+// ---------------------------------------------------------------------------
+
+/// Why a payload could not be built.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum PayloadError {
+    /// A payload reference was empty.
+    EmptyPayloadRef,
+}
+
+/// A reference to an earlier recorded payload.
+///
+/// Opaque here on the same terms as [`crate::relationship::DerivationRef`]:
+/// this crate stores the reference, the store resolves it.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PayloadRef(String);
+
+impl PayloadRef {
+    /// Wrap a reference.
+    ///
+    /// # Errors
+    ///
+    /// [`PayloadError::EmptyPayloadRef`] if empty or whitespace.
+    pub fn new(r: impl Into<String>) -> Result<Self, PayloadError> {
+        let r = r.into();
+        if r.trim().is_empty() {
+            return Err(PayloadError::EmptyPayloadRef);
+        }
+        Ok(Self(r))
+    }
+
+    /// The reference.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Where a payload's **content** came from — the distinction §9.2 rule 4 turns on.
+///
+/// Rule 4: *"An operator correcting a pose creates a `Correction` observation
+/// whose payload is itself an operator-sourced measurement, **visibly distinct
+/// from a sensed one**."*
+///
+/// "Visibly distinct" is the whole requirement, and it is a statement about
+/// provenance rather than about geometry — which is why this can be enforced
+/// here, in a crate that has no pose type and wants none.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum PayloadSource {
+    /// Produced directly by this class of producer.
+    Produced(SourceClass),
+    /// **An operator correction of an earlier payload.**
+    ///
+    /// There is deliberately no [`SourceClass`] field. §7.2 lists `Correction`
+    /// under the **Operator** source class, so a correction is operator-sourced
+    /// by definition — and with no field to fill, "a correction that presents
+    /// as sensed" cannot be spelled. Same move as
+    /// [`crate::relationship::Origination::Inferred`] carrying its derivation:
+    /// the thing that must never be dropped lives in the variant.
+    Correction {
+        /// What is being corrected. A correction that does not say what it
+        /// corrects breaks invalidate-by-provenance the same way an
+        /// uncited inference does.
+        of: PayloadRef,
+    },
+}
+
+/// An observation's payload: content, plus **who produced it**, inseparably.
+///
+/// # The body is a type parameter, not a type this crate invents
+///
+/// §7.1's `TypedPayload` is per-kind and versioned, and belongs to the store
+/// along with identity, hashing, frames and maps — see the module header's
+/// dependency argument. Making the body generic keeps that seam intact while
+/// still letting the rule below be enforced *here*, where the trust model is.
+/// The store plugs in its own body type and inherits the guarantee.
+///
+/// # Rule 4's geometry half, and what enforces it
+///
+/// The failure the rule names is *"an operator assertion silently rewriting a
+/// measured pose"*. Two things make it unavailable, neither of them a check:
+///
+/// 1. **There is no way to modify a payload.** No setter, no `&mut` accessor,
+///    and no method anywhere that takes a `Payload` and returns a changed one.
+///    A correction is built by [`Payload::correction`], an associated function
+///    — it never receives the payload it corrects, only a reference to it. The
+///    measured record is not merely protected from rewriting; it is not
+///    reachable from the operation.
+/// 2. **A correction cannot inherit the corrected payload's source class**,
+///    because [`PayloadSource::Correction`] has no such field. That is the
+///    laundering hole worth closing: had `correction` copied the original's
+///    class, an operator's numbers would carry `Sensor` provenance and become
+///    exactly the *invisible* rewrite the rule forbids.
+///
+/// # What this does NOT guarantee — read before relying on it
+///
+/// * **That `of` names the payload being corrected.** Identity is the store's
+///   (§7.1's `observation_id` is a ULID, absent here by the dependency
+///   argument), so this crate cannot check the reference resolves, let alone
+///   that it resolves to the right record. It guarantees a correction *cites
+///   something*, not that it cites truthfully.
+/// * **That a producer told the truth about its own class.** A writer
+///   constructing `Produced(SourceClass::Sensor)` for hand-typed numbers is
+///   lying at the producing edge, where §7.2's per-source schemas live. No type
+///   here can catch that, and pretending otherwise would be worse than saying so.
+/// * **Anything about the numbers.** The body is opaque by construction, so
+///   this module cannot tell a plausible corrected pose from an absurd one.
+///   Rule 4 does not ask it to; the rule is about provenance being visible, and
+///   that is the part being kept.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Payload<B> {
+    body: B,
+    source: PayloadSource,
+}
+
+impl<B> Payload<B> {
+    /// A payload produced directly by `by`.
+    #[must_use]
+    pub fn produced(body: B, by: SourceClass) -> Self {
+        Self {
+            body,
+            source: PayloadSource::Produced(by),
+        }
+    }
+
+    /// **An operator's correction of an earlier payload.**
+    ///
+    /// Note what is absent: this does not take the payload being corrected, so
+    /// there is no path by which the correction could copy its provenance, and
+    /// no path by which the original could be altered. It takes a *reference*,
+    /// and stamps the result operator-sourced itself.
+    #[must_use]
+    pub fn correction(of: PayloadRef, body: B) -> Self {
+        Self {
+            body,
+            source: PayloadSource::Correction { of },
+        }
+    }
+
+    /// The content.
+    #[must_use]
+    pub fn body(&self) -> &B {
+        &self.body
+    }
+
+    /// Where the content came from.
+    #[must_use]
+    pub fn source(&self) -> &PayloadSource {
+        &self.source
+    }
+
+    /// What this corrects, if it is a correction.
+    #[must_use]
+    pub fn corrects(&self) -> Option<&PayloadRef> {
+        match &self.source {
+            PayloadSource::Correction { of } => Some(of),
+            PayloadSource::Produced(_) => None,
+        }
+    }
+
+    /// **Whether an operator supplied these numbers** — the P10 read.
+    ///
+    /// True for a direct operator assertion *and* for a correction. A consumer
+    /// that must not take geometry from language asks this one question, and
+    /// the answer cannot be laundered by routing an assertion through a
+    /// correction.
+    #[must_use]
+    pub fn is_operator_supplied(&self) -> bool {
+        match &self.source {
+            PayloadSource::Produced(c) => *c == SourceClass::Operator,
+            PayloadSource::Correction { .. } => true,
+        }
+    }
+
+    /// Whether this system **sensed** the content.
+    ///
+    /// [`SourceClass::Sensor`] only — deliberately narrow, and not the negation
+    /// of [`Self::is_operator_supplied`]. An imported map layer and a derived
+    /// fact are neither operator-supplied nor sensed, and collapsing the three
+    /// into one boolean is how a relayed or inferred value comes to be read as
+    /// a local measurement. Compare [`SourceClass::origin`]'s refusal to map
+    /// `Network` to `Observed`, for the same reason.
+    #[must_use]
+    pub fn is_sensed(&self) -> bool {
+        matches!(&self.source, PayloadSource::Produced(SourceClass::Sensor))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -734,5 +939,101 @@ mod tests {
         let s = SubjectRef::Unbound;
         assert_eq!(s, SubjectRef::Unbound);
         assert_ne!(s, SubjectRef::Candidate("c-1".into()));
+    }
+
+    // -- §9.2 rule 4, geometry half: P10 -----------------------------------
+
+    fn pref(s: &str) -> PayloadRef {
+        PayloadRef::new(s).unwrap()
+    }
+
+    #[test]
+    fn a_correction_is_visibly_distinct_from_the_pose_it_corrects() {
+        // THE rule: "an operator correcting a pose creates a Correction
+        // observation whose payload is itself an operator-sourced measurement,
+        // visibly distinct from a sensed one."
+        let measured = Payload::produced("pose@sensor", SourceClass::Sensor);
+        let corrected = Payload::correction(pref("obs-77"), "pose@operator");
+
+        assert!(measured.is_sensed());
+        assert!(!measured.is_operator_supplied());
+
+        // Visibly distinct, on the one question P10 asks.
+        assert!(corrected.is_operator_supplied());
+        assert!(!corrected.is_sensed());
+        assert_eq!(corrected.corrects().unwrap().as_str(), "obs-77");
+    }
+
+    #[test]
+    fn a_correction_cannot_inherit_the_corrected_payloads_source_class() {
+        // The laundering hole: if `correction` copied the original's class, an
+        // operator's numbers would carry Sensor provenance — the INVISIBLE
+        // rewrite rule 4 forbids. The variant has no field to copy into.
+        let corrected = Payload::correction(pref("obs-77"), "pose@operator");
+        assert_eq!(
+            corrected.source(),
+            &PayloadSource::Correction { of: pref("obs-77") }
+        );
+        // Exhaustive over every producer class: none of them can be what a
+        // correction reports as its source.
+        for class in [
+            SourceClass::Sensor,
+            SourceClass::Operator,
+            SourceClass::Configuration,
+            SourceClass::Import,
+            SourceClass::Derivation,
+            SourceClass::Network,
+        ] {
+            assert_ne!(corrected.source(), &PayloadSource::Produced(class));
+        }
+    }
+
+    #[test]
+    fn the_measured_payload_is_untouched_by_a_correction() {
+        // `correction` never receives the payload it corrects — the original is
+        // not reachable from the operation, so "silently rewrite" has no path.
+        let measured = Payload::produced("pose@sensor", SourceClass::Sensor);
+        let before = measured.clone();
+        let _correction = Payload::correction(pref("obs-77"), "pose@operator");
+        assert_eq!(measured, before);
+        assert_eq!(*measured.body(), "pose@sensor");
+        assert!(measured.is_sensed());
+    }
+
+    #[test]
+    fn routing_an_assertion_through_a_correction_does_not_launder_it() {
+        // Both spellings of operator-supplied geometry answer P10's question the
+        // same way. A consumer that must not take geometry from language cannot
+        // be dodged by choosing the other variant.
+        let asserted = Payload::produced("pose@operator", SourceClass::Operator);
+        let corrected = Payload::correction(pref("obs-77"), "pose@operator");
+        assert!(asserted.is_operator_supplied());
+        assert!(corrected.is_operator_supplied());
+    }
+
+    #[test]
+    fn sensed_is_narrower_than_not_operator_supplied() {
+        // Deliberately NOT the negation of each other. An imported map layer and
+        // a derived fact are neither — collapsing the three is how a relayed or
+        // inferred value gets read as a local measurement.
+        for class in [
+            SourceClass::Configuration,
+            SourceClass::Import,
+            SourceClass::Derivation,
+            SourceClass::Network,
+        ] {
+            let p = Payload::produced("x", class);
+            assert!(!p.is_operator_supplied(), "{class:?}");
+            assert!(!p.is_sensed(), "{class:?}");
+        }
+    }
+
+    #[test]
+    fn a_correction_must_cite_something() {
+        // Same class of hole as an uncited inference: PayloadRef refuses empty,
+        // and the variant has no None case, so "corrects nothing" is unspellable.
+        assert_eq!(PayloadRef::new("  "), Err(PayloadError::EmptyPayloadRef));
+        assert_eq!(PayloadRef::new(""), Err(PayloadError::EmptyPayloadRef));
+        assert!(PayloadRef::new("obs-77").is_ok());
     }
 }

--- a/crates/kirra-world/src/observation.rs
+++ b/crates/kirra-world/src/observation.rs
@@ -553,7 +553,7 @@ pub enum PayloadSource {
     /// the thing that must never be dropped lives in the variant.
     Correction {
         /// What is being corrected. A correction that does not say what it
-        /// corrects breaks invalidate-by-provenance the same way an
+        /// corrects defeats the invalidate-by-provenance rule the same way an
         /// uncited inference does.
         of: PayloadRef,
     },

--- a/crates/kirra-world/src/trust.rs
+++ b/crates/kirra-world/src/trust.rs
@@ -43,7 +43,8 @@
 //! assertion outranks sensor evidence *for adjudication*, and never *for
 //! geometry*. Only the adjudication half lives here — see
 //! [`TrustAxes::operator_confirm`]. The geometry half is a constraint on the
-//! observation payload, which Tier 1's observation model owns.
+//! observation payload, and is now enforced there:
+//! [`crate::observation::Payload::correction`].
 
 // ---------------------------------------------------------------------------
 // Origin — rule 1: fixed at write, never changes
@@ -454,7 +455,10 @@ impl TrustAxes {
     /// pose must instead create a `Correction` observation whose payload is
     /// visibly operator-sourced (P10). That half is the observation model's to
     /// enforce, and this method's inability to reach a payload is the reason it
-    /// cannot be used to sidestep it.
+    /// cannot be used to sidestep it. It is now enforced there rather than
+    /// merely unreachable from here — see
+    /// [`crate::observation::Payload::correction`], which stamps the correction
+    /// operator-sourced with no field a caller could set otherwise.
     ///
     /// # Errors
     ///

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -373,16 +373,20 @@ not permission.
       why this did not need the entity taxonomy first), `ClockDomain`/
       `DomainInstant`/`ValidInterval` and the projection into
       `trust::ValidityWindow`.
-      **Two more rules made structural**, following rule 6's shape: cross-modal
+      **Three more rules made structural**, following rule 6's shape: cross-modal
       confidence comparison **errors** unless the caller names the decision
-      (`compare_across_bases`), and clock domains **cannot** be compared at all —
-      unsound rather than merely unwise, so there is deliberately no escape hatch.
+      (`compare_across_bases`); clock domains **cannot** be compared at all —
+      unsound rather than merely unwise, so there is deliberately no escape hatch;
+      and **rule 4's geometry half / P10** — `Payload` + `PayloadSource`, added
+      2026-08-06, which is what closed the transition rules at 7/7 above.
       **Still open, and it needs dependencies:** `observation_id` (ULID),
       `evidence_digest`/`prev_hash` (hashing), `frame`/`map`, and the per-kind
-      versioned `TypedPayload`. Those belong to the **store**, which already has
-      all three — pulling them into the core would spend ADR-0040's Q1 seam
-      decision without revisiting it. `ObservationKind` is also absent because
-      the blueprint names the field but never enumerates its variants.
+      versioned `TypedPayload` **body** — `Payload` carries that body's
+      provenance, but the body itself stays a type parameter. Those belong to the
+      **store**, which already has all three — pulling them into the core would
+      spend ADR-0040's Q1 seam decision without revisiting it. `ObservationKind`
+      is also absent because the blueprint names the field but never enumerates
+      its variants.
 - [x] **Relationship model** (§8) — **DONE 2026-08-06**,
       `crates/kirra-world/src/relationship.rs`, 20 tests, still zero-dependency.
       **All ten §8 record fields**, all 15 predicates across the four groups.
@@ -425,15 +429,28 @@ not permission.
       **structurally unbreakable** rather than a rule someone remembers —
       `validity_at` takes the clock as an argument and there is nowhere to write
       its answer down.
-- [ ] **The seven transition rules** (§9.2) — **six and a half of seven.**
-      Rules 1, 2, 3, 5, 6, 7 are implemented and tested, including the two
-      load-bearing ones. **Rule 4 is half done**: its *adjudication* half is
-      `TrustAxes::operator_confirm`; its *geometry* half (an operator assertion
-      may never silently rewrite a measured pose, P10) constrains the
-      **observation payload**, so it cannot be enforced until the observation
-      model exists. Deliberately left unticked rather than counted as done —
-      the module cannot reach a payload, which is why it cannot yet be
-      sidestepped, but "cannot be sidestepped from here" is not "enforced".
+- [x] **The seven transition rules** (§9.2) — **all seven, DONE 2026-08-06.**
+      Rules 1, 2, 3, 5, 6, 7 landed with the trust axes. **Rule 4's geometry
+      half** (an operator assertion may never silently rewrite a measured pose,
+      P10) landed with `observation::Payload` — its *adjudication* half was
+      already `TrustAxes::operator_confirm`.
+      **It did not need the geometry types this entry previously assumed.** The
+      rule asks that an operator's payload be *"visibly distinct from a sensed
+      one"* — a claim about **provenance**, not about pose contents — so a crate
+      with no pose type can keep it in full. `Payload`'s body is a type
+      parameter for exactly that reason, leaving §7.1's versioned `TypedPayload`
+      with the store where ADR-0040's Q1 seam decision put it.
+      Two things make the failure unavailable rather than checked:
+      `Payload::correction` is an **associated function that never receives the
+      payload it corrects** (the measured record is not reachable from the
+      operation), and `PayloadSource::Correction` has **no source-class field**
+      to inherit (so an operator's numbers cannot carry `Sensor` provenance —
+      the *invisible* rewrite is the one the rule actually forbids).
+      Three limits are stated in the type's docs rather than papered over: this
+      cannot verify that `of` names the right record (identity is the store's),
+      cannot catch a producer lying about its own class (that is §7.2's
+      producing edge), and cannot judge the numbers at all (the body is opaque
+      by construction).
 
 ### Why the axes are not one enum
 


### PR DESCRIPTION
**101 tests** in `kirra-world` (was 95). Still **zero dependencies**.

## The checklist said this was blocked. It wasn't, and the reason matters

`WM_SCOPE.md` recorded §9.2 rule 4 as *"six and a half of seven"*, its geometry half waiting on the observation payload — which waits on ULID/hashing/frames, which would spend ADR-0040's Q1 seam decision. That chain breaks at the first link. Read what the rule actually requires:

> An operator correcting a pose creates a `Correction` observation whose payload is itself an operator-sourced measurement, **visibly distinct from a sensed one**.

"Visibly distinct" is a claim about **provenance**, not about pose contents. A crate with no pose type can keep it in full — so rule 4's geometry half turned out not to need geometry, and the seam decision stayed unspent.

`Payload<B>` makes the body a **type parameter** for exactly that reason. §7.1's per-kind versioned `TypedPayload` stays with the store; the store plugs in its own body type and inherits the guarantee.

## Two things make the failure unavailable, neither of them a check

**1. The measured record is not reachable from the operation.** `Payload::correction` is an *associated function* — it never receives the payload it corrects, only a `PayloadRef` to it. There is no setter, no `&mut` accessor, and no method anywhere that takes a `Payload` and returns a changed one. "Silently rewrite a measured pose" has no path, rather than a guarded one.

**2. A correction cannot inherit the corrected payload's source class.**

```rust
pub enum PayloadSource {
    Produced(SourceClass),
    Correction { of: PayloadRef },   // no source-class field to fill
}
```

That is the laundering hole worth closing: had `correction()` copied the original's class, an operator's numbers would carry `Sensor` provenance — and *invisible* is precisely what the rule forbids. §7.2 lists `Correction` under **Operator**, so with no field to fill, "a correction that presents as sensed" cannot be spelled. Same shape as `Origination::Inferred` carrying its derivation.

## Two predicates, and why they are not complements

`is_operator_supplied()` is the P10 read — true for **both** a direct operator assertion and a correction, so routing an assertion through a correction does not dodge a consumer that must not take geometry from language.

`is_sensed()` is deliberately **not** its negation. `Sensor` only. An imported map layer and a derived fact are neither operator-supplied nor sensed, and collapsing the three into one boolean is how a relayed or inferred value comes to be read as a local measurement — the same reason `SourceClass::origin` refuses to map `Network` to `Observed`.

## Three limits stated in the docs rather than papered over

This **cannot** verify that `of` names the record being corrected (identity is the store's ULID). It **cannot** catch a producer lying about its own class (that is §7.2's producing edge). It **cannot** judge the numbers at all (the body is opaque by construction).

Rule 4 asks for none of the three. Claiming them would be the overclaim.

## Negative controls

| Guard reverted | Tests that fail |
|---|---|
| correction answering `is_operator_supplied` | 2 |
| `PayloadRef`'s empty refusal | 1 |
| `is_sensed` collapsed to `!is_operator_supplied` | 1 |

Each failed only its own tests.

## Docs de-staled

`trust.rs` carried two forward references saying the geometry half was the observation model's to enforce. It now is, and both point at it. `WM_SCOPE`'s transition-rules item ticks at 7/7 and records *why* the previous entry's blocking assumption was wrong, rather than quietly changing the box.

## Verification

101 tests pass; `kirra-world-store` and `kirra-world-service` still build; clippy clean under `#[warn(missing_docs)]`; rustfmt clean; both Kirra World fences INTACT; domain-logic gate unblocked; re-export shim ratchet 0; quality guardrails and website citations OK; still no dependencies section in the manifest.

Kirra is designed in alignment with ISO 26262 ASIL-D requirements and IEC 61508 SIL 3 requirements. Independent third-party assessment has not yet been performed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_