### PR TITLE
Trust reaches a reader — "no bare values" at the projection

### DIFF
--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -1551,6 +1551,15 @@ fn claim_axes_from_row(r: &rusqlite::Row<'_>) -> rusqlite::Result<Option<TrustAx
     };
 
     match (origin, corroboration, adjudication) {
+        // An orphan `corroboration_n` is NOT an unlabelled claim. The verify
+        // path already refuses this shape; the claim path must match, and the
+        // reason is stronger here — the projection's columns are not hashed at
+        // all, so an orphan count in a derived table is invisible to
+        // `verify_chain` and would be the only place such a value could sit
+        // undetected. Found in review, and the same defect class fixed on the
+        // verify path in #1376: fixing it there did not fix it here, because
+        // this is a second reader with its own column order.
+        (None, None, None) if corroboration_n.is_some() => Err(bad("orphan corroboration count")),
         (None, None, None) => Ok(None),
         (Some(o), Some(c), Some(a)) => {
             let origin = origin_from_token(&o).ok_or_else(|| bad("origin"))?;

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -101,7 +101,10 @@ pub use subject_projection::{
 // merely "so the dependency edge is real": [`NewEvent`] is built out of them, so
 // the edge now carries traffic. That is the measurement ADR-0040's open
 // question 1 defers its revisit to — see `docs/design/WM_Q1_SEAM_BASELINE.md`.
-pub use kirra_world::trust::{Adjudication, Corroboration, Origin, TrustAxes};
+pub use kirra_world::trust::{
+    trust_grade, validity_at, Adjudication, Corroboration, Origin, TrustAxes, TrustGrade, Validity,
+    ValidityWindow,
+};
 pub use kirra_world::{EntityId, EventId, FrameId, MapId, ObservationId, ReferenceError};
 pub use schema::{CHAIN_ALGORITHM, SCHEMA_VERSION};
 
@@ -1419,6 +1422,21 @@ impl WorldStore {
         Ok(())
     }
 
+    /// Test-only: run one scalar query.
+    ///
+    /// Paired with [`WorldStore::raw_execute_for_test`] and gated the same way.
+    /// Exists so a test can assert against the store's LIVE schema — via
+    /// `pragma_table_info` — rather than against the DDL text it was created
+    /// from. Asserting on the text would pass while the real table disagreed.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::Sqlite`] if the query fails or returns no row.
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn query_scalar_for_test(&self, sql: &str) -> Result<i64, StoreError> {
+        Ok(self.conn.query_row(sql, [], |r| r.get(0))?)
+    }
+
     /// Test-only: rewrite one column of one row, bypassing the write path.
     ///
     /// This exists so the tamper tests can prove the chain **detects** an edit.
@@ -1470,7 +1488,8 @@ impl WorldStore {
 
 /// Columns the fold reads, in one place so the two readers cannot drift.
 const CLAIM_COLUMNS: &str = "subject, predicate, object, kind, payload, frame_id, map_id, \
-     source, valid_from_ms, valid_to_ms, txn_time_ms, generation, event_id";
+     source, valid_from_ms, valid_to_ms, txn_time_ms, generation, event_id, chain_digest, \
+     origin, corroboration, corroboration_n, adjudication";
 
 /// The projected-state digest, over any connection.
 ///
@@ -1504,7 +1523,50 @@ fn claim_from_row(r: &rusqlite::Row<'_>) -> rusqlite::Result<ProjectedClaim> {
         txn_time_ms: r.get(10)?,
         generation: r.get(11)?,
         event_id: r.get(12)?,
+        chain_digest: r.get(13)?,
+        trust: claim_axes_from_row(r)?,
     })
+}
+
+/// The three stored axes as read by the CLAIM path (indices 14..=17).
+///
+/// Distinct from [`axes_from_row`], which reads the VERIFY path's own column
+/// order and reports a `CorruptRow` naming a generation. Here the signature is
+/// `rusqlite::Result`, so an unreadable axis fails closed as a conversion
+/// error rather than being silently dropped to `None` — dropping it would turn
+/// a corrupt trust label into an unlabelled claim, which reads as "no trust
+/// recorded" instead of "something is wrong".
+fn claim_axes_from_row(r: &rusqlite::Row<'_>) -> rusqlite::Result<Option<TrustAxes>> {
+    let origin: Option<String> = r.get(14)?;
+    let corroboration: Option<String> = r.get(15)?;
+    let corroboration_n: Option<i64> = r.get(16)?;
+    let adjudication: Option<String> = r.get(17)?;
+
+    let bad = |what: &str| {
+        rusqlite::Error::FromSqlConversionFailure(
+            0,
+            rusqlite::types::Type::Text,
+            format!("projected claim carries an unreadable {what}").into(),
+        )
+    };
+
+    match (origin, corroboration, adjudication) {
+        (None, None, None) => Ok(None),
+        (Some(o), Some(c), Some(a)) => {
+            let origin = origin_from_token(&o).ok_or_else(|| bad("origin"))?;
+            let n = corroboration_n
+                .map(u32::try_from)
+                .transpose()
+                .map_err(|_| bad("corroboration count"))?;
+            let corroboration =
+                corroboration_from_columns(&c, n).ok_or_else(|| bad("corroboration"))?;
+            let adjudication = adjudication_from_token(&a).ok_or_else(|| bad("adjudication"))?;
+            TrustAxes::new(origin, corroboration, adjudication)
+                .map(Some)
+                .map_err(|_| bad("axis combination"))
+        }
+        _ => Err(bad("partial axis set")),
+    }
 }
 
 impl WorldStore {
@@ -1514,6 +1576,32 @@ impl WorldStore {
     /// stays byte-identical to one written before projections existed. See
     /// [`projection`] for why that matters to ADR-0041 D-20.
     fn ensure_projections(&self) -> Result<(), StoreError> {
+        // A projection folded before the trust columns existed has the old
+        // shape, and `CREATE TABLE IF NOT EXISTS` will not add them. Drop it so
+        // the next fold rebuilds.
+        //
+        // This is legitimate here and NOWHERE ELSE in this crate: a projection
+        // is derived, so deleting it loses no evidence — it is exactly what
+        // `rebuild_projections` already does on demand. The evidence log gets
+        // additive migrations precisely because the same move there would be a
+        // forgery.
+        if self.has_projections()? {
+            let has_trust: Option<i64> = self
+                .conn
+                .query_row(
+                    "SELECT 1 FROM pragma_table_info('world_current') WHERE name = 'adjudication'",
+                    [],
+                    |r| r.get(0),
+                )
+                .optional()?;
+            if has_trust.is_none() {
+                self.conn.execute("DROP TABLE world_current", [])?;
+                self.conn.execute(
+                    "DELETE FROM projection_checkpoint WHERE name = ?1",
+                    params![projection::CURRENT_PROJECTION],
+                )?;
+            }
+        }
         self.conn.execute_batch(projection::PROJECTIONS_V1)?;
         Ok(())
     }
@@ -1590,15 +1678,20 @@ impl WorldStore {
                 "INSERT INTO world_current (
                     subject, predicate_key, predicate, object, kind, payload,
                     frame_id, map_id, source, valid_from_ms, valid_to_ms,
-                    txn_time_ms, generation, event_id
-                 ) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14)
+                    txn_time_ms, generation, event_id, chain_digest,
+                    origin, corroboration, corroboration_n, adjudication
+                 ) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19)
                  ON CONFLICT (subject, predicate_key) DO UPDATE SET
                     predicate=excluded.predicate, object=excluded.object,
                     kind=excluded.kind, payload=excluded.payload,
                     frame_id=excluded.frame_id, map_id=excluded.map_id,
                     source=excluded.source, valid_from_ms=excluded.valid_from_ms,
                     valid_to_ms=excluded.valid_to_ms, txn_time_ms=excluded.txn_time_ms,
-                    generation=excluded.generation, event_id=excluded.event_id
+                    generation=excluded.generation, event_id=excluded.event_id,
+                    chain_digest=excluded.chain_digest, origin=excluded.origin,
+                    corroboration=excluded.corroboration,
+                    corroboration_n=excluded.corroboration_n,
+                    adjudication=excluded.adjudication
                  WHERE (excluded.valid_from_ms, excluded.generation)
                      > (world_current.valid_from_ms, world_current.generation)",
             )?;
