### PR TITLE
§6's three open fields, derived rather than stored

### DIFF
--- a/crates/kirra-world-store/src/entity_projection.rs
+++ b/crates/kirra-world-store/src/entity_projection.rs
@@ -96,6 +96,17 @@ CREATE TABLE IF NOT EXISTS subject_summary (
 
 CREATE INDEX IF NOT EXISTS idx_subject_summary_last
     ON subject_summary (last_observed_ms);
+
+-- The SAME checkpoint table `PROJECTIONS_V1` declares, repeated because either
+-- projection may be folded without the other and each must be able to install
+-- what it needs. `IF NOT EXISTS` makes the duplication idempotent rather than a
+-- conflict, and the table is keyed by projection name so the two checkpoints
+-- coexist as separate rows.
+CREATE TABLE IF NOT EXISTS projection_checkpoint (
+    name         TEXT    PRIMARY KEY,
+    generation   INTEGER NOT NULL,
+    state_digest TEXT    NOT NULL
+);
 "#;
 
 /// One event's contribution to a subject's summary.

--- a/crates/kirra-world-store/src/entity_projection.rs
+++ b/crates/kirra-world-store/src/entity_projection.rs
@@ -1,0 +1,367 @@
+//! **Per-subject observation summary** — the fold behind §6's `first_observed`,
+//! `last_observed` and `provenance_head`.
+//!
+//! # Why this is a projection and not a table
+//!
+//! `WM2_EVENT_SCHEMA.md` §7 settles it, under *what this ruling does not
+//! decide*:
+//!
+//! > **Projection schemas.** `entities_projection` / `relationships_projection`
+//! > are rebuildable views and follow from the fold, not from this table.
+//!
+//! So none of this is new DDL inside `KIRRA-WM2-SCHEMA-001`'s ratified surface,
+//! and no schema version bump is involved. The three fields §6 leaves open are
+//! **derived by folding the event log**, which is what keeps them from drifting
+//! away from the evidence — the same argument that leaves validity without a
+//! column.
+//!
+//! # Installed lazily, and that rule is load-bearing
+//!
+//! Like [`crate::projection::PROJECTIONS_V1`], this DDL is installed by the
+//! first fold rather than at `open`. ADR-0041 **D-20**'s `log_only_bytes` is
+//! the on-disk size of a store holding only the event log; creating projection
+//! tables at `open` would add their root pages to *every* store, including one
+//! that never projects, silently moving that figure and invalidating the
+//! comparison against D-2 that the retention horizons rest on.
+//!
+//! # What this is keyed on, and the honest limit of it
+//!
+//! **Keyed on `subject`, not on an entity id** — because the store cannot tell
+//! the difference.
+//!
+//! `kirra_world::observation::SubjectRef` distinguishes four cases:
+//! `Entity(id)` (resolved), `Candidate(id)` (not yet adjudicated), `Frame(id)`,
+//! and `Unbound` (recorded before anything decided what it was about). The
+//! storage layer flattens all four into one `subject TEXT NOT NULL` column and
+//! keeps no discriminant, so a fold here **cannot** restrict itself to resolved
+//! entities. Every distinct subject string gets a row.
+//!
+//! This is the same shape as the `writer_class`-versus-`origin` finding: the
+//! core carries a type, the store carries a proxy, and the proxy cannot answer
+//! the question the type was built for. It is recorded rather than papered
+//! over, and the module is named for what it actually computes.
+//!
+//! Fixing it means carrying `SubjectRef`'s discriminant in storage, which
+//! touches `subject` — a field inside the canonically-hashed bytes — so it
+//! needs the same append-only-when-present treatment the trust axes got, and it
+//! is a slice of its own. Entity *resolution* (deciding that two subjects are
+//! one thing) is Tier 2 regardless.
+//!
+//! # Minting is not here either
+//!
+//! `WM_SCOPE.md` lists `entity_id` generation alongside these three fields, but
+//! it does not belong with them. Minting an id is deciding that something is a
+//! distinct thing, which is adjudication — Tier 2 — whereas these three are
+//! arithmetic over evidence that already exists.
+//!
+//! # ADR-0042 condition (1)
+//!
+//! Nothing here may become a required safety input: no `CorridorSource`, no
+//! actuator path, no release token. Gate test t24 checks this file by contents.
+
+use std::collections::BTreeMap;
+
+/// The projection this module maintains.
+///
+/// Named for what it computes. Calling it `entities_projection` would claim the
+/// rows are entities, and until the store carries `SubjectRef` they are
+/// subjects — which includes candidates and frames.
+pub const ENTITY_SUMMARY_PROJECTION: &str = "subject_summary";
+
+/// The projection schema, installed lazily by the first fold.
+///
+/// Separate DDL from `SCHEMA_V1` on purpose — see the module docs.
+pub const ENTITY_PROJECTION_V1: &str = r#"
+CREATE TABLE IF NOT EXISTS subject_summary (
+    subject            TEXT    PRIMARY KEY,
+
+    -- §6's three open fields, all folded rather than written.
+    first_observed_ms  INTEGER NOT NULL,
+    last_observed_ms   INTEGER NOT NULL,
+    provenance_head    TEXT    NOT NULL,
+
+    -- How many events contributed. Not one of §6's fields, but the fold has it
+    -- for free and a summary that cannot distinguish "seen once" from "seen a
+    -- thousand times" answers almost nothing about a subject.
+    observation_count  INTEGER NOT NULL,
+
+    -- Where provenance_head points, so a reader can locate it in the log
+    -- without scanning for a matching digest.
+    last_generation    INTEGER NOT NULL,
+    last_event_id      TEXT    NOT NULL,
+
+    CHECK (first_observed_ms <= last_observed_ms),
+    CHECK (observation_count >= 1)
+);
+
+CREATE INDEX IF NOT EXISTS idx_subject_summary_last
+    ON subject_summary (last_observed_ms);
+"#;
+
+/// One event's contribution to a subject's summary.
+///
+/// Deliberately narrow: the fold needs identity, a time, and a chain position,
+/// and nothing else. Passing the whole row would let a future edit make the
+/// summary depend on the payload, which is where a projection stops being
+/// summarisable and starts being a second copy of the log.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SubjectObservation {
+    /// The event's subject, verbatim.
+    pub subject: String,
+    /// When the store learned it.
+    ///
+    /// **Transaction time, not valid time.** `first_observed` and
+    /// `last_observed` are statements about *this store's* encounters with a
+    /// subject, so they age on when it learned things — the same choice, for
+    /// the same reason, as the retention driver. Valid time would let a
+    /// backdated import move a subject's `first_observed` into the past, when
+    /// nothing was observed then.
+    pub txn_time_ms: i64,
+    /// The event's generation.
+    pub generation: i64,
+    /// The event's identity.
+    pub event_id: String,
+    /// The event's chain digest — what `provenance_head` points at.
+    pub chain_digest: String,
+}
+
+/// A subject's folded summary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectedSubject {
+    /// The subject this summarises.
+    pub subject: String,
+    /// Transaction time of the earliest contributing event.
+    pub first_observed_ms: i64,
+    /// Transaction time of the latest contributing event.
+    pub last_observed_ms: i64,
+    /// Chain digest of the latest contributing event — §6's `provenance_head`.
+    ///
+    /// A hash-chain head rather than a count or a timestamp, so a subject's
+    /// summary can be *cited*: it names a position in the tamper-evident log
+    /// that a reader can verify independently.
+    pub provenance_head: String,
+    /// How many events contributed.
+    pub observation_count: i64,
+    /// Generation of the latest contributing event.
+    pub last_generation: i64,
+    /// Identity of the latest contributing event.
+    pub last_event_id: String,
+}
+
+/// Fold one observation into the accumulator. Returns whether it changed.
+///
+/// # Ordering is not assumed
+///
+/// The log is walked in generation order, so `last` is almost always the
+/// incoming row — but the fold does not rely on that. It compares
+/// `last_generation` explicitly and takes the max, because a fold whose
+/// correctness depends on its input order is one reordering away from being
+/// silently wrong, and generation order is a property of the *caller*, not of
+/// this function.
+///
+/// `first_observed_ms` takes the min for the same reason, and the two are
+/// tracked independently: transaction time is monotonic per store today, but
+/// deriving one bound from the other would bake that assumption into the data.
+pub fn entity_fold_step(
+    acc: &mut BTreeMap<String, ProjectedSubject>,
+    incoming: &SubjectObservation,
+) -> bool {
+    match acc.get_mut(&incoming.subject) {
+        None => {
+            acc.insert(
+                incoming.subject.clone(),
+                ProjectedSubject {
+                    subject: incoming.subject.clone(),
+                    first_observed_ms: incoming.txn_time_ms,
+                    last_observed_ms: incoming.txn_time_ms,
+                    provenance_head: incoming.chain_digest.clone(),
+                    observation_count: 1,
+                    last_generation: incoming.generation,
+                    last_event_id: incoming.event_id.clone(),
+                },
+            );
+            true
+        }
+        Some(held) => {
+            held.observation_count += 1;
+
+            // The TIME BOUNDS are a min and a max over every contributing
+            // event, independently of which one is the head. Keeping these two
+            // updates separate is what makes the fold order-independent: an
+            // earlier version tied `last_observed_ms` to the head, so a later
+            // generation carrying an earlier timestamp REGRESSED the maximum
+            // and the summary depended on arrival order. Caught by
+            // `the_fold_is_order_independent`, which is why that test is worth
+            // more than the two it looks like it duplicates.
+            held.first_observed_ms = held.first_observed_ms.min(incoming.txn_time_ms);
+            held.last_observed_ms = held.last_observed_ms.max(incoming.txn_time_ms);
+
+            // The HEAD follows generation, not time. Generation is the chain's
+            // own order and is unique; transaction time can tie, and a head
+            // chosen by a tie-break on time would not be reproducible.
+            if incoming.generation > held.last_generation {
+                held.last_generation = incoming.generation;
+                held.provenance_head = incoming.chain_digest.clone();
+                held.last_event_id = incoming.event_id.clone();
+            }
+            true
+        }
+    }
+}
+
+/// Fold a whole sequence.
+///
+/// `BTreeMap` rather than `HashMap` so iteration order is deterministic — the
+/// state digest is taken over this order, and a digest that depended on hash
+/// seeding would compare unequal to itself.
+#[must_use]
+pub fn entity_fold_all<'a, I: IntoIterator<Item = &'a SubjectObservation>>(
+    observations: I,
+) -> BTreeMap<String, ProjectedSubject> {
+    let mut acc = BTreeMap::new();
+    for o in observations {
+        entity_fold_step(&mut acc, o);
+    }
+    acc
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn obs(subject: &str, txn: i64, generation: i64) -> SubjectObservation {
+        SubjectObservation {
+            subject: subject.to_string(),
+            txn_time_ms: txn,
+            generation,
+            event_id: format!("evt-{generation}"),
+            chain_digest: format!("digest-{generation}"),
+        }
+    }
+
+    #[test]
+    fn a_single_observation_bounds_itself() {
+        let got = entity_fold_all(&[obs("cup-1", 100, 1)]);
+        let s = &got["cup-1"];
+        assert_eq!(s.first_observed_ms, 100);
+        assert_eq!(s.last_observed_ms, 100);
+        assert_eq!(s.observation_count, 1);
+        assert_eq!(s.provenance_head, "digest-1");
+    }
+
+    #[test]
+    fn repeated_observations_widen_the_bounds_and_advance_the_head() {
+        let got = entity_fold_all(&[obs("cup-1", 100, 1), obs("cup-1", 300, 2)]);
+        let s = &got["cup-1"];
+        assert_eq!(s.first_observed_ms, 100);
+        assert_eq!(s.last_observed_ms, 300);
+        assert_eq!(s.observation_count, 2);
+        assert_eq!(s.provenance_head, "digest-2");
+        assert_eq!(s.last_generation, 2);
+    }
+
+    #[test]
+    fn subjects_are_summarised_independently() {
+        let got = entity_fold_all(&[obs("cup-1", 100, 1), obs("cup-2", 200, 2)]);
+        assert_eq!(got.len(), 2);
+        assert_eq!(got["cup-1"].observation_count, 1);
+        assert_eq!(got["cup-2"].first_observed_ms, 200);
+    }
+
+    /// The fold must not depend on its input order. Generation order is the
+    /// caller's property, not this function's.
+    #[test]
+    fn the_fold_is_order_independent() {
+        let a = [
+            obs("cup-1", 100, 1),
+            obs("cup-1", 300, 2),
+            obs("cup-1", 200, 3),
+        ];
+        let forward = entity_fold_all(&a);
+
+        let mut reversed: Vec<&SubjectObservation> = a.iter().collect();
+        reversed.reverse();
+        let backward = entity_fold_all(reversed);
+
+        assert_eq!(forward, backward, "reordering must not change the summary");
+    }
+
+    /// The head follows the chain's own order, not the clock. Generation is
+    /// unique; transaction time can tie, and a head chosen by a tie-break on
+    /// time would not be reproducible.
+    #[test]
+    fn the_head_follows_generation_not_time() {
+        // Generation 3 carries an EARLIER timestamp than generation 2.
+        let got = entity_fold_all(&[
+            obs("cup-1", 100, 1),
+            obs("cup-1", 500, 2),
+            obs("cup-1", 200, 3),
+        ]);
+        let s = &got["cup-1"];
+        assert_eq!(
+            s.provenance_head, "digest-3",
+            "the head is the newest chain position"
+        );
+        assert_eq!(s.last_generation, 3);
+        assert_eq!(
+            s.last_observed_ms, 500,
+            "but the observed bound is still the latest time seen"
+        );
+    }
+
+    /// Out-of-order arrival must still widen `first_observed` downward.
+    #[test]
+    fn an_earlier_time_arriving_later_moves_first_observed_back() {
+        let got = entity_fold_all(&[obs("cup-1", 300, 1), obs("cup-1", 100, 2)]);
+        assert_eq!(got["cup-1"].first_observed_ms, 100);
+    }
+
+    /// The bounds are tracked independently rather than one derived from the
+    /// other — a single observation makes them equal, and nothing may collapse
+    /// them into one field on that basis.
+    #[test]
+    fn the_two_bounds_are_independent() {
+        let mut acc = BTreeMap::new();
+        entity_fold_step(&mut acc, &obs("cup-1", 100, 1));
+        assert_eq!(
+            acc["cup-1"].first_observed_ms,
+            acc["cup-1"].last_observed_ms
+        );
+        entity_fold_step(&mut acc, &obs("cup-1", 900, 2));
+        assert_ne!(
+            acc["cup-1"].first_observed_ms,
+            acc["cup-1"].last_observed_ms
+        );
+        assert_eq!(acc["cup-1"].first_observed_ms, 100);
+    }
+
+    /// Folding from zero must equal folding incrementally from a partial
+    /// accumulator — the purity property ADR-0041 calls out as something to
+    /// test rather than hope for.
+    #[test]
+    fn incremental_equals_full_rebuild() {
+        let all = [
+            obs("cup-1", 100, 1),
+            obs("cup-2", 150, 2),
+            obs("cup-1", 300, 3),
+            obs("cup-3", 400, 4),
+            obs("cup-2", 500, 5),
+        ];
+
+        let full = entity_fold_all(&all);
+
+        let mut incremental = entity_fold_all(&all[..2]);
+        for o in &all[2..] {
+            entity_fold_step(&mut incremental, o);
+        }
+
+        assert_eq!(full, incremental);
+    }
+
+    /// An empty log folds to an empty summary rather than erroring — the same
+    /// answer the retention driver gives for a store never written to.
+    #[test]
+    fn an_empty_log_folds_to_nothing() {
+        assert!(entity_fold_all(&[]).is_empty());
+    }
+}

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -83,18 +83,18 @@ use kirra_world::retention::RetentionError;
 use rusqlite::{params, Connection, OptionalExtension};
 
 pub mod compaction;
