### PR TITLE
The retention policy — ADR-0040's Tier 1 exit criterion, deciding half

### DIFF
--- a/crates/kirra-world/src/lib.rs
+++ b/crates/kirra-world/src/lib.rs
@@ -22,6 +22,9 @@
 //! * [`mod@relationship`] (§8) — directed, typed, time-bounded relations;
 //!   supersession instead of update; inferences that cannot omit their
 //!   derivation.
+//! * [`mod@retention`] — ADR-0040's Tier 1 exit criterion, deciding half. The
+//!   store has known *how* to compact since WM-2; nothing has ever decided
+//!   *when*, which is why the horizons OQ2 ruled have gone unenforced.
 //!
 //! **Still absent:** storage, API and queries — plus the parts of §6/§7 that
 //! need a dependency (ULID identity, content hashing, frames, maps, typed
@@ -111,6 +114,7 @@
 pub mod entity;
 pub mod observation;
 pub mod relationship;
+pub mod retention;
 pub mod trust;
 
 // ---------------------------------------------------------------------------

--- a/crates/kirra-world/src/retention.rs
+++ b/crates/kirra-world/src/retention.rs
@@ -45,6 +45,21 @@
 //! [`Blocker::may_compact_around`] is that distinction as a value rather than a
 //! paragraph, so a future driver cannot apply the escalation to the refusal it
 //! was never agreed for.
+//!
+//! # The survey shape, and a comment that was wrong
+//!
+//! [`RetentionSurvey`] first carried four loosely-coupled fields, two of them
+//! `Option`s over a coupling that is structural. That admitted a state with no
+//! meaning — *no compactable prefix and no blocker*, which says the first
+//! eligible generation was refused while naming nothing that refused it — and a
+//! comment in `decide` asserted it could not happen. It could: the survey
+//! constructed, and the decision had to carry an error arm for it.
+//!
+//! [`CompactablePrefix`] and [`Eligibility`] make that state and its twin (a
+//! prefix over a range nothing aged into) **unrepresentable**, which is worth
+//! more than the two runtime checks it replaced: [`decide`] is now infallible.
+//! Every survey that exists maps to a decision, and the only error moved to
+//! where the data is built — the one place it was ever answerable.
 
 use crate::observation::{ClockDomain, DomainInstant};
 
@@ -200,6 +215,54 @@ impl Blocker {
     }
 }
 
+/// How far `largest_compactable_prefix` reached over the eligible range.
+///
+/// # Why this is one enum and not two `Option`s
+///
+/// It was two — `compactable_through: Option<u64>` beside `blocked_by:
+/// Option<Blocker>` — and that admitted a state with no meaning: *no prefix and
+/// no blocker*, which says the very first eligible generation was refused while
+/// naming nothing that refused it. A comment asserted it could not happen. It
+/// could: the survey constructed, and the decision had to carry an error arm
+/// for it.
+///
+/// Here it does not typecheck. [`Self::Nothing`] must name its blocker, and a
+/// prefix that reached the end of the range simply has no blocker to name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CompactablePrefix {
+    /// Nothing is compactable: the first eligible generation is itself refused.
+    Nothing {
+        /// What refused it. Not optional — "refused by nothing" is not a state.
+        blocker: Blocker,
+    },
+    /// A prefix reaches `through`.
+    Through {
+        /// The last compactable generation.
+        through: u64,
+        /// What stopped it going further, or `None` if it reached the end of
+        /// the eligible range.
+        blocker: Option<Blocker>,
+    },
+}
+
+/// What age made eligible, and how far compaction can reach into it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Eligibility {
+    /// Nothing has aged past the cutoff, so there is nothing to survey.
+    ///
+    /// Pairing the age question with the prefix in one enum is what removes the
+    /// second impossible state the two-`Option` shape allowed: a compactable
+    /// prefix over a range that no event was old enough to enter.
+    NothingOldEnough,
+    /// Events aged out through `newest`.
+    Aged {
+        /// The newest generation older than the cutoff.
+        newest: u64,
+        /// How far a compactable prefix reached over that range.
+        prefix: CompactablePrefix,
+    },
+}
+
 /// What the store observed about its own log during one retention pass.
 ///
 /// Every field is something the store can answer cheaply; nothing here is