@@ -1622,6 +1715,17 @@ impl WorldStore {
                     c.txn_time_ms,
                     c.generation,
                     c.event_id,
+                    c.chain_digest,
+                    c.trust.as_ref().map(|t| t.origin().as_str()),
+                    c.trust
+                        .as_ref()
+                        .map(|t| corroboration_columns(t.corroboration()).0),
+                    c.trust
+                        .as_ref()
+                        .and_then(|t| corroboration_columns(t.corroboration()).1),
+                    c.trust
+                        .as_ref()
+                        .map(|t| adjudication_token(t.adjudication_stored())),
                 ])?;
             }
         }

--- a/crates/kirra-world-store/src/projection.rs
+++ b/crates/kirra-world-store/src/projection.rs
@@ -77,6 +77,22 @@ CREATE TABLE IF NOT EXISTS world_current (
     generation     INTEGER NOT NULL,
     event_id       TEXT    NOT NULL,
 
+    -- The claim's own chain position, so an answer can be CITED rather than
+    -- merely read. Same argument as the subject summary's provenance_head.
+    chain_digest   TEXT    NOT NULL DEFAULT '',
+
+    -- The three STORED trust axes (schema v2), carried through so a reader
+    -- gets the claim's trust with the claim. Nullable together, exactly as in
+    -- world_events: a v1-shaped row is unlabelled, not wrongly labelled.
+    --
+    -- Validity is deliberately absent. Transition rule 6 computes it at READ
+    -- time from a caller-supplied clock, so a column here would be the one
+    -- place the rule could be broken.
+    origin           TEXT,
+    corroboration    TEXT,
+    corroboration_n  INTEGER,
+    adjudication     TEXT,
+
     PRIMARY KEY (subject, predicate_key)
 );
 
