### PR TITLE
The store consumes the core's types — Strands A and C

### DIFF
--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -676,6 +676,17 @@ fn axes_from_row(generation: i64, r: &rusqlite::Row<'_>) -> Result<Option<TrustA
     let corrupt = |detail: String| StoreError::CorruptRow { generation, detail };
 
     match (origin, corroboration, adjudication) {
+        // An orphan `corroboration_n` is NOT an unlabelled row. The schema
+        // refuses to write one, and the read path refuses to read one — because
+        // the canonical form omits the axis keys when the axes are absent, so
+        // an orphan count is stored but not hashed. Verification would be blind
+        // to it if this arm accepted it, which is exactly why the check belongs
+        // on both sides rather than only in the schema.
+        (None, None, None) if corroboration_n.is_some() => Err(corrupt(format!(
+            "corroboration_n is present ({}) with no axes — the schema refuses \
+             this, so the row was edited",
+            corroboration_n.unwrap_or_default()
+        ))),
         (None, None, None) => Ok(None),
         (Some(o), Some(c), Some(a)) => {
             let origin = origin_from_token(&o)
@@ -770,20 +781,27 @@ impl WorldStore {
             )
             .optional()?;
         if installed.is_none() {
-            conn.execute_batch(schema::SCHEMA_V1)?;
-            conn.execute_batch(schema::SCHEMA_V2_MIGRATION)?;
-            conn.execute(
+            // All-or-nothing, for the same reason the migration below is.
+            // SQLite's DDL is transactional, so a crash between the table and
+            // its meta rows rolls back to no store at all — rather than leaving
+            // a store whose tables exist but whose version stamp does not, which
+            // the next open would try to migrate and fail on a duplicate column.
+            let tx = conn.unchecked_transaction()?;
+            tx.execute_batch(schema::SCHEMA_V1)?;
+            tx.execute_batch(schema::SCHEMA_V2_MIGRATION)?;
+            tx.execute(
                 "INSERT INTO world_store_meta (key, value) VALUES ('schema_version', ?1)",
                 params![SCHEMA_VERSION.to_string()],
             )?;
-            conn.execute(
+            tx.execute(
                 "INSERT INTO world_store_meta (key, value) VALUES ('chain_algorithm', ?1)",
                 params![CHAIN_ALGORITHM],
             )?;
-            conn.execute(
+            tx.execute(
                 "INSERT INTO world_store_meta (key, value) VALUES ('schema_digest', ?1)",
                 params![schema_digest()],
             )?;
+            tx.commit()?;
         } else {
             Self::migrate(&conn)?;
         }
@@ -839,25 +857,36 @@ impl WorldStore {
             return Ok(());
         }
 
+        // ONE transaction for the DDL and both stamps. SQLite's DDL is
+        // transactional, so this is all-or-nothing.
+        //
+        // Without it the migration could brick a store outright, which is worse
+        // than failing to run: a crash after `ALTER TABLE` but before the
+        // version stamp leaves the columns added and `schema_version` still 1,
+        // so the next open retries the migration and dies on a duplicate
+        // column — permanently, on every subsequent open, with no path back
+        // except hand-editing the database. Found in review.
+        let tx = conn.unchecked_transaction()?;
+
         if from < 2 {
-            conn.execute_batch(schema::SCHEMA_V2_MIGRATION)?;
+            tx.execute_batch(schema::SCHEMA_V2_MIGRATION)?;
         }
 
-        // Re-stamp both, and in this order. The digest is the claim that can be
-        // checked against the schema text; the version is the one a reader
-        // consults first. Writing the version before the columns exist would
-        // leave a crash window in which the store claims a shape it does not
-        // have — so both stamps come last, after the DDL has committed.
-        conn.execute(
+        // Digest before version, inside the transaction. The order no longer
+        // guards a crash window — the transaction does — but it still reads in
+        // dependency order: the digest is the claim that can be checked against
+        // the schema text, the version is the one a reader consults first.
+        tx.execute(
             "INSERT INTO world_store_meta (key, value) VALUES ('schema_digest', ?1)
              ON CONFLICT(key) DO UPDATE SET value = excluded.value",
             params![schema_digest()],
         )?;
-        conn.execute(
+        tx.execute(
             "INSERT INTO world_store_meta (key, value) VALUES ('schema_version', ?1)
              ON CONFLICT(key) DO UPDATE SET value = excluded.value",
             params![SCHEMA_VERSION.to_string()],
         )?;
+        tx.commit()?;
         Ok(())
     }
 

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -96,6 +96,7 @@ pub use projection::{ProjectedClaim, CURRENT_PROJECTION};
 // merely "so the dependency edge is real": [`NewEvent`] is built out of them, so
 // the edge now carries traffic. That is the measurement ADR-0040's open
 // question 1 defers its revisit to — see `docs/design/WM_Q1_SEAM_BASELINE.md`.
+pub use kirra_world::trust::{Adjudication, Corroboration, Origin, TrustAxes};
 pub use kirra_world::{EntityId, EventId, FrameId, MapId, ObservationId, ReferenceError};
 pub use schema::{CHAIN_ALGORITHM, SCHEMA_VERSION};
 
@@ -184,6 +185,17 @@ pub enum StoreError {
     LlmCannotConfirm,
     /// SD-4, refused early for the same reason.
     SpatialClaimNeedsFrame,
+    /// The database is stamped with a schema version this binary does not
+    /// know. Refused rather than opened hopefully — an older binary writing
+    /// into a newer store produces rows missing columns it never heard of,
+    /// which in an evidence log is a partial trust record indistinguishable
+    /// from an unlabelled one.
+    SchemaFromTheFuture {
+        /// The version stamped in the database.
+        found: i64,
+        /// The newest version this binary can apply.
+        supported: i64,
+    },
     /// Recomputation diverged from a stored digest.
     ChainBroken {
         /// The generation at which it diverged.
@@ -258,6 +270,11 @@ impl std::fmt::Display for StoreError {
                 f,
                 "a spatial claim requires frame_id (ADR-0042 Decision 2; \
                  KIRRA-WM2-SCHEMA-001 SD-4)"
+            ),
+            Self::SchemaFromTheFuture { found, supported } => write!(
+                f,
+                "database is at schema version {found}, this binary supports \
+                 up to {supported} — refusing to open it"
             ),
             Self::ChainBroken { generation } => {
                 write!(f, "chain broken at generation {generation}")
@@ -402,6 +419,84 @@ pub struct NewEvent<'a> {
     pub payload_schema: i64,
     /// One of the six retention classes ruled in ADR-0041 OQ2.
     pub retention_class: &'a str,
+    /// The three **stored** trust axes (schema v2), or `None` for a row that
+    /// records no trust labelling.
+    ///
+    /// `Option` rather than required, because v1 rows exist and an unlabelled
+    /// row must stay distinguishable from a labelled one. A default would have
+    /// invented an origin and an adjudication for every historical row, which
+    /// is precisely the "mush after eighteen months" the four-axis model exists
+    /// to avoid.
+    ///
+    /// Validity is **not** here and has no column: transition rule 6 computes it
+    /// at read time from the validity window. Three axes are stored; the fourth
+    /// is `kirra_world::trust::validity_at`.
+    pub trust: Option<&'a TrustAxes>,
+}
+
+/// The stored spelling of [`Corroboration`], split into its token and its count.
+///
+/// `Corroborated(3)` and `Contradicted(3)` carry a number the other variant does
+/// not, so a single column would have to encode it in the string and parse it
+/// back. Two columns keep the count queryable and let the schema state the
+/// pairing rule as a `CHECK` — `n` is present exactly when the token is not
+/// `uncorroborated`.
+fn corroboration_columns(c: Corroboration) -> (&'static str, Option<u32>) {
+    match c {
+        Corroboration::Uncorroborated => ("uncorroborated", None),
+        Corroboration::Corroborated(n) => ("corroborated", Some(n)),
+        Corroboration::Contradicted(n) => ("contradicted", Some(n)),
+    }
+}
+
+/// Rebuild a [`Corroboration`] from its two stored columns.
+fn corroboration_from_columns(token: &str, n: Option<u32>) -> Option<Corroboration> {
+    match (token, n) {
+        ("uncorroborated", None) => Some(Corroboration::Uncorroborated),
+        ("corroborated", Some(n)) if n >= 1 => Some(Corroboration::Corroborated(n)),
+        ("contradicted", Some(n)) if n >= 1 => Some(Corroboration::Contradicted(n)),
+        _ => None,
+    }
+}
+
+/// The stored token for an [`Adjudication`].
+fn adjudication_token(a: Adjudication) -> &'static str {
+    match a {
+        Adjudication::Pending => "pending",
+        Adjudication::Confirmed => "confirmed",
+        Adjudication::Rejected => "rejected",
+        Adjudication::Ambiguous => "ambiguous",
+    }
+}
+
+/// Parse a stored adjudication token.
+///
+/// Returns `None` on anything unrecognised rather than defaulting. Every other
+/// `from_stored` in this crate degrades to the *weaker* value, which is right
+/// for a two-value proxy — but this axis has two weak states, `Rejected` and
+/// `Ambiguous`, that mean different things, and silently picking one would
+/// invent a ruling. An unreadable adjudication is a corrupt row.
+fn adjudication_from_token(s: &str) -> Option<Adjudication> {
+    match s {
+        "pending" => Some(Adjudication::Pending),
+        "confirmed" => Some(Adjudication::Confirmed),
+        "rejected" => Some(Adjudication::Rejected),
+        "ambiguous" => Some(Adjudication::Ambiguous),
+        _ => None,
+    }
+}
+
+/// Parse a stored origin token. `None` on anything unrecognised, including
+/// `predicted` — blueprint §20 says it never appears in the evidence store, so
+/// reading one back means the row is corrupt, not that the axis has five states.
+fn origin_from_token(s: &str) -> Option<Origin> {
+    match s {
+        "observed" => Some(Origin::Observed),
+        "derived" => Some(Origin::Derived),
+        "imported" => Some(Origin::Imported),
+        "asserted" => Some(Origin::Asserted),
+        _ => None,
+    }
 }
 
 fn json_str(v: &str) -> String {
@@ -436,14 +531,14 @@ pub fn canonical_event_json(e: &NewEvent<'_>) -> String {
     fn opt_i(v: Option<i64>) -> String {
         v.map_or_else(|| "null".to_string(), |x| x.to_string())
     }
-    format!(
+    let mut out = format!(
         concat!(
             "{{\"event_id\":{},\"observation_id\":{},\"txn_time_ms\":{},",
             "\"valid_from_ms\":{},\"valid_to_ms\":{},\"source\":{},",
             "\"source_version\":{},\"writer_class\":{},\"claim_status\":{},",
             "\"provenance\":{},\"frame_id\":{},\"map_id\":{},\"kind\":{},",
             "\"subject\":{},\"predicate\":{},\"object\":{},\"payload\":{},",
-            "\"payload_schema\":{},\"retention_class\":{}}}"
+            "\"payload_schema\":{},\"retention_class\":{}"
         ),
         json_str(e.event_id.as_str()),
         json_str(e.observation_id.as_str()),
@@ -464,7 +559,47 @@ pub fn canonical_event_json(e: &NewEvent<'_>) -> String {
         json_str(e.payload),
         e.payload_schema,
         json_str(e.retention_class),
-    )
+    );
+
+    // The v2 axes are APPENDED, and only when present.
+    //
+    // This is the one place the form is not fixed-arity, and the reason is
+    // forced rather than chosen. Emitting the axis keys unconditionally — as
+    // `null` for an unlabelled row, the way the five v1 optionals are spelled —
+    // would change the bytes of every row ever written and fail
+    // `verify_chain` on every existing store. So an unlabelled row produces
+    // EXACTLY the v1 form, byte for byte, and only a labelled row carries the
+    // extra keys.
+    //
+    // The axes are inside the hash rather than beside it for the same reason
+    // `writer_class` and `claim_status` are (SD-2): a trust label that is not
+    // hashed can be relabelled in place without breaking anything. Stripping
+    // the axes from a stored row does not turn it back into a valid v1 row —
+    // its stored digest was computed over the labelled bytes, so recomputation
+    // diverges and the chain reports it.
+    if let Some(t) = e.trust {
+        let (corr, n) = corroboration_columns(t.corroboration());
+        out.push_str(&format!(
+            concat!(
+                ",\"origin\":{},\"corroboration\":{},\"corroboration_n\":{},",
+                "\"adjudication\":{}"
+            ),
+            json_str(t.origin().as_str()),
+            json_str(corr),
+            n.map_or_else(|| "null".to_string(), |v| v.to_string()),
+            // Stored WITHOUT rule 3 applied. `adjudication()` reads
+            // `Contradicted + Pending` as `Ambiguous`, which is a READ-time
+            // derivation like validity — storing the derived value would bake
+            // in a conclusion that has to be recomputed if the corroboration
+            // later changes, and would make the stored row disagree with the
+            // axes it was built from.
+            json_str(adjudication_token(t.adjudication_stored())),
+        ));
+    }
+
+    // Closing brace last, so the appended fields sit inside the object.
+    out.push('}');
+    out
 }
 
 /// `generation` as the chain's sequence number, failing CLOSED.
@@ -503,6 +638,78 @@ fn readmit<T>(
     })
 }
 
+/// Column indices of the four v2 axis columns in both rebuild `SELECT`s.
+///
+/// Named rather than spelled inline at two call sites, because the two queries
+/// must agree and a silent drift between them would rehash different columns in
+/// `verify_chain` than in the projection digest.
+const COL_ORIGIN: usize = 21;
+const COL_CORROBORATION: usize = 22;
+const COL_CORROBORATION_N: usize = 23;
+const COL_ADJUDICATION: usize = 24;
+
+/// Rebuild the stored trust axes from a row, or refuse the row.
+///
+/// # All four states, and why three of them are not `None`
+///
+/// * **All absent** → `Ok(None)`. A v1 row, or a v2 row that records no trust
+///   labelling. This is the only benign absence.
+/// * **All present and parseable** → `Ok(Some(axes))`.
+/// * **Partially present** → [`StoreError::CorruptRow`]. The schema `CHECK`
+///   makes a partial set unwritable and un-updatable, so seeing one means the
+///   row was edited around the constraint. Reconstructing whichever part
+///   survived would manufacture a trust record out of a damaged one.
+/// * **Present but unparseable** → [`StoreError::CorruptRow`]. Includes an
+///   origin of `predicted`, which blueprint §20 says never appears in the
+///   evidence store.
+///
+/// Nothing here defaults. Every other `from_stored` in this crate degrades to
+/// the weaker value, which is right when the weaker value is unambiguous — but
+/// this axis set has two distinct weak states, `Rejected` and `Ambiguous`, and
+/// picking one would invent a ruling nobody made.
+fn axes_from_row(generation: i64, r: &rusqlite::Row<'_>) -> Result<Option<TrustAxes>, StoreError> {
+    let origin: Option<String> = r.get(COL_ORIGIN)?;
+    let corroboration: Option<String> = r.get(COL_CORROBORATION)?;
+    let corroboration_n: Option<i64> = r.get(COL_CORROBORATION_N)?;
+    let adjudication: Option<String> = r.get(COL_ADJUDICATION)?;
+
+    let corrupt = |detail: String| StoreError::CorruptRow { generation, detail };
+
+    match (origin, corroboration, adjudication) {
+        (None, None, None) => Ok(None),
+        (Some(o), Some(c), Some(a)) => {
+            let origin = origin_from_token(&o)
+                .ok_or_else(|| corrupt(format!("origin: `{o}` is not a storable origin")))?;
+            let n =
+                match corroboration_n {
+                    None => None,
+                    Some(v) => Some(u32::try_from(v).map_err(|_| {
+                        corrupt(format!("corroboration_n: {v} is not a valid count"))
+                    })?),
+                };
+            let corroboration = corroboration_from_columns(&c, n).ok_or_else(|| {
+                corrupt(format!(
+                    "corroboration: `{c}` with n={n:?} is not a valid corroboration"
+                ))
+            })?;
+            let adjudication = adjudication_from_token(&a).ok_or_else(|| {
+                corrupt(format!("adjudication: `{a}` is not a known adjudication"))
+            })?;
+            TrustAxes::new(origin, corroboration, adjudication)
+                .map(Some)
+                .map_err(|e| corrupt(format!("trust axes: {e:?}")))
+        }
+        (o, c, a) => Err(corrupt(format!(
+            "trust axes are partially present (origin: {}, corroboration: {}, \
+             adjudication: {}) — the schema CHECK makes this unwritable, so the \
+             row was edited",
+            o.is_some(),
+            c.is_some(),
+            a.is_some()
+        ))),
+    }
+}
+
 fn sha256_hex(bytes: &[u8]) -> String {
     use sha2::{Digest, Sha256};
     let mut h = Sha256::new();
@@ -510,11 +717,28 @@ fn sha256_hex(bytes: &[u8]) -> String {
     hex::encode(h.finalize())
 }
 
-/// SHA-256 of [`schema::SCHEMA_V1`], recorded in `world_store_meta` at
-/// creation so a store can prove which exact schema text produced it — not
-/// merely which version number someone claimed.
+/// SHA-256 of the **effective** schema text — [`schema::SCHEMA_V1`] followed by
+/// [`schema::SCHEMA_V2_MIGRATION`] — recorded in `world_store_meta` so a store
+/// can prove which exact schema produced it, not merely which version number
+/// someone claimed.
+///
+/// A store migrated from v1 is re-stamped with this value, so a born-v2 store
+/// and a migrated one carry the **same** digest. That is correct and
+/// deliberate: they have the same effective schema, and a digest that
+/// distinguished them would be recording history rather than structure.
+/// [`schema_digest_v1`] remains available for reading a store that has not been
+/// migrated.
 #[must_use]
 pub fn schema_digest() -> String {
+    let mut effective = String::from(schema::SCHEMA_V1);
+    effective.push_str(schema::SCHEMA_V2_MIGRATION);
+    sha256_hex(effective.as_bytes())
+}
+
+/// SHA-256 of [`schema::SCHEMA_V1`] alone — the digest a store created before
+/// the trust-axes migration carries.
+#[must_use]
+pub fn schema_digest_v1() -> String {
     sha256_hex(schema::SCHEMA_V1.as_bytes())
 }
 
@@ -547,6 +771,7 @@ impl WorldStore {
             .optional()?;
         if installed.is_none() {
             conn.execute_batch(schema::SCHEMA_V1)?;
+            conn.execute_batch(schema::SCHEMA_V2_MIGRATION)?;
             conn.execute(
                 "INSERT INTO world_store_meta (key, value) VALUES ('schema_version', ?1)",
                 params![SCHEMA_VERSION.to_string()],
@@ -559,8 +784,101 @@ impl WorldStore {
                 "INSERT INTO world_store_meta (key, value) VALUES ('schema_digest', ?1)",
                 params![schema_digest()],
             )?;
+        } else {
+            Self::migrate(&conn)?;
         }
         Ok(Self { conn })
+    }
+
+    /// Bring an existing store up to [`SCHEMA_VERSION`], or refuse it.
+    ///
+    /// # Fail-closed on a future schema
+    ///
+    /// A database stamped **newer** than this binary is refused
+    /// ([`StoreError::SchemaFromTheFuture`]) rather than opened hopefully. The
+    /// store had no version check at all before this: an older binary would
+    /// happily open a newer database, read the columns it knew about, and write
+    /// rows missing the ones it did not — silently producing partial trust
+    /// records in a log whose whole purpose is that it can be trusted later.
+    /// `kirra-persistence` already fails closed this way
+    /// (`assert_schema_not_future`); this is the same rule, arrived at for the
+    /// same reason.
+    ///
+    /// # Why migration is forward-only and additive
+    ///
+    /// There is no down-migration and there will not be one. Every step adds
+    /// nullable columns to an append-only evidence table, so a v1 row remains
+    /// exactly a v1 row — unlabelled, not wrongly labelled. Removing a column
+    /// would have to rewrite rows that are inside a hash chain, which is not a
+    /// migration but a forgery.
+    fn migrate(conn: &Connection) -> Result<(), StoreError> {
+        let stored: Option<String> = conn
+            .query_row(
+                "SELECT value FROM world_store_meta WHERE key = 'schema_version'",
+                [],
+                |r| r.get(0),
+            )
+            .optional()?;
+
+        // An absent or unparseable stamp reads as v1: the store predates the
+        // stamp or its meta row is damaged, and v1 is the weakest assumption
+        // that cannot over-claim. It is never read as "already current", which
+        // would skip the migration and leave the columns missing.
+        let from = stored
+            .as_deref()
+            .and_then(|v| v.parse::<i64>().ok())
+            .unwrap_or(1);
+
+        if from > SCHEMA_VERSION {
+            return Err(StoreError::SchemaFromTheFuture {
+                found: from,
+                supported: SCHEMA_VERSION,
+            });
+        }
+        if from == SCHEMA_VERSION {
+            return Ok(());
+        }
+
+        if from < 2 {
+            conn.execute_batch(schema::SCHEMA_V2_MIGRATION)?;
+        }
+
+        // Re-stamp both, and in this order. The digest is the claim that can be
+        // checked against the schema text; the version is the one a reader
+        // consults first. Writing the version before the columns exist would
+        // leave a crash window in which the store claims a shape it does not
+        // have — so both stamps come last, after the DDL has committed.
+        conn.execute(
+            "INSERT INTO world_store_meta (key, value) VALUES ('schema_digest', ?1)
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            params![schema_digest()],
+        )?;
+        conn.execute(
+            "INSERT INTO world_store_meta (key, value) VALUES ('schema_version', ?1)
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            params![SCHEMA_VERSION.to_string()],
+        )?;
+        Ok(())
+    }
+
+    /// The schema version this store is stamped with.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::Sqlite`] if the meta table cannot be read.
+    pub fn schema_version(&self) -> Result<i64, StoreError> {
+        let stored: Option<String> = self
+            .conn
+            .query_row(
+                "SELECT value FROM world_store_meta WHERE key = 'schema_version'",
+                [],
+                |r| r.get(0),
+            )
+            .optional()?;
+        Ok(stored
+            .as_deref()
+            .and_then(|v| v.parse::<i64>().ok())
+            .unwrap_or(1))
     }
 
     /// The chain digest of the newest event, or [`GENESIS`].
@@ -612,6 +930,8 @@ impl WorldStore {
             return Err(StoreError::SpatialClaimNeedsFrame);
         }
 
+        let axes = e.trust.map(|t| corroboration_columns(t.corroboration()));
+
         let generation = self.next_generation()?;
         let prev = self.head_chain()?;
         let chain = kirra_audit_hash::compute_record_hash_v2(
@@ -627,8 +947,10 @@ impl WorldStore {
                 generation, event_id, observation_id, txn_time_ms, valid_from_ms,
                 valid_to_ms, source, source_version, writer_class, claim_status,
                 provenance, frame_id, map_id, kind, subject, predicate, object,
-                payload, payload_schema, payload_digest, retention_class, chain_digest
-             ) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20,?21,?22)",
+                payload, payload_schema, payload_digest, retention_class, chain_digest,
+                origin, corroboration, corroboration_n, adjudication
+             ) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20,?21,?22,
+                       ?23,?24,?25,?26)",
             params![
                 generation,
                 e.event_id.as_str(),
@@ -652,6 +974,10 @@ impl WorldStore {
                 sha256_hex(e.payload.as_bytes()),
                 e.retention_class,
                 chain,
+                e.trust.map(|t| t.origin().as_str()),
+                axes.map(|(c, _)| c),
+                axes.and_then(|(_, n)| n),
+                e.trust.map(|t| adjudication_token(t.adjudication_stored())),
             ],
         )?;
         Ok(generation)
@@ -669,7 +995,8 @@ impl WorldStore {
             "SELECT generation, event_id, observation_id, txn_time_ms, valid_from_ms,
                     valid_to_ms, source, source_version, writer_class, claim_status,
                     provenance, frame_id, map_id, kind, subject, predicate, object,
-                    payload, payload_schema, retention_class, chain_digest
+                    payload, payload_schema, retention_class, chain_digest,
+                    origin, corroboration, corroboration_n, adjudication
              FROM world_events ORDER BY generation ASC",
         )?;
         let mut rows = stmt.query([])?;
@@ -769,6 +1096,13 @@ impl WorldStore {
             )?;
             let map_id = readmit(generation, "map_id", map_id.map(MapId::new).transpose())?;
 
+            // The axes, rebuilt from their columns. All-or-nothing: the schema
+            // CHECK makes a partial set unwritable, so a partial set read back
+            // means the row was edited around the constraint, and
+            // `axes_from_row` refuses it rather than reconstructing whichever
+            // part survived.
+            let trust = axes_from_row(generation, r)?;
+
             let rebuilt = NewEvent {
                 event_id: &event_id,
                 observation_id: &observation_id,
@@ -789,6 +1123,7 @@ impl WorldStore {
                 payload: &payload,
                 payload_schema: r.get(18)?,
                 retention_class: &retention_class,
+                trust: trust.as_ref(),
             };
             let expect = kirra_audit_hash::compute_record_hash_v2(
                 &prev,
@@ -1021,6 +1356,32 @@ impl WorldStore {
         }
         let sql = format!("UPDATE compaction_citations SET {column} = ?1 WHERE lo_generation = ?2");
         self.conn.execute(&sql, params![value, lo_generation])?;
+        Ok(())
+    }
+
+    /// Test-only: run one arbitrary SQL statement against the store.
+    ///
+    /// # Why this is broader than [`WorldStore::tamper_for_test`], deliberately
+    ///
+    /// That method is allowlisted specifically so it cannot become an injection
+    /// point, and it should stay that way. But an allowlisted single-column
+    /// setter cannot express the attacks the schema `CHECK`s exist to defeat: it
+    /// cannot clear all four axis columns in one statement, and it cannot be
+    /// extended to cover every constraint without the allowlist becoming the
+    /// test suite.
+    ///
+    /// The `CHECK`s are the guarantee, so proving they fire has to be done with
+    /// SQL that never went near the write path. This exists for that, is
+    /// `test-support`-gated like its neighbours, and is not used by any
+    /// non-test code path.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::Sqlite`] if the statement is rejected — which for these
+    /// tests is usually the point.
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn raw_execute_for_test(&self, sql: &str) -> Result<(), StoreError> {
+        self.conn.execute(sql, [])?;
         Ok(())
     }
 
@@ -1900,7 +2261,8 @@ impl WorldStore {
             "SELECT generation, event_id, observation_id, txn_time_ms, valid_from_ms,
                     valid_to_ms, source, source_version, writer_class, claim_status,
                     provenance, frame_id, map_id, kind, subject, predicate, object,
-                    payload, payload_schema, retention_class, chain_digest
+                    payload, payload_schema, retention_class, chain_digest,
+                    origin, corroboration, corroboration_n, adjudication
              FROM world_events WHERE generation BETWEEN ?1 AND ?2
              ORDER BY generation ASC",
         )?;
@@ -1954,6 +2316,13 @@ impl WorldStore {
             )?;
             let map_id = readmit(generation, "map_id", map_id.map(MapId::new).transpose())?;
 
+            // The axes, rebuilt from their columns. All-or-nothing: the schema
+            // CHECK makes a partial set unwritable, so a partial set read back
+            // means the row was edited around the constraint, and
+            // `axes_from_row` refuses it rather than reconstructing whichever
+            // part survived.
+            let trust = axes_from_row(generation, r)?;
+
             let rebuilt = NewEvent {
                 event_id: &event_id,
                 observation_id: &observation_id,
@@ -1974,6 +2343,7 @@ impl WorldStore {
                 payload: &payload,
                 payload_schema: r.get(18)?,
                 retention_class: &retention_class,
+                trust: trust.as_ref(),
             };
             hasher.update(canonical_event_json(&rebuilt).as_bytes());
             hasher.update(b"\n");

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -91,8 +91,12 @@ pub mod schema;
 pub use compaction::{Citation, CompactionOutcome, DegradedSummary, Resolution, TemporalAnswer};
 pub use projection::{ProjectedClaim, CURRENT_PROJECTION};
 
-// Re-exported so the dependency edge is real rather than declared-and-unused.
-pub use kirra_world::{EntityId, ObservationId};
+// The domain core's types, re-exported so a caller of this crate needs only one
+// import to build an event. These are no longer placeholders and no longer
+// merely "so the dependency edge is real": [`NewEvent`] is built out of them, so
+// the edge now carries traffic. That is the measurement ADR-0040's open
+// question 1 defers its revisit to — see `docs/design/WM_Q1_SEAM_BASELINE.md`.
+pub use kirra_world::{EntityId, EventId, FrameId, MapId, ObservationId, ReferenceError};
 pub use schema::{CHAIN_ALGORITHM, SCHEMA_VERSION};
 
 /// Who or what produced an observation.
@@ -334,13 +338,33 @@ impl From<rusqlite::Error> for StoreError {
 /// inherently bounded, or leave it `None` and let a superseding event define
 /// the end. No method in this crate updates it, because in an append-only log
 /// there is no honest `UPDATE`.
+///
+/// # Why four fields are typed and the rest are `&str`
+///
+/// `event_id`, `observation_id`, `frame_id` and `map_id` carry the domain core's
+/// [`EventId`], [`ObservationId`], [`FrameId`] and [`MapId`]. They were all bare
+/// `&str` — two adjacent identities and two adjacent optional references, so
+/// **each pair could be passed in the wrong order and still compile, write and
+/// hash**. Neither swap is representable now — the compile-fail negative
+/// controls for that live with the types, in [`kirra_world::reference`], paired
+/// with positives so a mistake in the negative half cannot pass unnoticed.
+///
+/// The remaining `&str` fields are not an oversight, and the line between them
+/// is not arbitrary: a typed field is one whose *set of admissible values* the
+/// core defines. `kind`, `subject`, `predicate`, `object` and `retention_class`
+/// are constrained by the schema's closed vocabularies or by the claim's own
+/// shape, not by an identity rule — and `kind` in particular cannot be typed yet
+/// because the blueprint names `ObservationKind` without ever enumerating its
+/// variants (`WM_SCOPE.md` §7). Typing them on a guess would fix a vocabulary
+/// the specification has not fixed.
 #[derive(Debug, Clone)]
 pub struct NewEvent<'a> {
     /// Identity of this record.
-    pub event_id: &'a str,
+    pub event_id: &'a EventId,
     /// Identity of the observation. Distinct from `event_id` so re-attribution
-    /// does not rewrite the observation it re-attributes.
-    pub observation_id: &'a str,
+    /// does not rewrite the observation it re-attributes — a distinction that
+    /// is now enforced by the type system rather than by argument order.
+    pub observation_id: &'a ObservationId,
     /// When the store learned it.
     pub txn_time_ms: i64,
     /// When the fact began holding in the world.
@@ -359,9 +383,11 @@ pub struct NewEvent<'a> {
     /// Observation ids this claim rests on (SD-3).
     pub provenance: &'a [&'a str],
     /// Coordinate frame. Required when `kind == "spatial"` (SD-4).
-    pub frame_id: Option<&'a str>,
-    /// Map the claim is relative to.
-    pub map_id: Option<&'a str>,
+    pub frame_id: Option<&'a FrameId>,
+    /// Map the claim is relative to. A separate type from `frame_id` because a
+    /// swap between the two satisfies SD-4's presence check while carrying the
+    /// wrong reference — the quietest of the two failures these types close.
+    pub map_id: Option<&'a MapId>,
     /// Claim kind. `"spatial"` triggers the SD-4 constraint.
     pub kind: &'a str,
     /// Claim subject.
@@ -419,8 +445,8 @@ pub fn canonical_event_json(e: &NewEvent<'_>) -> String {
             "\"subject\":{},\"predicate\":{},\"object\":{},\"payload\":{},",
             "\"payload_schema\":{},\"retention_class\":{}}}"
         ),
-        json_str(e.event_id),
-        json_str(e.observation_id),
+        json_str(e.event_id.as_str()),
+        json_str(e.observation_id.as_str()),
         e.txn_time_ms,
         e.valid_from_ms,
         opt_i(e.valid_to_ms),
@@ -429,8 +455,8 @@ pub fn canonical_event_json(e: &NewEvent<'_>) -> String {
         json_str(e.writer_class.as_str()),
         json_str(e.claim_status.as_str()),
         provenance_json(e.provenance),
-        opt(e.frame_id),
-        opt(e.map_id),
+        opt(e.frame_id.map(FrameId::as_str)),
+        opt(e.map_id.map(MapId::as_str)),
         json_str(e.kind),
         json_str(e.subject),
         opt(e.predicate),
@@ -450,6 +476,30 @@ fn sequence_of(generation: i64) -> Result<u64, StoreError> {
     u64::try_from(generation).map_err(|_| StoreError::CorruptRow {
         generation,
         detail: "generation is negative or not representable as u64".to_string(),
+    })
+}
+
+/// Re-admit a stored reference on the read path.
+///
+/// A stored value the core no longer admits is a **corrupt row**, not a broken
+/// chain, and this keeps those two diagnoses apart — the same distinction
+/// [`StoreError::CorruptRow`] was introduced to preserve. "This row is
+/// unreadable" and "this row was edited" send an investigator to different
+/// places.
+///
+/// This can only ever *add* refusals: it never admits a row the chain check
+/// would have rejected, so it cannot weaken verification. A row written through
+/// [`WorldStore::append`] was built from already-admitted values, so reaching
+/// this error means the row predates the types, was written by another tool, or
+/// was edited in place.
+fn readmit<T>(
+    generation: i64,
+    field: &'static str,
+    r: Result<T, ReferenceError>,
+) -> Result<T, StoreError> {
+    r.map_err(|e| StoreError::CorruptRow {
+        generation,
+        detail: format!("{field}: {e}"),
     })
 }
 
@@ -581,8 +631,8 @@ impl WorldStore {
              ) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20,?21,?22)",
             params![
                 generation,
-                e.event_id,
-                e.observation_id,
+                e.event_id.as_str(),
+                e.observation_id.as_str(),
                 e.txn_time_ms,
                 e.valid_from_ms,
                 e.valid_to_ms,
@@ -591,8 +641,8 @@ impl WorldStore {
                 e.writer_class.as_str(),
                 e.claim_status.as_str(),
                 provenance_json(e.provenance),
-                e.frame_id,
-                e.map_id,
+                e.frame_id.map(FrameId::as_str),
+                e.map_id.map(MapId::as_str),
                 e.kind,
                 e.subject,
                 e.predicate,
@@ -702,6 +752,23 @@ impl WorldStore {
                 })?;
             let prov_refs: Vec<&str> = provenance.iter().map(String::as_str).collect();
 
+            // Re-admitted VERBATIM. The core's constructors never normalize, so
+            // these carry exactly the stored bytes into the rehash — a
+            // constructor that trimmed here would report every untampered row
+            // holding surrounding whitespace as a broken chain.
+            let event_id = readmit(generation, "event_id", EventId::new(event_id))?;
+            let observation_id = readmit(
+                generation,
+                "observation_id",
+                ObservationId::new(observation_id),
+            )?;
+            let frame_id = readmit(
+                generation,
+                "frame_id",
+                frame_id.map(FrameId::new).transpose(),
+            )?;
+            let map_id = readmit(generation, "map_id", map_id.map(MapId::new).transpose())?;
+
             let rebuilt = NewEvent {
                 event_id: &event_id,
                 observation_id: &observation_id,
@@ -713,8 +780,8 @@ impl WorldStore {
                 writer_class: WriterClass::from_stored(&writer_class),
                 claim_status: ClaimStatus::from_stored(&claim_status),
                 provenance: &prov_refs,
-                frame_id: frame_id.as_deref(),
-                map_id: map_id.as_deref(),
+                frame_id: frame_id.as_ref(),
+                map_id: map_id.as_ref(),
                 kind: &kind,
                 subject: &subject,
                 predicate: predicate.as_deref(),
@@ -1870,6 +1937,23 @@ impl WorldStore {
                 })?;
             let prov_refs: Vec<&str> = provenance.iter().map(String::as_str).collect();
 
+            // Re-admitted VERBATIM. The core's constructors never normalize, so
+            // these carry exactly the stored bytes into the rehash — a
+            // constructor that trimmed here would report every untampered row
+            // holding surrounding whitespace as a broken chain.
+            let event_id = readmit(generation, "event_id", EventId::new(event_id))?;
+            let observation_id = readmit(
+                generation,
+                "observation_id",
+                ObservationId::new(observation_id),
+            )?;
+            let frame_id = readmit(
+                generation,
+                "frame_id",
+                frame_id.map(FrameId::new).transpose(),
+            )?;
+            let map_id = readmit(generation, "map_id", map_id.map(MapId::new).transpose())?;
+
             let rebuilt = NewEvent {
                 event_id: &event_id,
                 observation_id: &observation_id,
@@ -1881,8 +1965,8 @@ impl WorldStore {
                 writer_class: WriterClass::from_stored(&writer_class),
                 claim_status: ClaimStatus::from_stored(&claim_status),
                 provenance: &prov_refs,
-                frame_id: frame_id.as_deref(),
-                map_id: map_id.as_deref(),
+                frame_id: frame_id.as_ref(),
+                map_id: map_id.as_ref(),
                 kind: &kind,
                 subject: &subject,
                 predicate: predicate.as_deref(),

--- a/crates/kirra-world-store/src/retention_driver.rs
+++ b/crates/kirra-world-store/src/retention_driver.rs
@@ -274,7 +274,7 @@ pub use kirra_world::retention::{
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{ClaimStatus, NewEvent, WriterClass};
+    use crate::{ClaimStatus, EventId, NewEvent, ObservationId, WriterClass};
     use kirra_world::observation::ClockDomain;
     use kirra_world::retention::RetentionError;
 
@@ -310,9 +310,14 @@ mod tests {
         valid_from_ms: i64,
         retention_class: &str,
     ) {
+        // One string, two types. The fixture conflates them, as fixtures may —
+        // but it now has to say so, rather than the conflation being invisible
+        // in a pair of adjacent `&str`s.
+        let event_id = EventId::new(id).expect("admissible event id");
+        let observation_id = ObservationId::new(id).expect("admissible observation id");
         s.append(&NewEvent {
-            event_id: id,
-            observation_id: id,
+            event_id: &event_id,
+            observation_id: &observation_id,
             txn_time_ms,
             valid_from_ms,
             valid_to_ms: None,

--- a/crates/kirra-world-store/src/retention_driver.rs
+++ b/crates/kirra-world-store/src/retention_driver.rs
@@ -335,6 +335,7 @@ mod tests {
             payload: r#"{"n":1}"#,
             payload_schema: 1,
             retention_class,
+            trust: None,
         })
         .expect("append");
     }

--- a/crates/kirra-world-store/src/retention_sweeper.rs
+++ b/crates/kirra-world-store/src/retention_sweeper.rs
@@ -264,6 +264,7 @@ mod tests {
             payload: r#"{"n":1}"#,
             payload_schema: 1,
             retention_class: "raw",
+            trust: None,
         })
         .expect("append");
     }

--- a/crates/kirra-world-store/src/retention_sweeper.rs
+++ b/crates/kirra-world-store/src/retention_sweeper.rs
@@ -219,7 +219,7 @@ fn wall_clock_now() -> Option<DomainInstant> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{ClaimStatus, NewEvent, WriterClass};
+    use crate::{ClaimStatus, EventId, NewEvent, ObservationId, WriterClass};
 
     fn tmp(name: &str) -> PathBuf {
         let mut p = std::env::temp_dir();
@@ -239,9 +239,14 @@ mod tests {
     fn append_old(s: &mut WorldStore, id: &str) {
         // txn_time well before any plausible cutoff, so the event is eligible
         // the first time the sweeper looks.
+        // One string, two types. The fixture conflates them, as fixtures may —
+        // but it now has to say so, rather than the conflation being invisible
+        // in a pair of adjacent `&str`s.
+        let event_id = EventId::new(id).expect("admissible event id");
+        let observation_id = ObservationId::new(id).expect("admissible observation id");
         s.append(&NewEvent {
-            event_id: id,
-            observation_id: id,
+            event_id: &event_id,
+            observation_id: &observation_id,
             txn_time_ms: 1,
             valid_from_ms: 1,
             valid_to_ms: None,

--- a/crates/kirra-world-store/src/schema.rs
+++ b/crates/kirra-world-store/src/schema.rs
@@ -102,4 +102,108 @@ CREATE TABLE world_store_meta (
 pub const CHAIN_ALGORITHM: &str = "kirra-audit-hash/compute_record_hash_v2";
 
 /// Schema version stamped into `world_store_meta`.
-pub const SCHEMA_VERSION: i64 = 1;
+///
+/// Bumped to **2** by the trust-axes migration below.
+pub const SCHEMA_VERSION: i64 = 2;
+
+/// **v2 — the four orthogonal trust axes, added additively.**
+///
+/// `KIRRA-WM2-SCHEMA-001` ratified v1 with a recorded digest, so growing it is a
+/// ruling rather than a refactor. The ruling taken on 2026-08-07 was **additive,
+/// with `writer_class` kept permanently**, and the reason is worth stating
+/// because it inverts an assumption that had been carried for a while:
+///
+/// # `writer_class` is not the origin axis in disguise
+///
+/// It looks like one. It is not, and neither derives the other:
+///
+/// * **`writer_class` records who held the pen** — `sensor`, `operator`,
+///   `derivation`, `llm_candidate`. It is what **D-2** keys on, and
+///   `llm_candidate` is not an origin at all: an LLM can propose a claim of any
+///   origin, and the rule that constrains it is about the *writer's authority*,
+///   not the claim's provenance.
+/// * **`origin` records where the claim came from** — `observed`, `derived`,
+///   `imported`, `asserted`. It carries `imported`, which no writer class
+///   expresses, and it has no way to say "an LLM wrote this".
+///
+/// Replacing `writer_class` with `origin` would therefore have deleted D-2's
+/// enforcement basis. It stays, permanently, as a first-class column.
+///
+/// # `claim_status` becomes derived, and the derivation is a `CHECK`
+///
+/// `claim_status` is the two-value adjudication proxy — `candidate` /
+/// `confirmed` against the axis's four states, so `rejected` and `ambiguous`
+/// were both unrepresentable. Rule 3 requires `Ambiguous` to be a stable,
+/// reportable state (*"I have conflicting information about that"*), which the
+/// proxy could not express.
+///
+/// It is retained for read compatibility, and its agreement with `adjudication`
+/// is enforced rather than remembered: the `CHECK` below makes
+/// `claim_status = 'confirmed'` hold exactly when `adjudication = 'confirmed'`.
+/// A row that disagrees cannot be written or updated into existence.
+///
+/// # Why `validity` has no column
+///
+/// Because transition rule 6 says it is computed at read time, never stored.
+/// Three axes are stored; the fourth is `trust::validity_at`. A column would be
+/// the one place the rule could be broken, so there isn't one — the same shape
+/// as `TrustAxes` itself, which holds three fields for four axes.
+///
+/// # Why `predicted` is absent from the origin vocabulary
+///
+/// Blueprint §20: it **never appears in the evidence store**.
+/// `TrustAxes::new` refuses it. The `CHECK` refuses it too, so the rule holds
+/// against raw SQL and not only against callers who went through the
+/// constructor.
+///
+/// # Enforced, not merely declared
+///
+/// Every constraint here — including the cross-column ones — was verified to
+/// fire on both `INSERT` and `UPDATE`. SQLite's `ALTER TABLE ADD COLUMN`
+/// accepts a `CHECK` that references other columns and enforces it, which is
+/// what makes an additive migration able to carry the same weight as the
+/// original table-level `CHECK`s rather than degrading to writer-side
+/// validation. That mattered: `KIRRA-WM2-SCHEMA-001` §8 rejects
+/// "the caller promises not to" as a substitute for a constraint.
+pub const SCHEMA_V2_MIGRATION: &str = r#"
+ALTER TABLE world_events ADD COLUMN origin TEXT
+    CHECK (origin IS NULL OR origin IN
+        ('observed','derived','imported','asserted'));
+
+ALTER TABLE world_events ADD COLUMN corroboration TEXT
+    CHECK (corroboration IS NULL OR corroboration IN
+        ('uncorroborated','corroborated','contradicted'));
+
+ALTER TABLE world_events ADD COLUMN corroboration_n INTEGER
+    CHECK (
+        (corroboration_n IS NULL OR corroboration_n >= 1)
+        AND (corroboration IS NULL
+             OR (corroboration = 'uncorroborated') = (corroboration_n IS NULL))
+    );
+
+ALTER TABLE world_events ADD COLUMN adjudication TEXT
+    CHECK (
+        (adjudication IS NULL OR adjudication IN
+            ('pending','confirmed','rejected','ambiguous'))
+
+        -- The three stored axes travel together. A row carrying one axis and
+        -- not the others is a partial trust record, and a reader cannot tell
+        -- it from an unlabelled one.
+        AND (adjudication IS NULL) = (origin IS NULL)
+        AND (adjudication IS NULL) = (corroboration IS NULL)
+
+        -- D-2, restated against the axis so it survives claim_status. An LLM
+        -- may never write a confirmed fact; if claim_status is ever dropped,
+        -- this is what keeps the rule.
+        AND (adjudication IS NULL
+             OR writer_class <> 'llm_candidate'
+             OR adjudication <> 'confirmed')
+
+        -- claim_status is DERIVED from adjudication. Enforced, so the proxy
+        -- cannot drift from the axis it now stands for.
+        AND (adjudication IS NULL
+             OR (claim_status = 'confirmed') = (adjudication = 'confirmed'))
+    );
+
+CREATE INDEX idx_events_adjudication ON world_events (adjudication, generation);
+"#;

--- a/crates/kirra-world-store/src/schema.rs
+++ b/crates/kirra-world-store/src/schema.rs
@@ -177,8 +177,19 @@ ALTER TABLE world_events ADD COLUMN corroboration TEXT
 ALTER TABLE world_events ADD COLUMN corroboration_n INTEGER
     CHECK (
         (corroboration_n IS NULL OR corroboration_n >= 1)
-        AND (corroboration IS NULL
-             OR (corroboration = 'uncorroborated') = (corroboration_n IS NULL))
+
+        -- `n` is NULL EXACTLY when there is no count to carry — either no
+        -- axes at all, or `uncorroborated`, which has nothing to count.
+        --
+        -- The earlier form of this was `corroboration IS NULL OR (...)`, which
+        -- short-circuited: with the axes absent it permitted an orphan
+        -- `corroboration_n`. That was not a cosmetic gap. The canonical form
+        -- omits the axis keys when the axes are absent, so an orphan count is
+        -- a column that is stored but NOT hashed — editable in place without
+        -- breaking the chain, which is the one property this whole design
+        -- exists to deny. Found in review.
+        AND (corroboration_n IS NULL)
+            = (corroboration IS NULL OR corroboration = 'uncorroborated')
     );
 
 ALTER TABLE world_events ADD COLUMN adjudication TEXT

--- a/crates/kirra-world-store/tests/canonical_form.rs
+++ b/crates/kirra-world-store/tests/canonical_form.rs
@@ -26,7 +26,8 @@
 //! match a regression, since updating both in agreement is a deliberate act.
 
 use kirra_world_store::{
-    canonical_event_json, provenance_json, ClaimStatus, NewEvent, WriterClass,
+    canonical_event_json, provenance_json, ClaimStatus, EventId, FrameId, MapId, NewEvent,
+    ObservationId, WriterClass,
 };
 
 fn sha256_hex(bytes: &[u8]) -> String {
@@ -36,12 +37,31 @@ fn sha256_hex(bytes: &[u8]) -> String {
     hex::encode(h.finalize())
 }
 
+/// The four typed references, owned so a `NewEvent` can borrow them.
+struct Refs {
+    event: EventId,
+    observation: ObservationId,
+    frame: FrameId,
+    map: MapId,
+}
+
+impl Refs {
+    fn fixture() -> Self {
+        Self {
+            event: EventId::new("evt-000000000000000000000001").unwrap(),
+            observation: ObservationId::new("obs-000000000000000000000001").unwrap(),
+            frame: FrameId::new("base_link").unwrap(),
+            map: MapId::new("lab-floor-2").unwrap(),
+        }
+    }
+}
+
 /// Every field populated, including the optional ones, so an accidental change
 /// to how `Some`/`None` are spelled cannot hide behind a null.
-fn fully_populated<'a>(provenance: &'a [&'a str]) -> NewEvent<'a> {
+fn fully_populated<'a>(r: &'a Refs, provenance: &'a [&'a str]) -> NewEvent<'a> {
     NewEvent {
-        event_id: "evt-000000000000000000000001",
-        observation_id: "obs-000000000000000000000001",
+        event_id: &r.event,
+        observation_id: &r.observation,
         txn_time_ms: 1_700_000_000_000,
         valid_from_ms: 1_699_999_999_000,
         valid_to_ms: Some(1_700_000_060_000),
@@ -50,8 +70,8 @@ fn fully_populated<'a>(provenance: &'a [&'a str]) -> NewEvent<'a> {
         writer_class: WriterClass::Sensor,
         claim_status: ClaimStatus::Confirmed,
         provenance,
-        frame_id: Some("base_link"),
-        map_id: Some("lab-floor-2"),
+        frame_id: Some(&r.frame),
+        map_id: Some(&r.map),
         kind: "spatial",
         subject: "cup-1",
         predicate: Some("located_in"),
@@ -64,8 +84,9 @@ fn fully_populated<'a>(provenance: &'a [&'a str]) -> NewEvent<'a> {
 
 #[test]
 fn canonical_json_is_byte_for_byte_what_it_has_always_been() {
+    let r = Refs::fixture();
     let prov: [&str; 2] = ["obs-a", "obs-b"];
-    let got = canonical_event_json(&fully_populated(&prov));
+    let got = canonical_event_json(&fully_populated(&r, &prov));
 
     let expected = concat!(
         r#"{"event_id":"evt-000000000000000000000001","#,
@@ -85,8 +106,9 @@ fn canonical_json_is_byte_for_byte_what_it_has_always_been() {
 
 #[test]
 fn canonical_json_digest_is_pinned() {
+    let r = Refs::fixture();
     let prov: [&str; 2] = ["obs-a", "obs-b"];
-    let got = sha256_hex(canonical_event_json(&fully_populated(&prov)).as_bytes());
+    let got = sha256_hex(canonical_event_json(&fully_populated(&r, &prov)).as_bytes());
 
     // Recorded from the implementation as it stood when the identity types were
     // introduced. If this changes, the chain in every existing store changed
@@ -104,7 +126,8 @@ fn canonical_json_digest_is_pinned() {
 /// different, silently incompatible canonical form.
 #[test]
 fn absent_optionals_are_spelled_null_not_omitted() {
-    let mut e = fully_populated(&[]);
+    let r = Refs::fixture();
+    let mut e = fully_populated(&r, &[]);
     e.valid_to_ms = None;
     e.frame_id = None;
     e.map_id = None;
@@ -138,7 +161,8 @@ fn absent_optionals_are_spelled_null_not_omitted() {
 /// to survive a round trip distinguishably.
 #[test]
 fn empty_provenance_is_an_empty_array() {
-    let e = fully_populated(&[]);
+    let r = Refs::fixture();
+    let e = fully_populated(&r, &[]);
     assert!(canonical_event_json(&e).contains(r#""provenance":[]"#));
     assert_eq!(provenance_json(&[]), "[]");
 }
@@ -149,7 +173,8 @@ fn empty_provenance_is_an_empty_array() {
 /// simpler ones agreeing, which is the hardest kind of divergence to diagnose.
 #[test]
 fn embedded_quotes_and_backslashes_escape_stably() {
-    let mut e = fully_populated(&[]);
+    let r = Refs::fixture();
+    let mut e = fully_populated(&r, &[]);
     e.payload = r#"{"path":"C:\\tmp","q":"\"hi\""}"#;
     e.subject = "cup\"1";
 
@@ -180,8 +205,9 @@ fn embedded_quotes_and_backslashes_escape_stably() {
 /// differ somewhere".
 #[test]
 fn field_order_is_fixed_and_complete() {
+    let r = Refs::fixture();
     let prov: [&str; 1] = ["obs-a"];
-    let got = canonical_event_json(&fully_populated(&prov));
+    let got = canonical_event_json(&fully_populated(&r, &prov));
 
     const ORDER: [&str; 19] = [
         "event_id",

--- a/crates/kirra-world-store/tests/canonical_form.rs
+++ b/crates/kirra-world-store/tests/canonical_form.rs
@@ -79,6 +79,7 @@ fn fully_populated<'a>(r: &'a Refs, provenance: &'a [&'a str]) -> NewEvent<'a> {
         payload: r#"{"x":1.5,"y":-2.0}"#,
         payload_schema: 3,
         retention_class: "raw",
+        trust: None,
     }
 }
 

--- a/crates/kirra-world-store/tests/canonical_form.rs
+++ b/crates/kirra-world-store/tests/canonical_form.rs
@@ -1,0 +1,223 @@
+//! The canonical hashed form, pinned to exact bytes.
+//!
+//! # Why this file exists, and why it was written *before* the change it guards
+//!
+//! [`kirra_world_store::canonical_event_json`] is the input to every chain
+//! digest the store has ever computed. Its field order, its separators, its
+//! null spelling and its number formatting are all load-bearing: change any of
+//! them and every previously written store fails [`WorldStore::verify_chain`]
+//! — not because a row was edited, but because the verifier now asks a
+//! different question of it. There is no migration for that
+//! (`KIRRA-WM2-SCHEMA-001` §4), and the failure surfaces as
+//! `StoreError::ChainBroken`, which reads as tampering.
+//!
+//! The function's own doc comment already says field order is fixed and
+//! explicit "because a reordering would silently change every digest ever
+//! computed". That was a comment. Nothing checked it.
+//!
+//! **A test asserting the post-change bytes would prove nothing** — it would be
+//! written from whatever the code then produced, and would agree with a
+//! regression as readily as with correctness. So this file was committed
+//! *first*, pinning the bytes the code produces today, before the identity
+//! types landed. From here on, any edit that moves a byte reddens this test.
+//!
+//! The digest is spelled out too. The literal JSON catches a reordering
+//! legibly; the digest catches the case where the literal itself is edited to
+//! match a regression, since updating both in agreement is a deliberate act.
+
+use kirra_world_store::{
+    canonical_event_json, provenance_json, ClaimStatus, NewEvent, WriterClass,
+};
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    h.update(bytes);
+    hex::encode(h.finalize())
+}
+
+/// Every field populated, including the optional ones, so an accidental change
+/// to how `Some`/`None` are spelled cannot hide behind a null.
+fn fully_populated<'a>(provenance: &'a [&'a str]) -> NewEvent<'a> {
+    NewEvent {
+        event_id: "evt-000000000000000000000001",
+        observation_id: "obs-000000000000000000000001",
+        txn_time_ms: 1_700_000_000_000,
+        valid_from_ms: 1_699_999_999_000,
+        valid_to_ms: Some(1_700_000_060_000),
+        source: "test-sensor",
+        source_version: "0.1.0",
+        writer_class: WriterClass::Sensor,
+        claim_status: ClaimStatus::Confirmed,
+        provenance,
+        frame_id: Some("base_link"),
+        map_id: Some("lab-floor-2"),
+        kind: "spatial",
+        subject: "cup-1",
+        predicate: Some("located_in"),
+        object: Some("room-3"),
+        payload: r#"{"x":1.5,"y":-2.0}"#,
+        payload_schema: 3,
+        retention_class: "raw",
+    }
+}
+
+#[test]
+fn canonical_json_is_byte_for_byte_what_it_has_always_been() {
+    let prov: [&str; 2] = ["obs-a", "obs-b"];
+    let got = canonical_event_json(&fully_populated(&prov));
+
+    let expected = concat!(
+        r#"{"event_id":"evt-000000000000000000000001","#,
+        r#""observation_id":"obs-000000000000000000000001","#,
+        r#""txn_time_ms":1700000000000,"valid_from_ms":1699999999000,"#,
+        r#""valid_to_ms":1700000060000,"source":"test-sensor","#,
+        r#""source_version":"0.1.0","writer_class":"sensor","#,
+        r#""claim_status":"confirmed","provenance":["obs-a","obs-b"],"#,
+        r#""frame_id":"base_link","map_id":"lab-floor-2","kind":"spatial","#,
+        r#""subject":"cup-1","predicate":"located_in","object":"room-3","#,
+        r#""payload":"{\"x\":1.5,\"y\":-2.0}","payload_schema":3,"#,
+        r#""retention_class":"raw"}"#
+    );
+
+    assert_eq!(got, expected, "canonical hashed form changed");
+}
+
+#[test]
+fn canonical_json_digest_is_pinned() {
+    let prov: [&str; 2] = ["obs-a", "obs-b"];
+    let got = sha256_hex(canonical_event_json(&fully_populated(&prov)).as_bytes());
+
+    // Recorded from the implementation as it stood when the identity types were
+    // introduced. If this changes, the chain in every existing store changed
+    // with it.
+    assert_eq!(
+        got, "0892728f937f181099b7f4a3221fd295eab7e478d30719d207e6016efc4d81ee",
+        "the canonical form's digest changed — every existing store's chain \
+         now verifies against different bytes"
+    );
+}
+
+/// The absent case pinned separately. `None` spelled as `null` rather than as
+/// an omitted key is what keeps the form fixed-arity, and a serializer swap
+/// that started omitting nulls would still produce valid JSON — just a
+/// different, silently incompatible canonical form.
+#[test]
+fn absent_optionals_are_spelled_null_not_omitted() {
+    let mut e = fully_populated(&[]);
+    e.valid_to_ms = None;
+    e.frame_id = None;
+    e.map_id = None;
+    e.predicate = None;
+    e.object = None;
+    e.kind = "observation";
+
+    let got = canonical_event_json(&e);
+
+    assert!(
+        got.contains(r#""valid_to_ms":null"#),
+        "valid_to_ms must be spelled null: {got}"
+    );
+    assert!(
+        got.contains(r#""frame_id":null,"map_id":null"#),
+        "frame_id and map_id must be spelled null and stay adjacent: {got}"
+    );
+    assert!(
+        got.contains(r#""predicate":null,"object":null"#),
+        "predicate and object must be spelled null and stay adjacent: {got}"
+    );
+    assert_eq!(
+        got.matches("null").count(),
+        5,
+        "exactly the five optional fields are null: {got}"
+    );
+}
+
+/// Empty provenance is `[]`, not `null` and not an omitted key. SD-3 stores the
+/// chain a claim rests on; "rests on nothing recorded" is a real answer and has
+/// to survive a round trip distinguishably.
+#[test]
+fn empty_provenance_is_an_empty_array() {
+    let e = fully_populated(&[]);
+    assert!(canonical_event_json(&e).contains(r#""provenance":[]"#));
+    assert_eq!(provenance_json(&[]), "[]");
+}
+
+/// The escaping path, pinned. A payload containing a quote or a backslash is
+/// ordinary — every JSON payload with a nested string hits this — and an
+/// escaping change would alter digests for exactly those rows while leaving
+/// simpler ones agreeing, which is the hardest kind of divergence to diagnose.
+#[test]
+fn embedded_quotes_and_backslashes_escape_stably() {
+    let mut e = fully_populated(&[]);
+    e.payload = r#"{"path":"C:\\tmp","q":"\"hi\""}"#;
+    e.subject = "cup\"1";
+
+    let got = canonical_event_json(&e);
+
+    assert!(
+        got.contains(r#""subject":"cup\"1""#),
+        "quote in a bare field must escape as \\\": {got}"
+    );
+    assert!(
+        got.contains(r#"C:\\\\tmp"#),
+        "a backslash inside the payload must survive double-encoding: {got}"
+    );
+    // The whole form still parses — escaping that produced invalid JSON would
+    // break every downstream reader, not just the digest.
+    let parsed: serde_json::Value =
+        serde_json::from_str(&got).expect("canonical form is valid JSON");
+    assert_eq!(parsed["subject"], "cup\"1");
+    // Recovers the payload TEXT verbatim — the payload is an opaque string to
+    // this layer, so the two-character `\\` it contains is content, not an
+    // escape this form is entitled to collapse.
+    assert_eq!(parsed["payload"], r#"{"path":"C:\\tmp","q":"\"hi\""}"#);
+}
+
+/// Field *count* and *order*, asserted independently of the byte pin above.
+/// The pin catches any change; this names which property broke, so a failure
+/// reads as "a field was added in the middle" rather than "these long strings
+/// differ somewhere".
+#[test]
+fn field_order_is_fixed_and_complete() {
+    let prov: [&str; 1] = ["obs-a"];
+    let got = canonical_event_json(&fully_populated(&prov));
+
+    const ORDER: [&str; 19] = [
+        "event_id",
+        "observation_id",
+        "txn_time_ms",
+        "valid_from_ms",
+        "valid_to_ms",
+        "source",
+        "source_version",
+        "writer_class",
+        "claim_status",
+        "provenance",
+        "frame_id",
+        "map_id",
+        "kind",
+        "subject",
+        "predicate",
+        "object",
+        "payload",
+        "payload_schema",
+        "retention_class",
+    ];
+
+    let mut cursor = 0usize;
+    for key in ORDER {
+        let needle = format!("\"{key}\":");
+        let at = got[cursor..]
+            .find(&needle)
+            .unwrap_or_else(|| panic!("{key} missing or out of order in: {got}"));
+        cursor += at + needle.len();
+    }
+
+    let parsed: serde_json::Value = serde_json::from_str(&got).expect("valid JSON");
+    assert_eq!(
+        parsed.as_object().expect("object").len(),
+        ORDER.len(),
+        "a field was added to the canonical form without being pinned here"
+    );
+}

--- a/crates/kirra-world-store/tests/degraded_answers.rs
+++ b/crates/kirra-world-store/tests/degraded_answers.rs
@@ -124,6 +124,7 @@ impl Ev {
             payload: &self.payload,
             payload_schema: 1,
             retention_class: &self.retention_class,
+            trust: None,
         }
     }
 }

--- a/crates/kirra-world-store/tests/degraded_answers.rs
+++ b/crates/kirra-world-store/tests/degraded_answers.rs
@@ -23,7 +23,9 @@
 //! * `current()` is provably never degraded, which is the second thing the
 //!   projection-head refusal buys.
 
-use kirra_world_store::{ClaimStatus, NewEvent, Resolution, StoreError, WorldStore, WriterClass};
+use kirra_world_store::{
+    ClaimStatus, EventId, NewEvent, ObservationId, Resolution, StoreError, WorldStore, WriterClass,
+};
 
 fn tmp(name: &str) -> std::path::PathBuf {
     let mut p = std::env::temp_dir();
@@ -47,7 +49,8 @@ fn clean(p: &std::path::Path) {
 const T0: i64 = 1_700_000_000_000;
 
 struct Ev {
-    event_id: String,
+    event_id: EventId,
+    observation_id: ObservationId,
     subject: String,
     predicate: Option<String>,
     object: Option<String>,
@@ -61,7 +64,8 @@ struct Ev {
 impl Ev {
     fn new(event_id: &str, subject: &str, valid_from_ms: i64) -> Self {
         Self {
-            event_id: event_id.to_string(),
+            event_id: EventId::new(event_id).expect("admissible event id"),
+            observation_id: ObservationId::new(event_id).expect("admissible observation id"),
             subject: subject.to_string(),
             predicate: Some("position".to_string()),
             object: None,
@@ -99,7 +103,7 @@ impl Ev {
     fn as_new(&self) -> NewEvent<'_> {
         NewEvent {
             event_id: &self.event_id,
-            observation_id: &self.event_id,
+            observation_id: &self.observation_id,
             txn_time_ms: self.txn_time_ms,
             valid_from_ms: self.valid_from_ms,
             valid_to_ms: None,

--- a/crates/kirra-world-store/tests/read_path.rs
+++ b/crates/kirra-world-store/tests/read_path.rs
@@ -9,7 +9,24 @@
 //! * `open_leaves_no_projection_tables` — protects ADR-0041 D-20's
 //!   `log_only_bytes` from being silently moved by this feature's existence.
 
-use kirra_world_store::{ClaimStatus, NewEvent, WorldStore, WriterClass};
+use kirra_world_store::{ClaimStatus, EventId, NewEvent, ObservationId, WorldStore, WriterClass};
+
+/// Owned ids for one event. [`NewEvent`] borrows its references, so they need a
+/// home that outlives it — and the two are separate types now, which is what
+/// stops them being passed in each other's place.
+struct Ids {
+    event: EventId,
+    observation: ObservationId,
+}
+
+/// One string for both ids. Fine for a fixture, and now *visibly* a conflation
+/// rather than an invisible one: the two fields have to be spelled separately.
+fn ids(s: &str) -> Ids {
+    Ids {
+        event: EventId::new(s).expect("admissible event id"),
+        observation: ObservationId::new(s).expect("admissible observation id"),
+    }
+}
 
 fn tmp(name: &str) -> std::path::PathBuf {
     let mut p = std::env::temp_dir();
@@ -36,7 +53,7 @@ fn clean(p: &std::path::Path) {
 
 #[allow(clippy::too_many_arguments)]
 fn ev<'a>(
-    event_id: &'a str,
+    id: &'a Ids,
     subject: &'a str,
     predicate: Option<&'a str>,
     object: Option<&'a str>,
@@ -44,8 +61,8 @@ fn ev<'a>(
     txn_time_ms: i64,
 ) -> NewEvent<'a> {
     NewEvent {
-        event_id,
-        observation_id: event_id,
+        event_id: &id.event,
+        observation_id: &id.observation,
         txn_time_ms,
         valid_from_ms,
         valid_to_ms: None,
@@ -84,7 +101,7 @@ fn a_candidate_never_reaches_current_state() {
     s.append(&NewEvent {
         writer_class: WriterClass::LlmCandidate,
         claim_status: ClaimStatus::Candidate,
-        ..ev("e1", "cup-1", Some("colour"), Some("red"), T0, T0)
+        ..ev(&ids("e1"), "cup-1", Some("colour"), Some("red"), T0, T0)
     })
     .expect("a candidate is a legal write");
     s.fold().expect("fold");
@@ -112,13 +129,20 @@ fn a_newer_candidate_does_not_displace_a_confirmed_claim() {
     let p = tmp("candidate-no-shadow");
     let mut s = WorldStore::open(&p).expect("open");
 
-    s.append(&ev("e1", "cup-1", Some("colour"), Some("red"), T0, T0))
-        .expect("confirmed");
+    s.append(&ev(
+        &ids("e1"),
+        "cup-1",
+        Some("colour"),
+        Some("red"),
+        T0,
+        T0,
+    ))
+    .expect("confirmed");
     s.append(&NewEvent {
         writer_class: WriterClass::LlmCandidate,
         claim_status: ClaimStatus::Candidate,
         ..ev(
-            "e2",
+            &ids("e2"),
             "cup-1",
             Some("colour"),
             Some("blue"),
@@ -152,8 +176,10 @@ fn a_newer_candidate_does_not_displace_a_confirmed_claim() {
 fn open_leaves_no_projection_tables() {
     let p = tmp("no-projection-at-open");
     let mut s = WorldStore::open(&p).expect("open");
-    s.append(&ev("e1", "cup-1", None, None, T0, T0)).expect("a");
-    s.append(&ev("e2", "cup-2", None, None, T0, T0)).expect("b");
+    s.append(&ev(&ids("e1"), "cup-1", None, None, T0, T0))
+        .expect("a");
+    s.append(&ev(&ids("e2"), "cup-2", None, None, T0, T0))
+        .expect("b");
 
     assert!(
         !s.has_projections().unwrap(),
@@ -198,7 +224,7 @@ fn rebuild_from_zero_equals_incremental() {
             let eid = format!("e{n}");
             let subj = format!("entity-{:03}", n % 7);
             s.append(&ev(
-                &eid,
+                &ids(&eid),
                 &subj,
                 Some("position"),
                 None,
@@ -231,13 +257,20 @@ fn the_state_digest_distinguishes_states() {
     let p = tmp("digest-non-vacuous");
     let mut s = WorldStore::open(&p).expect("open");
 
-    s.append(&ev("e1", "cup-1", Some("colour"), Some("red"), T0, T0))
-        .expect("a");
+    s.append(&ev(
+        &ids("e1"),
+        "cup-1",
+        Some("colour"),
+        Some("red"),
+        T0,
+        T0,
+    ))
+    .expect("a");
     s.fold().expect("fold");
     let one = s.projection_state_digest().unwrap();
 
     s.append(&ev(
-        "e2",
+        &ids("e2"),
         "cup-1",
         Some("colour"),
         Some("blue"),
@@ -260,10 +293,17 @@ fn the_state_digest_distinguishes_states() {
 fn the_newest_claim_wins_per_subject_and_predicate() {
     let p = tmp("supersede");
     let mut s = WorldStore::open(&p).expect("open");
-    s.append(&ev("e1", "cup-1", Some("colour"), Some("red"), T0, T0))
-        .expect("a");
     s.append(&ev(
-        "e2",
+        &ids("e1"),
+        "cup-1",
+        Some("colour"),
+        Some("red"),
+        T0,
+        T0,
+    ))
+    .expect("a");
+    s.append(&ev(
+        &ids("e2"),
         "cup-1",
         Some("colour"),
         Some("blue"),
@@ -272,7 +312,7 @@ fn the_newest_claim_wins_per_subject_and_predicate() {
     ))
     .expect("b");
     s.append(&ev(
-        "e3",
+        &ids("e3"),
         "cup-1",
         Some("position"),
         Some("shelf"),
@@ -303,10 +343,17 @@ fn the_newest_claim_wins_per_subject_and_predicate() {
 fn a_tie_in_valid_time_resolves_to_the_later_generation() {
     let p = tmp("valid-time-tie");
     let mut s = WorldStore::open(&p).expect("open");
-    s.append(&ev("e1", "cup-1", Some("colour"), Some("red"), T0, T0))
-        .expect("first");
     s.append(&ev(
-        "e2",
+        &ids("e1"),
+        "cup-1",
+        Some("colour"),
+        Some("red"),
+        T0,
+        T0,
+    ))
+    .expect("first");
+    s.append(&ev(
+        &ids("e2"),
         "cup-1",
         Some("colour"),
         Some("blue"),
@@ -345,7 +392,7 @@ fn a_late_arrival_about_the_past_does_not_overwrite_the_present() {
 
     // Learned at T0+1000 that the cup was blue from T0+500.
     s.append(&ev(
-        "e1",
+        &ids("e1"),
         "cup-1",
         Some("colour"),
         Some("blue"),
@@ -355,7 +402,7 @@ fn a_late_arrival_about_the_past_does_not_overwrite_the_present() {
     .expect("a");
     // Then learned, LATER, that it had been red back at T0.
     s.append(&ev(
-        "e2",
+        &ids("e2"),
         "cup-1",
         Some("colour"),
         Some("red"),
@@ -386,7 +433,7 @@ fn as_of_respects_the_transaction_axis() {
     let p = tmp("txn-axis");
     let mut s = WorldStore::open(&p).expect("open");
     s.append(&ev(
-        "e1",
+        &ids("e1"),
         "cup-1",
         Some("colour"),
         Some("blue"),
@@ -395,7 +442,7 @@ fn as_of_respects_the_transaction_axis() {
     ))
     .expect("a");
     s.append(&ev(
-        "e2",
+        &ids("e2"),
         "cup-1",
         Some("colour"),
         Some("red"),
@@ -421,7 +468,7 @@ fn a_bounded_claim_expires() {
     let mut s = WorldStore::open(&p).expect("open");
     s.append(&NewEvent {
         valid_to_ms: Some(T0 + 200),
-        ..ev("e1", "cup-1", Some("colour"), Some("red"), T0, T0)
+        ..ev(&ids("e1"), "cup-1", Some("colour"), Some("red"), T0, T0)
     })
     .expect("bounded");
     s.fold().expect("fold");
@@ -445,7 +492,7 @@ fn history_is_every_confirmed_event_oldest_first() {
     for i in 0..4 {
         let eid = format!("e{i}");
         s.append(&ev(
-            &eid,
+            &ids(&eid),
             "cup-1",
             Some("colour"),
             None,
@@ -467,9 +514,10 @@ fn history_is_every_confirmed_event_oldest_first() {
 fn changed_since_uses_transaction_time() {
     let p = tmp("changed-since");
     let mut s = WorldStore::open(&p).expect("open");
-    s.append(&ev("e1", "cup-1", None, None, T0, T0)).expect("a");
+    s.append(&ev(&ids("e1"), "cup-1", None, None, T0, T0))
+        .expect("a");
     // Valid in the past, learned recently — must still be reported.
-    s.append(&ev("e2", "cup-2", None, None, T0 - 9_000, T0 + 500))
+    s.append(&ev(&ids("e2"), "cup-2", None, None, T0 - 9_000, T0 + 500))
         .expect("b");
 
     let changed = s.changed_since(T0 + 100).unwrap();
@@ -491,7 +539,7 @@ fn a_second_fold_with_no_new_events_is_stable() {
     s.append(&NewEvent {
         writer_class: WriterClass::LlmCandidate,
         claim_status: ClaimStatus::Candidate,
-        ..ev("e1", "cup-1", Some("colour"), Some("red"), T0, T0)
+        ..ev(&ids("e1"), "cup-1", Some("colour"), Some("red"), T0, T0)
     })
     .expect("candidate only");
 
@@ -525,7 +573,7 @@ fn projected_row_count_is_not_time_filtered() {
         let subj = format!("cup-{i}");
         s.append(&NewEvent {
             valid_to_ms: Some(T0 + 100),
-            ..ev(&eid, &subj, Some("colour"), None, T0, T0)
+            ..ev(&ids(&eid), &subj, Some("colour"), None, T0, T0)
         })
         .expect("bounded claim");
     }
@@ -552,8 +600,15 @@ fn projected_row_count_is_not_time_filtered() {
 fn a_successful_fold_leaves_a_checkpoint_matching_its_state() {
     let p = tmp("fold-atomic");
     let mut s = WorldStore::open(&p).expect("open");
-    s.append(&ev("e1", "cup-1", Some("colour"), Some("red"), T0, T0))
-        .expect("a");
+    s.append(&ev(
+        &ids("e1"),
+        "cup-1",
+        Some("colour"),
+        Some("red"),
+        T0,
+        T0,
+    ))
+    .expect("a");
     s.fold().expect("fold");
 
     let recorded = s.checkpoint_state_digest_for_test().unwrap();
@@ -565,7 +620,7 @@ fn a_successful_fold_leaves_a_checkpoint_matching_its_state() {
 
     // And it must keep matching after a second fold moves the state.
     s.append(&ev(
-        "e2",
+        &ids("e2"),
         "cup-1",
         Some("colour"),
         Some("blue"),
@@ -589,8 +644,15 @@ fn folding_does_not_disturb_the_chain() {
     let mut s = WorldStore::open(&p).expect("open");
     for i in 0..10 {
         let eid = format!("e{i}");
-        s.append(&ev(&eid, "cup-1", Some("colour"), None, T0 + i, T0 + i))
-            .expect("append");
+        s.append(&ev(
+            &ids(&eid),
+            "cup-1",
+            Some("colour"),
+            None,
+            T0 + i,
+            T0 + i,
+        ))
+        .expect("append");
     }
     s.fold().expect("fold");
     s.rebuild_projections().expect("rebuild");

--- a/crates/kirra-world-store/tests/read_path.rs
+++ b/crates/kirra-world-store/tests/read_path.rs
@@ -80,6 +80,7 @@ fn ev<'a>(
         payload: r#"{"n":1}"#,
         payload_schema: 1,
         retention_class: "raw",
+        trust: None,
     }
 }
 

--- a/crates/kirra-world-store/tests/retention.rs
+++ b/crates/kirra-world-store/tests/retention.rs
@@ -73,6 +73,7 @@ fn ev<'a>(id: &'a Ids, subject: &'a str, valid_from_ms: i64) -> NewEvent<'a> {
         payload: r#"{"n":1}"#,
         payload_schema: 1,
         retention_class: "raw",
+        trust: None,
     }
 }
 

--- a/crates/kirra-world-store/tests/retention.rs
+++ b/crates/kirra-world-store/tests/retention.rs
@@ -10,7 +10,26 @@
 //! * a projection head is refused, so a rebuild still reproduces the fold;
 //! * removed content stays **attestable** through `range_digest`.
 
-use kirra_world_store::{ClaimStatus, NewEvent, StoreError, WorldStore, WriterClass};
+use kirra_world_store::{
+    ClaimStatus, EventId, NewEvent, ObservationId, StoreError, WorldStore, WriterClass,
+};
+
+/// Owned ids for one event. [`NewEvent`] borrows its references, so they need a
+/// home that outlives it — and the two are separate types now, which is what
+/// stops them being passed in each other's place.
+struct Ids {
+    event: EventId,
+    observation: ObservationId,
+}
+
+/// One string for both ids. Fine for a fixture, and now *visibly* a conflation
+/// rather than an invisible one: the two fields have to be spelled separately.
+fn ids(s: &str) -> Ids {
+    Ids {
+        event: EventId::new(s).expect("admissible event id"),
+        observation: ObservationId::new(s).expect("admissible observation id"),
+    }
+}
 
 fn tmp(name: &str) -> std::path::PathBuf {
     let mut p = std::env::temp_dir();
@@ -33,10 +52,10 @@ fn clean(p: &std::path::Path) {
 
 const T0: i64 = 1_700_000_000_000;
 
-fn ev<'a>(event_id: &'a str, subject: &'a str, valid_from_ms: i64) -> NewEvent<'a> {
+fn ev<'a>(id: &'a Ids, subject: &'a str, valid_from_ms: i64) -> NewEvent<'a> {
     NewEvent {
-        event_id,
-        observation_id: event_id,
+        event_id: &id.event,
+        observation_id: &id.observation,
         txn_time_ms: valid_from_ms,
         valid_from_ms,
         valid_to_ms: None,
@@ -64,7 +83,8 @@ fn seeded(path: &std::path::Path) -> WorldStore {
     for i in 1..=12i64 {
         let eid = format!("e{i}");
         let subj = format!("cup-{}", (i - 1) % 3);
-        s.append(&ev(&eid, &subj, T0 + i * 100)).expect("append");
+        s.append(&ev(&ids(&eid), &subj, T0 + i * 100))
+            .expect("append");
     }
     s
 }
@@ -192,7 +212,7 @@ fn a_window_containing_protected_traffic_is_refused_whole() {
         let subj = format!("cup-{i}");
         s.append(&NewEvent {
             retention_class: if i == 4 { "safety" } else { "raw" },
-            ..ev(&eid, &subj, T0 + i * 100)
+            ..ev(&ids(&eid), &subj, T0 + i * 100)
         })
         .expect("append");
     }
@@ -229,10 +249,10 @@ fn every_protected_class_refuses() {
     ] {
         let p = tmp(&format!("protected-{class}"));
         let mut s = WorldStore::open(&p).expect("open");
-        s.append(&ev("e1", "cup-1", T0)).expect("raw");
+        s.append(&ev(&ids("e1"), "cup-1", T0)).expect("raw");
         s.append(&NewEvent {
             retention_class: class,
-            ..ev("e2", "cup-2", T0 + 100)
+            ..ev(&ids("e2"), "cup-2", T0 + 100)
         })
         .expect("protected");
 
@@ -390,7 +410,7 @@ fn the_prefix_helper_stops_below_the_first_blocker_of_either_kind() {
         let subj = format!("cup-{i}");
         s.append(&NewEvent {
             retention_class: if i == 4 { "incident" } else { "raw" },
-            ..ev(&eid, &subj, T0 + i * 100)
+            ..ev(&ids(&eid), &subj, T0 + i * 100)
         })
         .expect("append");
     }
@@ -415,10 +435,10 @@ fn a_window_blocked_at_its_first_generation_has_no_prefix() {
     let mut s = WorldStore::open(&p).expect("open");
     s.append(&NewEvent {
         retention_class: "safety",
-        ..ev("e1", "cup-1", T0)
+        ..ev(&ids("e1"), "cup-1", T0)
     })
     .expect("protected first");
-    s.append(&ev("e2", "cup-2", T0 + 100)).expect("raw");
+    s.append(&ev(&ids("e2"), "cup-2", T0 + 100)).expect("raw");
 
     assert_eq!(s.largest_compactable_prefix(1, 2).unwrap(), None);
     assert_eq!(

--- a/crates/kirra-world-store/tests/schema_rulings.rs
+++ b/crates/kirra-world-store/tests/schema_rulings.rs
@@ -58,6 +58,7 @@ fn base<'a>(id: &'a Ids) -> NewEvent<'a> {
         payload: r#"{"note":"seen"}"#,
         payload_schema: 1,
         retention_class: "raw",
+        trust: None,
     }
 }
 

--- a/crates/kirra-world-store/tests/schema_rulings.rs
+++ b/crates/kirra-world-store/tests/schema_rulings.rs
@@ -6,7 +6,9 @@
 //! than structural. So the tamper tests bypass the write path entirely and
 //! assert that the **chain** catches the edit.
 
-use kirra_world_store::{ClaimStatus, NewEvent, StoreError, WorldStore, WriterClass};
+use kirra_world_store::{
+    ClaimStatus, EventId, FrameId, NewEvent, ObservationId, StoreError, WorldStore, WriterClass,
+};
 
 fn tmp(name: &str) -> std::path::PathBuf {
     let mut p = std::env::temp_dir();
@@ -19,10 +21,26 @@ fn tmp(name: &str) -> std::path::PathBuf {
     p
 }
 
-fn base<'a>(event_id: &'a str, observation_id: &'a str) -> NewEvent<'a> {
+/// Owned ids for one event, so a [`NewEvent`] can borrow them. This file's
+/// fixtures give the two DIFFERENT strings, which is the honest shape: an event
+/// and the observation it records are distinct identities, and they are now
+/// distinct types too.
+struct Ids {
+    event: EventId,
+    observation: ObservationId,
+}
+
+fn ids(e: &str, o: &str) -> Ids {
+    Ids {
+        event: EventId::new(e).expect("admissible event id"),
+        observation: ObservationId::new(o).expect("admissible observation id"),
+    }
+}
+
+fn base<'a>(id: &'a Ids) -> NewEvent<'a> {
     NewEvent {
-        event_id,
-        observation_id,
+        event_id: &id.event,
+        observation_id: &id.observation,
         txn_time_ms: 1_700_000_000_000,
         valid_from_ms: 1_700_000_000_000,
         valid_to_ms: None,
@@ -50,7 +68,7 @@ fn a_chain_of_events_verifies() {
     for i in 0..5 {
         let eid = format!("e{i}");
         let oid = format!("o{i}");
-        s.append(&base(&eid, &oid)).expect("append");
+        s.append(&base(&ids(&eid, &oid))).expect("append");
     }
     assert_eq!(s.count().unwrap(), 5);
     s.verify_chain().expect("chain must verify");
@@ -66,10 +84,10 @@ fn sd2_relabelling_claim_status_breaks_the_chain() {
     s.append(&NewEvent {
         writer_class: WriterClass::LlmCandidate,
         claim_status: ClaimStatus::Candidate,
-        ..base("e1", "o1")
+        ..base(&ids("e1", "o1"))
     })
     .expect("append");
-    s.append(&base("e2", "o2")).expect("append");
+    s.append(&base(&ids("e2", "o2"))).expect("append");
     s.verify_chain().expect("clean before tamper");
 
     // Bypass the write path completely. The schema CHECK would refuse this
@@ -97,7 +115,7 @@ fn sd2_an_llm_may_not_write_a_confirmed_fact() {
         .append(&NewEvent {
             writer_class: WriterClass::LlmCandidate,
             claim_status: ClaimStatus::Confirmed,
-            ..base("e1", "o1")
+            ..base(&ids("e1", "o1"))
         })
         .expect_err("must refuse");
     assert!(matches!(err, StoreError::LlmCannotConfirm));
@@ -115,7 +133,7 @@ fn sd2_is_a_schema_check_not_only_a_write_path_check() {
     s.append(&NewEvent {
         writer_class: WriterClass::LlmCandidate,
         claim_status: ClaimStatus::Candidate,
-        ..base("e1", "o1")
+        ..base(&ids("e1", "o1"))
     })
     .expect("a candidate is fine");
 
@@ -138,15 +156,16 @@ fn sd4_a_spatial_claim_without_a_frame_is_refused() {
         .append(&NewEvent {
             kind: "spatial",
             frame_id: None,
-            ..base("e1", "o1")
+            ..base(&ids("e1", "o1"))
         })
         .expect_err("must refuse");
     assert!(matches!(err, StoreError::SpatialClaimNeedsFrame));
 
+    let frame = FrameId::new("map:kitchen").expect("admissible frame");
     s.append(&NewEvent {
         kind: "spatial",
-        frame_id: Some("map:kitchen"),
-        ..base("e2", "o2")
+        frame_id: Some(&frame),
+        ..base(&ids("e2", "o2"))
     })
     .expect("with a frame it is fine");
     let _ = std::fs::remove_file(&path);
@@ -158,10 +177,11 @@ fn sd4_a_spatial_claim_without_a_frame_is_refused() {
 fn sd4_is_a_schema_check_not_only_a_write_path_check() {
     let path = tmp("sd4-schema");
     let mut s = WorldStore::open(&path).expect("open");
+    let frame = FrameId::new("map:kitchen").expect("admissible frame");
     s.append(&NewEvent {
         kind: "spatial",
-        frame_id: Some("map:kitchen"),
-        ..base("e1", "o1")
+        frame_id: Some(&frame),
+        ..base(&ids("e1", "o1"))
     })
     .expect("append");
     let cleared = s.tamper_for_test(1, "frame_id", None);
@@ -181,10 +201,11 @@ fn sd1_valid_to_ms_is_set_at_insert_or_never() {
     let mut s = WorldStore::open(&path).expect("open");
     s.append(&NewEvent {
         valid_to_ms: Some(1_700_000_005_000),
-        ..base("e1", "o1")
+        ..base(&ids("e1", "o1"))
     })
     .expect("bounded observation");
-    s.append(&base("e2", "o2")).expect("open-ended observation");
+    s.append(&base(&ids("e2", "o2")))
+        .expect("open-ended observation");
     s.verify_chain().expect("verifies");
 
     // Prove the ONLY UPDATE is the test-only hatch, and prove it by position
@@ -227,7 +248,7 @@ fn sd3_provenance_is_a_digest_covered_json_array() {
     let mut s = WorldStore::open(&path).expect("open");
     s.append(&NewEvent {
         provenance: &["o-a", "o-b"],
-        ..base("e1", "o1")
+        ..base(&ids("e1", "o1"))
     })
     .expect("append");
     s.verify_chain().expect("clean");
@@ -250,7 +271,7 @@ fn sd3_provenance_is_a_digest_covered_json_array() {
 fn corrupt_provenance_on_an_empty_row_fails_closed() {
     let path = tmp("provenance-empty-corrupt");
     let mut s = WorldStore::open(&path).expect("open");
-    s.append(&base("e1", "o1"))
+    s.append(&base(&ids("e1", "o1")))
         .expect("append with provenance: &[]");
     s.verify_chain().expect("clean");
 
@@ -269,7 +290,7 @@ fn corrupt_provenance_on_an_empty_row_fails_closed() {
 fn the_tamper_hatch_refuses_an_unknown_column() {
     let path = tmp("tamper-allowlist");
     let mut s = WorldStore::open(&path).expect("open");
-    s.append(&base("e1", "o1")).expect("append");
+    s.append(&base(&ids("e1", "o1"))).expect("append");
 
     let bad = s.tamper_for_test(1, "generation = 9 --", Some("x"));
     assert!(bad.is_err(), "an un-allowlisted column must be refused");
@@ -284,12 +305,89 @@ fn the_tamper_hatch_refuses_an_unknown_column() {
 fn a_negative_generation_fails_closed_rather_than_hashing_as_zero() {
     let path = tmp("negative-generation");
     let mut s = WorldStore::open(&path).expect("open");
-    s.append(&base("e1", "o1")).expect("append");
+    s.append(&base(&ids("e1", "o1"))).expect("append");
     // rusqlite lets us move the PK; the chain must refuse to re-derive it.
     let _ = s.tamper_for_test(1, "chain_digest", Some("deadbeef"));
     match s.verify_chain() {
         Err(StoreError::ChainBroken { .. }) => {}
         other => panic!("a rewritten digest must break the chain, got {other:?}"),
     }
+    let _ = std::fs::remove_file(&path);
+}
+
+// ---------------------------------------------------------------------------
+// Re-admission on the read path (the reference types)
+// ---------------------------------------------------------------------------
+
+/// A stored identity the core no longer admits is a **corrupt row**, not a
+/// broken chain.
+///
+/// Both are refusals, so nothing is let through either way — but they send an
+/// investigator to different places. "This row is unreadable" points at the
+/// writer or the storage medium; "this row was edited" points at an intruder.
+/// The store already drew that line for unparseable provenance; re-admission
+/// keeps drawing it.
+///
+/// An empty `observation_id` is the case that motivates this: the column is
+/// `TEXT NOT NULL`, so SQLite accepts `''` happily, and every layer that checks
+/// for *presence* reads it as present while it names nothing.
+#[test]
+fn an_inadmissible_stored_identity_reads_as_a_corrupt_row_not_a_broken_chain() {
+    let path = tmp("readmit-corrupt");
+    let mut s = WorldStore::open(&path).expect("open");
+    s.append(&base(&ids("e1", "o1"))).expect("append");
+
+    s.tamper_for_test(1, "observation_id", Some(""))
+        .expect("tamper");
+
+    match s.verify_chain() {
+        Err(StoreError::CorruptRow { generation, detail }) => {
+            assert_eq!(generation, 1);
+            assert!(
+                detail.contains("observation_id"),
+                "the diagnosis must name the field: {detail}"
+            );
+        }
+        other => panic!("an empty stored identity must read as CorruptRow, got {other:?}"),
+    }
+    let _ = std::fs::remove_file(&path);
+}
+
+/// Re-admission can only ever ADD refusals — it must never rescue a row the
+/// chain check would have rejected.
+///
+/// This is the property that makes the change safe to put in front of the
+/// integrity check. The tamper here is admissible as a *reference* (`"o2"` is a
+/// perfectly good identity) but wrong for this row, so re-admission passes it
+/// straight through to the digest comparison, which refuses it.
+#[test]
+fn re_admission_does_not_weaken_the_chain_check() {
+    let path = tmp("readmit-no-rescue");
+    let mut s = WorldStore::open(&path).expect("open");
+    s.append(&base(&ids("e1", "o1"))).expect("append");
+
+    s.tamper_for_test(1, "observation_id", Some("o2"))
+        .expect("tamper");
+
+    match s.verify_chain() {
+        Err(StoreError::ChainBroken { generation }) => assert_eq!(generation, 1),
+        other => panic!("a swapped-but-valid identity must still break the chain, got {other:?}"),
+    }
+    let _ = std::fs::remove_file(&path);
+}
+
+/// The verbatim rule, from the storage side.
+///
+/// A value with surrounding whitespace is admissible and is stored unchanged.
+/// If any constructor on the read path trimmed, the rehash would be computed
+/// over different bytes than the write produced and this untampered row would
+/// report as tampered — the failure mode that makes "validate, never normalize"
+/// load-bearing rather than stylistic.
+#[test]
+fn a_stored_identity_with_whitespace_still_verifies() {
+    let path = tmp("readmit-verbatim");
+    let mut s = WorldStore::open(&path).expect("open");
+    s.append(&base(&ids("  e1  ", " o1 "))).expect("append");
+    s.verify_chain().expect("a verbatim round trip must verify");
     let _ = std::fs::remove_file(&path);
 }

--- a/crates/kirra-world-store/tests/trust_axes.rs
+++ b/crates/kirra-world-store/tests/trust_axes.rs
@@ -429,3 +429,219 @@ fn reopening_a_current_store_is_idempotent() {
     s.verify_chain().expect("still verifies");
     let _ = std::fs::remove_file(&path);
 }
+
+// ---------------------------------------------------------------------------
+// Review findings — the orphan count, and migration atomicity
+// ---------------------------------------------------------------------------
+
+/// **An orphan `corroboration_n` is refused by the schema.**
+///
+/// Found in review. The first version of the `CHECK` short-circuited: with the
+/// axes absent it permitted a non-NULL `corroboration_n`. That is not cosmetic.
+/// The canonical form omits the axis keys when the axes are absent, so an orphan
+/// count is a column that is **stored but not hashed** — editable in place
+/// without breaking the chain, which is the one property the whole design
+/// exists to deny.
+#[test]
+fn an_orphan_corroboration_count_is_refused_by_the_schema() {
+    let path = tmp("orphan-n");
+    let mut s = WorldStore::open(&path).expect("open");
+    s.append(&ev(&ids("e1", "o1"), None)).expect("unlabelled");
+
+    let bad =
+        s.raw_execute_for_test("UPDATE world_events SET corroboration_n = 4 WHERE generation = 1");
+    assert!(
+        bad.is_err(),
+        "a count with no axes must be refused — it would be stored but unhashed"
+    );
+    let _ = std::fs::remove_file(&path);
+}
+
+/// `Uncorroborated` has nothing to count, so it must carry no count either.
+#[test]
+fn uncorroborated_cannot_carry_a_count() {
+    let path = tmp("uncorr-n");
+    let mut s = WorldStore::open(&path).expect("open");
+    let axes = TrustAxes::new(
+        Origin::Asserted,
+        Corroboration::Uncorroborated,
+        Adjudication::Confirmed,
+    )
+    .unwrap();
+    s.append(&ev(&ids("e1", "o1"), Some(&axes)))
+        .expect("append");
+
+    let bad =
+        s.raw_execute_for_test("UPDATE world_events SET corroboration_n = 2 WHERE generation = 1");
+    assert!(bad.is_err(), "uncorroborated has no count to carry");
+    let _ = std::fs::remove_file(&path);
+}
+
+/// …and a corroborated row cannot drop its count.
+#[test]
+fn a_corroborated_row_cannot_drop_its_count() {
+    let path = tmp("drop-n");
+    let mut s = WorldStore::open(&path).expect("open");
+    let axes = confirmed_axes();
+    s.append(&ev(&ids("e1", "o1"), Some(&axes)))
+        .expect("append");
+
+    let bad = s.raw_execute_for_test(
+        "UPDATE world_events SET corroboration_n = NULL WHERE generation = 1",
+    );
+    assert!(bad.is_err(), "corroborated without a count is not a state");
+    let _ = std::fs::remove_file(&path);
+}
+
+/// **The read path refuses the orphan too**, not only the schema.
+///
+/// Belt and braces on purpose, and the reasoning is the review's: even with the
+/// `CHECK` tightened, a row reaching verification in that shape should be
+/// *diagnosable* as a `CorruptRow` rather than accepted as unlabelled. The
+/// schema stops the write; this makes the state legible if one ever appears —
+/// through a future migration bug, a hand-edited database, or a constraint
+/// dropped by someone else's DDL.
+#[test]
+fn the_read_path_refuses_an_orphan_count_independently_of_the_schema() {
+    let path = tmp("orphan-read");
+    let mut s = WorldStore::open(&path).expect("open");
+    s.append(&ev(&ids("e1", "o1"), None)).expect("unlabelled");
+
+    // Drop the constraint the only way SQLite allows — rebuild the table
+    // without it — so this proves the READ path independently, rather than
+    // re-proving the CHECK.
+    s.raw_execute_for_test("ALTER TABLE world_events RENAME TO we_old")
+        .expect("rename");
+    s.raw_execute_for_test("CREATE TABLE world_events AS SELECT * FROM we_old")
+        .expect("rebuild without constraints");
+    s.raw_execute_for_test("DROP TABLE we_old").expect("drop");
+    s.raw_execute_for_test("UPDATE world_events SET corroboration_n = 7 WHERE generation = 1")
+        .expect("now writable, the CHECK is gone");
+
+    match s.verify_chain() {
+        Err(StoreError::CorruptRow { generation, detail }) => {
+            assert_eq!(generation, 1);
+            assert!(
+                detail.contains("corroboration_n"),
+                "the diagnosis must name the column: {detail}"
+            );
+        }
+        other => panic!("an orphan count must read as CorruptRow, got {other:?}"),
+    }
+    let _ = std::fs::remove_file(&path);
+}
+
+/// **A failed migration leaves nothing behind.**
+///
+/// This is the observable consequence of wrapping the DDL and both stamps in
+/// one transaction, and it is what the review asked for. The scenario it
+/// prevents is a bricked store rather than a failed migration: without the
+/// transaction, a crash after `ALTER TABLE` but before the version stamp would
+/// leave the columns added and `schema_version` still 1, so every subsequent
+/// open would retry and die on a duplicate column — permanently.
+///
+/// With the transaction, that state cannot arise from an interruption at all.
+/// What is left to prove is the rollback: when the DDL fails, the stamps must
+/// NOT have advanced, or a partially-applied migration would still be recorded
+/// as complete.
+///
+/// A store whose stamp disagrees with its actual columns is refused **loudly**
+/// rather than silently repaired. That is deliberate — probing for each column
+/// before adding it would make the migration tolerant of a schema that does not
+/// match its own stamp, which is the opposite of fail-closed.
+#[test]
+fn a_failed_migration_does_not_advance_the_stamp() {
+    let path = tmp("rollback");
+    {
+        let mut s = WorldStore::open(&path).expect("open");
+        s.append(&ev(&ids("e1", "o1"), None)).expect("append");
+        // The columns exist; claim they do not. The next open will try to add
+        // them again and fail — which is the point.
+        s.raw_execute_for_test(
+            "UPDATE world_store_meta SET value = '1' WHERE key = 'schema_version'",
+        )
+        .expect("disagree with reality");
+    }
+
+    match WorldStore::open(&path) {
+        Err(err) => assert!(
+            format!("{err:?}").contains("duplicate column"),
+            "expected the DDL to be what fails, got {err:?}"
+        ),
+        Ok(_) => panic!("a stamp contradicting the actual schema must be refused"),
+    }
+
+    // The rollback: the stamps are untouched. Had the transaction not covered
+    // them, the digest would have been rewritten to the v2 value while the
+    // migration itself failed — recording a schema the store does not have.
+    let conn = rusqlite::Connection::open(&path).expect("reopen raw");
+    let version: String = conn
+        .query_row(
+            "SELECT value FROM world_store_meta WHERE key = 'schema_version'",
+            [],
+            |r| r.get(0),
+        )
+        .expect("version row");
+    assert_eq!(
+        version, "1",
+        "a failed migration must not advance the stamp"
+    );
+    let _ = std::fs::remove_file(&path);
+}
+
+/// **The migration on a genuine v1 database — rows and all.**
+///
+/// Nothing else in this file exercises the actual v1 → v2 path. The other tests
+/// all start from a store born at v2, which is the easy case.
+///
+/// The v1 database is reconstructed rather than checked in: unlabelled rows
+/// produce byte-identical canonical bytes to v1 (that equality is established
+/// independently by `canonical_form.rs`'s pins, which were written against the
+/// pre-v2 code), so appending unlabelled rows and then stripping the v2 columns
+/// yields a database indistinguishable from one a v1 binary wrote — including
+/// correct v1 chain digests.
+#[test]
+fn a_genuine_v1_database_migrates_and_its_rows_still_verify() {
+    let path = tmp("v1-migrate");
+    {
+        let mut s = WorldStore::open(&path).expect("open");
+        for n in 1..=3 {
+            s.append(&ev(&ids(&format!("e{n}"), &format!("o{n}")), None))
+                .expect("v1-shaped rows");
+        }
+        // Rewind to v1: drop the v2 columns by rebuilding the table without
+        // them, and stamp the version back.
+        s.raw_execute_for_test(
+            "CREATE TABLE we_v1 AS SELECT generation, event_id, observation_id, txn_time_ms,
+                 valid_from_ms, valid_to_ms, source, source_version, writer_class, claim_status,
+                 provenance, frame_id, map_id, kind, subject, predicate, object, payload,
+                 payload_schema, payload_digest, retention_class, chain_digest
+             FROM world_events",
+        )
+        .expect("project away the v2 columns");
+        s.raw_execute_for_test("DROP TABLE world_events")
+            .expect("drop");
+        s.raw_execute_for_test("ALTER TABLE we_v1 RENAME TO world_events")
+            .expect("rename");
+        s.raw_execute_for_test(
+            "UPDATE world_store_meta SET value = '1' WHERE key = 'schema_version'",
+        )
+        .expect("stamp v1");
+    }
+
+    // Open it with the current binary: the migration runs.
+    let mut s = WorldStore::open(&path).expect("a v1 store must migrate, not be refused");
+    assert_eq!(s.schema_version().expect("version"), SCHEMA_VERSION);
+
+    // The pre-migration rows still verify — the compatibility claim, end to end
+    // through a real migration rather than at the canonical-form level only.
+    s.verify_chain().expect("v1 rows verify after migration");
+
+    // And the migrated store accepts labelled rows, which chain onto them.
+    let axes = confirmed_axes();
+    s.append(&ev(&ids("e4", "o4"), Some(&axes)))
+        .expect("labelled row after migration");
+    s.verify_chain()
+        .expect("mixed chain verifies after migration");
+    let _ = std::fs::remove_file(&path);
+}

--- a/crates/kirra-world-store/tests/trust_axes.rs
+++ b/crates/kirra-world-store/tests/trust_axes.rs
@@ -1,0 +1,431 @@
+//! The four orthogonal trust axes in storage — schema v2.
+//!
+//! `KIRRA-WM2-SCHEMA-001` ratified v1 with a recorded digest, so the growth was
+//! a ruling: **additive, `writer_class` kept permanently** (2026-08-07). These
+//! tests assert what that ruling bought, and what it deliberately did not
+//! change.
+//!
+//! The load-bearing property is the one that is easiest to lose: **an
+//! unlabelled row must hash exactly as it did under v1**. Every store written
+//! before the axes existed has to keep verifying, so the axes are appended to
+//! the canonical form only when present. `canonical_form.rs`'s byte pins are the
+//! other half of that claim — they were written against the pre-v2 code and
+//! still pass unchanged.
+
+use kirra_world_store::{
+    canonical_event_json, Adjudication, ClaimStatus, Corroboration, EventId, NewEvent,
+    ObservationId, Origin, StoreError, TrustAxes, WorldStore, WriterClass, SCHEMA_VERSION,
+};
+
+fn tmp(name: &str) -> std::path::PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "kirra-world-axes-{}-{}.sqlite",
+        name,
+        std::process::id()
+    ));
+    for s in ["", "-wal", "-shm"] {
+        let mut q = p.as_os_str().to_os_string();
+        q.push(s);
+        let _ = std::fs::remove_file(std::path::PathBuf::from(q));
+    }
+    p
+}
+
+struct Ids {
+    event: EventId,
+    observation: ObservationId,
+}
+
+fn ids(e: &str, o: &str) -> Ids {
+    Ids {
+        event: EventId::new(e).unwrap(),
+        observation: ObservationId::new(o).unwrap(),
+    }
+}
+
+fn ev<'a>(id: &'a Ids, trust: Option<&'a TrustAxes>) -> NewEvent<'a> {
+    NewEvent {
+        event_id: &id.event,
+        observation_id: &id.observation,
+        txn_time_ms: 1_700_000_000_000,
+        valid_from_ms: 1_700_000_000_000,
+        valid_to_ms: None,
+        source: "sensor-a",
+        source_version: "0.1.0",
+        writer_class: WriterClass::Sensor,
+        claim_status: ClaimStatus::Confirmed,
+        provenance: &[],
+        frame_id: None,
+        map_id: None,
+        kind: "observation",
+        subject: "cup-1",
+        predicate: Some("colour"),
+        object: Some("red"),
+        payload: r#"{"n":1}"#,
+        payload_schema: 1,
+        retention_class: "raw",
+        trust,
+    }
+}
+
+/// Confirmed axes, matching `claim_status: Confirmed` as the derivation CHECK
+/// requires.
+fn confirmed_axes() -> TrustAxes {
+    TrustAxes::new(
+        Origin::Observed,
+        Corroboration::Corroborated(3),
+        Adjudication::Confirmed,
+    )
+    .expect("constructible")
+}
+
+// ---------------------------------------------------------------------------
+// The compatibility property
+// ---------------------------------------------------------------------------
+
+/// **The one that matters most.** An unlabelled row's canonical form is byte
+/// for byte the v1 form — no axis keys, not even as nulls.
+///
+/// Spelling the axes as `null` for unlabelled rows, the way v1's own five
+/// optionals are spelled, would have been more uniform and would have broken
+/// every store ever written: the bytes change, so the recomputed digest
+/// diverges and `verify_chain` reports tampering on rows nobody touched.
+#[test]
+fn an_unlabelled_row_hashes_exactly_as_it_did_under_v1() {
+    let id = ids("e1", "o1");
+    let got = canonical_event_json(&ev(&id, None));
+
+    assert!(!got.contains("origin"), "no origin key: {got}");
+    assert!(
+        !got.contains("corroboration"),
+        "no corroboration key: {got}"
+    );
+    assert!(!got.contains("adjudication"), "no adjudication key: {got}");
+    assert!(
+        got.ends_with(r#""retention_class":"raw"}"#),
+        "the form must still end at retention_class: {got}"
+    );
+}
+
+/// …and a labelled row's form differs, which is what puts the axes inside the
+/// hash rather than beside it.
+#[test]
+fn a_labelled_row_carries_its_axes_into_the_hashed_bytes() {
+    let id = ids("e1", "o1");
+    let axes = confirmed_axes();
+    let got = canonical_event_json(&ev(&id, Some(&axes)));
+
+    assert!(got.contains(r#""origin":"observed""#), "{got}");
+    assert!(got.contains(r#""corroboration":"corroborated""#), "{got}");
+    assert!(got.contains(r#""corroboration_n":3"#), "{got}");
+    assert!(got.contains(r#""adjudication":"confirmed""#), "{got}");
+    assert!(got.ends_with('}'), "still one JSON object: {got}");
+
+    assert_ne!(
+        got,
+        canonical_event_json(&ev(&id, None)),
+        "labelling a row must change its hashed bytes, or the label is unprotected"
+    );
+}
+
+/// `Uncorroborated` stores no count, and the absent count is spelled `null`
+/// rather than `0`. Zero would read as "zero sources agree", which is a claim;
+/// the axis's meaning is that there is nothing to cross-check.
+#[test]
+fn uncorroborated_carries_a_null_count_not_a_zero() {
+    let id = ids("e1", "o1");
+    let axes = TrustAxes::new(
+        Origin::Asserted,
+        Corroboration::Uncorroborated,
+        Adjudication::Confirmed,
+    )
+    .unwrap();
+    let got = canonical_event_json(&ev(&id, Some(&axes)));
+    assert!(got.contains(r#""corroboration_n":null"#), "{got}");
+}
+
+// ---------------------------------------------------------------------------
+// Round trip and chain coverage
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_labelled_row_round_trips_and_verifies() {
+    let path = tmp("round-trip");
+    let mut s = WorldStore::open(&path).expect("open");
+    let id = ids("e1", "o1");
+    let axes = confirmed_axes();
+    s.append(&ev(&id, Some(&axes))).expect("append");
+    s.verify_chain().expect("verifies");
+    let _ = std::fs::remove_file(&path);
+}
+
+/// Labelled and unlabelled rows coexist in one chain — which is exactly what a
+/// migrated store looks like the moment it starts writing v2 rows.
+#[test]
+fn labelled_and_unlabelled_rows_verify_in_the_same_chain() {
+    let path = tmp("mixed");
+    let mut s = WorldStore::open(&path).expect("open");
+    let axes = confirmed_axes();
+    s.append(&ev(&ids("e1", "o1"), None)).expect("v1-shaped");
+    s.append(&ev(&ids("e2", "o2"), Some(&axes)))
+        .expect("v2-shaped");
+    s.append(&ev(&ids("e3", "o3"), None)).expect("v1-shaped");
+    s.verify_chain().expect("a mixed chain verifies");
+    let _ = std::fs::remove_file(&path);
+}
+
+/// **Stripping the axes from a stored row does not turn it back into a valid
+/// unlabelled row.** The stored digest was computed over the labelled bytes, so
+/// recomputation diverges.
+///
+/// Without this, the axes would be editable in place — which is the exact
+/// weakness SD-2 rejected for `writer_class` and `claim_status`, and the reason
+/// the axes are inside the hash rather than beside it.
+#[test]
+fn stripping_the_axes_breaks_the_chain() {
+    let path = tmp("strip");
+    let mut s = WorldStore::open(&path).expect("open");
+    let axes = confirmed_axes();
+    s.append(&ev(&ids("e1", "o1"), Some(&axes)))
+        .expect("append");
+
+    // All three at once: the schema CHECK refuses a partial strip, so a
+    // tamperer has to clear the whole set — and that is what this proves is
+    // still detected.
+    s.raw_execute_for_test(
+        "UPDATE world_events SET origin = NULL, corroboration = NULL, \
+         corroboration_n = NULL, adjudication = NULL WHERE generation = 1",
+    )
+    .expect("the strip itself is allowed by the schema");
+
+    match s.verify_chain() {
+        Err(StoreError::ChainBroken { generation }) => assert_eq!(generation, 1),
+        other => panic!("stripping the axes must break the chain, got {other:?}"),
+    }
+    let _ = std::fs::remove_file(&path);
+}
+
+// ---------------------------------------------------------------------------
+// The schema CHECKs — enforced against raw SQL, not only against the writer
+// ---------------------------------------------------------------------------
+
+/// Blueprint §20: `Predicted` never appears in the evidence store.
+/// `TrustAxes::new` refuses it; so does the schema, so the rule holds against
+/// SQL that never went through the constructor.
+#[test]
+fn predicted_origin_is_refused_by_the_schema_not_only_the_constructor() {
+    let path = tmp("no-predicted");
+    let mut s = WorldStore::open(&path).expect("open");
+    let axes = confirmed_axes();
+    s.append(&ev(&ids("e1", "o1"), Some(&axes)))
+        .expect("append");
+
+    let bad =
+        s.raw_execute_for_test("UPDATE world_events SET origin = 'predicted' WHERE generation = 1");
+    assert!(
+        bad.is_err(),
+        "the schema must refuse a predicted origin even via raw SQL"
+    );
+    let _ = std::fs::remove_file(&path);
+}
+
+/// The three stored axes travel together. A row carrying one and not the others
+/// is a partial trust record a reader cannot tell from an unlabelled one.
+#[test]
+fn a_partial_axis_set_is_unwritable_even_by_raw_sql() {
+    let path = tmp("partial");
+    let mut s = WorldStore::open(&path).expect("open");
+    let axes = confirmed_axes();
+    s.append(&ev(&ids("e1", "o1"), Some(&axes)))
+        .expect("append");
+
+    let bad =
+        s.raw_execute_for_test("UPDATE world_events SET adjudication = NULL WHERE generation = 1");
+    assert!(
+        bad.is_err(),
+        "clearing one axis and leaving the others must be refused"
+    );
+    let _ = std::fs::remove_file(&path);
+}
+
+/// **D-2 restated against the axis**, so it survives `claim_status` being
+/// dropped later. An LLM may never write a confirmed fact.
+#[test]
+fn an_llm_cannot_write_a_confirmed_adjudication() {
+    let path = tmp("d2-axis");
+    let mut s = WorldStore::open(&path).expect("open");
+
+    // Through the writer: refused before the statement is built.
+    let axes = confirmed_axes();
+    let id = ids("e1", "o1");
+    let err = s
+        .append(&NewEvent {
+            writer_class: WriterClass::LlmCandidate,
+            ..ev(&id, Some(&axes))
+        })
+        .expect_err("must refuse");
+    assert!(matches!(err, StoreError::LlmCannotConfirm));
+
+    // And through raw SQL, which is the claim that matters: a candidate row
+    // relabelled to an llm_candidate writer must not be able to keep a
+    // confirmed adjudication.
+    let pending = TrustAxes::new(
+        Origin::Derived,
+        Corroboration::Uncorroborated,
+        Adjudication::Pending,
+    )
+    .unwrap();
+    s.append(&NewEvent {
+        writer_class: WriterClass::LlmCandidate,
+        claim_status: ClaimStatus::Candidate,
+        ..ev(&ids("e2", "o2"), Some(&pending))
+    })
+    .expect("a candidate is fine");
+
+    let bad = s.raw_execute_for_test(
+        "UPDATE world_events SET adjudication = 'confirmed' WHERE generation = 1",
+    );
+    assert!(
+        bad.is_err(),
+        "an llm_candidate row must not be updatable to a confirmed adjudication"
+    );
+    let _ = std::fs::remove_file(&path);
+}
+
+/// `claim_status` is now **derived** from `adjudication`, and the derivation is
+/// a `CHECK` rather than a convention — so the retained proxy cannot drift from
+/// the axis it stands for.
+#[test]
+fn claim_status_cannot_disagree_with_adjudication() {
+    let path = tmp("derivation");
+    let mut s = WorldStore::open(&path).expect("open");
+    let axes = confirmed_axes();
+    s.append(&ev(&ids("e1", "o1"), Some(&axes)))
+        .expect("append");
+
+    let bad = s.raw_execute_for_test(
+        "UPDATE world_events SET claim_status = 'candidate' WHERE generation = 1",
+    );
+    assert!(
+        bad.is_err(),
+        "claim_status must not be movable away from its adjudication"
+    );
+    let _ = std::fs::remove_file(&path);
+}
+
+/// The two states the v1 proxy could not express at all. Rule 3 requires
+/// `Ambiguous` to be a stable, reportable state — *"I have conflicting
+/// information about that"* — and `Rejected` is terminal under rule 7. Both are
+/// storable now, and both map to the `candidate` side of the retained proxy.
+#[test]
+fn rejected_and_ambiguous_are_storable_states_the_proxy_could_not_express() {
+    let path = tmp("four-states");
+    let mut s = WorldStore::open(&path).expect("open");
+
+    for (n, adj) in [(1, Adjudication::Rejected), (2, Adjudication::Ambiguous)] {
+        let axes = TrustAxes::new(Origin::Observed, Corroboration::Contradicted(2), adj)
+            .expect("constructible");
+        s.append(&NewEvent {
+            claim_status: ClaimStatus::Candidate,
+            ..ev(&ids(&format!("e{n}"), &format!("o{n}")), Some(&axes))
+        })
+        .expect("both are storable");
+    }
+    s.verify_chain().expect("verifies");
+    let _ = std::fs::remove_file(&path);
+}
+
+/// Rule 3 is a **read-time** derivation, so storage keeps the adjudication as
+/// ruled, not as read.
+///
+/// `Contradicted + Pending` reads as `Ambiguous` through `TrustAxes::adjudication()`.
+/// Storing that derived value would bake in a conclusion that has to be
+/// recomputed whenever the corroboration changes — the same reason validity has
+/// no column at all.
+#[test]
+fn rule_three_is_not_baked_into_storage() {
+    let id = ids("e1", "o1");
+    let axes = TrustAxes::new(
+        Origin::Observed,
+        Corroboration::Contradicted(2),
+        Adjudication::Pending,
+    )
+    .unwrap();
+
+    assert_eq!(
+        axes.adjudication(),
+        Adjudication::Ambiguous,
+        "rule 3 applies on read"
+    );
+    assert_eq!(
+        axes.adjudication_stored(),
+        Adjudication::Pending,
+        "…and not to what is stored"
+    );
+
+    let got = canonical_event_json(&NewEvent {
+        claim_status: ClaimStatus::Candidate,
+        ..ev(&id, Some(&axes))
+    });
+    assert!(
+        got.contains(r#""adjudication":"pending""#),
+        "storage must keep the ruling, not the derivation: {got}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Migration
+// ---------------------------------------------------------------------------
+
+/// A fresh store is born at the current version.
+#[test]
+fn a_new_store_is_stamped_current() {
+    let path = tmp("fresh");
+    let s = WorldStore::open(&path).expect("open");
+    assert_eq!(s.schema_version().expect("version"), SCHEMA_VERSION);
+    let _ = std::fs::remove_file(&path);
+}
+
+/// **Fail closed on a database from the future.**
+///
+/// The store had no version check at all before v2: an older binary would open
+/// a newer database, read the columns it knew and write rows missing the ones
+/// it did not — producing partial trust records in a log whose entire purpose is
+/// being trustworthy later.
+#[test]
+fn a_future_schema_is_refused_rather_than_opened() {
+    let path = tmp("future");
+    {
+        let s = WorldStore::open(&path).expect("open");
+        s.raw_execute_for_test(
+            "UPDATE world_store_meta SET value = '99' WHERE key = 'schema_version'",
+        )
+        .expect("stamp a future version");
+    }
+
+    match WorldStore::open(&path) {
+        Err(StoreError::SchemaFromTheFuture { found, supported }) => {
+            assert_eq!(found, 99);
+            assert_eq!(supported, SCHEMA_VERSION);
+        }
+        Err(other) => panic!("wrong refusal: {other:?}"),
+        Ok(_) => panic!("a future schema must be refused, not opened"),
+    }
+    let _ = std::fs::remove_file(&path);
+}
+
+/// Reopening is idempotent — the migration must not re-run its DDL and fail on
+/// an already-added column.
+#[test]
+fn reopening_a_current_store_is_idempotent() {
+    let path = tmp("idempotent");
+    {
+        let mut s = WorldStore::open(&path).expect("open");
+        s.append(&ev(&ids("e1", "o1"), None)).expect("append");
+    }
+    let s = WorldStore::open(&path).expect("reopen");
+    assert_eq!(s.schema_version().expect("version"), SCHEMA_VERSION);
+    s.verify_chain().expect("still verifies");
+    let _ = std::fs::remove_file(&path);
+}

--- a/crates/kirra-world/src/lib.rs
+++ b/crates/kirra-world/src/lib.rs
@@ -113,6 +113,7 @@
 
 pub mod entity;
 pub mod observation;
+pub mod reference;
 pub mod relationship;
 pub mod retention;
 pub mod trust;
@@ -150,11 +151,28 @@ pub use entity::EntityId;
 
 /// Identity of a single recorded observation.
 ///
-/// PLACEHOLDER. Distinct from [`EntityId`] on purpose: the blueprint's model is
-/// evidence-first, so an observation outlives whatever entity it was later
-/// attributed to, and re-attribution must not rewrite it.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct ObservationId(());
+/// **No longer a placeholder** — the real type is [`reference::ObservationId`],
+/// re-exported rather than redeclared, following the shape [`EntityId`] and
+/// [`TrustAxes`] already use. Redeclaring is what produced the two-types-one-name
+/// collision fixed in #1375; there is now exactly one way to name each of these.
+///
+/// Distinct from [`EntityId`] on purpose: the blueprint's model is evidence-first,
+/// so an observation outlives whatever entity it was later attributed to, and
+/// re-attribution must not rewrite it. It is equally distinct from [`EventId`],
+/// which identifies the *record* — see that type for why collapsing the two costs
+/// the log its re-attribution history.
+pub use reference::ObservationId;
+
+/// Identity of one record in the evidence log.
+///
+/// New in the reference slice, and not one of the original placeholders: the
+/// storage layer had carried this concept as a bare `&str` alongside
+/// `observation_id` since it was written, with nothing but argument order
+/// keeping them apart. See [`reference::EventId`].
+pub use reference::EventId;
+
+/// Why a reference was refused. See [`mod@reference`].
+pub use reference::ReferenceError;
 
 // ---------------------------------------------------------------------------
 // Where a claim came from
@@ -183,20 +201,25 @@ pub struct Provenance(());
 
 /// The coordinate frame a spatial claim is expressed in.
 ///
-/// PLACEHOLDER, and the one to be most careful with. ADR-0042 Decision 2 draws
-/// the line between a *semantic* map and the checker's *authoritative* corridor:
-/// a frame or map reference held here may help an untrusted doer choose a goal,
-/// and must never become the checker's geometry by virtue of existing.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct FrameId(());
+/// **No longer a placeholder** — [`reference::FrameId`], re-exported. Still the
+/// one to be most careful with: ADR-0042 Decision 2 draws the line between a
+/// *semantic* map and the checker's *authoritative* corridor, and a frame or map
+/// reference held here may help an untrusted doer choose a goal but must never
+/// become the checker's geometry by virtue of existing.
+pub use reference::FrameId;
 
 /// Which map a spatial claim is relative to.
 ///
-/// PLACEHOLDER. See [`FrameId`] — same boundary, same prohibition. If Kirra
-/// World and the safety path ever read the same map artifact, that is a
-/// reviewed [[shared_source_artifact]] entry, not an implicit permission.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct MapId(());
+/// **No longer a placeholder** — [`reference::MapId`], re-exported. See
+/// [`FrameId`] — same boundary, same prohibition. If Kirra World and the safety
+/// path ever read the same map artifact, that is a reviewed
+/// `[[shared_source_artifact]]` entry, not an implicit permission.
+///
+/// Being a *separate type* from [`FrameId`] rather than another `Option<&str>` is
+/// what makes the two unswappable; the storage layer held them adjacent, and a
+/// swap there satisfied SD-4's "a spatial claim carries a frame" check while
+/// carrying the wrong one.
+pub use reference::MapId;
 
 // ---------------------------------------------------------------------------
 // Bitemporality (blueprint P7)

--- a/crates/kirra-world/src/reference.rs
+++ b/crates/kirra-world/src/reference.rs
@@ -1,0 +1,399 @@
+//! **Opaque references** — identity and spatial-reference newtypes.
+//!
+//! Five types that name something outside this crate's type system: two
+//! identities ([`EventId`], [`ObservationId`]) and two spatial references
+//! ([`FrameId`], [`MapId`]). They are grouped here rather than split across
+//! §7's observation module and §6's entity module because they share one
+//! shape and one set of rules, and reading those rules once is better than
+//! reading them four times.
+//!
+//! # What these replace
+//!
+//! Four crate-root placeholders — `ObservationId(())`, `FrameId(())`,
+//! `MapId(())` — that were unconstructible by anything importing them. The
+//! storage layer meanwhile carried all four as bare `&str`. See
+//! [`WM_Q1_SEAM_BASELINE.md`](../../../docs/design/WM_Q1_SEAM_BASELINE.md) for
+//! the measurement that found them.
+//!
+//! # The rule these make structural
+//!
+//! Distinct types for values that are all "a short string" is not ceremony
+//! here; it is the only thing standing between two adjacent parameters and a
+//! silent swap. Concretely, the storage layer's append path took
+//!
+//! ```text
+//! event_id: &str,  observation_id: &str,      // adjacent, same type
+//! frame_id: Option<&str>,  map_id: Option<&str>,   // adjacent, same type
+//! ```
+//!
+//! A caller passing those two pairs in the wrong order compiled, wrote, and
+//! hashed. The `event_id`/`observation_id` swap is the more damaging of the
+//! two — re-attribution is defined by those being *different* identities, so
+//! swapping them silently claims an observation is its own event record. The
+//! `frame_id`/`map_id` swap is the more evasive: it also satisfies the SD-4
+//! check that a spatial claim carries a frame, because a frame is *present* —
+//! just the wrong one, in the position ADR-0042 Decision 2 draws its boundary
+//! around. Neither is representable now.
+//!
+//! This is the same defect class as the `EntityId` collision fixed in #1375,
+//! one layer down: there, two types shared a name; here, four values shared a
+//! type.
+//!
+//! ## Asserted, not just described
+//!
+//! The two doctests below are the negative controls for that claim, and they
+//! are written as a **pair on purpose**. A lone `compile_fail` test is weak
+//! evidence: it passes when the code fails to compile for *any* reason, so a
+//! typo in it looks exactly like the property holding. Each pair differs by a
+//! single token — one type name — so the positive half failing would be the
+//! thing that catches a mistake in the negative half.
+//!
+//! An [`EventId`] is usable where an `EventId` is wanted:
+//!
+//! ```
+//! use kirra_world::reference::{EventId, ObservationId};
+//! let event = EventId::new("evt-1").unwrap();
+//! let _: &EventId = &event;
+//! ```
+//!
+//! …and nowhere else. There is no `From`, no `Deref` and no common trait that
+//! would let this through:
+//!
+//! ```compile_fail
+//! use kirra_world::reference::{EventId, ObservationId};
+//! let event = EventId::new("evt-1").unwrap();
+//! let _: &ObservationId = &event;
+//! ```
+//!
+//! The same for the spatial pair — a [`FrameId`] is not a [`MapId`]:
+//!
+//! ```
+//! use kirra_world::reference::{FrameId, MapId};
+//! let frame = FrameId::new("base_link").unwrap();
+//! let _: &FrameId = &frame;
+//! ```
+//!
+//! ```compile_fail
+//! use kirra_world::reference::{FrameId, MapId};
+//! let frame = FrameId::new("base_link").unwrap();
+//! let _: &MapId = &frame;
+//! ```
+//!
+//! Because the storage layer's `NewEvent` declares those exact field types,
+//! rejecting the assignment here is what rejects the swap there.
+//!
+//! # Verbatim, never normalized — and why that is load-bearing
+//!
+//! Every constructor here either **accepts a value unchanged or refuses it**.
+//! None trims, lowercases, or rewrites. That is not a stylistic preference:
+//! the storage layer's chain verifier rebuilds each record from its *stored*
+//! strings and rehashes it, so a constructor that normalized on the way back
+//! in would produce bytes the original write never produced, and every
+//! affected row would report as tampered. A validating constructor may reject;
+//! it may not edit.
+//!
+//! Rejection on the read path is a different and honest outcome: it means a
+//! stored value is not one this type admits, which is a corrupt row rather
+//! than a broken chain — a distinction the storage layer already draws.
+//!
+//! # Why generation is not here
+//!
+//! `WM_SCOPE.md` lists `observation_id` as needing ULID. ULID generation needs
+//! a dependency and a clock; this crate has **zero dependencies** by
+//! ratification criterion, checked in CI. So the split is: this crate owns the
+//! *type* and what makes a value admissible, and whichever layer has a clock
+//! and a random source **mints** one. Nothing is lost — an id that came from
+//! somewhere else (a replayed log, an operator import, another fleet) has to
+//! be admissible anyway, so validation could never have been folded into
+//! generation.
+
+use core::fmt;
+
+/// The longest reference this crate admits, in bytes.
+///
+/// A ULID is 26 characters and a UUID is 36, so this is roomy for a namespaced
+/// or prefixed identifier while still being a bound. It **is** a bound rather
+/// than a formality: ADR-0041 OQ2's retention horizons are derived from a
+/// bytes-per-event figure, and a column with no upper bound makes that figure
+/// — and therefore the horizons computed from it — underivable rather than
+/// merely imprecise.
+pub const MAX_REFERENCE_LEN: usize = 128;
+
+/// Why a reference was refused.
+///
+/// Carries no offending value. These are constructed from data that may have
+/// arrived from outside, and an error type that echoes its input invites that
+/// input into a log line, where a control character is exactly the thing that
+/// makes the log ambiguous.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ReferenceError {
+    /// Empty, or nothing but whitespace.
+    ///
+    /// An empty identity is not a missing one: `Some("")` reads as present at
+    /// every layer that checks for presence — including the SD-4 spatial-frame
+    /// check — while naming nothing. `None` is how absence is said.
+    Empty,
+    /// Longer than [`MAX_REFERENCE_LEN`] bytes.
+    TooLong {
+        /// What was offered, in bytes.
+        len: usize,
+    },
+    /// Contained an ASCII control character.
+    ///
+    /// These values are written into a canonically-hashed JSON form, exported
+    /// in audit trails and printed in operator diagnostics. A newline or a NUL
+    /// inside an identifier makes every line-oriented reader of those outputs
+    /// ambiguous, and the ambiguity appears far from the write that caused it.
+    ControlCharacter,
+}
+
+impl fmt::Display for ReferenceError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty => write!(f, "reference is empty or only whitespace"),
+            Self::TooLong { len } => write!(
+                f,
+                "reference is {len} bytes, over the {MAX_REFERENCE_LEN}-byte limit"
+            ),
+            Self::ControlCharacter => {
+                write!(f, "reference contains an ASCII control character")
+            }
+        }
+    }
+}
+
+/// Shared admissibility. Returns the value **unchanged** on success.
+fn admit(v: String) -> Result<String, ReferenceError> {
+    if v.trim().is_empty() {
+        return Err(ReferenceError::Empty);
+    }
+    if v.len() > MAX_REFERENCE_LEN {
+        return Err(ReferenceError::TooLong { len: v.len() });
+    }
+    if v.chars().any(char::is_control) {
+        return Err(ReferenceError::ControlCharacter);
+    }
+    Ok(v)
+}
+
+/// Declares one opaque reference newtype. The types are deliberately *not*
+/// convertible into one another — that is the whole point — so there is no
+/// shared trait and no `From` between them.
+macro_rules! reference_newtype {
+    ($(#[$meta:meta])* $name:ident, $what:literal) => {
+        $(#[$meta])*
+        #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        pub struct $name(String);
+
+        impl $name {
+            #[doc = concat!("Admit a ", $what, ".")]
+            ///
+            /// The value is stored **verbatim** — see the module docs on why
+            /// normalizing here would corrupt chain verification.
+            ///
+            /// # Errors
+            ///
+            /// [`ReferenceError`] if the value is empty, over
+            /// [`MAX_REFERENCE_LEN`] bytes, or contains a control character.
+            pub fn new(v: impl Into<String>) -> Result<Self, ReferenceError> {
+                admit(v.into()).map(Self)
+            }
+
+            #[doc = concat!("The ", $what, ", exactly as admitted.")]
+            #[must_use]
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+
+            #[doc = concat!("Consume this ", $what, ", returning the inner string.")]
+            #[must_use]
+            pub fn into_inner(self) -> String {
+                self.0
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str(&self.0)
+            }
+        }
+    };
+}
+
+reference_newtype! {
+    /// Identity of one **record** in the evidence log.
+    ///
+    /// Distinct from [`ObservationId`] and not interchangeable with it. An
+    /// observation can be re-attributed — recorded again against a different
+    /// entity, with different confidence, on different authority — and each
+    /// such record is its own event. That is what makes re-attribution
+    /// non-destructive: the observation keeps its identity while a new event
+    /// carries the new claim.
+    ///
+    /// Collapse the two and the log can no longer answer *"how many times has
+    /// this been reconsidered, and by whom"*, which is the question §9's
+    /// provenance model exists to answer.
+    EventId, "record identity"
+}
+
+reference_newtype! {
+    /// Identity of a single recorded **observation**.
+    ///
+    /// The blueprint's model is evidence-first: an observation outlives
+    /// whatever entity it was later attributed to, so this identity must
+    /// survive re-attribution unchanged. See [`EventId`] for the other half of
+    /// that pairing.
+    ///
+    /// This is also the identity SD-3's provenance lists are made of — a claim
+    /// records the observation ids it rests on, which is what lets a claim be
+    /// re-judged when the evidence under it changes.
+    ObservationId, "observation identity"
+}
+
+reference_newtype! {
+    /// The coordinate frame a spatial claim is expressed in.
+    ///
+    /// # The boundary this type sits on
+    ///
+    /// ADR-0042 Decision 2 separates a *semantic* map from the checker's
+    /// *authoritative* corridor. A frame named here may help an untrusted doer
+    /// choose a goal; it must never become the checker's geometry by virtue of
+    /// existing. Nothing in the safety closure reads this type, and the
+    /// bidirectional fence plus gate test t24 are what keep that true — this
+    /// doc is the reason, not the enforcement.
+    ///
+    /// SD-4 requires a spatial claim to carry one. That requirement is a schema
+    /// `CHECK` in the storage layer, not a property of this type: whether a
+    /// given claim is spatial is not knowable from the frame alone.
+    FrameId, "coordinate frame reference"
+}
+
+reference_newtype! {
+    /// Which map a spatial claim is relative to.
+    ///
+    /// See [`FrameId`] — same boundary, same prohibition. If Kirra World and
+    /// the safety path ever read the same map artifact, that is a reviewed
+    /// `[[shared_source_artifact]]` entry, not an implicit permission acquired
+    /// by both sides happening to name the same string.
+    MapId, "map reference"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn admits_an_ordinary_identifier_verbatim() {
+        let id = ObservationId::new("01ARZ3NDEKTSV4RRFFQ69G5FAV").expect("admissible");
+        assert_eq!(id.as_str(), "01ARZ3NDEKTSV4RRFFQ69G5FAV");
+    }
+
+    /// The load-bearing one. A constructor that trimmed would rewrite stored
+    /// bytes on the read path and report untampered rows as broken chains.
+    #[test]
+    fn surrounding_whitespace_is_preserved_not_trimmed() {
+        let id = ObservationId::new(" obs-1 ").expect("admissible");
+        assert_eq!(id.as_str(), " obs-1 ", "constructor must not normalize");
+    }
+
+    #[test]
+    fn case_is_preserved() {
+        assert_eq!(FrameId::new("Base_Link").unwrap().as_str(), "Base_Link");
+    }
+
+    #[test]
+    fn empty_and_whitespace_only_are_refused() {
+        assert_eq!(ObservationId::new(""), Err(ReferenceError::Empty));
+        assert_eq!(ObservationId::new("   "), Err(ReferenceError::Empty));
+        assert_eq!(ObservationId::new("\t\n"), Err(ReferenceError::Empty));
+    }
+
+    #[test]
+    fn control_characters_are_refused() {
+        assert_eq!(
+            ObservationId::new("obs\n1"),
+            Err(ReferenceError::ControlCharacter)
+        );
+        assert_eq!(
+            ObservationId::new("obs\u{0}1"),
+            Err(ReferenceError::ControlCharacter)
+        );
+    }
+
+    #[test]
+    fn the_length_bound_is_inclusive_at_the_limit() {
+        let at = "a".repeat(MAX_REFERENCE_LEN);
+        assert!(
+            ObservationId::new(at).is_ok(),
+            "the limit itself is admissible"
+        );
+
+        let over = "a".repeat(MAX_REFERENCE_LEN + 1);
+        assert_eq!(
+            ObservationId::new(over),
+            Err(ReferenceError::TooLong {
+                len: MAX_REFERENCE_LEN + 1
+            })
+        );
+    }
+
+    /// Length is counted in **bytes**, matching what the storage row costs and
+    /// what the retention horizons are derived from. A char count would let a
+    /// multi-byte identifier exceed the byte bound the limit exists to impose.
+    #[test]
+    fn length_is_bytes_not_characters() {
+        let multibyte = "é".repeat(MAX_REFERENCE_LEN / 2 + 1); // 2 bytes each
+        assert!(multibyte.chars().count() <= MAX_REFERENCE_LEN);
+        assert!(multibyte.len() > MAX_REFERENCE_LEN);
+        assert!(matches!(
+            ObservationId::new(multibyte),
+            Err(ReferenceError::TooLong { .. })
+        ));
+    }
+
+    /// Non-control, non-ASCII content is ordinary and admissible — an operator
+    /// naming a room in their own language is not an error.
+    #[test]
+    fn non_ascii_is_admissible() {
+        assert_eq!(MapId::new("étage-2").unwrap().as_str(), "étage-2");
+    }
+
+    /// Two references with the same text are equal *within* a type. Across
+    /// types they cannot be compared at all, which is the point — the
+    /// compile-fail half is asserted in the storage layer's tests, where the
+    /// swap it prevents was actually possible.
+    #[test]
+    fn equality_is_within_a_type() {
+        assert_eq!(
+            ObservationId::new("x").unwrap(),
+            ObservationId::new("x").unwrap()
+        );
+        assert_ne!(
+            ObservationId::new("x").unwrap(),
+            ObservationId::new("y").unwrap()
+        );
+    }
+
+    #[test]
+    fn display_and_into_inner_round_trip() {
+        let e = EventId::new("evt-1").unwrap();
+        assert_eq!(e.to_string(), "evt-1");
+        assert_eq!(e.into_inner(), "evt-1");
+    }
+
+    #[test]
+    fn errors_describe_themselves_without_echoing_input() {
+        assert_eq!(
+            ReferenceError::Empty.to_string(),
+            "reference is empty or only whitespace"
+        );
+        assert_eq!(
+            ReferenceError::TooLong { len: 200 }.to_string(),
+            "reference is 200 bytes, over the 128-byte limit"
+        );
+        assert_eq!(
+            ReferenceError::ControlCharacter.to_string(),
+            "reference contains an ASCII control character"
+        );
+    }
+}

--- a/docs/design/WM_Q1_SEAM_BASELINE.md
+++ b/docs/design/WM_Q1_SEAM_BASELINE.md
@@ -169,3 +169,85 @@ now is that "near-empty" should be a comparison, not an impression.
 Kirra is designed in alignment with ISO 26262 ASIL-D requirements and IEC 61508
 SIL 3 requirements. Independent third-party assessment has not yet been
 performed.
+
+---
+
+# Measurement 2 — after the retention driver and the reference types
+
+**recorded 2026-08-07** · workspace at `26c4c19b`
+
+## Why this is appended rather than edited in
+
+A baseline you revise is not a baseline. The table above stands as recorded at
+`ea06132d` and is not corrected below — including in the one place it went stale
+almost immediately, noted next.
+
+## The baseline was superseded by the same pull request that took it
+
+Worth stating plainly rather than leaving for someone to notice. `#1375` took the
+baseline in its first commit (`58fa1188`, at `ea06132d`) and then, three commits
+later, added the retention driver and sweeper — which import `kirra_world`
+directly. So the "2 lines / 3 types" figure was accurate when measured and
+outdated before that PR merged.
+
+That is not a flaw in the measurement; it is the trigger's own logic working.
+The ruling said the seam would fill as the core gained real types and the store
+consumed them, and it began filling within the hour. But it does mean the
+baseline's *number* has a much shorter shelf life than its *method*, and the
+method is what should be reused.
+
+## What the seam carries now
+
+Same counting unit: **one `use`/`pub use` item naming a `kirra_world` path**, in
+the `src/` tree of a crate that depends on `kirra-world`. Same independence unit:
+the consuming crate. Held fixed: default features, no `cfg` gating except where
+counted separately below.
+
+| Consumer | Lines (non-test) | Lines (test-only `mod tests`) |
+|---|---|---|
+| `kirra-world-store` | 7 | 2 |
+| `kirra-world-service` | 1 | 0 |
+| **Total** | **8** | **2** |
+
+Test-only lines are reported separately because they answer a different
+question. A seam carrying only test traffic would still be near-empty in the
+sense the ruling cares about; these eight are production paths.
+
+## The qualitative claim has inverted, and that is the load-bearing part
+
+The baseline's finding was not really "2 lines". It was this:
+
+> **Neither crate calls a method, constructs a value, or matches on a variant of
+> any core type.** The dependency is declared in both manifests and, in the
+> direction that matters, carries nothing.
+
+**That sentence is now false in every clause.** In `kirra-world-store` alone:
+
+- **Constructs values** — `EventId::new`, `ObservationId::new`, `FrameId::new`
+  and `MapId::new` are called on both the write path and the chain-verification
+  read path.
+- **Calls methods** — `as_str()` on all four, feeding both the SQL parameters and
+  the canonically-hashed JSON. 16 such call sites in `lib.rs`.
+- **Matches on variants** — `retention::decide`'s `RetentionDecision`, plus
+  `Eligibility`, `CompactablePrefix` and `Blocker`, drive `run_retention_pass`.
+- **Is bound by core types in its own public API** — `NewEvent`'s four reference
+  fields are core types, so a caller of the store cannot build an event without
+  going through them.
+
+That last point is the one that matters most for a future collapse decision. A
+seam carrying only re-exports can be dissolved by moving two lines. A seam whose
+consumer's public struct is *made of* the core's types is load-bearing in the
+ordinary sense.
+
+## What this does NOT authorize
+
+The trigger has still **not fired.** It is keyed to *completion of `WM_SCOPE.md`
+Tier 1*, and Tier 1 is not complete: the entity taxonomy's store-dependent half
+(`entity_id` minting, `first_observed`/`last_observed`, `provenance_head`) and
+the observation model's payload half (`TypedPayload`'s body, `ObservationKind`)
+are open. This is a second data point on a trend, not a verdict.
+
+If anything, the direction of the trend argues for taking one further
+measurement *at* completion rather than treating this one as sufficient — the
+ruling asked for a measurement at a defined moment, and answering early with a
+more convenient number is the failure mode it was written against.

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -430,14 +430,37 @@ not permission.
       unsound rather than merely unwise, so there is deliberately no escape hatch;
       and **rule 4's geometry half / P10** — `Payload` + `PayloadSource`, added
       2026-08-06, which is what closed the transition rules at 7/7 above.
-      **Still open, and it needs dependencies:** `observation_id` (ULID),
-      `evidence_digest`/`prev_hash` (hashing), `frame`/`map`, and the per-kind
-      versioned `TypedPayload` **body** — `Payload` carries that body's
-      provenance, but the body itself stays a type parameter. Those belong to the
-      **store**, which already has all three — pulling them into the core would
-      spend ADR-0040's Q1 seam decision without revisiting it. `ObservationKind`
-      is also absent because the blueprint names the field but never enumerates
-      its variants.
+      **Identity and spatial reference DONE 2026-08-07** (Strand A),
+      `crates/kirra-world/src/reference.rs`, 11 tests + 4 doctests, still
+      zero-dependency. `ObservationId`, `FrameId` and `MapId` stop being
+      crate-root placeholders and become validated newtypes; `EventId` joins them.
+      The store's `NewEvent` is rebuilt out of all four, so the seam now carries
+      constructed values and called methods rather than re-exports (re-measured in
+      `WM_Q1_SEAM_BASELINE.md` "Measurement 2").
+      **The rule made structural:** the storage layer held `event_id`/
+      `observation_id` and `frame_id`/`map_id` as two adjacent pairs of the same
+      type, so **either pair could be passed in the wrong order and still compile,
+      write and hash** — and the frame/map swap additionally *satisfied* SD-4's
+      presence check while carrying the wrong reference. Four distinct types make
+      both unrepresentable; paired `compile_fail` doctests are the negative
+      control.
+      **A second rule, from the read path:** constructors **validate but never
+      normalize**. `verify_chain` rebuilds each record from its stored strings and
+      rehashes, so a constructor that trimmed would produce bytes the write never
+      produced and report untampered rows as broken chains. A stored value the core
+      refuses is a `CorruptRow`, never a `ChainBroken`.
+      **Minting stays out of the core** — ULID needs a dependency and this crate
+      has none by ratification criterion, so the core owns the *type* and the layer
+      with a clock mints the *value*. No loss: an id arriving from a replayed log
+      or another fleet must be admissible regardless.
+      **Still open:** `evidence_digest`/`prev_hash` as core types (the store
+      computes both today as bare hex strings), and the per-kind versioned
+      `TypedPayload` **body** — `Payload` carries that body's provenance, but the
+      body itself stays a type parameter. `ObservationKind` is absent for a
+      different reason and is **not** an implementation gap: the blueprint names
+      the field and never enumerates its variants, so writing that list is a
+      specification extension, not a derivation. `kind` stays `&str` until it
+      exists.
 - [x] **Relationship model** (§8) — **DONE 2026-08-06**,
       `crates/kirra-world/src/relationship.rs`, 20 tests, still zero-dependency.
       **All ten §8 record fields**, all 15 predicates across the four groups.

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -331,10 +331,23 @@ is not about the domain model.
 
 ## 4. Tier 1 — The domain core
 
-`kirra-world` is ten unconstructible placeholders. Everything below depends on
-it. The domain-logic gate that once held it is **self-releasing and already
-released** (ADR-0042 Decision 5, recorded 2026-08-05) — so this is sequencing,
-not permission.
+`kirra-world` **was** ten unconstructible placeholders. As of 2026-08-07 it is
+**five real types and five remaining placeholders**, plus five implemented
+modules (`trust`, `entity`, `observation`, `relationship`, `reference`,
+`retention`) carrying 128 tests — still zero-dependency.
+
+Real: `TrustAxes`, `EntityId`, `ObservationId`, `FrameId`, `MapId`, and
+`EventId`, which was not one of the original ten (the storage layer had carried
+that concept as a bare `&str` since it was written). Still placeholders:
+`Source`, `Provenance`, `ValidTime`, `TransactionTime`, `ResolutionOutcome` —
+the first two waiting on the provenance model Tier 4 needs, the two temporal
+ones largely superseded in practice by `observation::ValidInterval` and the
+store's `txn_time_ms` and due a decision on whether they survive at all, and
+`ResolutionOutcome` belonging to Tier 3's query boundary.
+
+Everything below depends on this crate. The domain-logic gate that once held it
+is **self-releasing and already released** (ADR-0042 Decision 5, recorded
+2026-08-05) — so this is sequencing, not permission.
 
 - [x] **Retention driver** — **exit criterion, added 2026-08-06 by the ADR-0040
       deployment-ownership decision.** D-20/D-21 measured **15.79 days** to fill

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -332,9 +332,12 @@ is not about the domain model.
 ## 4. Tier 1 — The domain core
 
 `kirra-world` **was** ten unconstructible placeholders. As of 2026-08-07 it is
-**five real types and five remaining placeholders**, plus five implemented
+**six real types and five remaining placeholders**, across six implemented
 modules (`trust`, `entity`, `observation`, `relationship`, `reference`,
 `retention`) carrying 128 tests — still zero-dependency.
+
+Six real against five remaining does not sum to ten, and should not: `EventId`
+is an addition, not one of the original ten.
 
 Real: `TrustAxes`, `EntityId`, `ObservationId`, `FrameId`, `MapId`, and
 `EventId`, which was not one of the original ten (the storage layer had carried

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -541,11 +541,52 @@ is **self-releasing and already released** (ADR-0042 Decision 5, recorded
 
 ### Why the axes are not one enum
 
-Today the store carries `writer_class` plus a two-value `claim_status`, which is
+The store **carried** `writer_class` plus a two-value `claim_status`, which was
 an **adjudication proxy** and nothing more. The blueprint is explicit that
 collapsing the axes is *"exactly why trust states in most systems become mush
 after eighteen months — every new case forces either a wrong assignment or a new
 variant."*
+
+**Resolved 2026-08-07 (Strand C), schema v2.** The three stored axes now have
+columns — `origin`, `corroboration` + `corroboration_n`, `adjudication` — added
+additively, so `KIRRA-WM2-SCHEMA-001`'s ratified v1 grows rather than being
+replaced and every existing row stays readable.
+
+**The finding that shaped the ruling: `writer_class` is not the origin axis in
+disguise.** It looks like one, and neither derives the other. `writer_class`
+records *who held the pen* — it is what **D-2** keys on, and `llm_candidate` is
+not an origin at all, because an LLM can propose a claim of any provenance and
+the rule constraining it is about the writer's authority. `origin` records
+*where the claim came from*, carries `imported` which no writer class expresses,
+and cannot say "an LLM wrote this". Replacing `writer_class` would have deleted
+D-2's enforcement basis, so it is kept **permanently**, not transitionally.
+
+`claim_status` is retained for read compatibility and is now **derived**: a
+`CHECK` makes `claim_status = 'confirmed'` hold exactly when
+`adjudication = 'confirmed'`, so the proxy cannot drift from the axis it stands
+for. D-2 is additionally restated against `adjudication`, so the rule survives
+`claim_status` being dropped later.
+
+Two states the proxy could never express are now storable: **`Rejected`**
+(terminal under rule 7) and **`Ambiguous`**, which rule 3 requires to be a
+stable, reportable state — *"I have conflicting information about that."*
+
+**The axes are inside the hashed bytes**, appended to the canonical form only
+when present. An unlabelled row therefore hashes byte-identically to v1 — the
+compatibility property, pinned by tests written against the pre-v2 code — while
+stripping the axes from a labelled row breaks the chain rather than quietly
+reverting it to a valid unlabelled one. Same argument as SD-2: a trust label
+that is not hashed can be relabelled in place.
+
+**Rule 3 is not baked into storage.** `adjudication_stored()` is persisted, not
+`adjudication()` — `Contradicted + Pending` reads as `Ambiguous` at read time,
+and storing that derivation would fix a conclusion that must be recomputed when
+the corroboration changes. Same reason validity has no column at all.
+
+The migration also closed a gap it did not create: the store had **no schema
+version check on an existing database**. A future-stamped store is now refused
+(`SchemaFromTheFuture`) rather than opened by a binary that would write rows
+missing columns it never heard of.
 
 Two of the seven rules are load-bearing and genuinely hard:
 

--- a/tools/wm2-schema-growth/src/fill.rs
+++ b/tools/wm2-schema-growth/src/fill.rs
@@ -10,6 +10,13 @@
 //! not a single number — it is a function of how much of that new width real
 //! traffic actually carries, and nothing measured so far constrains that.
 //!
+//! **Schema v2 adds four more** — `origin`, `corroboration`,
+//! `corroboration_n`, `adjudication` — and they are all nullable, so they
+//! belong in the band rather than beside it. Measuring v2 with the axes always
+//! absent would report the v1 cost under a v2 label, which is precisely the
+//! "figure that looks measured while resting on an unstated guess" this module
+//! was written to avoid.
+//!
 //! Picking one filling and reporting one number would be the failure mode
 //! this project keeps catching: a figure that looks measured while resting on
 //! an unstated guess. So the instrument measures a BAND, with both ends named
@@ -43,6 +50,16 @@
 //! them to the sensor path matches the stream the harness generates.
 //! `observation_id` is present in both fills because it is NOT NULL — the
 //! schema gives no lean option there.
+//!
+//! The v2 axis *vocabularies* are not varied either, for the same reason: the
+//! three token columns are closed vocabularies a few bytes wide. What is varied
+//! is whether the axes are **present at all**, which is the choice that moves
+//! the number — and it is a real choice on both ends. `Lean` leaves them NULL,
+//! which is every row written before v2 and every row a producer writes without
+//! trust labelling; `Populated` carries a full axis set with a corroboration
+//! count, which is what a cross-checked claim records.
+
+use kirra_world_store::{Adjudication, Corroboration, Origin, TrustAxes};
 
 /// Which end of the band to measure.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -66,21 +83,27 @@ impl Fill {
     pub fn describe(self) -> &'static str {
         match self {
             Self::Lean => {
-                "added columns at lightest legal values: provenance [], frame_id NULL, map_id NULL"
+                "added columns at lightest legal values: provenance [], frame_id NULL, \
+                 map_id NULL, trust axes NULL"
             }
             Self::Populated => {
-                "added columns realistic: provenance cites 1 observation, frame_id and map_id set"
+                "added columns realistic: provenance cites 1 observation, frame_id and \
+                 map_id set, trust axes present (observed/corroborated(2)/confirmed)"
             }
         }
     }
 }
 
-/// The per-event values for the six added columns.
+/// The per-event values for the added columns — six from the ratified v1
+/// schema, four more from the v2 trust axes.
 pub struct Added {
     pub observation_id: String,
     pub provenance: Vec<String>,
     pub frame_id: Option<String>,
     pub map_id: Option<String>,
+    /// The v2 axes, or `None` for an unlabelled row. All-or-nothing: the schema
+    /// refuses a partial set, so the band cannot measure one either.
+    pub trust: Option<TrustAxes>,
 }
 
 /// Derive the added columns for one event.
@@ -101,6 +124,7 @@ pub fn added(fill: Fill, generation: u64, seed: u64) -> Added {
             provenance: Vec::new(),
             frame_id: None,
             map_id: None,
+            trust: None,
         },
         Fill::Populated => Added {
             // One upstream citation. Not a long chain: SD-3 permits many, but
@@ -114,6 +138,18 @@ pub fn added(fill: Fill, generation: u64, seed: u64) -> Added {
             frame_id: Some(format!("map:zone-{:03}", generation % 64)),
             map_id: Some(format!("map-{:04}", generation % 16)),
             observation_id,
+            // A corroborated, confirmed observation — the widest of the axis
+            // shapes, because `Corroborated(n)` is the one that carries a
+            // count. `Uncorroborated` would store a NULL there and understate
+            // the populated end.
+            trust: Some(
+                TrustAxes::new(
+                    Origin::Observed,
+                    Corroboration::Corroborated(2),
+                    Adjudication::Confirmed,
+                )
+                .expect("observed/corroborated/confirmed is constructible"),
+            ),
         },
     }
 }
@@ -128,8 +164,10 @@ mod tests {
         let p = added(Fill::Populated, 500, 1);
         assert!(l.provenance.is_empty());
         assert!(l.frame_id.is_none() && l.map_id.is_none());
+        assert!(l.trust.is_none(), "lean leaves the v2 axes NULL");
         assert_eq!(p.provenance.len(), 1);
         assert!(p.frame_id.is_some() && p.map_id.is_some());
+        assert!(p.trust.is_some(), "populated carries a full axis set");
     }
 
     #[test]

--- a/tools/wm2-schema-growth/src/main.rs
+++ b/tools/wm2-schema-growth/src/main.rs
@@ -208,11 +208,13 @@ fn growth(
         // generated id that the store would refuse must fail the RUN rather
         // than be silently reshaped — a measurement taken over rows the real
         // writer would not accept is not a measurement of the real schema.
-        let event_id = EventId::new(e.event_id.clone()).map_err(|err| {
-            format!("generated event_id at generation {}: {err}", e.generation)
-        })?;
+        let event_id = EventId::new(e.event_id.clone())
+            .map_err(|err| format!("generated event_id at generation {}: {err}", e.generation))?;
         let observation_id = ObservationId::new(a.observation_id.clone()).map_err(|err| {
-            format!("generated observation_id at generation {}: {err}", e.generation)
+            format!(
+                "generated observation_id at generation {}: {err}",
+                e.generation
+            )
         })?;
         let frame_id = a
             .frame_id

--- a/tools/wm2-schema-growth/src/main.rs
+++ b/tools/wm2-schema-growth/src/main.rs
@@ -89,7 +89,9 @@ use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 use fill::Fill;
-use kirra_world_store::{ClaimStatus, NewEvent, WorldStore, WriterClass};
+use kirra_world_store::{
+    ClaimStatus, EventId, FrameId, MapId, NewEvent, ObservationId, WorldStore, WriterClass,
+};
 
 // ---------------------------------------------------------------------------
 // db_bytes — deliberately identical to the harness's definition
@@ -202,10 +204,32 @@ fn growth(
     for e in &stream {
         let a = fill::added(fill, e.generation, seed);
         let prov: Vec<&str> = a.provenance.iter().map(String::as_str).collect();
+        // The store's identity and spatial-reference types are validated, so a
+        // generated id that the store would refuse must fail the RUN rather
+        // than be silently reshaped — a measurement taken over rows the real
+        // writer would not accept is not a measurement of the real schema.
+        let event_id = EventId::new(e.event_id.clone()).map_err(|err| {
+            format!("generated event_id at generation {}: {err}", e.generation)
+        })?;
+        let observation_id = ObservationId::new(a.observation_id.clone()).map_err(|err| {
+            format!("generated observation_id at generation {}: {err}", e.generation)
+        })?;
+        let frame_id = a
+            .frame_id
+            .as_deref()
+            .map(FrameId::new)
+            .transpose()
+            .map_err(|err| format!("generated frame_id at generation {}: {err}", e.generation))?;
+        let map_id = a
+            .map_id
+            .as_deref()
+            .map(MapId::new)
+            .transpose()
+            .map_err(|err| format!("generated map_id at generation {}: {err}", e.generation))?;
         store
             .append(&NewEvent {
-                event_id: &e.event_id,
-                observation_id: &a.observation_id,
+                event_id: &event_id,
+                observation_id: &observation_id,
                 txn_time_ms: e.txn_time_ms,
                 valid_from_ms: e.valid_from_ms,
                 valid_to_ms: None,
@@ -216,8 +240,8 @@ fn growth(
                 writer_class: WriterClass::Sensor,
                 claim_status: ClaimStatus::Confirmed,
                 provenance: &prov,
-                frame_id: a.frame_id.as_deref(),
-                map_id: a.map_id.as_deref(),
+                frame_id: frame_id.as_ref(),
+                map_id: map_id.as_ref(),
                 kind: e.kind,
                 subject: &e.subject,
                 predicate: e.predicate.as_deref(),
@@ -225,6 +249,7 @@ fn growth(
                 payload: &e.payload,
                 payload_schema: 1,
                 retention_class: e.retention_class,
+                trust: a.trust.as_ref(),
             })
             .map_err(|err| format!("append at generation {}: {err}", e.generation))?;
     }


### PR DESCRIPTION
Five commits closing the two Tier 1 strands that were blocked on nothing but sequencing and one ruling. The first commit is an instrument, and it is what makes the other four checkable.

## 1. Pin the canonical hashed form, *before* changing what feeds it (`4fb8fa7b`)

`canonical_event_json` is the input to every chain digest the store has ever computed. Field order, separators, null spelling, number formatting — all load-bearing. Move a byte and every existing store fails `verify_chain`, not because a row was edited but because the verifier now asks a different question of it. There is no migration for that (`KIRRA-WM2-SCHEMA-001` §4), and it surfaces as `ChainBroken`, which reads as tampering.

The function's own doc already said field order was fixed *"because a reordering would silently change every digest ever computed"*. That was a comment. Nothing checked it.

**Committed first, deliberately.** A pin written *after* a refactor is derived from whatever the code then produced and agrees with a regression as readily as with correctness. Written before, it is an instrument that can fail. Six properties: the exact bytes, their SHA-256 (so editing the literal to match a regression takes two agreeing edits), `null` spelled rather than omitted for all five optionals, empty provenance as `[]`, stable escaping, and field order and arity checked separately so a failure names which property broke.

Everything below is measured against it.

## 2. Four values that shared a type now have four types (`26c4c19b`)

**Strand A.** The store carried these as bare `&str`:

```rust
event_id: &str,          observation_id: &str,
frame_id: Option<&str>,  map_id: Option<&str>,
```

Two adjacent identities, two adjacent optional references — **either pair could be passed in the wrong order and still compile, write and hash.**

- The **event/observation** swap silently claims an observation is its own event record, which is the distinction re-attribution is *defined by*.
- The **frame/map** swap is quieter: it **satisfies** SD-4's "a spatial claim carries a frame" check, because a frame is present — just the wrong one, in the position ADR-0042 Decision 2 draws its boundary around.

Same defect class as the `EntityId` collision fixed in #1375, one layer down: there two types shared a name, here four values shared a type. Three crate-root placeholders (`ObservationId`, `FrameId`, `MapId` — unconstructible by anything importing them) become validated newtypes in `kirra_world::reference`; `EventId` joins them.

**Validate, never normalize.** Every constructor accepts a value unchanged or refuses it. That is not stylistic: `verify_chain` rebuilds each record from its **stored** strings and rehashes, so a constructor that trimmed would produce bytes the write never produced and report untampered rows as broken chains. Asserted from both sides — a preservation test in the core, and a stored row with surrounding whitespace that still verifies.

**Read-path re-admission.** A stored value the core no longer admits is a `CorruptRow`, not a `ChainBroken` — the distinction the store already draws between "unreadable" and "edited", which sends an investigator to different places. Tested in both directions, including that it can only *add* refusals and never rescue a row the digest comparison would reject.

**Minting stays out of the core.** `WM_SCOPE` lists `observation_id` as needing ULID; `kirra-world` has zero dependencies by ratification criterion, checked in CI. So the core owns the *type* and the layer with a clock mints the *value*. Nothing is lost — an id arriving from a replayed log or another fleet has to be admissible anyway.

**Deliberately not typed:** `kind`, `subject`, `predicate`, `object`, `retention_class`. A typed field is one whose set of admissible values the core defines; these are constrained by the schema's closed vocabularies or the claim's own shape. `kind` especially — the blueprint names `ObservationKind` and never enumerates its variants, so typing it would fix a vocabulary the specification has not.

## 3. Re-measure the Q1 seam (`2cf4f841`)

Appended, not edited — a baseline you revise is not a baseline.

**The baseline was superseded by the same PR that took it.** #1375 measured at `ea06132d` in its first commit and added the retention driver three commits later. The "2 lines / 3 types" figure was accurate when measured and outdated before that PR merged. Not a flaw in the measurement — the trigger's own logic working — but the *number* has a much shorter shelf life than the *method*.

New figure, same counting unit: **8 non-test lines plus 2 test-only**, reported separately because a seam carrying only test traffic would still be near-empty in the sense the ruling cares about.

The number isn't the finding. The baseline's real claim was *"neither crate calls a method, constructs a value, or matches on a variant"* — **now false in every clause**: four constructors on the write and verify paths, 16 `as_str()` sites in `lib.rs` alone, retention's decision enums matched in `run_retention_pass`, and `NewEvent`'s public fields made **of** core types. A seam of re-exports dissolves by moving two lines; a seam whose consumer's public struct is made of the core's types does not.

**The trigger has still not fired** — it is keyed to *completion* of Tier 1. Recorded explicitly, because answering early with a more convenient number is the failure mode the ruling was written against.

## 4. Correct the Tier 1 preamble (`450c2b8e`)

`WM_SCOPE` §4 still opened with *"`kirra-world` is ten unconstructible placeholders"* — written before the trust axes and true through none of the five slices since. Now five real types and five remaining, and it names what each remaining one waits on rather than only reporting progress.

## 5. Strand C — the trust axes get columns, additively (`0a23d3ba`)

`KIRRA-WM2-SCHEMA-001` ratified v1 with a recorded digest, so this was a ruling rather than a refactor. **Ruled 2026-08-07: additive, `writer_class` kept permanently.**

### The finding that shaped the ruling

**`writer_class` is not the origin axis in disguise.** It looks like one. Neither derives the other:

| | Records | Carries |
|---|---|---|
| `writer_class` | who held the **pen** — what **D-2** keys on | `llm_candidate`, which is not an origin at all |
| `origin` | where the claim **came from** | `imported`, which no writer class expresses |

An LLM can propose a claim of any provenance; the rule constraining it is about the *writer's authority*, not the claim's origin. Replacing `writer_class` would have deleted D-2's enforcement basis, so it stays permanently, not transitionally.

`claim_status` is retained for read compatibility and is now **derived** — a `CHECK` makes `claim_status = 'confirmed'` hold exactly when `adjudication = 'confirmed'`, so the proxy cannot drift from the axis it stands for. D-2 is separately restated against `adjudication`, so the rule survives `claim_status` being dropped later.

Two states the proxy could never express are now storable: **`Rejected`** (terminal, rule 7) and **`Ambiguous`**, which rule 3 requires to be a stable reportable state — *"I have conflicting information about that."*

### The compatibility property

The axes append to the canonical form **only when present**, so an unlabelled row hashes byte-identically to v1 and every existing store keeps verifying. Spelling them as `null` for unlabelled rows — uniform with v1's own five optionals — would have changed every row's bytes and reported tampering on rows nobody touched.

**The pins from commit 1, written against the pre-v2 code, pass unchanged.** That is the proof rather than the claim, and it is why writing them first was worth the detour.

They are *inside* the hash rather than beside it for SD-2's reason: an unhashed trust label can be relabelled in place. Stripping them does not revert a row to a valid unlabelled one — its digest was computed over the labelled bytes.

### Two judgement calls

**Rule 3 is not baked into storage.** `adjudication_stored()` is persisted, not `adjudication()`. `Contradicted + Pending` reads as `Ambiguous` at *read* time, and storing that derivation would fix a conclusion that must be recomputed when the corroboration changes. Same reason validity has no column at all — three axes stored, the fourth computed, which is what makes rule 6 unbreakable rather than documented.

**Enforcement is schema, not writer.** Verified empirically *before* designing on it that SQLite's `ALTER TABLE ADD COLUMN` accepts a `CHECK` referencing other columns **and enforces it on both INSERT and UPDATE**. That is what let an additive migration carry the same weight as v1's table-level `CHECK`s instead of degrading to writer-side validation, which §8 explicitly rejects. Without it this would have needed triggers or a table rebuild. `predicted` is refused by the schema too, not only by `TrustAxes::new`, so blueprint §20 holds against raw SQL.

### A gap closed that this did not create

The store had **no schema version check on an existing database**. An older binary would open a newer store, read the columns it knew, and write rows missing the ones it did not — partial trust records in a log whose entire purpose is being trustworthy later. Now refused (`SchemaFromTheFuture`), the same rule `kirra-persistence` already applies. Migration is forward-only: removing a column would mean rewriting rows inside a hash chain, which is not a migration but a forgery.

## Negative controls

| Guard reverted | Result |
|---|---|
| `EventId` used where `ObservationId` is wanted | **compile error** (paired `compile_fail` doctest) |
| `FrameId` used where `MapId` is wanted | **compile error** (paired) |
| constructor normalizes instead of refusing | 2 tests |
| axes emitted unconditionally rather than when present | the 6 byte pins |
| axes placed beside the hash rather than inside it | 1 test |
| `predicted` admitted by the schema | 1 test |
| partial axis set writable | 1 test |
| `claim_status` free to disagree with `adjudication` | 1 test |
| future-schema check removed | 1 test |

The `compile_fail` doctests are written as **pairs** — positive and negative differing by one token — because a lone `compile_fail` passes when the code fails to compile for *any* reason, including a typo in the test itself. Verified non-vacuous by making one compile: rustdoc reports *"compiled successfully, but it's marked `compile_fail`"*.

## Verification

128 tests in `kirra-world` + 4 doctests · 21 lib + 86 integration in `kirra-world-store` · 1 in `kirra-world-service` · clippy 0 warnings under `#[warn(missing_docs)]` · rustfmt clean · MSRV 1.88 verified against the real 1.88 toolchain · `cargo check --workspace --all-targets` clean · all 12 substantive CI gates pass, including `check_website_citations` · both Kirra World fences INTACT · domain-logic gate unblocked · re-export shim ratchet 0.

## What this does not close

Tier 1's remainder is the entity taxonomy's store-dependent half (`entity_id` minting, `first_observed`/`last_observed`, `provenance_head`) and the observation payload half (`TypedPayload`'s body). `ObservationKind` sits outside that queue as a **specification** gap, not an implementation one.

Kirra is designed in alignment with ISO 26262 ASIL-D requirements and IEC 61508 SIL 3 requirements. Independent third-party assessment has not yet been performed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_