@@ -208,66 +271,49 @@ impl Blocker {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct RetentionSurvey {
     oldest_generation: u64,
-    newest_past_cutoff: Option<u64>,
-    compactable_through: Option<u64>,
-    blocked_by: Option<Blocker>,
+    eligibility: Eligibility,
 }
 
 impl RetentionSurvey {
     /// Record a survey.
     ///
     /// * `oldest_generation` — the oldest generation still present.
-    /// * `newest_past_cutoff` — the newest generation whose event is older than
-    ///   the cutoff, or `None` if none are. This is the *age* question.
-    /// * `compactable_through` — `largest_compactable_prefix` over that range,
-    ///   or `None` if even the first generation is refused.
-    /// * `blocked_by` — which refusal stopped it, if one did.
+    /// * `eligibility` — what age made eligible, and how far
+    ///   `largest_compactable_prefix` reached into it.
     ///
     /// # Errors
     ///
     /// [`RetentionError::IncoherentSurvey`] for a log that cannot exist:
     /// eligibility or a compactable prefix below the oldest surviving
-    /// generation, a compactable prefix beyond what age made eligible, a
-    /// blocker with nothing eligible to block, or a prefix that reached the end
-    /// of the eligible range while still claiming a blocker. Refused rather
-    /// than normalized — a survey this wrong means the caller's queries
-    /// disagree with each other, and compacting on it would act on a log
-    /// nobody actually observed.
-    pub fn new(
-        oldest_generation: u64,
-        newest_past_cutoff: Option<u64>,
-        compactable_through: Option<u64>,
-        blocked_by: Option<Blocker>,
-    ) -> Result<Self, RetentionError> {
-        if let Some(n) = newest_past_cutoff {
-            if n < oldest_generation {
+    /// generation, or a prefix past what age made eligible. Refused rather than
+    /// normalized — a survey this wrong means the caller's queries disagree with
+    /// each other, and compacting on it would act on a log nobody observed.
+    ///
+    /// The two impossibilities the previous shape needed runtime checks for —
+    /// a prefix of nothing, and a refusal naming no blocker — are now
+    /// unrepresentable, so they are absent from this list rather than enforced
+    /// in it.
+    pub fn new(oldest_generation: u64, eligibility: Eligibility) -> Result<Self, RetentionError> {
+        if let Eligibility::Aged { newest, prefix } = eligibility {
+            if newest < oldest_generation {
                 return Err(RetentionError::IncoherentSurvey);
             }
-        }
-        match (newest_past_cutoff, compactable_through) {
-            // A prefix of nothing.
-            (None, Some(_)) => return Err(RetentionError::IncoherentSurvey),
-            (Some(n), Some(c)) => {
-                if c < oldest_generation || c > n {
+            if let CompactablePrefix::Through { through, blocker } = prefix {
+                if through < oldest_generation || through > newest {
                     return Err(RetentionError::IncoherentSurvey);
                 }
-                // Reached the end of the eligible range, so nothing blocked it.
-                if c == n && blocked_by.is_some() {
+                // Reached the end of the eligible range while still naming a
+                // blocker. `largest_compactable_prefix` is capped at the range's
+                // end, so a refusal it reports must lie *within* the range —
+                // one that does not means the caller's two queries disagree.
+                if through == newest && blocker.is_some() {
                     return Err(RetentionError::IncoherentSurvey);
                 }
             }
-            _ => {}
-        }
-        // A blocker with nothing eligible is a refusal of a window that was
-        // never a candidate.
-        if newest_past_cutoff.is_none() && blocked_by.is_some() {
-            return Err(RetentionError::IncoherentSurvey);
         }
         Ok(Self {
             oldest_generation,
-            newest_past_cutoff,
-            compactable_through,
-            blocked_by,
+            eligibility,
         })
     }
 
@@ -277,22 +323,10 @@ impl RetentionSurvey {
         self.oldest_generation
     }
 
-    /// The newest generation older than the cutoff, if any.
+    /// What age made eligible, and how far compaction reached into it.
     #[must_use]
-    pub fn newest_past_cutoff(&self) -> Option<u64> {
-        self.newest_past_cutoff
-    }
-
-    /// How far a compactable prefix reached, if at all.
-    #[must_use]
-    pub fn compactable_through(&self) -> Option<u64> {
-        self.compactable_through
-    }
-
-    /// Which refusal stopped the prefix, if one did.
-    #[must_use]
-    pub fn blocked_by(&self) -> Option<Blocker> {
-        self.blocked_by
+    pub fn eligibility(&self) -> Eligibility {
+        self.eligibility
     }
 }
 
@@ -367,30 +401,38 @@ impl RetentionDecision {
 /// yields the same decision — the property that lets a retention run be
 /// replayed during incident reconstruction rather than reasoned about.
 ///
-/// # Errors
+/// # It cannot fail, and that is the point of [`RetentionSurvey::new`]
 ///
-/// [`RetentionError::IncoherentSurvey`] if the survey reports a blocker at a
-/// generation outside the eligible range. Every other coherence rule is already
-/// enforced by [`RetentionSurvey::new`].
-pub fn decide(survey: &RetentionSurvey) -> Result<RetentionDecision, RetentionError> {
-    let Some(newest) = survey.newest_past_cutoff else {
-        return Ok(RetentionDecision::NothingOldEnough);
+/// This returned a `Result` while the survey was four loosely-coupled fields,
+/// because one field combination had no meaning and had to be rejected
+/// *somewhere*. With [`CompactablePrefix`] making that combination
+/// unrepresentable and the constructor refusing the rest, every survey that
+/// exists maps to a decision. The error moved to where the data is built, which
+/// is the only place it was ever answerable.
+#[must_use]
+pub fn decide(survey: &RetentionSurvey) -> RetentionDecision {
+    let Eligibility::Aged { prefix, .. } = survey.eligibility else {
+        return RetentionDecision::NothingOldEnough;
     };
     let lo = survey.oldest_generation;
 
-    match (survey.compactable_through, survey.blocked_by) {
-        (None, Some(blocker)) => Ok(RetentionDecision::FullyBlocked {
+    match prefix {
+        CompactablePrefix::Nothing { blocker } => RetentionDecision::FullyBlocked {
             blocker,
             at_generation: lo,
-        }),
-        // No prefix and no blocker cannot happen: something refused generation
-        // `lo`, or the prefix would have reached at least that far.
-        (None, None) => Err(RetentionError::IncoherentSurvey),
-        (Some(hi), Some(blocker)) => Ok(RetentionDecision::CompactPartial { lo, hi, blocker }),
-        (Some(hi), None) => {
-            debug_assert_eq!(hi, newest, "survey construction guarantees this");
-            Ok(RetentionDecision::Compact { lo, hi })
-        }
+        },
+        CompactablePrefix::Through {
+            through,
+            blocker: Some(blocker),
+        } => RetentionDecision::CompactPartial {
+            lo,
+            hi: through,
+            blocker,
+        },
+        CompactablePrefix::Through {
+            through,
+            blocker: None,
+        } => RetentionDecision::Compact { lo, hi: through },
     }
 }
 
@@ -486,16 +528,31 @@ mod tests {
 
     // -- the four outcomes -------------------------------------------------
 
+    fn aged(newest: u64, prefix: CompactablePrefix) -> Eligibility {
+        Eligibility::Aged { newest, prefix }
+    }
+    fn through(through: u64, blocker: Option<Blocker>) -> CompactablePrefix {
+        CompactablePrefix::Through { through, blocker }
+    }
+
     #[test]
     fn nothing_old_enough_is_distinct_from_blocked() {
         // THE reason this is not Option<Range>. Both do nothing; only one is
         // worth waking someone for.
-        let young = RetentionSurvey::new(1, None, None, None).unwrap();
-        let pinned =
-            RetentionSurvey::new(1, Some(500), None, Some(Blocker::ProtectedClass)).unwrap();
+        let young = RetentionSurvey::new(1, Eligibility::NothingOldEnough).unwrap();
+        let pinned = RetentionSurvey::new(
+            1,
+            aged(
+                500,
+                CompactablePrefix::Nothing {
+                    blocker: Blocker::ProtectedClass,
+                },
+            ),
+        )
+        .unwrap();
 
-        let a = decide(&young).unwrap();
-        let b = decide(&pinned).unwrap();
+        let a = decide(&young);
+        let b = decide(&pinned);
 
         assert_eq!(a, RetentionDecision::NothingOldEnough);
         assert_eq!(
@@ -516,21 +573,18 @@ mod tests {
 
     #[test]
     fn a_clear_range_compacts_whole() {
-        let s = RetentionSurvey::new(1, Some(500), Some(500), None).unwrap();
-        assert_eq!(
-            decide(&s).unwrap(),
-            RetentionDecision::Compact { lo: 1, hi: 500 }
-        );
-        assert_eq!(decide(&s).unwrap().range(), Some((1, 500)));
+        let s = RetentionSurvey::new(1, aged(500, through(500, None))).unwrap();
+        assert_eq!(decide(&s), RetentionDecision::Compact { lo: 1, hi: 500 });
+        assert_eq!(decide(&s).range(), Some((1, 500)));
     }
 
     #[test]
     fn a_partial_prefix_is_progress_and_says_what_stopped_it() {
         // The designed shape: largest_compactable_prefix exists so a refusal is
         // a redirect, not a dead end.
-        let s =
-            RetentionSurvey::new(1, Some(500), Some(310), Some(Blocker::ProjectionHead)).unwrap();
-        let d = decide(&s).unwrap();
+        let s = RetentionSurvey::new(1, aged(500, through(310, Some(Blocker::ProjectionHead))))
+            .unwrap();
+        let d = decide(&s);
         assert_eq!(
             d,
             RetentionDecision::CompactPartial {
@@ -548,12 +602,56 @@ mod tests {
     fn the_decision_is_a_pure_function_of_the_survey() {
         // Replayability: the property that lets a retention run be reconstructed
         // during an incident rather than argued about.
-        let s =
-            RetentionSurvey::new(7, Some(900), Some(412), Some(Blocker::ProtectedClass)).unwrap();
-        let first = decide(&s).unwrap();
+        let s = RetentionSurvey::new(7, aged(900, through(412, Some(Blocker::ProtectedClass))))
+            .unwrap();
+        let first = decide(&s);
         for _ in 0..5 {
-            assert_eq!(decide(&s).unwrap(), first);
+            assert_eq!(decide(&s), first);
         }
+    }
+
+    #[test]
+    fn a_survey_reports_back_what_it_was_told() {
+        // The accessors a driver reads when it wants to log WHY, not just what.
+        let e = aged(900, through(412, Some(Blocker::ProtectedClass)));
+        let s = RetentionSurvey::new(7, e).unwrap();
+        assert_eq!(s.oldest_generation(), 7);
+        assert_eq!(s.eligibility(), e);
+
+        let young = RetentionSurvey::new(3, Eligibility::NothingOldEnough).unwrap();
+        assert_eq!(young.oldest_generation(), 3);
+        assert_eq!(young.eligibility(), Eligibility::NothingOldEnough);
+    }
+
+    // -- states that used to be representable, and now are not -------------
+
+    #[test]
+    fn a_refusal_that_names_no_blocker_does_not_typecheck() {
+        // Formerly (compactable_through: None, blocked_by: None) — "the first
+        // generation was refused by nothing". It CONSTRUCTED, a comment claimed
+        // it could not happen, and `decide` carried an error arm for it.
+        // CompactablePrefix::Nothing has a non-optional blocker, so the state is
+        // now unspellable and `decide` is infallible.
+        let must_name_it = CompactablePrefix::Nothing {
+            blocker: Blocker::ProtectedClass,
+        };
+        assert!(matches!(must_name_it, CompactablePrefix::Nothing { .. }));
+
+        // And the infallibility that follows: no `.unwrap()` anywhere above.
+        let s = RetentionSurvey::new(1, aged(9, must_name_it)).unwrap();
+        assert!(decide(&s).is_pinned());
+    }
+
+    #[test]
+    fn a_prefix_over_a_range_nothing_aged_into_does_not_typecheck() {
+        // Formerly (newest_past_cutoff: None, compactable_through: Some(_)).
+        // Eligibility::NothingOldEnough has nowhere to put a prefix.
+        let none = Eligibility::NothingOldEnough;
+        assert!(matches!(none, Eligibility::NothingOldEnough));
+        assert_eq!(
+            decide(&RetentionSurvey::new(1, none).unwrap()),
+            RetentionDecision::NothingOldEnough
+        );
     }
 
     // -- surveys that describe an impossible log ---------------------------
@@ -562,27 +660,19 @@ mod tests {
     fn a_survey_that_contradicts_itself_is_refused() {
         // Eligibility below the oldest surviving generation.
         assert_eq!(
-            RetentionSurvey::new(10, Some(5), None, None),
+            RetentionSurvey::new(10, aged(5, through(5, None))),
             Err(RetentionError::IncoherentSurvey)
         );
         // A compactable prefix past what age made eligible.
         assert_eq!(
-            RetentionSurvey::new(1, Some(100), Some(101), None),
+            RetentionSurvey::new(1, aged(100, through(101, None))),
             Err(RetentionError::IncoherentSurvey)
         );
-        // A prefix of nothing.
+        // Reached the end of the eligible range while still naming a blocker:
+        // largest_compactable_prefix is capped at the range end, so a refusal it
+        // reports must lie within the range.
         assert_eq!(
-            RetentionSurvey::new(1, None, Some(50), None),
-            Err(RetentionError::IncoherentSurvey)
-        );
-        // A blocker with nothing eligible to block.
-        assert_eq!(
-            RetentionSurvey::new(1, None, None, Some(Blocker::ProtectedClass)),
-            Err(RetentionError::IncoherentSurvey)
-        );
-        // Reached the end of the eligible range while still claiming a blocker.
-        assert_eq!(
-            RetentionSurvey::new(1, Some(500), Some(500), Some(Blocker::ProjectionHead)),
+            RetentionSurvey::new(1, aged(500, through(500, Some(Blocker::ProjectionHead)))),
             Err(RetentionError::IncoherentSurvey)
         );
     }
@@ -591,11 +681,11 @@ mod tests {
     fn a_prefix_below_the_oldest_generation_is_refused() {
         // Compacting generations that are already gone.
         assert_eq!(
-            RetentionSurvey::new(10, Some(100), Some(9), None),
+            RetentionSurvey::new(10, aged(100, through(9, None))),
             Err(RetentionError::IncoherentSurvey)
         );
         assert!(
-            RetentionSurvey::new(10, Some(100), Some(10), Some(Blocker::ProjectionHead)).is_ok()
+            RetentionSurvey::new(10, aged(100, through(10, Some(Blocker::ProjectionHead)))).is_ok()
         );
     }
 }

--- a/crates/kirra-world/src/retention.rs
+++ b/crates/kirra-world/src/retention.rs
@@ -1,0 +1,601 @@
+//! The retention policy — ADR-0040's Tier 1 exit criterion, pure half.
+//!
+//! `kirra-world-store` already implements *how* to compact: `compact_range`
+//! removes a span and leaves a citation, refusing any window that holds a
+//! protected class or a projection head (ADR-0041 §11.3, and
+//! `kirra_world_store::compaction`'s header for why those two refusals are not
+//! alike). What has never existed is *when* — nothing in the workspace calls
+//! it, which is why the horizons OQ2 ruled have never been enforced and the
+//! store fills in the 15.79 days D-20/D-21 measured.
+//!
+//! This module is the deciding half: pure, clock-injected, and dependency-free
+//! like the rest of the crate. The scheduler that acts on it is the store side's.
+//!
+//! # Why the answer is not `Option<Range>`
+//!
+//! The same reasoning [`crate::ResolutionOutcome`] records for query results,
+//! and here it is load-bearing rather than tidy. A retention pass has four
+//! outcomes an operator must be able to tell apart:
+//!
+//! * nothing is old enough yet,
+//! * something is old enough but a **protected class** pins it,
+//! * something is old enough but a **projection head** pins it,
+//! * compact this range.
+//!
+//! `Option<(lo, hi)>` collapses the first three into `None`. That matters
+//! because the second one is the failure mode worth watching: a long-lived
+//! protected event sits in front of a large raw span and holds it, so the store
+//! keeps growing while retention reports, truthfully and uselessly, that it did
+//! nothing. Making the blocked cases distinct values is what lets the driver
+//! observe that instead of discovering it as a full disk.
+//!
+//! # The two refusals are not alike, and that is encoded
+//!
+//! Taken verbatim from the store's own analysis, which pre-agreed the
+//! escalation rather than leaving it to be argued later:
+//!
+//! * A **protected class** makes the window a policy unit — refusing it whole
+//!   is the *requirement*, because compacting around it would make "how much of
+//!   this span survives" a question about arrival order.
+//! * A **projection head** only requires that the head itself survive.
+//!   Refusing the whole window is a conservative simplification, and the agreed
+//!   escalation, should measurement ever justify it, is to compact *around*
+//!   heads.
+//!
+//! [`Blocker::may_compact_around`] is that distinction as a value rather than a
+//! paragraph, so a future driver cannot apply the escalation to the refusal it
+//! was never agreed for.
+
+use crate::observation::{ClockDomain, DomainInstant};
+
+/// Milliseconds in a day.
+const MS_PER_DAY: u64 = 24 * 60 * 60 * 1_000;
+
+/// OQ2's ruled horizon for the `raw` retention class, in days.
+pub const RAW_HORIZON_DAYS: u64 = 30;
+
+/// OQ2's ruled horizon for the protected classes, in days.
+///
+/// The classes are `safety`, `incident`, `calibration`, `adjudication` and
+/// `operator` — enumerated in `kirra_world_store::compaction::PROTECTED_CLASSES`
+/// and deliberately not duplicated here, since two copies of one list is how
+/// they come to disagree.
+pub const PROTECTED_HORIZON_DAYS: u64 = 365;
+
+/// Why a retention policy could not be built, or a decision could not be made.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RetentionError {
+    /// A horizon of zero days would make every event immediately eligible.
+    /// Refused rather than honoured: a policy that deletes on arrival is far
+    /// more likely to be a units mistake than an intent.
+    HorizonZero,
+    /// **The protected horizon was shorter than the raw one.** Refused, because
+    /// it inverts the entire point: protected classes would age out *before*
+    /// the ordinary traffic they exist to outlive.
+    ProtectedShorterThanRaw {
+        /// The raw horizon offered, in days.
+        raw_days: u64,
+        /// The protected horizon offered, in days.
+        protected_days: u64,
+    },
+    /// A retention decision was asked of a non-wall clock.
+    ///
+    /// Retention is a question about calendar durations. The
+    /// [`ClockDomain::Boundary`] clock is the safety timing domain, and a
+    /// 30-day horizon read against it is not merely imprecise but meaningless —
+    /// the same non-mixing rule [`DomainInstant::compare`] enforces, applied to
+    /// the one decision here that is irreversible.
+    NotWallClock(ClockDomain),
+    /// A survey described a log that cannot exist — see
+    /// [`RetentionSurvey::new`].
+    IncoherentSurvey,
+}
+
+/// How long each retention class is kept before it may be compacted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct RetentionPolicy {
+    raw_ms: u64,
+    protected_ms: u64,
+}
+
+impl RetentionPolicy {
+    /// The horizons OQ2 ruled: 30 days `raw`, 365 days protected.
+    #[must_use]
+    pub fn oq2() -> Self {
+        Self {
+            raw_ms: RAW_HORIZON_DAYS * MS_PER_DAY,
+            protected_ms: PROTECTED_HORIZON_DAYS * MS_PER_DAY,
+        }
+    }
+
+    /// Build a policy from horizons in **days**.
+    ///
+    /// Days rather than milliseconds on purpose: the horizons were ruled in
+    /// days, and the one unit conversion happens here, once, instead of at
+    /// every call site where a factor of 1000 could go missing.
+    ///
+    /// # Errors
+    ///
+    /// * [`RetentionError::HorizonZero`] if either horizon is zero.
+    /// * [`RetentionError::ProtectedShorterThanRaw`] if protected data would
+    ///   age out before raw data.
+    pub fn new(raw_days: u64, protected_days: u64) -> Result<Self, RetentionError> {
+        if raw_days == 0 || protected_days == 0 {
+            return Err(RetentionError::HorizonZero);
+        }
+        if protected_days < raw_days {
+            return Err(RetentionError::ProtectedShorterThanRaw {
+                raw_days,
+                protected_days,
+            });
+        }
+        Ok(Self {
+            raw_ms: raw_days.saturating_mul(MS_PER_DAY),
+            protected_ms: protected_days.saturating_mul(MS_PER_DAY),
+        })
+    }
+
+    /// The instant before which `raw` events are eligible for compaction.
+    ///
+    /// Saturating: on a clock reading less than one horizon since the epoch the
+    /// cutoff is 0, which makes **nothing** eligible. That is the fail-closed
+    /// direction — an underflow that wrapped would make *everything* eligible,
+    /// and this operation is not reversible.
+    ///
+    /// # Errors
+    ///
+    /// [`RetentionError::NotWallClock`] if `now` is not on the system clock.
+    pub fn raw_cutoff_ms(&self, now: DomainInstant) -> Result<u64, RetentionError> {
+        Self::require_wall_clock(now)?;
+        Ok(now.ms.saturating_sub(self.raw_ms))
+    }
+
+    /// The instant before which protected events are eligible.
+    ///
+    /// Nothing in this crate acts on it yet — the store refuses protected
+    /// windows outright, so this horizon is currently a *statement of the
+    /// policy*, not a trigger. It is here because leaving it out would make the
+    /// invariant in [`Self::new`] unverifiable from the outside.
+    ///
+    /// # Errors
+    ///
+    /// [`RetentionError::NotWallClock`] if `now` is not on the system clock.
+    pub fn protected_cutoff_ms(&self, now: DomainInstant) -> Result<u64, RetentionError> {
+        Self::require_wall_clock(now)?;
+        Ok(now.ms.saturating_sub(self.protected_ms))
+    }
+
+    fn require_wall_clock(now: DomainInstant) -> Result<(), RetentionError> {
+        match now.domain {
+            ClockDomain::System => Ok(()),
+            other => Err(RetentionError::NotWallClock(other)),
+        }
+    }
+}
+
+/// Which of the store's two refusals stopped a compactable prefix.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Blocker {
+    /// A protected-class event. Refusing the window whole is the requirement.
+    ProtectedClass,
+    /// A projection head — the event defining a `(subject, predicate)`'s
+    /// current claim, which a rebuild must still be able to reproduce.
+    ProjectionHead,
+}
+
+impl Blocker {
+    /// Whether §11.3's **pre-agreed** escalation — compacting around the
+    /// blocker instead of refusing the window whole — applies to this one.
+    ///
+    /// True only for [`Blocker::ProjectionHead`]. The store's analysis agreed
+    /// that escalation in advance *for heads*, and explicitly did not for
+    /// protected classes, where refusing whole is what makes survival a
+    /// question about policy rather than about interleaving.
+    ///
+    /// Encoded rather than documented so that a driver implementing the
+    /// escalation cannot reach for it on the refusal it was never agreed for.
+    #[must_use]
+    pub fn may_compact_around(self) -> bool {
+        matches!(self, Self::ProjectionHead)
+    }
+}
+
+/// What the store observed about its own log during one retention pass.
+///
+/// Every field is something the store can answer cheaply; nothing here is
+/// derived. Keeping the observation and the decision apart is what lets the
+/// decision be tested without a database.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct RetentionSurvey {
+    oldest_generation: u64,
+    newest_past_cutoff: Option<u64>,
+    compactable_through: Option<u64>,
+    blocked_by: Option<Blocker>,
+}
+
+impl RetentionSurvey {
+    /// Record a survey.
+    ///
+    /// * `oldest_generation` — the oldest generation still present.
+    /// * `newest_past_cutoff` — the newest generation whose event is older than
+    ///   the cutoff, or `None` if none are. This is the *age* question.
+    /// * `compactable_through` — `largest_compactable_prefix` over that range,
+    ///   or `None` if even the first generation is refused.
+    /// * `blocked_by` — which refusal stopped it, if one did.
+    ///
+    /// # Errors
+    ///
+    /// [`RetentionError::IncoherentSurvey`] for a log that cannot exist:
+    /// eligibility or a compactable prefix below the oldest surviving
+    /// generation, a compactable prefix beyond what age made eligible, a
+    /// blocker with nothing eligible to block, or a prefix that reached the end
+    /// of the eligible range while still claiming a blocker. Refused rather
+    /// than normalized — a survey this wrong means the caller's queries
+    /// disagree with each other, and compacting on it would act on a log
+    /// nobody actually observed.
+    pub fn new(
+        oldest_generation: u64,
+        newest_past_cutoff: Option<u64>,
+        compactable_through: Option<u64>,
+        blocked_by: Option<Blocker>,
+    ) -> Result<Self, RetentionError> {
+        if let Some(n) = newest_past_cutoff {
+            if n < oldest_generation {
+                return Err(RetentionError::IncoherentSurvey);
+            }
+        }
+        match (newest_past_cutoff, compactable_through) {
+            // A prefix of nothing.
+            (None, Some(_)) => return Err(RetentionError::IncoherentSurvey),
+            (Some(n), Some(c)) => {
+                if c < oldest_generation || c > n {
+                    return Err(RetentionError::IncoherentSurvey);
+                }
+                // Reached the end of the eligible range, so nothing blocked it.
+                if c == n && blocked_by.is_some() {
+                    return Err(RetentionError::IncoherentSurvey);
+                }
+            }
+            _ => {}
+        }
+        // A blocker with nothing eligible is a refusal of a window that was
+        // never a candidate.
+        if newest_past_cutoff.is_none() && blocked_by.is_some() {
+            return Err(RetentionError::IncoherentSurvey);
+        }
+        Ok(Self {
+            oldest_generation,
+            newest_past_cutoff,
+            compactable_through,
+            blocked_by,
+        })
+    }
+
+    /// The oldest generation still present.
+    #[must_use]
+    pub fn oldest_generation(&self) -> u64 {
+        self.oldest_generation
+    }
+
+    /// The newest generation older than the cutoff, if any.
+    #[must_use]
+    pub fn newest_past_cutoff(&self) -> Option<u64> {
+        self.newest_past_cutoff
+    }
+
+    /// How far a compactable prefix reached, if at all.
+    #[must_use]
+    pub fn compactable_through(&self) -> Option<u64> {
+        self.compactable_through
+    }
+
+    /// Which refusal stopped the prefix, if one did.
+    #[must_use]
+    pub fn blocked_by(&self) -> Option<Blocker> {
+        self.blocked_by
+    }
+}
+
+/// What a retention pass should do — **four outcomes, never three**.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RetentionDecision {
+    /// Nothing has aged past the horizon. The ordinary state of a young store,
+    /// and the only one of the three no-op outcomes that is uneventful.
+    NothingOldEnough,
+    /// Events aged out, but the very first one is refused, so no prefix exists.
+    ///
+    /// Carries its blocker because the two mean different things operationally:
+    /// [`Blocker::ProtectedClass`] here means retention is pinned and the store
+    /// will keep growing until that event itself ages out, which is the
+    /// condition worth alerting on.
+    FullyBlocked {
+        /// Which refusal.
+        blocker: Blocker,
+        /// The generation that was refused — the one to look at first.
+        at_generation: u64,
+    },
+    /// A prefix is compactable, and something refused the rest.
+    ///
+    /// Not a failure: this is the designed shape, since
+    /// `largest_compactable_prefix` exists precisely so a refusal is a redirect
+    /// rather than a dead end. The blocker rides along so the driver can tell
+    /// a partial pass that is progressing from one that is stuck.
+    CompactPartial {
+        /// First generation to compact.
+        lo: u64,
+        /// Last generation to compact.
+        hi: u64,
+        /// What stopped it going further.
+        blocker: Blocker,
+    },
+    /// Everything eligible by age is compactable.
+    Compact {
+        /// First generation to compact.
+        lo: u64,
+        /// Last generation to compact.
+        hi: u64,
+    },
+}
+
+impl RetentionDecision {
+    /// The range to hand to `compact_range`, if there is one.
+    ///
+    /// A convenience for a driver that only wants to act; it deliberately does
+    /// **not** replace matching on the variant, because the two no-op cases it
+    /// flattens are the ones worth reporting differently.
+    #[must_use]
+    pub fn range(self) -> Option<(u64, u64)> {
+        match self {
+            Self::Compact { lo, hi } | Self::CompactPartial { lo, hi, .. } => Some((lo, hi)),
+            Self::NothingOldEnough | Self::FullyBlocked { .. } => None,
+        }
+    }
+
+    /// Whether retention made no progress **and** something is pinning it.
+    ///
+    /// The signal a driver should surface. Distinct from "did nothing", which
+    /// on a store younger than the horizon is correct and expected.
+    #[must_use]
+    pub fn is_pinned(self) -> bool {
+        matches!(self, Self::FullyBlocked { .. })
+    }
+}
+
+/// Decide what one retention pass should compact.
+///
+/// Pure: every input is observed, `now` is injected, and the same survey always
+/// yields the same decision — the property that lets a retention run be
+/// replayed during incident reconstruction rather than reasoned about.
+///
+/// # Errors
+///
+/// [`RetentionError::IncoherentSurvey`] if the survey reports a blocker at a
+/// generation outside the eligible range. Every other coherence rule is already
+/// enforced by [`RetentionSurvey::new`].
+pub fn decide(survey: &RetentionSurvey) -> Result<RetentionDecision, RetentionError> {
+    let Some(newest) = survey.newest_past_cutoff else {
+        return Ok(RetentionDecision::NothingOldEnough);
+    };
+    let lo = survey.oldest_generation;
+
+    match (survey.compactable_through, survey.blocked_by) {
+        (None, Some(blocker)) => Ok(RetentionDecision::FullyBlocked {
+            blocker,
+            at_generation: lo,
+        }),
+        // No prefix and no blocker cannot happen: something refused generation
+        // `lo`, or the prefix would have reached at least that far.
+        (None, None) => Err(RetentionError::IncoherentSurvey),
+        (Some(hi), Some(blocker)) => Ok(RetentionDecision::CompactPartial { lo, hi, blocker }),
+        (Some(hi), None) => {
+            debug_assert_eq!(hi, newest, "survey construction guarantees this");
+            Ok(RetentionDecision::Compact { lo, hi })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn now(ms: u64) -> DomainInstant {
+        DomainInstant {
+            ms,
+            domain: ClockDomain::System,
+        }
+    }
+
+    // -- horizons ----------------------------------------------------------
+
+    #[test]
+    fn the_oq2_horizons_are_the_ruled_ones() {
+        let p = RetentionPolicy::oq2();
+        assert_eq!(p, RetentionPolicy::new(30, 365).unwrap());
+        // 30 days back from an instant exactly 100 days after the epoch.
+        let hundred_days = 100 * MS_PER_DAY;
+        assert_eq!(p.raw_cutoff_ms(now(hundred_days)).unwrap(), 70 * MS_PER_DAY);
+    }
+
+    #[test]
+    fn protected_data_can_never_age_out_before_raw_data() {
+        // The inversion that would defeat the entire point of the classes.
+        assert_eq!(
+            RetentionPolicy::new(30, 29),
+            Err(RetentionError::ProtectedShorterThanRaw {
+                raw_days: 30,
+                protected_days: 29,
+            })
+        );
+        // Equal is admitted — degenerate but not inverted.
+        assert!(RetentionPolicy::new(30, 30).is_ok());
+    }
+
+    #[test]
+    fn a_zero_horizon_is_refused_rather_than_honoured() {
+        assert_eq!(
+            RetentionPolicy::new(0, 365),
+            Err(RetentionError::HorizonZero)
+        );
+        assert_eq!(
+            RetentionPolicy::new(30, 0),
+            Err(RetentionError::HorizonZero)
+        );
+    }
+
+    #[test]
+    fn a_cutoff_saturates_toward_deleting_nothing() {
+        // A clock reading less than one horizon since the epoch. Wrapping here
+        // would make EVERY event eligible, and compaction is irreversible.
+        let p = RetentionPolicy::oq2();
+        assert_eq!(p.raw_cutoff_ms(now(0)).unwrap(), 0);
+        assert_eq!(p.raw_cutoff_ms(now(MS_PER_DAY)).unwrap(), 0);
+        // A cutoff of 0 leaves nothing older than it: no event has a negative
+        // timestamp, so nothing is eligible. Fail-closed, not fail-open.
+        assert_eq!(p.protected_cutoff_ms(now(MS_PER_DAY)).unwrap(), 0);
+    }
+
+    #[test]
+    fn retention_cannot_be_decided_on_the_safety_clock() {
+        // A 30-day horizon read against the boundary timing domain is
+        // meaningless, and this is the one decision that cannot be undone.
+        let p = RetentionPolicy::oq2();
+        let boundary = DomainInstant {
+            ms: 100 * MS_PER_DAY,
+            domain: ClockDomain::Boundary,
+        };
+        assert_eq!(
+            p.raw_cutoff_ms(boundary),
+            Err(RetentionError::NotWallClock(ClockDomain::Boundary))
+        );
+        assert_eq!(
+            p.protected_cutoff_ms(boundary),
+            Err(RetentionError::NotWallClock(ClockDomain::Boundary))
+        );
+    }
+
+    // -- the two refusals are not alike ------------------------------------
+
+    #[test]
+    fn only_the_head_refusal_carries_a_pre_agreed_escalation() {
+        // §11.3 agreed compacting AROUND heads in advance, and explicitly did
+        // not agree it for protected classes, where refusing whole is what
+        // keeps survival a question about policy rather than arrival order.
+        assert!(Blocker::ProjectionHead.may_compact_around());
+        assert!(!Blocker::ProtectedClass.may_compact_around());
+    }
+
+    // -- the four outcomes -------------------------------------------------
+
+    #[test]
+    fn nothing_old_enough_is_distinct_from_blocked() {
+        // THE reason this is not Option<Range>. Both do nothing; only one is
+        // worth waking someone for.
+        let young = RetentionSurvey::new(1, None, None, None).unwrap();
+        let pinned =
+            RetentionSurvey::new(1, Some(500), None, Some(Blocker::ProtectedClass)).unwrap();
+
+        let a = decide(&young).unwrap();
+        let b = decide(&pinned).unwrap();
+
+        assert_eq!(a, RetentionDecision::NothingOldEnough);
+        assert_eq!(
+            b,
+            RetentionDecision::FullyBlocked {
+                blocker: Blocker::ProtectedClass,
+                at_generation: 1,
+            }
+        );
+        // Both compact nothing...
+        assert_eq!(a.range(), None);
+        assert_eq!(b.range(), None);
+        // ...and they are still tellable apart, which is the whole point.
+        assert!(!a.is_pinned());
+        assert!(b.is_pinned());
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn a_clear_range_compacts_whole() {
+        let s = RetentionSurvey::new(1, Some(500), Some(500), None).unwrap();
+        assert_eq!(
+            decide(&s).unwrap(),
+            RetentionDecision::Compact { lo: 1, hi: 500 }
+        );
+        assert_eq!(decide(&s).unwrap().range(), Some((1, 500)));
+    }
+
+    #[test]
+    fn a_partial_prefix_is_progress_and_says_what_stopped_it() {
+        // The designed shape: largest_compactable_prefix exists so a refusal is
+        // a redirect, not a dead end.
+        let s =
+            RetentionSurvey::new(1, Some(500), Some(310), Some(Blocker::ProjectionHead)).unwrap();
+        let d = decide(&s).unwrap();
+        assert_eq!(
+            d,
+            RetentionDecision::CompactPartial {
+                lo: 1,
+                hi: 310,
+                blocker: Blocker::ProjectionHead,
+            }
+        );
+        assert_eq!(d.range(), Some((1, 310)));
+        // Progress, so not pinned — the distinction a driver alerts on.
+        assert!(!d.is_pinned());
+    }
+
+    #[test]
+    fn the_decision_is_a_pure_function_of_the_survey() {
+        // Replayability: the property that lets a retention run be reconstructed
+        // during an incident rather than argued about.
+        let s =
+            RetentionSurvey::new(7, Some(900), Some(412), Some(Blocker::ProtectedClass)).unwrap();
+        let first = decide(&s).unwrap();
+        for _ in 0..5 {
+            assert_eq!(decide(&s).unwrap(), first);
+        }
+    }
+
+    // -- surveys that describe an impossible log ---------------------------
+
+    #[test]
+    fn a_survey_that_contradicts_itself_is_refused() {
+        // Eligibility below the oldest surviving generation.
+        assert_eq!(
+            RetentionSurvey::new(10, Some(5), None, None),
+            Err(RetentionError::IncoherentSurvey)
+        );
+        // A compactable prefix past what age made eligible.
+        assert_eq!(
+            RetentionSurvey::new(1, Some(100), Some(101), None),
+            Err(RetentionError::IncoherentSurvey)
+        );
+        // A prefix of nothing.
+        assert_eq!(
+            RetentionSurvey::new(1, None, Some(50), None),
+            Err(RetentionError::IncoherentSurvey)
+        );
+        // A blocker with nothing eligible to block.
+        assert_eq!(
+            RetentionSurvey::new(1, None, None, Some(Blocker::ProtectedClass)),
+            Err(RetentionError::IncoherentSurvey)
+        );
+        // Reached the end of the eligible range while still claiming a blocker.
+        assert_eq!(
+            RetentionSurvey::new(1, Some(500), Some(500), Some(Blocker::ProjectionHead)),
+            Err(RetentionError::IncoherentSurvey)
+        );
+    }
+
+    #[test]
+    fn a_prefix_below_the_oldest_generation_is_refused() {
+        // Compacting generations that are already gone.
+        assert_eq!(
+            RetentionSurvey::new(10, Some(100), Some(9), None),
+            Err(RetentionError::IncoherentSurvey)
+        );
+        assert!(
+            RetentionSurvey::new(10, Some(100), Some(10), Some(Blocker::ProjectionHead)).is_ok()
+        );
+    }
+}

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -344,6 +344,27 @@ not permission.
       something empties the store. This is the one item here that is not about
       the domain model; it is here because that decision put it here rather than
       leaving the fill date unowned.
+      **DECIDING HALF DONE 2026-08-06**, `crates/kirra-world/src/retention.rs`,
+      12 tests, still zero-dependency: `RetentionPolicy` (OQ2's 30/365-day
+      horizons, with **protected ≥ raw refused at construction** — the inversion
+      would age protected classes out *before* the traffic they exist to
+      outlive), saturating cutoffs (an underflow that wrapped would make
+      *everything* eligible, and compaction is irreversible), a wall-clock
+      requirement (a 30-day horizon read against the boundary timing domain is
+      meaningless), `RetentionSurvey` refusing logs that cannot exist, and
+      `decide` returning **four outcomes rather than `Option<Range>`** — because
+      "nothing is old enough" and "a protected event is pinning the store" both
+      compact nothing, and only the second is worth waking someone for.
+      `Blocker::may_compact_around` encodes §11.3's asymmetry: the pre-agreed
+      escalation to compact *around* a blocker applies to projection heads and
+      **not** to protected classes.
+      **STILL OPEN — the acting half.** Nothing calls
+      `WorldStore::compact_range`; the mechanism has existed since WM-2 and has
+      never been reached. What remains is the store-side survey queries and a
+      scheduled driver (precedent: `src/campaign_monitor.rs`,
+      `src/cert_expiry_monitor.rs`). **The box stays unticked until something
+      actually empties the store** — a policy that decides correctly and is
+      never run leaves the 15.79 days exactly where they were.
 - [ ] **Entity taxonomy** (§6) — **structure and kinds DONE 2026-08-06**,
       `crates/kirra-world/src/entity.rs`, 18 tests, still zero-dependency.
       Delivered: the 19-kind root-closed taxonomy + `EntityGroup`, `Lifecycle`
@@ -546,6 +567,10 @@ current**, **never supply geometry**.
 - [ ] **Retention policy driver** — the horizons OQ2 ruled are still applied by
       hand. Its precondition is already recorded in ADR-0041's WM-2 milestone:
       *the first doer-side consumer wired to the store ends the deferral.*
+      **Superseded in part:** ADR-0040 promoted this to a **Tier 1 exit
+      criterion** (§4), so it no longer waits on that precondition, and its
+      *deciding* half landed 2026-08-06 as `kirra_world::retention`. This entry
+      now covers only the scheduled driver, tracked at §4.
 - [ ] `kirra-world-service` as real CQRS — 9 commands, 8 queries, 10 emitted
       events — still inside Fence A
 - [ ] Operator teaching surface (§17): `AssertEntity`, corrections

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -345,7 +345,7 @@ not permission.
       the domain model; it is here because that decision put it here rather than
       leaving the fill date unowned.
       **DECIDING HALF DONE 2026-08-06**, `crates/kirra-world/src/retention.rs`,
-      12 tests, still zero-dependency: `RetentionPolicy` (OQ2's 30/365-day
+      15 tests, still zero-dependency: `RetentionPolicy` (OQ2's 30/365-day
       horizons, with **protected ≥ raw refused at construction** — the inversion
       would age protected classes out *before* the traffic they exist to
       outlive), saturating cutoffs (an underflow that wrapped would make
@@ -357,7 +357,10 @@ not permission.
       compact nothing, and only the second is worth waking someone for.
       `Blocker::may_compact_around` encodes §11.3's asymmetry: the pre-agreed
       escalation to compact *around* a blocker applies to projection heads and
-      **not** to protected classes.
+      **not** to protected classes. `CompactablePrefix`/`Eligibility` make two
+      meaningless survey states unrepresentable — a refusal naming no blocker,
+      and a prefix over a range nothing aged into — which is what makes `decide`
+      **infallible**: every survey that exists maps to a decision.
       **STILL OPEN — the acting half.** Nothing calls
       `WorldStore::compact_range`; the mechanism has existed since WM-2 and has
       never been reached. What remains is the store-side survey queries and a


### PR DESCRIPTION
**116 tests** in `kirra-world` (was 101). Still **zero dependencies**.

## The gap was narrower than "not started" implied, and in a different place

`kirra-world-store` has implemented compaction-with-citation since WM-2 — `compact_range`, the protected-class refusal, the projection-head refusal, `largest_compactable_prefix`, the per-key `DegradedSummary`. OQ2 ruled the horizons. What has never existed is anything that **decides**: nothing in the workspace calls `compact_range`. The mechanism is complete and unreached, which is why the store still fills in the 15.79 days D-20/D-21 measured despite being able to empty itself.

This PR is the deciding half. The scheduler is the store side's and is **not** here — see *The box stays unticked* below.

## Four outcomes, not `Option<Range>`

The load-bearing choice. A retention pass has four results an operator must tell apart:

- nothing is old enough yet,
- something aged out but a **protected class** pins it,
- something aged out but a **projection head** pins it,
- compact this range.

`Option<(lo, hi)>` collapses the first three into `None`. That matters because the second is the failure mode worth watching: a long-lived protected event sits in front of a large raw span and holds it, so the store keeps growing while retention reports — truthfully and uselessly — that it did nothing. Distinct values are what let a driver **observe** that instead of discovering it as a full disk.

`is_pinned()` is the signal a driver alerts on. `range()` is a convenience and deliberately does not replace matching on the variant.

## A comment of mine was false, and fixing it made `decide` infallible

Worth reading as the substantive change in this PR. `RetentionSurvey` first carried four loosely-coupled fields, two of them `Option`s over a coupling that is structural — and `decide` had this arm:

```rust
// No prefix and no blocker cannot happen: something refused generation
// `lo`, or the prefix would have reached at least that far.
(None, None) => Err(RetentionError::IncoherentSurvey),
```

It could happen. `RetentionSurvey::new(1, Some(500), None, None)` constructed fine and landed there. The claim was about what the *store* would report, not about what the *type* permitted — and the type permitted it. An untested error path guarded by a comment asserting it was unreachable is exactly the shape this module argues against.

Two of the four field combinations had no meaning: *no prefix and no blocker* ("refused by nothing"), and *a prefix over a range nothing aged into*. Both are now unrepresentable:

```rust
pub enum CompactablePrefix {
    Nothing { blocker: Blocker },                       // not optional
    Through { through: u64, blocker: Option<Blocker> },
}
pub enum Eligibility {
    NothingOldEnough,                                   // nowhere to put a prefix
    Aged { newest: u64, prefix: CompactablePrefix },
}
```

**`decide` is infallible as a result**, and that is the part worth having: it returned `Result` only because one combination had to be rejected somewhere. The error moved to where the data is built — the one place it was ever answerable.

Two runtime checks deleted; one kept and re-stated: a prefix reaching the end of the eligible range while still naming a blocker stays refused, since `largest_compactable_prefix` is capped at the range end, so a refusal it reports must lie *within* the range.

Also caught while checking this: four accessors had no test at all. They are what a driver reads when it logs *why* rather than just *what*, so leaving the observability path uncovered would have been the wrong thing to ship.

## The two refusals are not alike, and that is now a value

The store's own header pre-agreed the escalation rather than leaving it to be argued later: *if measurement ever shows head refusals blocking a material fraction of reclaimable space, compact around heads instead* — and explicitly did **not** agree it for protected classes, where refusing the window whole is what keeps "how much of this span survives" a question about policy rather than arrival order.

`Blocker::may_compact_around` encodes exactly that, so a future driver implementing the escalation cannot reach for it on the refusal it was never agreed for.

## Three more rules made structural

- **`protected >= raw`, refused at construction.** The inversion would age protected classes out *before* the ordinary traffic they exist to outlive.
- **Cutoffs saturate.** On a clock reading less than one horizon since the epoch, a wrapped underflow would make *every* event eligible. Saturating to 0 makes nothing eligible — fail-closed, for the one operation here that cannot be undone.
- **Retention is a wall-clock question.** A 30-day horizon read against the boundary timing domain is meaningless, so it is refused — the same non-mixing rule `DomainInstant::compare` enforces, applied where the consequence is deletion.

Two smaller calls: horizons are taken in **days** because they were *ruled* in days — one unit conversion, here, instead of at every call site where a factor of 1000 could go missing. And the protected-class **list** is deliberately not duplicated from the store; two copies of one list is how they come to disagree.

## Negative controls

| Guard reverted | Tests that fail |
|---|---|
| `protected >= raw` invariant | 1 |
| saturating cutoff → wrapping | 1 |
| wall-clock requirement | 1 |
| escalation applied to both refusals | 1 |
| `FullyBlocked` collapsed into `NothingOldEnough` | 1 |

Each failed only its own test.

## The box stays unticked, deliberately

The acting half — the store-side survey queries and a scheduled driver (precedent: `src/campaign_monitor.rs`, `src/cert_expiry_monitor.rs`) — does not exist yet. **A policy that decides correctly and is never run leaves the 15.79 days exactly where they were.**

`WM_SCOPE` records what is done and what is not, in both places retention appears: the Tier 1 exit criterion (unticked, with the remaining half named), and the Tier 5 entry, which ADR-0040 superseded in part when it promoted retention to Tier 1.

## Note on the earlier red lanes

The first run's two failures — `Branch Coverage (workspace)` and `copilot-pull-request-reviewer` — both died in setup with `Failed to resolve action download info. Error: Service Unavailable` and never ran a line of this diff. Infrastructure, during a window where 24 lanes sat queued for 20 minutes. No code change was made for them; the redesign above came from asking what the coverage lane *would* have found.

## Verification

116 tests pass; `kirra-world-store` and `kirra-world-service` still build; clippy clean under `#[warn(missing_docs)]`; rustfmt clean; both Kirra World fences INTACT; domain-logic gate unblocked; re-export shim ratchet 0; quality guardrails and website citations OK; still no dependencies section in the manifest.

Kirra is designed in alignment with ISO 26262 ASIL-D requirements and IEC 61508 SIL 3 requirements. Independent third-party assessment has not yet been performed.