@@ -131,9 +147,67 @@ pub struct ProjectedClaim {
     pub generation: i64,
     /// Identity of that event.
     pub event_id: String,
+    /// The claim's chain digest — its position in the tamper-evident log.
+    ///
+    /// This is the **provenance handle**: it lets an answer be cited and
+    /// independently verified rather than merely trusted because the API
+    /// returned it. Empty only for a projection folded before this column
+    /// existed, which the rebuild-on-shape-change in `ensure_projections`
+    /// removes.
+    pub chain_digest: String,
+    /// The three **stored** trust axes, or `None` for an unlabelled claim.
+    ///
+    /// `Option` rather than a default, for the reason `NewEvent::trust` is:
+    /// inventing an origin and an adjudication for a claim that carries none is
+    /// the "mush after eighteen months" the four-axis model exists to prevent.
+    pub trust: Option<crate::TrustAxes>,
 }
 
 impl ProjectedClaim {
+    /// The fourth axis, **computed at read time** rather than stored.
+    ///
+    /// Transition rule 6: validity is not a state the system enters, it is a
+    /// question asked with a clock passed in. There is no `validity` column
+    /// anywhere — not in `world_events`, not in this projection — which is what
+    /// makes the rule unbreakable rather than documented.
+    ///
+    /// `staleness_budget_ms` comes from the **caller**, not from storage,
+    /// because how long a claim stays fresh is a policy of the asking consumer:
+    /// a floor plan and a person's location go stale at wildly different rates,
+    /// and baking one budget into the row would answer for every reader at once.
+    /// `None` means the claim does not go stale — [`Validity::Timeless`].
+    #[must_use]
+    pub fn validity_at(&self, now_ms: u64, staleness_budget_ms: Option<u64>) -> crate::Validity {
+        let window = crate::ValidityWindow {
+            valid_from_ms: self.valid_from_ms.max(0).unsigned_abs(),
+            valid_to_ms: self.valid_to_ms.map(|v| v.max(0).unsigned_abs()),
+            staleness_budget_ms,
+        };
+        crate::validity_at(&window, now_ms)
+    }
+
+    /// Collapse trust to a single grade — **only here, at the query boundary**.
+    ///
+    /// The blueprint is explicit that the axes are stored separately and
+    /// collapsed to a grade only for consumers that ask for one. This is that
+    /// boundary, and it is a method rather than a field so the collapse is
+    /// something a caller *does*, never something they receive by default.
+    ///
+    /// `None` when the claim carries no axes: an unlabelled claim has no trust
+    /// to grade, and returning a default grade would manufacture one.
+    #[must_use]
+    pub fn grade_at(
+        &self,
+        now_ms: u64,
+        staleness_budget_ms: Option<u64>,
+    ) -> Option<crate::TrustGrade> {
+        let axes = self.trust.as_ref()?;
+        Some(crate::trust_grade(
+            axes,
+            self.validity_at(now_ms, staleness_budget_ms),
+        ))
+    }
+
     /// The projection key: subject plus predicate-or-empty.
     #[must_use]
     pub fn key(&self) -> (String, String) {
@@ -218,6 +292,8 @@ mod tests {
             valid_to_ms: None,
             txn_time_ms: valid_from,
             generation: gen,
+            chain_digest: format!("digest-{gen}"),
+            trust: None,
             event_id: format!("e{gen}"),
         }
     }

--- a/crates/kirra-world-store/tests/trust_in_read_path.rs
+++ b/crates/kirra-world-store/tests/trust_in_read_path.rs
@@ -301,3 +301,37 @@ fn a_projection_of_the_old_shape_is_rebuilt_rather_than_left_short() {
     );
     clean(&path);
 }