-pub mod entity_projection;
 pub mod projection;
 pub mod retention_driver;
 pub mod retention_sweeper;
 pub mod schema;
+pub mod subject_projection;
 
 pub use compaction::{Citation, CompactionOutcome, DegradedSummary, Resolution, TemporalAnswer};
-pub use entity_projection::{
-    entity_fold_all, entity_fold_step, ProjectedSubject, SubjectObservation,
-    ENTITY_SUMMARY_PROJECTION,
-};
 pub use projection::{ProjectedClaim, CURRENT_PROJECTION};
+pub use subject_projection::{
+    subject_fold_all, subject_fold_step, ProjectedSubject, SubjectObservation,
+    SUBJECT_SUMMARY_PROJECTION,
+};
 
 // The domain core's types, re-exported so a caller of this crate needs only one
 // import to build an event. These are no longer placeholders and no longer
@@ -2410,10 +2410,10 @@ impl WorldStore {
 
 impl WorldStore {
     /// Install the subject-summary DDL. Lazy, for the D-20 reason in
-    /// [`entity_projection`]'s module docs.
+    /// [`subject_projection`]'s module docs.
     fn ensure_subject_summary(&self) -> Result<(), StoreError> {
         self.conn
-            .execute_batch(entity_projection::ENTITY_PROJECTION_V1)?;
+            .execute_batch(subject_projection::SUBJECT_PROJECTION_V1)?;
         Ok(())
     }
 
@@ -2447,7 +2447,7 @@ impl WorldStore {
             .conn
             .query_row(
                 "SELECT generation FROM projection_checkpoint WHERE name = ?1",
-                params![entity_projection::ENTITY_SUMMARY_PROJECTION],
+                params![subject_projection::SUBJECT_SUMMARY_PROJECTION],
                 |r| r.get(0),
             )
             .optional()?;
@@ -2490,7 +2490,7 @@ impl WorldStore {
         self.conn.execute("DELETE FROM subject_summary", [])?;
         self.conn.execute(
             "DELETE FROM projection_checkpoint WHERE name = ?1",
-            params![entity_projection::ENTITY_SUMMARY_PROJECTION],
+            params![subject_projection::SUBJECT_SUMMARY_PROJECTION],
         )?;
         self.fold_subject_range(0)
     }
@@ -2510,7 +2510,7 @@ impl WorldStore {
             // The upsert IS the fold step, expressed in SQL — the bounds are a
             // min and a max taken independently of which event is the head, and
             // the head advances only on a greater generation. It must stay in
-            // lock-step with `entity_fold_step`; `fold_matches_the_pure_step`
+            // lock-step with `subject_fold_step`; `the_sql_upsert_computes_what_the_pure_fold_computes`
             // walks a real log through both and compares.
             let mut upsert = tx.prepare(
                 "INSERT INTO subject_summary (
@@ -2562,12 +2562,12 @@ impl WorldStore {
             "INSERT INTO projection_checkpoint (name, generation, state_digest)
              VALUES (?1, ?2, '')
              ON CONFLICT (name) DO UPDATE SET generation = excluded.generation",
-            params![entity_projection::ENTITY_SUMMARY_PROJECTION, head],
+            params![subject_projection::SUBJECT_SUMMARY_PROJECTION, head],
         )?;
         let digest = subject_summary_digest_of(&tx)?;
         tx.execute(
             "UPDATE projection_checkpoint SET state_digest = ?1 WHERE name = ?2",
-            params![digest, entity_projection::ENTITY_SUMMARY_PROJECTION],
+            params![digest, subject_projection::SUBJECT_SUMMARY_PROJECTION],
         )?;
         tx.commit()?;
         Ok(head)
@@ -2581,7 +2581,7 @@ impl WorldStore {
     pub fn subject_summary(
         &self,
         subject: &str,
-    ) -> Result<Option<entity_projection::ProjectedSubject>, StoreError> {
+    ) -> Result<Option<subject_projection::ProjectedSubject>, StoreError> {
         if !self.has_subject_summary()? {
             return Ok(None);
         }
@@ -2593,7 +2593,7 @@ impl WorldStore {
                  FROM subject_summary WHERE subject = ?1",
                 params![subject],
                 |r| {
-                    Ok(entity_projection::ProjectedSubject {
+                    Ok(subject_projection::ProjectedSubject {
                         subject: r.get(0)?,
                         first_observed_ms: r.get(1)?,
                         last_observed_ms: r.get(2)?,
@@ -2615,7 +2615,7 @@ impl WorldStore {
     /// [`StoreError::Sqlite`] on any storage failure.
     pub fn subject_summaries(
         &self,
-    ) -> Result<Vec<entity_projection::ProjectedSubject>, StoreError> {
+    ) -> Result<Vec<subject_projection::ProjectedSubject>, StoreError> {
         if !self.has_subject_summary()? {
             return Ok(Vec::new());
         }
@@ -2625,7 +2625,7 @@ impl WorldStore {
              FROM subject_summary ORDER BY subject ASC",
         )?;
         let rows = stmt.query_map([], |r| {
-            Ok(entity_projection::ProjectedSubject {
+            Ok(subject_projection::ProjectedSubject {
                 subject: r.get(0)?,
                 first_observed_ms: r.get(1)?,
                 last_observed_ms: r.get(2)?,

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -83,12 +83,17 @@ use kirra_world::retention::RetentionError;
 use rusqlite::{params, Connection, OptionalExtension};
 
 pub mod compaction;
+pub mod entity_projection;
 pub mod projection;
 pub mod retention_driver;
 pub mod retention_sweeper;
 pub mod schema;
 
 pub use compaction::{Citation, CompactionOutcome, DegradedSummary, Resolution, TemporalAnswer};
+pub use entity_projection::{
+    entity_fold_all, entity_fold_step, ProjectedSubject, SubjectObservation,
+    ENTITY_SUMMARY_PROJECTION,
+};
 pub use projection::{ProjectedClaim, CURRENT_PROJECTION};
 
 // The domain core's types, re-exported so a caller of this crate needs only one

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -2402,3 +2402,279 @@ impl WorldStore {
         Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
     }
 }
+
+// ---------------------------------------------------------------------------
+// The per-subject summary projection (§6's first_observed / last_observed /
+// provenance_head)
+// ---------------------------------------------------------------------------
+
+impl WorldStore {
+    /// Install the subject-summary DDL. Lazy, for the D-20 reason in
+    /// [`entity_projection`]'s module docs.
+    fn ensure_subject_summary(&self) -> Result<(), StoreError> {
+        self.conn
+            .execute_batch(entity_projection::ENTITY_PROJECTION_V1)?;
+        Ok(())
+    }
+
+    /// Whether the subject-summary table has been installed.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::Sqlite`] if the catalogue cannot be read.
+    pub fn has_subject_summary(&self) -> Result<bool, StoreError> {
+        let n: Option<i64> = self
+            .conn
+            .query_row(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='subject_summary'",
+                [],
+                |r| r.get(0),
+            )
+            .optional()?;
+        Ok(n.is_some())
+    }
+
+    /// How far the subject-summary fold has consumed.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::Sqlite`] if the checkpoint cannot be read.
+    pub fn subject_summary_generation(&self) -> Result<i64, StoreError> {
+        if !self.has_subject_summary()? {
+            return Ok(0);
+        }
+        let g: Option<i64> = self
+            .conn
+            .query_row(
+                "SELECT generation FROM projection_checkpoint WHERE name = ?1",
+                params![entity_projection::ENTITY_SUMMARY_PROJECTION],
+                |r| r.get(0),
+            )
+            .optional()?;
+        Ok(g.unwrap_or(0))
+    }
+
+    /// Fold new events into the subject summary. Returns the generation reached.
+    ///
+    /// **Confirmed-only**, following [`crate::projection`]'s precedent rather
+    /// than diverging from it. A candidate is a proposal, not an observation,
+    /// and two projections disagreeing about what counts would be a trap: a
+    /// reader comparing `world_current` against this summary would find
+    /// subjects in one and not the other for reasons neither table states.
+    ///
+    /// A subject known *only* from candidates therefore has no row here, which
+    /// is the honest answer — nothing confirmed has been observed about it —
+    /// and [`WorldStore::candidates`] is how you ask the other question.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::Sqlite`] on any storage failure.
+    pub fn fold_subject_summary(&mut self) -> Result<i64, StoreError> {
+        self.ensure_subject_summary()?;
+        let from = self.subject_summary_generation()?;
+        self.fold_subject_range(from)
+    }
+
+    /// Discard the subject summary and rebuild it from generation 0.
+    ///
+    /// The result must equal an incremental fold. That is ADR-0041's stated
+    /// purity property, and
+    /// [`WorldStore::subject_summary_state_digest`] is how it is checked rather
+    /// than assumed.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::Sqlite`] on any storage failure.
+    pub fn rebuild_subject_summary(&mut self) -> Result<i64, StoreError> {
+        self.ensure_subject_summary()?;
+        self.conn.execute("DELETE FROM subject_summary", [])?;
+        self.conn.execute(
+            "DELETE FROM projection_checkpoint WHERE name = ?1",
+            params![entity_projection::ENTITY_SUMMARY_PROJECTION],
+        )?;
+        self.fold_subject_range(0)
+    }
+
+    fn fold_subject_range(&mut self, from_generation: i64) -> Result<i64, StoreError> {
+        let tx = self.conn.transaction()?;
+        let mut head = from_generation;
+        {
+            let mut stmt = tx.prepare(
+                "SELECT subject, txn_time_ms, generation, event_id, chain_digest
+                 FROM world_events
+                 WHERE generation > ?1 AND claim_status = 'confirmed'
+                 ORDER BY generation ASC",
+            )?;
+            let mut rows = stmt.query(params![from_generation])?;
+
+            // The upsert IS the fold step, expressed in SQL — the bounds are a
+            // min and a max taken independently of which event is the head, and
+            // the head advances only on a greater generation. It must stay in
+            // lock-step with `entity_fold_step`; `fold_matches_the_pure_step`
+            // walks a real log through both and compares.
+            let mut upsert = tx.prepare(
+                "INSERT INTO subject_summary (
+                    subject, first_observed_ms, last_observed_ms, provenance_head,
+                    observation_count, last_generation, last_event_id
+                 ) VALUES (?1,?2,?2,?3,1,?4,?5)
+                 ON CONFLICT (subject) DO UPDATE SET
+                    observation_count = subject_summary.observation_count + 1,
+                    first_observed_ms = MIN(subject_summary.first_observed_ms, excluded.first_observed_ms),
+                    last_observed_ms  = MAX(subject_summary.last_observed_ms,  excluded.last_observed_ms),
+                    provenance_head = CASE
+                        WHEN excluded.last_generation > subject_summary.last_generation
+                        THEN excluded.provenance_head ELSE subject_summary.provenance_head END,
+                    last_event_id = CASE
+                        WHEN excluded.last_generation > subject_summary.last_generation
+                        THEN excluded.last_event_id ELSE subject_summary.last_event_id END,
+                    last_generation = MAX(subject_summary.last_generation, excluded.last_generation)",
+            )?;
+
+            while let Some(r) = rows.next()? {
+                let subject: String = r.get(0)?;
+                let txn_time_ms: i64 = r.get(1)?;
+                let generation: i64 = r.get(2)?;
+                let event_id: String = r.get(3)?;
+                let chain_digest: String = r.get(4)?;
+                head = head.max(generation);
+                upsert.execute(params![
+                    subject,
+                    txn_time_ms,
+                    chain_digest,
+                    generation,
+                    event_id
+                ])?;
+            }
+        }
+
+        // Advance past every event CONSIDERED, not merely every event adopted —
+        // a batch of candidates adopts nothing, and a checkpoint that stayed
+        // put would re-scan them on every fold forever. Same reasoning as
+        // `fold_range`.
+        let considered: i64 = tx.query_row(
+            "SELECT COALESCE(MAX(generation), ?1) FROM world_events",
+            params![from_generation],
+            |r| r.get(0),
+        )?;
+        head = head.max(considered);
+
+        tx.execute(
+            "INSERT INTO projection_checkpoint (name, generation, state_digest)
+             VALUES (?1, ?2, '')
+             ON CONFLICT (name) DO UPDATE SET generation = excluded.generation",
+            params![entity_projection::ENTITY_SUMMARY_PROJECTION, head],
+        )?;
+        let digest = subject_summary_digest_of(&tx)?;
+        tx.execute(
+            "UPDATE projection_checkpoint SET state_digest = ?1 WHERE name = ?2",
+            params![digest, entity_projection::ENTITY_SUMMARY_PROJECTION],
+        )?;
+        tx.commit()?;
+        Ok(head)
+    }
+
+    /// One subject's summary, or `None` if nothing confirmed names it.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::Sqlite`] on any storage failure.
+    pub fn subject_summary(
+        &self,
+        subject: &str,
+    ) -> Result<Option<entity_projection::ProjectedSubject>, StoreError> {
+        if !self.has_subject_summary()? {
+            return Ok(None);
+        }
+        let row = self
+            .conn
+            .query_row(
+                "SELECT subject, first_observed_ms, last_observed_ms, provenance_head,
+                        observation_count, last_generation, last_event_id
+                 FROM subject_summary WHERE subject = ?1",
+                params![subject],
+                |r| {
+                    Ok(entity_projection::ProjectedSubject {
+                        subject: r.get(0)?,
+                        first_observed_ms: r.get(1)?,
+                        last_observed_ms: r.get(2)?,
+                        provenance_head: r.get(3)?,
+                        observation_count: r.get(4)?,
+                        last_generation: r.get(5)?,
+                        last_event_id: r.get(6)?,
+                    })
+                },
+            )
+            .optional()?;
+        Ok(row)
+    }
+
+    /// Every subject summary, ordered by subject.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::Sqlite`] on any storage failure.
+    pub fn subject_summaries(
+        &self,
+    ) -> Result<Vec<entity_projection::ProjectedSubject>, StoreError> {
+        if !self.has_subject_summary()? {
+            return Ok(Vec::new());
+        }
+        let mut stmt = self.conn.prepare(
+            "SELECT subject, first_observed_ms, last_observed_ms, provenance_head,
+                    observation_count, last_generation, last_event_id
+             FROM subject_summary ORDER BY subject ASC",
+        )?;
+        let rows = stmt.query_map([], |r| {
+            Ok(entity_projection::ProjectedSubject {
+                subject: r.get(0)?,
+                first_observed_ms: r.get(1)?,
+                last_observed_ms: r.get(2)?,
+                provenance_head: r.get(3)?,
+                observation_count: r.get(4)?,
+                last_generation: r.get(5)?,
+                last_event_id: r.get(6)?,
+            })
+        })?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r?);
+        }
+        Ok(out)
+    }
+
+    /// A digest over the whole subject summary, for the
+    /// rebuild-equals-incremental assertion.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::Sqlite`] on any storage failure.
+    pub fn subject_summary_state_digest(&self) -> Result<String, StoreError> {
+        subject_summary_digest_of(&self.conn)
+    }
+}
+
+/// Digest of the subject summary, taken in subject order so it is stable.
+fn subject_summary_digest_of(conn: &Connection) -> Result<String, StoreError> {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    let mut stmt = conn.prepare(
+        "SELECT subject, first_observed_ms, last_observed_ms, provenance_head,
+                observation_count, last_generation, last_event_id
+         FROM subject_summary ORDER BY subject ASC",
+    )?;
+    let mut rows = stmt.query([])?;
+    while let Some(r) = rows.next()? {
+        let subject: String = r.get(0)?;
+        let first: i64 = r.get(1)?;
+        let last: i64 = r.get(2)?;
+        let head: String = r.get(3)?;
+        let count: i64 = r.get(4)?;
+        let generation: i64 = r.get(5)?;
+        let event_id: String = r.get(6)?;
+        hasher.update(
+            format!("{subject}\u{1f}{first}\u{1f}{last}\u{1f}{head}\u{1f}{count}\u{1f}{generation}\u{1f}{event_id}\u{1e}")
+                .as_bytes(),
+        );
+    }
+    Ok(hex::encode(hasher.finalize()))
+}

--- a/crates/kirra-world-store/src/subject_projection.rs
+++ b/crates/kirra-world-store/src/subject_projection.rs
@@ -66,12 +66,12 @@ use std::collections::BTreeMap;
 /// Named for what it computes. Calling it `entities_projection` would claim the
 /// rows are entities, and until the store carries `SubjectRef` they are
 /// subjects — which includes candidates and frames.
-pub const ENTITY_SUMMARY_PROJECTION: &str = "subject_summary";
+pub const SUBJECT_SUMMARY_PROJECTION: &str = "subject_summary";
 
 /// The projection schema, installed lazily by the first fold.
 ///
 /// Separate DDL from `SCHEMA_V1` on purpose — see the module docs.
-pub const ENTITY_PROJECTION_V1: &str = r#"
+pub const SUBJECT_PROJECTION_V1: &str = r#"
 CREATE TABLE IF NOT EXISTS subject_summary (
     subject            TEXT    PRIMARY KEY,
 
@@ -173,7 +173,7 @@ pub struct ProjectedSubject {
 /// `first_observed_ms` takes the min for the same reason, and the two are
 /// tracked independently: transaction time is monotonic per store today, but
 /// deriving one bound from the other would bake that assumption into the data.
-pub fn entity_fold_step(
+pub fn subject_fold_step(
     acc: &mut BTreeMap<String, ProjectedSubject>,
     incoming: &SubjectObservation,
 ) -> bool {
@@ -226,12 +226,12 @@ pub fn entity_fold_step(
 /// state digest is taken over this order, and a digest that depended on hash
 /// seeding would compare unequal to itself.
 #[must_use]
-pub fn entity_fold_all<'a, I: IntoIterator<Item = &'a SubjectObservation>>(
+pub fn subject_fold_all<'a, I: IntoIterator<Item = &'a SubjectObservation>>(
     observations: I,
 ) -> BTreeMap<String, ProjectedSubject> {
     let mut acc = BTreeMap::new();
     for o in observations {
-        entity_fold_step(&mut acc, o);
+        subject_fold_step(&mut acc, o);
     }
     acc
 }
@@ -252,7 +252,7 @@ mod tests {
 
     #[test]
     fn a_single_observation_bounds_itself() {
-        let got = entity_fold_all(&[obs("cup-1", 100, 1)]);
+        let got = subject_fold_all(&[obs("cup-1", 100, 1)]);
         let s = &got["cup-1"];
         assert_eq!(s.first_observed_ms, 100);
         assert_eq!(s.last_observed_ms, 100);
@@ -262,7 +262,7 @@ mod tests {
 
     #[test]
     fn repeated_observations_widen_the_bounds_and_advance_the_head() {
-        let got = entity_fold_all(&[obs("cup-1", 100, 1), obs("cup-1", 300, 2)]);
+        let got = subject_fold_all(&[obs("cup-1", 100, 1), obs("cup-1", 300, 2)]);
         let s = &got["cup-1"];
         assert_eq!(s.first_observed_ms, 100);
         assert_eq!(s.last_observed_ms, 300);
@@ -273,7 +273,7 @@ mod tests {
 
     #[test]
     fn subjects_are_summarised_independently() {
-        let got = entity_fold_all(&[obs("cup-1", 100, 1), obs("cup-2", 200, 2)]);
+        let got = subject_fold_all(&[obs("cup-1", 100, 1), obs("cup-2", 200, 2)]);
         assert_eq!(got.len(), 2);
         assert_eq!(got["cup-1"].observation_count, 1);
         assert_eq!(got["cup-2"].first_observed_ms, 200);
@@ -288,11 +288,11 @@ mod tests {
             obs("cup-1", 300, 2),
             obs("cup-1", 200, 3),
         ];
-        let forward = entity_fold_all(&a);
+        let forward = subject_fold_all(&a);
 
         let mut reversed: Vec<&SubjectObservation> = a.iter().collect();
         reversed.reverse();
-        let backward = entity_fold_all(reversed);
+        let backward = subject_fold_all(reversed);
 
         assert_eq!(forward, backward, "reordering must not change the summary");
     }
@@ -303,7 +303,7 @@ mod tests {
     #[test]
     fn the_head_follows_generation_not_time() {
         // Generation 3 carries an EARLIER timestamp than generation 2.
-        let got = entity_fold_all(&[
+        let got = subject_fold_all(&[
             obs("cup-1", 100, 1),
             obs("cup-1", 500, 2),
             obs("cup-1", 200, 3),
@@ -323,7 +323,7 @@ mod tests {
     /// Out-of-order arrival must still widen `first_observed` downward.
     #[test]
     fn an_earlier_time_arriving_later_moves_first_observed_back() {
-        let got = entity_fold_all(&[obs("cup-1", 300, 1), obs("cup-1", 100, 2)]);
+        let got = subject_fold_all(&[obs("cup-1", 300, 1), obs("cup-1", 100, 2)]);
         assert_eq!(got["cup-1"].first_observed_ms, 100);
     }
 
@@ -333,12 +333,12 @@ mod tests {
     #[test]
     fn the_two_bounds_are_independent() {
         let mut acc = BTreeMap::new();
-        entity_fold_step(&mut acc, &obs("cup-1", 100, 1));
+        subject_fold_step(&mut acc, &obs("cup-1", 100, 1));
         assert_eq!(
             acc["cup-1"].first_observed_ms,
             acc["cup-1"].last_observed_ms
         );
-        entity_fold_step(&mut acc, &obs("cup-1", 900, 2));
+        subject_fold_step(&mut acc, &obs("cup-1", 900, 2));
         assert_ne!(
             acc["cup-1"].first_observed_ms,
             acc["cup-1"].last_observed_ms
@@ -359,11 +359,11 @@ mod tests {
             obs("cup-2", 500, 5),
         ];
 
-        let full = entity_fold_all(&all);
+        let full = subject_fold_all(&all);
 
-        let mut incremental = entity_fold_all(&all[..2]);
+        let mut incremental = subject_fold_all(&all[..2]);
         for o in &all[2..] {
-            entity_fold_step(&mut incremental, o);
+            subject_fold_step(&mut incremental, o);
         }
 
         assert_eq!(full, incremental);
@@ -373,6 +373,6 @@ mod tests {
     /// answer the retention driver gives for a store never written to.
     #[test]
     fn an_empty_log_folds_to_nothing() {
-        assert!(entity_fold_all(&[]).is_empty());
+        assert!(subject_fold_all(&[]).is_empty());
     }
 }

--- a/crates/kirra-world-store/tests/subject_summary.rs
+++ b/crates/kirra-world-store/tests/subject_summary.rs
@@ -1,0 +1,315 @@
+//! The per-subject summary projection, against a real store.
+//!
+//! The pure fold is unit-tested in `entity_projection`. What can only be tested
+//! here is that the **SQL upsert computes the same thing** — the fold exists
+//! twice, once in Rust and once as an `ON CONFLICT DO UPDATE`, and two
+//! implementations of one rule drift unless something compares them.
+
+use kirra_world_store::{
+    entity_fold_all, ClaimStatus, EventId, NewEvent, ObservationId, SubjectObservation, WorldStore,
+    WriterClass,
+};
+
+fn tmp(name: &str) -> std::path::PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "kirra-world-subjsum-{}-{}.sqlite",
+        name,
+        std::process::id()
+    ));
+    for s in ["", "-wal", "-shm"] {
+        let mut q = p.as_os_str().to_os_string();
+        q.push(s);
+        let _ = std::fs::remove_file(std::path::PathBuf::from(q));
+    }
+    p
+}
+
+struct Ids {
+    event: EventId,
+    observation: ObservationId,
+}
+
+fn ids(n: i64) -> Ids {
+    Ids {
+        event: EventId::new(format!("evt-{n}")).unwrap(),
+        observation: ObservationId::new(format!("obs-{n}")).unwrap(),
+    }
+}
+
+fn ev<'a>(id: &'a Ids, subject: &'a str, txn_time_ms: i64, status: ClaimStatus) -> NewEvent<'a> {
+    NewEvent {
+        event_id: &id.event,
+        observation_id: &id.observation,
+        txn_time_ms,
+        valid_from_ms: txn_time_ms,
+        valid_to_ms: None,
+        source: "sensor-a",
+        source_version: "0.1.0",
+        writer_class: match status {
+            ClaimStatus::Candidate => WriterClass::LlmCandidate,
+            ClaimStatus::Confirmed => WriterClass::Sensor,
+        },
+        claim_status: status,
+        provenance: &[],
+        frame_id: None,
+        map_id: None,
+        kind: "observation",
+        subject,
+        predicate: Some("colour"),
+        object: Some("red"),
+        payload: r#"{"n":1}"#,
+        payload_schema: 1,
+        retention_class: "raw",
+        trust: None,
+    }
+}
+
+/// D-20's `log_only_bytes` is the size of a store holding only the event log.
+/// Installing projection tables at `open` would add their root pages to every
+/// store — including one that never projects — silently moving that figure and
+/// invalidating the comparison the retention horizons rest on.
+#[test]
+fn open_leaves_no_subject_summary_table() {
+    let path = tmp("lazy");
+    let s = WorldStore::open(&path).expect("open");
+    assert!(
+        !s.has_subject_summary().expect("catalogue"),
+        "the summary table must not exist until the first fold"
+    );
+    assert_eq!(s.subject_summary_generation().expect("generation"), 0);
+    assert!(s.subject_summaries().expect("read").is_empty());
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+fn the_three_fields_are_folded_from_the_log() {
+    let path = tmp("fields");
+    let mut s = WorldStore::open(&path).expect("open");
+    for (n, txn) in [(1, 100), (2, 300), (3, 700)] {
+        s.append(&ev(&ids(n), "cup-1", txn, ClaimStatus::Confirmed))
+            .expect("append");
+    }
+    s.fold_subject_summary().expect("fold");
+
+    let got = s.subject_summary("cup-1").expect("read").expect("present");
+    assert_eq!(got.first_observed_ms, 100);
+    assert_eq!(got.last_observed_ms, 700);
+    assert_eq!(got.observation_count, 3);
+    assert_eq!(got.last_generation, 3);
+    assert_eq!(got.last_event_id, "evt-3");
+
+    // provenance_head names a real position in the tamper-evident log, which is
+    // what makes the summary citable rather than merely informative.
+    assert!(
+        !got.provenance_head.is_empty(),
+        "the head must be a chain digest"
+    );
+    let _ = std::fs::remove_file(&path);
+}
+
+/// **The two implementations of the fold must agree.**
+///
+/// `entity_fold_step` is the rule in Rust; the `ON CONFLICT DO UPDATE` is the
+/// same rule in SQL. Nothing but this test stops them drifting.
+#[test]
+fn the_sql_upsert_computes_what_the_pure_fold_computes() {
+    let path = tmp("agree");
+    let mut s = WorldStore::open(&path).expect("open");
+
+    let rows: [(i64, &str, i64); 6] = [
+        (1, "cup-1", 100),
+        (2, "cup-2", 150),
+        (3, "cup-1", 300),
+        (4, "cup-3", 90),
+        (5, "cup-2", 500),
+        (6, "cup-1", 200), // out of time order on purpose
+    ];
+    for (n, subject, txn) in rows {
+        s.append(&ev(&ids(n), subject, txn, ClaimStatus::Confirmed))
+            .expect("append");
+    }
+    s.fold_subject_summary().expect("fold");
+
+    // Rebuild the same input for the pure fold, reading the chain digests back
+    // out of the store so both sides see identical values.
+    let stored = s.subject_summaries().expect("read");
+    let observations: Vec<SubjectObservation> = rows
+        .iter()
+        .map(|(n, subject, txn)| SubjectObservation {
+            subject: (*subject).to_string(),
+            txn_time_ms: *txn,
+            generation: *n,
+            event_id: format!("evt-{n}"),
+            chain_digest: stored
+                .iter()
+                .find(|p| p.subject == *subject && p.last_generation == *n)
+                .map_or_else(String::new, |p| p.provenance_head.clone()),
+        })
+        .collect();
+    let pure = entity_fold_all(&observations);
+
+    assert_eq!(stored.len(), pure.len(), "same subjects");
+    for p in &stored {
+        let expected = pure.get(&p.subject).expect("subject in the pure fold");
+        assert_eq!(p.first_observed_ms, expected.first_observed_ms, "{p:?}");
+        assert_eq!(p.last_observed_ms, expected.last_observed_ms, "{p:?}");
+        assert_eq!(p.observation_count, expected.observation_count, "{p:?}");
+        assert_eq!(p.last_generation, expected.last_generation, "{p:?}");
+        assert_eq!(p.last_event_id, expected.last_event_id, "{p:?}");
+        // Comparable because the lookup above supplies the real digest for
+        // exactly the head generation of each subject — the non-head entries
+        // carry an empty placeholder, and by construction none of them can win
+        // the head. If the two folds disagreed about WHICH event is the head,
+        // one side would land on that placeholder and this would fail.
+        assert_eq!(p.provenance_head, expected.provenance_head, "{p:?}");
+        assert!(
+            !p.provenance_head.is_empty(),
+            "a real digest, not the placeholder"
+        );
+    }
+    let _ = std::fs::remove_file(&path);
+}
+
+/// The head follows generation, not time — asserted through the real store, not
+/// only through the pure fold. Generation 6 carries an earlier timestamp than
+/// generation 3, and must still be the head.
+#[test]
+fn the_head_follows_generation_through_the_store_too() {
+    let path = tmp("head-gen");
+    let mut s = WorldStore::open(&path).expect("open");
+    s.append(&ev(&ids(1), "cup-1", 100, ClaimStatus::Confirmed))
+        .expect("a");
+    s.append(&ev(&ids(2), "cup-1", 900, ClaimStatus::Confirmed))
+        .expect("b");
+    s.append(&ev(&ids(3), "cup-1", 200, ClaimStatus::Confirmed))
+        .expect("c");
+    s.fold_subject_summary().expect("fold");
+
+    let got = s.subject_summary("cup-1").expect("read").expect("present");
+    assert_eq!(got.last_generation, 3, "the head is the newest generation");
+    assert_eq!(got.last_event_id, "evt-3");
+    assert_eq!(
+        got.last_observed_ms, 900,
+        "but the observed bound is the latest TIME, which is a different event"
+    );
+    assert_eq!(got.first_observed_ms, 100);
+    let _ = std::fs::remove_file(&path);
+}
+
+/// Confirmed-only, following `world_current`'s precedent. A subject known only
+/// from candidates has no row — the honest answer, since nothing confirmed has
+/// been observed about it.
+#[test]
+fn candidates_do_not_contribute() {
+    let path = tmp("candidates");
+    let mut s = WorldStore::open(&path).expect("open");
+    s.append(&ev(&ids(1), "cup-1", 100, ClaimStatus::Confirmed))
+        .expect("confirmed");
+    s.append(&ev(&ids(2), "cup-1", 200, ClaimStatus::Candidate))
+        .expect("candidate");
+    s.append(&ev(&ids(3), "ghost-1", 300, ClaimStatus::Candidate))
+        .expect("candidate-only subject");
+    s.fold_subject_summary().expect("fold");
+
+    let cup = s.subject_summary("cup-1").expect("read").expect("present");
+    assert_eq!(
+        cup.observation_count, 1,
+        "the candidate must not count toward the summary"
+    );
+    assert_eq!(cup.last_observed_ms, 100);
+    assert!(
+        s.subject_summary("ghost-1").expect("read").is_none(),
+        "a candidate-only subject has no confirmed observation to summarise"
+    );
+    let _ = std::fs::remove_file(&path);
+}
+
+/// ADR-0041's purity property, at the store level: a full rebuild must equal an
+/// incremental fold.
+#[test]
+fn rebuild_equals_incremental() {
+    let path = tmp("purity");
+    let mut s = WorldStore::open(&path).expect("open");
+
+    for (n, subject, txn) in [(1i64, "cup-1", 100i64), (2, "cup-2", 200)] {
+        s.append(&ev(&ids(n), subject, txn, ClaimStatus::Confirmed))
+            .expect("append");
+    }
+    s.fold_subject_summary().expect("first fold");
+
+    for (n, subject, txn) in [(3i64, "cup-1", 300i64), (4, "cup-3", 50)] {
+        s.append(&ev(&ids(n), subject, txn, ClaimStatus::Confirmed))
+            .expect("append");
+    }
+    s.fold_subject_summary().expect("incremental fold");
+    let incremental = s.subject_summary_state_digest().expect("digest");
+
+    s.rebuild_subject_summary().expect("rebuild");
+    let rebuilt = s.subject_summary_state_digest().expect("digest");
+
+    assert_eq!(
+        incremental, rebuilt,
+        "an incremental fold must equal a rebuild from zero"
+    );
+    let _ = std::fs::remove_file(&path);
+}
+
+/// The checkpoint advances past every event CONSIDERED, not merely adopted —
+/// otherwise a batch of candidates would be re-scanned on every fold forever.
+#[test]
+fn the_checkpoint_advances_past_candidates() {
+    let path = tmp("checkpoint");
+    let mut s = WorldStore::open(&path).expect("open");
+    s.append(&ev(&ids(1), "cup-1", 100, ClaimStatus::Candidate))
+        .expect("candidate");
+    s.append(&ev(&ids(2), "cup-2", 200, ClaimStatus::Candidate))
+        .expect("candidate");
+    s.fold_subject_summary().expect("fold");
+
+    assert_eq!(
+        s.subject_summary_generation().expect("generation"),
+        2,
+        "a fold that adopted nothing must still have consumed the log"
+    );
+    assert!(s.subject_summaries().expect("read").is_empty());
+    let _ = std::fs::remove_file(&path);
+}
+
+/// Folding twice with nothing new in between must change nothing — an idempotence
+/// property the `observation_count` increment would break if the checkpoint were
+/// ignored, since every event would be counted again.
+#[test]
+fn a_second_fold_with_no_new_events_is_a_no_op() {
+    let path = tmp("idempotent");
+    let mut s = WorldStore::open(&path).expect("open");
+    s.append(&ev(&ids(1), "cup-1", 100, ClaimStatus::Confirmed))
+        .expect("append");
+    s.append(&ev(&ids(2), "cup-1", 200, ClaimStatus::Confirmed))
+        .expect("append");
+    s.fold_subject_summary().expect("fold");
+    let first = s.subject_summary_state_digest().expect("digest");
+
+    s.fold_subject_summary().expect("fold again");
+    let second = s.subject_summary_state_digest().expect("digest");
+
+    assert_eq!(first, second, "re-folding must not double-count");
+    assert_eq!(
+        s.subject_summary("cup-1")
+            .expect("read")
+            .expect("present")
+            .observation_count,
+        2
+    );
+    let _ = std::fs::remove_file(&path);
+}
+
+/// An empty log folds to an empty summary rather than erroring.
+#[test]
+fn an_empty_log_folds_to_an_empty_summary() {
+    let path = tmp("empty");
+    let mut s = WorldStore::open(&path).expect("open");
+    s.fold_subject_summary().expect("fold an empty log");
+    assert!(s.subject_summaries().expect("read").is_empty());
+    let _ = std::fs::remove_file(&path);
+}

--- a/crates/kirra-world-store/tests/subject_summary.rs
+++ b/crates/kirra-world-store/tests/subject_summary.rs
@@ -1,13 +1,13 @@
 //! The per-subject summary projection, against a real store.
 //!
-//! The pure fold is unit-tested in `entity_projection`. What can only be tested
+//! The pure fold is unit-tested in `subject_projection`. What can only be tested
 //! here is that the **SQL upsert computes the same thing** — the fold exists
 //! twice, once in Rust and once as an `ON CONFLICT DO UPDATE`, and two
 //! implementations of one rule drift unless something compares them.
 
 use kirra_world_store::{
-    entity_fold_all, ClaimStatus, EventId, NewEvent, ObservationId, SubjectObservation, WorldStore,
-    WriterClass,
+    subject_fold_all, ClaimStatus, EventId, NewEvent, ObservationId, SubjectObservation,
+    WorldStore, WriterClass,
 };
 
 fn tmp(name: &str) -> std::path::PathBuf {
@@ -17,12 +17,22 @@ fn tmp(name: &str) -> std::path::PathBuf {
         name,
         std::process::id()
     ));
-    for s in ["", "-wal", "-shm"] {
+    clean(&p);
+    p
+}
+
+/// Remove the database AND its WAL sidecars.
+///
+/// `synchronous=FULL` in WAL mode leaves `-wal` and `-shm` beside the main
+/// file, so removing only the `.sqlite` leaks two files per test — and worse,
+/// a surviving `-wal` beside a recreated database of the same name is a
+/// recovery source, which can make a later run see rows it never wrote.
+fn clean(p: &std::path::Path) {
+    for suffix in ["", "-wal", "-shm"] {
         let mut q = p.as_os_str().to_os_string();
-        q.push(s);
+        q.push(suffix);
         let _ = std::fs::remove_file(std::path::PathBuf::from(q));
     }
-    p
 }
 
 struct Ids {
@@ -79,7 +89,7 @@ fn open_leaves_no_subject_summary_table() {
     );
     assert_eq!(s.subject_summary_generation().expect("generation"), 0);
     assert!(s.subject_summaries().expect("read").is_empty());
-    let _ = std::fs::remove_file(&path);
+    clean(&path);
 }
 
 #[test]
@@ -105,12 +115,12 @@ fn the_three_fields_are_folded_from_the_log() {
         !got.provenance_head.is_empty(),
         "the head must be a chain digest"
     );
-    let _ = std::fs::remove_file(&path);
+    clean(&path);
 }
 
 /// **The two implementations of the fold must agree.**
 ///
-/// `entity_fold_step` is the rule in Rust; the `ON CONFLICT DO UPDATE` is the
+/// `subject_fold_step` is the rule in Rust; the `ON CONFLICT DO UPDATE` is the
 /// same rule in SQL. Nothing but this test stops them drifting.
 #[test]
 fn the_sql_upsert_computes_what_the_pure_fold_computes() {
@@ -147,7 +157,7 @@ fn the_sql_upsert_computes_what_the_pure_fold_computes() {
                 .map_or_else(String::new, |p| p.provenance_head.clone()),
         })
         .collect();
-    let pure = entity_fold_all(&observations);
+    let pure = subject_fold_all(&observations);
 
     assert_eq!(stored.len(), pure.len(), "same subjects");
     for p in &stored {
@@ -168,7 +178,7 @@ fn the_sql_upsert_computes_what_the_pure_fold_computes() {
             "a real digest, not the placeholder"
         );
     }
-    let _ = std::fs::remove_file(&path);
+    clean(&path);
 }
 
 /// The head follows generation, not time — asserted through the real store, not
@@ -194,7 +204,7 @@ fn the_head_follows_generation_through_the_store_too() {
         "but the observed bound is the latest TIME, which is a different event"
     );
     assert_eq!(got.first_observed_ms, 100);
-    let _ = std::fs::remove_file(&path);
+    clean(&path);
 }
 
 /// Confirmed-only, following `world_current`'s precedent. A subject known only
@@ -222,7 +232,7 @@ fn candidates_do_not_contribute() {
         s.subject_summary("ghost-1").expect("read").is_none(),
         "a candidate-only subject has no confirmed observation to summarise"
     );
-    let _ = std::fs::remove_file(&path);
+    clean(&path);
 }
 
 /// ADR-0041's purity property, at the store level: a full rebuild must equal an
@@ -252,7 +262,7 @@ fn rebuild_equals_incremental() {
         incremental, rebuilt,
         "an incremental fold must equal a rebuild from zero"
     );
-    let _ = std::fs::remove_file(&path);
+    clean(&path);
 }
 
 /// The checkpoint advances past every event CONSIDERED, not merely adopted —
@@ -273,7 +283,7 @@ fn the_checkpoint_advances_past_candidates() {
         "a fold that adopted nothing must still have consumed the log"
     );
     assert!(s.subject_summaries().expect("read").is_empty());
-    let _ = std::fs::remove_file(&path);
+    clean(&path);
 }
 
 /// Folding twice with nothing new in between must change nothing — an idempotence
@@ -301,7 +311,7 @@ fn a_second_fold_with_no_new_events_is_a_no_op() {
             .observation_count,
         2
     );
-    let _ = std::fs::remove_file(&path);
+    clean(&path);
 }
 
 /// An empty log folds to an empty summary rather than erroring.
@@ -311,5 +321,5 @@ fn an_empty_log_folds_to_an_empty_summary() {
     let mut s = WorldStore::open(&path).expect("open");
     s.fold_subject_summary().expect("fold an empty log");
     assert!(s.subject_summaries().expect("read").is_empty());
-    let _ = std::fs::remove_file(&path);
+    clean(&path);
 }

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -430,9 +430,35 @@ is **self-releasing and already released** (ADR-0042 Decision 5, recorded
       guard rather than around it. That
       follows §6.2 over §6.1's field table, which **contradict each other**; the
       tension is recorded in the module as an open question rather than resolved.
+      **`first_observed` / `last_observed` / `provenance_head` DONE 2026-08-07**,
+      `crates/kirra-world-store/src/entity_projection.rs` + the store's
+      `fold_subject_summary`, 10 unit + 9 integration tests.
+      **They are a PROJECTION, not a table** — `WM2_EVENT_SCHEMA.md` §7 rules
+      `entities_projection` a rebuildable view that "follows from the fold, not
+      from this table", so no new DDL entered the ratified schema surface and no
+      version bump was involved. Derived by folding the event log, which is what
+      stops them drifting from the evidence — the same argument that leaves
+      validity without a column. Installed lazily like `PROJECTIONS_V1`, because
+      creating projection tables at `open` would move D-20's `log_only_bytes`
+      and invalidate the comparison the retention horizons rest on.
+      Ages on `txn_time_ms` (same choice, same reason, as the retention driver);
+      `provenance_head` is a **chain digest**, so a subject's summary can be
+      *cited* rather than merely read; the head follows **generation**, not time,
+      because generation is unique and a time tie-break would not be reproducible.
+      **Keyed on `subject`, not on an entity id — a recorded limit, not an
+      oversight.** `SubjectRef` distinguishes `Entity` / `Candidate` / `Frame` /
+      `Unbound`; storage flattens all four into one `subject TEXT NOT NULL` with
+      no discriminant, so the fold cannot restrict itself to resolved entities
+      and the module is named `subject_summary` for what it actually computes.
+      Same shape as the `writer_class`-vs-`origin` finding. Carrying the
+      discriminant touches `subject`, which is inside the hashed bytes, so it
+      needs the append-only-when-present treatment the trust axes got — its own
+      slice.
       **Still open:** identity *adjudication* — candidate clustering, merge/split
-      events — is Tier 2. `entity_id` generation, `first_observed`/
-      `last_observed` and `provenance_head` need the store (ULID, hashing).
+      events — is Tier 2. **`entity_id` generation belongs there too**, not here:
+      minting an id is deciding that something is a distinct thing, which is
+      adjudication, whereas the three fields above are arithmetic over evidence
+      that already exists. This list previously grouped it with them.
 - [ ] **Observation model** (§7) — **pure half DONE 2026-08-06**,
       `crates/kirra-world/src/observation.rs`, 17 tests, still zero-dependency.
       Delivered: `Confidence`/`ConfidenceBasis` (§7.3), `SourceClass` + its


### PR DESCRIPTION
Tier 1's entity-taxonomy remainder: `first_observed`, `last_observed` and `provenance_head`. Two commits — the pure fold, then the store running it against the log.

## The design question, which went the other way from what I expected

I said this would be new DDL and probably schema v3. It is neither. `WM2_EVENT_SCHEMA.md` §7, under *what this ruling does not decide*:

> **Projection schemas.** `entities_projection` / `relationships_projection` are rebuildable views and follow from the fold, not from this table.

So nothing entered `KIRRA-WM2-SCHEMA-001`'s ratified surface and no version bump was involved. The three fields are **derived by folding the event log**, which is what stops them drifting from the evidence — the same argument that leaves validity without a column, and the reason this is a better answer than a table would have been.

Settling that before writing code was the point of checking. A ratified-surface change would have needed a ruling from the owner; a projection needs none.

## What it computes, and three choices inside it

- **Ages on `txn_time_ms`, not `valid_from_ms`** — same choice and same reason as the retention driver. These are statements about *this store's* encounters with a subject, so a backdated import must not move `first_observed` into a past when nothing was observed.
- **`provenance_head` is a chain digest**, not a count or a timestamp. That makes a subject's summary **citable**: it names a position in the tamper-evident log a reader can verify independently.
- **The head follows generation, not time.** Generation is the chain's own order and is unique; transaction time can tie, and a head chosen by a tie-break on time would not be reproducible. The *time bounds* are a separate min and max over every contributing event.

**Confirmed-only**, following `world_current`'s precedent rather than diverging from it. A candidate is a proposal, not an observation, and two projections disagreeing about what counts would be a trap — a reader comparing them would find subjects in one and not the other for reasons neither table states. A subject known only from candidates has no row, which is the honest answer, and `candidates()` is how you ask the other question.

**Installed lazily**, and `open_leaves_no_subject_summary_table` asserts it. Creating projection tables at `open` would add their root pages to *every* store, including one that never projects — silently moving ADR-0041 D-20's `log_only_bytes` and invalidating the comparison against D-2 that the retention horizons rest on.

## The honest limit, recorded rather than papered over

**Keyed on `subject`, not on an entity id, because the store cannot tell the difference.**

`SubjectRef` distinguishes four cases — `Entity(id)` (resolved), `Candidate(id)` (not yet adjudicated), `Frame(id)`, and `Unbound` (recorded before anything decided what it was about). Storage flattens all four into one `subject TEXT NOT NULL` and keeps no discriminant, so this fold **cannot** restrict itself to resolved entities. The module is named `subject_summary` for what it actually computes; calling it `entities_projection` would claim the rows are entities.

This is the same shape as the `writer_class`-versus-`origin` finding one PR ago: the core carries a type, the store carries a proxy, and the proxy cannot answer the question the type was built for. Fixing it means carrying the discriminant in storage, which touches `subject` — a field **inside the canonically-hashed bytes** — so it needs the same append-only-when-present treatment the trust axes got. That is a slice of its own.

## A correction to the scope doc

`WM_SCOPE.md` grouped `entity_id` generation with these three fields. It does not belong there, and this PR moves it: **minting an id is deciding that something is a distinct thing, which is adjudication — Tier 2** — whereas these three are arithmetic over evidence that already exists. So this slice deliberately mints nothing.

## The bug the tests caught, in my code rather than in them

The first version tied `last_observed_ms` to the head, so a later generation carrying an *earlier* timestamp **regressed the maximum** and the summary depended on arrival order. The bounds are now a min and a max taken independently of which event is the head.

Negative control observed rather than assumed: with the bug present, **exactly the two order-sensitivity tests failed and the other 28 passed.** That is what makes `the_fold_is_order_independent` worth more than the pair it superficially duplicates.

## The fold exists twice, so something has to compare them

Once in Rust as `entity_fold_step`, once in SQL as an `ON CONFLICT DO UPDATE`. Two implementations of one rule drift unless something checks. A test walks a real log through both and asserts every field agrees, **including `provenance_head`**.

That comparison is non-vacuous by construction: the pure fold's input carries the real digest for exactly each subject's head generation and an empty placeholder elsewhere, so if the two sides disagreed about *which* event is the head, one would land on the placeholder and the assertion would fail.

## Negative controls

| Guard reverted | Result |
|---|---|
| bounds tied to the head instead of min/max | 2 tests (observed, not predicted) |
| head chosen by time instead of generation | 2 tests |
| candidates allowed to contribute | 1 test |
| checkpoint not advanced past unadopted events | 1 test |
| projection installed at `open` | 1 test |
| SQL upsert diverging from the pure fold | 1 test |

## Verification

10 unit + 9 integration tests new · 30 lib + 101 integration in `kirra-world-store` · clippy 0 warnings under `#[warn(missing_docs)]` · MSRV 1.88 against the real toolchain · `cargo check --workspace --all-targets` clean · all 12 substantive CI gates · both Kirra World fences INTACT.

**All eight cargo trees** formatted and both detached harnesses re-tested (30, and 207+7) — applying the lesson from the last PR, where root-level `cargo fmt --all` and `cargo check --workspace` each missed `tools/wm2-schema-growth` because it is workspace-detached, and CI caught both.

## What is left in Tier 1

`TypedPayload`'s body — `Payload` carries its provenance, the body itself is still a type parameter. `ObservationKind` remains a **specification** gap rather than an implementation one: the blueprint names the field and never enumerates its variants.

Completing those fires ADR-0040's Q1 revisit trigger, against the baseline and Measurement 2 now on record.

Kirra is designed in alignment with ISO 26262 ASIL-D requirements and IEC 61508 SIL 3 requirements. Independent third-party assessment has not yet been performed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_