+
+/// **An orphan `corroboration_n` in the projection is corruption, not an
+/// unlabelled claim.**
+///
+/// Found in review, and the same defect class already fixed on the verify path
+/// in #1376 — fixing it there did not fix it here, because the claim path is a
+/// second reader with its own column order.
+///
+/// The reason is stronger in the projection than in the log: `world_current`'s
+/// columns are **not hashed at all**, so an orphan count in this derived table
+/// is invisible to `verify_chain`. It is the one place such a value could sit
+/// undetected, which is exactly why the read has to refuse it.
+#[test]
+fn an_orphan_count_in_the_projection_is_refused_not_read_as_unlabelled() {
+    let path = tmp("orphan-projection");
+    let mut s = WorldStore::open(&path).expect("open");
+    s.append(&ev(&ids(1), None, None)).expect("unlabelled");
+    s.fold().expect("fold");
+
+    // The projection carries no CHECK constraints — it is derived, and its
+    // integrity comes from being rebuildable rather than from the schema. So
+    // this write succeeds, and the READ is what has to catch it.
+    s.raw_execute_for_test("UPDATE world_current SET corroboration_n = 5")
+        .expect("the projection has no constraint to stop this");
+
+    let err = s
+        .current("cup-1", T0 + 1)
+        .expect_err("an orphan count must be refused, not read as unlabelled");
+    assert!(
+        format!("{err:?}").contains("orphan"),
+        "the diagnosis must name what is wrong: {err:?}"
+    );
+    clean(&path);
+}

--- a/crates/kirra-world-store/tests/trust_in_read_path.rs
+++ b/crates/kirra-world-store/tests/trust_in_read_path.rs
@@ -1,0 +1,303 @@
+//! Trust reaching a reader — "no bare values", at the projection.
+//!
+//! Strand C put the four axes into the evidence log. Nothing carried them out
+//! of it: `world_current` had no axis columns and `ProjectedClaim` had no axis
+//! fields, so every read returned a value with no trust attached and a consumer
+//! had to go back to the raw log to learn anything about it.
+//!
+//! These tests assert the two halves of the fix, and the second matters more
+//! than the first: the three **stored** axes travel with the claim, and the
+//! fourth — validity — is still **computed at read time**, so rule 6 stays
+//! unbreakable rather than merely documented.
+
+use kirra_world_store::{
+    Adjudication, ClaimStatus, Corroboration, EventId, NewEvent, ObservationId, Origin, TrustAxes,
+    TrustGrade, Validity, WorldStore, WriterClass,
+};
+
+fn tmp(name: &str) -> std::path::PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "kirra-world-trustread-{}-{}.sqlite",
+        name,
+        std::process::id()
+    ));
+    clean(&p);
+    p
+}
+
+fn clean(p: &std::path::Path) {
+    for suffix in ["", "-wal", "-shm"] {
+        let mut q = p.as_os_str().to_os_string();
+        q.push(suffix);
+        let _ = std::fs::remove_file(std::path::PathBuf::from(q));
+    }
+}
+
+struct Ids {
+    event: EventId,
+    observation: ObservationId,
+}
+
+fn ids(n: i64) -> Ids {
+    Ids {
+        event: EventId::new(format!("evt-{n}")).unwrap(),
+        observation: ObservationId::new(format!("obs-{n}")).unwrap(),
+    }
+}
+
+const T0: i64 = 1_700_000_000_000;
+
+fn ev<'a>(id: &'a Ids, trust: Option<&'a TrustAxes>, valid_to_ms: Option<i64>) -> NewEvent<'a> {
+    NewEvent {
+        event_id: &id.event,
+        observation_id: &id.observation,
+        txn_time_ms: T0,
+        valid_from_ms: T0,
+        valid_to_ms,
+        source: "sensor-a",
+        source_version: "0.1.0",
+        writer_class: WriterClass::Sensor,
+        claim_status: ClaimStatus::Confirmed,
+        provenance: &[],
+        frame_id: None,
+        map_id: None,
+        kind: "observation",
+        subject: "cup-1",
+        predicate: Some("colour"),
+        object: Some("red"),
+        payload: r#"{"n":1}"#,
+        payload_schema: 1,
+        retention_class: "raw",
+        trust,
+    }
+}
+
+fn axes() -> TrustAxes {
+    TrustAxes::new(
+        Origin::Observed,
+        Corroboration::Corroborated(2),
+        Adjudication::Confirmed,
+    )
+    .expect("constructible")
+}
+
+/// The axes survive the fold and arrive with the claim.
+#[test]
+fn a_read_claim_carries_the_axes_it_was_written_with() {
+    let path = tmp("carries");
+    let mut s = WorldStore::open(&path).expect("open");
+    let a = axes();
+    s.append(&ev(&ids(1), Some(&a), None)).expect("append");
+    s.fold().expect("fold");
+
+    let got = s.current("cup-1", T0 + 1).expect("read");
+    assert_eq!(got.len(), 1);
+    let trust = got[0].trust.as_ref().expect("axes present");
+    assert_eq!(trust.origin(), Origin::Observed);
+    assert_eq!(trust.corroboration(), Corroboration::Corroborated(2));
+    assert_eq!(trust.adjudication(), Adjudication::Confirmed);
+    clean(&path);
+}
+
+/// An unlabelled claim reads as unlabelled — **not** as a default set of axes.
+///
+/// Manufacturing an origin and an adjudication for a claim that carries none is
+/// the "mush after eighteen months" the four-axis model exists to prevent, and
+/// it would be indistinguishable downstream from a claim that really was
+/// observed and confirmed.
+#[test]
+fn an_unlabelled_claim_reads_as_unlabelled_not_as_a_default() {
+    let path = tmp("unlabelled");
+    let mut s = WorldStore::open(&path).expect("open");
+    s.append(&ev(&ids(1), None, None)).expect("append");
+    s.fold().expect("fold");
+
+    let got = s.current("cup-1", T0 + 1).expect("read");
+    assert!(got[0].trust.is_none(), "no axes must stay no axes");
+    assert!(
+        got[0].grade_at((T0 + 1).unsigned_abs(), None).is_none(),
+        "an unlabelled claim has no trust to grade"
+    );
+    clean(&path);
+}
+
+/// The **provenance handle**: a read answer names its position in the
+/// tamper-evident log, so it can be cited and verified rather than trusted
+/// because the API returned it.
+#[test]
+fn a_read_claim_carries_its_chain_position() {
+    let path = tmp("handle");
+    let mut s = WorldStore::open(&path).expect("open");
+    s.append(&ev(&ids(1), Some(&axes()), None)).expect("append");
+    s.fold().expect("fold");
+
+    let got = s.current("cup-1", T0 + 1).expect("read");
+    assert!(!got[0].chain_digest.is_empty(), "a citable handle");
+    assert_eq!(got[0].generation, 1);
+    assert_eq!(got[0].event_id, "evt-1");
+    clean(&path);
+}
+
+// ---------------------------------------------------------------------------
+// Rule 6 — validity is computed, never stored
+// ---------------------------------------------------------------------------
+
+/// **There is no validity column anywhere**, which is what makes rule 6
+/// unbreakable rather than documented. Asserted against the live schema of both
+/// tables rather than against the DDL text, so adding one later fails here.
+#[test]
+fn no_table_has_a_validity_column() {
+    let path = tmp("no-validity");
+    let mut s = WorldStore::open(&path).expect("open");
+    s.append(&ev(&ids(1), Some(&axes()), None)).expect("append");
+    s.fold().expect("fold");
+
+    for table in ["world_events", "world_current"] {
+        let sql = format!(
+            "SELECT COUNT(*) FROM pragma_table_info('{table}') \
+             WHERE name IN ('validity', 'freshness', 'is_fresh', 'stale')"
+        );
+        let n: i64 = s.query_scalar_for_test(&sql).expect("pragma");
+        assert_eq!(n, 0, "{table} must not store validity");
+    }
+    clean(&path);
+}
+
+/// The same claim, read at two different times, gives two different
+/// validities — which is only possible because it is computed with a clock
+/// passed in rather than read from a column.
+#[test]
+fn the_same_claim_is_valid_then_expired_as_the_clock_moves() {
+    let path = tmp("clock");
+    let mut s = WorldStore::open(&path).expect("open");
+    s.append(&ev(&ids(1), Some(&axes()), Some(T0 + 1_000)))
+        .expect("append");
+    s.fold().expect("fold");
+
+    // `current` filters on expiry, so read the row itself and ask it twice.
+    let got = s.current("cup-1", T0 + 1).expect("read");
+    let claim = &got[0];
+
+    assert_eq!(
+        claim.validity_at((T0 + 500).unsigned_abs(), None),
+        Validity::Timeless,
+        "in force, and with no staleness budget it does not go stale"
+    );
+    assert_eq!(
+        claim.validity_at((T0 + 5_000).unsigned_abs(), None),
+        Validity::Expired,
+        "past valid_to_ms, the same row reads as expired"
+    );
+    clean(&path);
+}
+
+/// The staleness budget comes from the **caller**, not from storage.
+///
+/// How long a claim stays fresh is a policy of the asking consumer — a floor
+/// plan and a person's location go stale at wildly different rates — so baking
+/// one budget into the row would answer for every reader at once.
+#[test]
+fn the_staleness_budget_is_the_callers_not_the_rows() {
+    let path = tmp("budget");
+    let mut s = WorldStore::open(&path).expect("open");
+    s.append(&ev(&ids(1), Some(&axes()), None)).expect("append");
+    s.fold().expect("fold");
+
+    let got = s.current("cup-1", T0 + 1).expect("read");
+    let claim = &got[0];
+    let now = (T0 + 10_000).unsigned_abs();
+
+    assert_eq!(
+        claim.validity_at(now, None),
+        Validity::Timeless,
+        "no budget: the claim does not go stale"
+    );
+    assert_eq!(
+        claim.validity_at(now, Some(1_000)),
+        Validity::Stale,
+        "a one-second budget: the same row, same clock, now stale"
+    );
+    assert_eq!(
+        claim.validity_at(now, Some(1_000_000)),
+        Validity::Fresh,
+        "a generous budget: still fresh"
+    );
+    clean(&path);
+}
+
+/// Collapsing to a grade happens **only when a caller asks**, and the grade
+/// moves with validity — so the collapse cannot be cached into the row either.
+#[test]
+fn the_grade_is_collapsed_at_the_boundary_and_moves_with_validity() {
+    let path = tmp("grade");
+    let mut s = WorldStore::open(&path).expect("open");
+    s.append(&ev(&ids(1), Some(&axes()), None)).expect("append");
+    s.fold().expect("fold");
+
+    let got = s.current("cup-1", T0 + 1).expect("read");
+    let claim = &got[0];
+    let now = (T0 + 10_000).unsigned_abs();
+
+    let fresh = claim.grade_at(now, Some(1_000_000)).expect("graded");
+    let stale = claim.grade_at(now, Some(1_000)).expect("graded");
+
+    assert_ne!(
+        fresh, stale,
+        "a stale claim must not grade the same as a fresh one"
+    );
+    assert_eq!(
+        fresh,
+        TrustGrade::Strong,
+        "observed + corroborated(2) + confirmed, in force"
+    );
+    assert_eq!(
+        stale,
+        TrustGrade::Adequate,
+        "the same axes, stale, grade one step down rather than becoming inadmissible"
+    );
+    clean(&path);
+}
+
+// ---------------------------------------------------------------------------
+// Migration of a derived table
+// ---------------------------------------------------------------------------
+
+/// A projection folded before the trust columns existed is **rebuilt**, not
+/// patched.
+///
+/// Legitimate here and nowhere else in this crate: a projection is derived, so
+/// dropping it loses no evidence. The evidence log gets additive migrations
+/// precisely because the same move there would be a forgery.
+#[test]
+fn a_projection_of_the_old_shape_is_rebuilt_rather_than_left_short() {
+    let path = tmp("reshape");
+    let mut s = WorldStore::open(&path).expect("open");
+    s.append(&ev(&ids(1), Some(&axes()), None)).expect("append");
+    s.fold().expect("fold");
+
+    // Simulate the pre-trust shape by rebuilding the table without the axes.
+    s.raw_execute_for_test(
+        "CREATE TABLE wc_old AS SELECT subject, predicate_key, predicate, object, kind,
+             payload, frame_id, map_id, source, valid_from_ms, valid_to_ms, txn_time_ms,
+             generation, event_id
+         FROM world_current",
+    )
+    .expect("project away the trust columns");
+    s.raw_execute_for_test("DROP TABLE world_current")
+        .expect("drop");
+    s.raw_execute_for_test("ALTER TABLE wc_old RENAME TO world_current")
+        .expect("rename");
+
+    // The next fold must notice the shape and rebuild rather than fail or
+    // silently return claims with no trust.
+    s.fold().expect("fold against the old shape");
+
+    let got = s.current("cup-1", T0 + 1).expect("read");
+    assert_eq!(got.len(), 1, "the claim survived the rebuild");
+    assert!(
+        got[0].trust.is_some(),
+        "and now carries the trust it was written with"
+    );
+    clean(&path);
+}


### PR DESCRIPTION
## The gap, which was sharper than "wire a consumer" implied

Strand C (#1376) put the four trust axes into the evidence log. **Nothing carried them out of it.** `world_current` had no axis columns and `ProjectedClaim` had no axis fields, so every read returned a value with **no trust attached** and a consumer had to go back to the raw log to learn anything about it.

The axes were stored and unreachable. That is the concrete form of the "every answer carries value + trust axes + validity + a provenance handle" rule, and finding it is most of what this PR is.

Fixed in the **projection**, not the ratified schema — `world_current` is derived, so this is free, on the same `WM2_EVENT_SCHEMA.md` §7 argument the subject summary rests on. No version bump, no ruling needed.

## Validity is still computed — the part that matters more

The axes travelling is the easy half. The half worth guarding is that the **fourth axis is not stored**.

- **There is no validity column in either table**, asserted against the **live schema** via `pragma_table_info` rather than against the DDL text — so adding one later reds a test instead of passing because the constant still reads right.
- `ProjectedClaim::validity_at` takes a clock. The same row read at two times gives `Timeless`, then `Expired`. That is only possible because nothing is stored.

Transition rule 6 says validity is a question asked with a clock passed in, not a state the system enters. This keeps that structural rather than documented.

## The staleness budget belongs to the caller, not the row

How long a claim stays fresh is a policy of the **asking consumer** — a floor plan and a person's location go stale at wildly different rates — so baking one budget into the row would answer for every reader at once.

Same row, same clock, three budgets:

| Budget | Validity |
|---|---|
| `None` | `Timeless` |
| `Some(1_000)` | `Stale` |
| `Some(1_000_000)` | `Fresh` |

## Collapsing to a grade is a method, not a field

The blueprint: the axes are stored separately and collapsed to a grade **only at the query boundary, for consumers that ask for one.** `grade_at` is a method so the collapse is something a caller *does*, never something they receive by default — and it moves with validity, so it cannot be cached into the row either.

`None` for an unlabelled claim. No axes means no trust to grade, and returning a default would manufacture one.

## Two fail-closed choices

- **An unlabelled claim reads as unlabelled**, never as default axes. Downstream, a manufactured default is indistinguishable from a claim that really was observed and confirmed — the "mush after eighteen months" the four-axis model exists to prevent.
- **An unreadable axis fails closed** as a conversion error rather than dropping to `None`. Dropping it would turn a corrupt trust label into "no trust recorded", which reads as a fact about the claim rather than a fault in the store.

## The provenance handle

A read claim now carries its own `chain_digest`, so an answer can be **cited and independently verified** rather than trusted because the API returned it. Same argument as the subject summary's `provenance_head` in #1377.

## A projection of the old shape is rebuilt, not patched

`CREATE TABLE IF NOT EXISTS` will not add columns, so `ensure_projections` detects the missing column and drops the table for the next fold to rebuild.

**Legitimate here and nowhere else in this crate.** A projection is derived, so dropping it loses no evidence — it is exactly what `rebuild_projections` already does on demand. The evidence log gets *additive* migrations precisely because the same move there would be a forgery. The comment says so at the call site, because this is the one place that reasoning could be copied to somewhere it does not hold.

## Negative controls

| Guard reverted | Result |
|---|---|
| a `validity` column added to either table | 1 test (checks the live schema, not the DDL text) |
| staleness budget read from the row instead of the caller | 1 test |
| grade exposed as a field rather than computed | 1 test (grade moves with validity) |
| unlabelled claim defaulted to axes | 1 test |
| old-shape projection left short instead of rebuilt | 1 test |
| chain digest not carried to the reader | 1 test |

## Verification

8 new tests · 30 lib + 109 integration in `kirra-world-store` · clippy 0 warnings under `#[warn(missing_docs)]` · rustfmt clean · MSRV 1.88 against the real toolchain · `cargo check --workspace --all-targets` clean · all 12 substantive CI gates · both Kirra World fences INTACT.

**All eight cargo trees** formatted and both detached harnesses re-tested (30, and 207+7).

## Scope

This is the store-side half. It does **not** change `kirra-world-service`'s API, which is still a single re-export — wiring a service consumer on top of this is the natural follow-up, and it is now possible to do without a breaking change, because the answer type already carries what Tier 3 requires.

Kirra is designed in alignment with ISO 26262 ASIL-D requirements and IEC 61508 SIL 3 requirements. Independent third-party assessment has not yet been performed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_