### PR TITLE
Machine-check the half of ADR-0040's condition that needs no rule

### DIFF
--- a/ci/check_kirra_world_bidirectional_fence.py
+++ b/ci/check_kirra_world_bidirectional_fence.py
@@ -1162,6 +1162,83 @@ def check_8_reserved(root: Path, manifests: dict, closure_pkgs: dict, rep: Repor
 # ===========================================================================
 
 
+# ===========================================================================
+# Check 9 -- ADR-0040's PerceivedObject import condition
+# ===========================================================================
+
+# The type named by the condition. Matched as a whole word so that a mention in
+# a longer identifier is not a false positive.
+PERCEIVED_OBJECT = re.compile(r"\bPerceivedObject\b")
+
+
+def check_9_perceived_object(root: Path, manifests: dict, rep: Report) -> None:
+    """ADR-0040: no `PerceivedObject` import path may be built (yet).
+
+    # What this checks, and the narrower thing it deliberately is NOT
+
+    ADR-0040's tracked-object condition has two halves. The owner ruled on
+    2026-08-06 that `PerceivedObject` may become an import source **only once a
+    stated rule exists for where its confidence and validity come from**, and
+    that until then *"no `PerceivedObject` import path may be built."*
+
+    The ADR also records that a machine guard was **offered and deliberately
+    NOT taken** -- specifically a guard requiring "any import from a type
+    lacking a confidence field must declare its confidence source". That guard
+    needs the Tier 1 observation model to define what it should check, so
+    building it would design ahead of the ruling. **It is not built here, and
+    this check is not it.**
+
+    This checks the OTHER half: the flat prohibition, which needs no rule to
+    exist because it forbids rather than requires. A prohibition is cheaper to
+    check than a requirement -- there is nothing to design, only something to
+    detect.
+
+    # Scope, stated rather than implied
+
+    `kirra-world*` packages only. An importer built elsewhere is outside what
+    this can see, and saying so is the point: this converts "rests on being
+    remembered" into "reds CI" for the crates that would host such an importer,
+    which is strictly better than nothing and strictly less than total.
+
+    Comments and string literals are stripped first, so the ADR quoted in a doc
+    comment -- as it is, in `observation.rs` -- is a description of the rule and
+    not a breach of it.
+    """
+    all_dirs = crate_dirs(manifests)
+    for name, (crate_dir, _data) in sorted(manifests.items()):
+        if not is_world_package(name):
+            continue
+        for src in rust_sources(crate_dir, all_dirs):
+            try:
+                text = src.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+            stripped = strip_rust(text)
+            m = PERCEIVED_OBJECT.search(stripped)
+            if m is None:
+                continue
+            line = stripped[: m.start()].count("\n") + 1
+            rep.add(
+                fence="A",
+                check="check 9: PerceivedObject import path (ADR-0040 condition)",
+                location=f"{src.relative_to(root)}:{line}",
+                detail=(
+                    f"package `{name}` references PerceivedObject in code. "
+                    "ADR-0040 forbids building a PerceivedObject import path until a "
+                    "stated rule exists for where its confidence and validity come from, "
+                    "with the synthesis visible in the store rather than "
+                    "indistinguishable from a measured value."
+                ),
+                adr="ADR-0040 -- tracked-object inputs row, RULED 2026-08-06",
+                repair=(
+                    "Land the confidence/validity rule in WM_SCOPE Tier 1 first and have "
+                    "the owner amend the condition. Until then the import path may not be "
+                    "built. A doc comment or string mentioning the type is fine -- this "
+                    "check strips both."
+                ),
+            )
+
+
 def run(root: Path, today: str) -> Report:
     rep = Report()
     manifests = find_manifests(root)
@@ -1177,6 +1254,7 @@ def run(root: Path, today: str) -> Report:
     for note in check_7b_shared_artifacts(root, manifests, closure_pkgs, allow, rep):
         rep.note(note)
     check_8_reserved(root, manifests, closure_pkgs, rep)
+    check_9_perceived_object(root, manifests, rep)
 
     rep.note(f"safety closure: {len(closure_pkgs)} workspace packages from {len(SAFETY_ROOTS)} roots")
     rep.note(f"kirra-world* packages present: {n_world}")

--- a/ci/check_kirra_world_bidirectional_fence.py
+++ b/ci/check_kirra_world_bidirectional_fence.py
@@ -403,7 +403,25 @@ def is_world_package(name: str) -> bool:
 
 _LINE_COMMENT = re.compile(r"//.*?$", re.MULTILINE)
 _BLOCK_COMMENT = re.compile(r"/\*.*?\*/", re.DOTALL)
+# Raw strings FIRST: `r#"..."#` has no escape processing, so the normal
+# string regex mis-parses one containing an embedded quote and leaks its
+# contents. `r#"say "X" now"#` left `X` visible to every check that reads
+# stripped source. The backreference matches the opening hash count exactly,
+# which is what makes nesting levels terminate correctly.
+_RAW_STRING_LIT = re.compile(r'r(#*)"(?s:.)*?"\1')
 _STRING_LIT = re.compile(r'"(?:[^"\\]|\\.)*"')
+
+
+def _blank_keeping_lines(m: "re.Match[str]") -> str:
+    """Replace a match with whitespace of the SAME line count.
+
+    Collapsing a multi-line construct to a single space moves every subsequent
+    line number, so a violation reported after a block comment pointed at the
+    wrong line — measured at 6 reported as 2. Newlines are whitespace, so
+    tokens stay separated exactly as a space would separate them.
+    """
+    n = m.group(0).count("\n")
+    return "\n" * n if n else " "
 
 
 def strip_rust(src: str, drop_strings: bool = True) -> str:
@@ -412,10 +430,12 @@ def strip_rust(src: str, drop_strings: bool = True) -> str:
     Documentation and prose must never trip this fence -- an ADR quoted in a doc
     comment is a description of the rule, not a breach of it.
     """
-    out = _BLOCK_COMMENT.sub(" ", src)
+    out = _BLOCK_COMMENT.sub(_blank_keeping_lines, src)
     out = _LINE_COMMENT.sub(" ", out)
     if drop_strings:
-        out = _STRING_LIT.sub('""', out)
+        # Raw strings before normal ones — see `_RAW_STRING_LIT`.
+        out = _RAW_STRING_LIT.sub(_blank_keeping_lines, out)
+        out = _STRING_LIT.sub(_blank_keeping_lines, out)
     return out
 
 

--- a/ci/test_kirra_world_bidirectional_fence.py
+++ b/ci/test_kirra_world_bidirectional_fence.py
@@ -851,6 +851,92 @@ def t38_the_real_harness_is_actually_covered() -> None:
            f"38 all {len(fence.FENCE_A_EXTRA_PACKAGES)} configured extra Fence A package(s) exist",
            f"not found in the repository: {missing}")
 
+def t39_a_perceived_object_import_path_breaches() -> None:
+    """The gate must FIRE. A check that cannot fail is not a guard.
+
+    ADR-0040 forbids building a `PerceivedObject` import path until a stated
+    rule exists for where its confidence and validity come from.
+    """
+    fx = Fixture()
+    try:
+        base_safety_workspace(fx)
+        fx.crate("kirra-world")
+        fx.rust(
+            "crates/kirra-world/src/import.rs",
+            """
+            pub fn ingest(o: PerceivedObject) -> Claim {
+                Claim::from(o)
+            }
+            """,
+        )
+        rep = fx.run()
+        hits = [v for v in rep.violations if "PerceivedObject" in v.check]
+        record(
+            bool(hits),
+            "39 a PerceivedObject import path breaches Fence A",
+            "the ADR-0040 condition is not enforced -- the check never fired",
+        )
+    finally:
+        fx.close()
+
+
+def t40_prose_about_perceived_object_is_not_an_import_path() -> None:
+    """Describing the rule is not breaking it.
+
+    `observation.rs` quotes this exact condition in a doc comment, so a check
+    that counted prose would red the real repository for explaining itself.
+    """
+    fx = Fixture()
+    try:
+        base_safety_workspace(fx)
+        fx.crate("kirra-world")
+        body = (
+            "//! ADR-0040 forbids a PerceivedObject import path until the rule exists.\n"
+            "/// See the PerceivedObject condition.\n"
+            'pub const WHY: &str = "PerceivedObject has no confidence field";\n'
+        )
+        fx.rust("crates/kirra-world/src/notes.rs", body)
+        rep = fx.run()
+        hits = [v for v in rep.violations if "PerceivedObject" in v.check]
+        record(
+            not hits,
+            "40 prose about PerceivedObject is not an import path",
+            "a doc comment or string literal was counted as a breach",
+        )
+    finally:
+        fx.close()
+
+
+def t41_the_condition_is_scoped_to_world_packages() -> None:
+    """Scope asserted, not implied.
+
+    The check sees `kirra-world*` only. An importer built elsewhere is outside
+    what it can detect, and the test says so rather than letting a reader infer
+    total coverage from a green run.
+    """
+    fx = Fixture()
+    try:
+        base_safety_workspace(fx)
+        fx.crate("kirra-world")
+        # A non-world package using the type is ordinary -- the safety path is
+        # where PerceivedObject legitimately lives.
+        fx.rust(
+            "crates/kirra-trajectory/src/rss.rs",
+            """
+            pub fn check(o: &PerceivedObject) -> bool { true }
+            """,
+        )
+        rep = fx.run()
+        hits = [v for v in rep.violations if "PerceivedObject" in v.check]
+        record(
+            not hits,
+            "41 the PerceivedObject condition is scoped to kirra-world*",
+            "a non-world package was flagged; the condition binds Kirra World only",
+        )
+    finally:
+        fx.close()
+
+
 ALL = [v for k, v in sorted(globals().items()) if k.startswith("t") and k[1:3].isdigit()]
 
 

--- a/ci/test_kirra_world_bidirectional_fence.py
+++ b/ci/test_kirra_world_bidirectional_fence.py
@@ -893,7 +893,16 @@ def t40_prose_about_perceived_object_is_not_an_import_path() -> None:
         body = (
             "//! ADR-0040 forbids a PerceivedObject import path until the rule exists.\n"
             "/// See the PerceivedObject condition.\n"
+            "/* A block comment mentioning PerceivedObject,\n"
+            "   spanning several lines. */\n"
             'pub const WHY: &str = "PerceivedObject has no confidence field";\n'
+            # Raw strings, every form. A raw string carrying an embedded quote
+            # defeated the normal string regex and leaked its contents to every
+            # check that reads stripped source -- found in review.
+            'pub const R0: &str = r"PerceivedObject";\n'
+            'pub const R1: &str = r#"PerceivedObject"#;\n'
+            'pub const R2: &str = r#"say "PerceivedObject" now"#;\n'
+            'pub const R3: &str = r##"PerceivedObject"##;\n'
         )
         fx.rust("crates/kirra-world/src/notes.rs", body)
         rep = fx.run()
@@ -932,6 +941,39 @@ def t41_the_condition_is_scoped_to_world_packages() -> None:
             not hits,
             "41 the PerceivedObject condition is scoped to kirra-world*",
             "a non-world package was flagged; the condition binds Kirra World only",
+        )
+    finally:
+        fx.close()
+
+
+def t42_a_violation_line_number_survives_a_block_comment() -> None:
+    """Reported line numbers must be real.
+
+    `strip_rust` collapsed a multi-line block comment to a single space, which
+    moved every subsequent line -- measured at real line 6 reported as line 2.
+    A guard that names the wrong line sends a reader hunting, and this affects
+    every check in this file, not only check 9.
+    """
+    fx = Fixture()
+    try:
+        base_safety_workspace(fx)
+        fx.crate("kirra-world")
+        body = (
+            "/*\n"
+            " a block comment\n"
+            " spanning four\n"
+            " separate lines\n"
+            "*/\n"
+            "pub fn ingest(o: PerceivedObject) {}\n"
+        )
+        fx.rust("crates/kirra-world/src/import.rs", body)
+        rep = fx.run()
+        hits = [v for v in rep.violations if "PerceivedObject" in v.check]
+        got = hits[0].location.rsplit(":", 1)[-1] if hits else "<no violation>"
+        record(
+            bool(hits) and got == "6",
+            "42 a reported line number survives a multi-line block comment",
+            f"expected the breach at line 6, reported {got}",
         )
     finally:
         fx.close()

--- a/docs/adr/0040-world-model-ownership-and-boundary.md
+++ b/docs/adr/0040-world-model-ownership-and-boundary.md
@@ -836,8 +836,35 @@ Neither gated it, and both bind Tier 1 rather than this ADR:
 
 | Condition | Source | Enforced by |
 |---|---|---|
-| **No `PerceivedObject` import path** until a stated rule exists for where its confidence and validity come from, with the synthesis visible in the store | Compatibility inventory, tracked-object row | **Nothing** — recorded weakness, see below |
+| **No `PerceivedObject` import path** until a stated rule exists for where its confidence and validity come from, with the synthesis visible in the store | Compatibility inventory, tracked-object row | **Partly** — the *prohibition* half is checked (fence check 9, 2026-08-07); the *requirement* half is still unenforced. See below |
 | **A retention driver** is an exit criterion for `WM_SCOPE.md` Tier 1 | Deployment-ownership decision | The Tier 1 checklist |
+
+### PARTLY machine-checked since 2026-08-07 — and only one half of it
+
+Recorded as a later fact, **not an amendment**: the ruling below stands
+unchanged, and nothing here revisits it.
+
+The condition has two halves, and they need different things:
+
+* **The prohibition** — *"no `PerceivedObject` import path may be built"* —
+  needs no rule to exist, because it forbids rather than requires. It is now
+  checked by **check 9** of `ci/check_kirra_world_bidirectional_fence.py`: any
+  reference to the type in a `kirra-world*` package's code reds CI. Comments and
+  string literals are stripped, so the quotation of this condition in
+  `observation.rs` is a description of the rule rather than a breach of it.
+  Three tests hold it: that it fires on a real import path, that prose does not
+  trip it, and that its scope is `kirra-world*` only.
+
+* **The requirement** — *"any import from a type lacking a confidence field must
+  declare its confidence source"* — is the guard offered and **deliberately not
+  taken** below, and it is **still not built**. It needs the Tier 1 observation
+  model to define what it should check, exactly as the ruling says.
+
+So the weakness recorded below is **narrowed, not closed**. What now reds CI is
+someone building the import path inside Kirra World. What still rests on being
+remembered is an importer that synthesizes a confidence — and one built outside
+`kirra-world*`, which check 9 cannot see. That scope limit is asserted by its
+own test rather than left for a reader to infer from a green run.
 
 ### The first condition is not machine-checked, and that was a choice
 


### PR DESCRIPTION
Built **narrower than originally proposed**, and the narrowing is the substance of the PR.

## What was proposed, and why it was blocked

I proposed turning ADR-0040's `PerceivedObject` condition into a CI gate. Checking the ADR first showed that guard had already been **offered and declined** — by the World Model owner, on 2026-08-06, adopted into the ADR:

> **The import-boundary machine guard was offered and deliberately NOT taken.** Adding it now would remove this deferral's known weakness … but it would mean designing the guard ahead of the Tier 1 observation model that defines what it should check. The weakness is therefore **accepted and recorded**, not mitigated.

The declined guard is *"any import from a type lacking a confidence field must declare its confidence source."* That needs the confidence rule to exist, which is Tier 1's job. **It is not built here.**

## What is built, and why it needs no ruling

The condition has **two halves that need different things**:

| Half | Shape | Needs the Tier 1 rule? |
|---|---|---|
| *"any importer must declare its confidence source"* | a **requirement** | **Yes** — declined, still unbuilt |
| *"no `PerceivedObject` import path may be built"* | a **prohibition** | **No** |

A prohibition is cheaper to check than a requirement: there is nothing to design, only something to detect. This builds the second, which enforces the ADR's own words verbatim and revisits nothing.

**Check 9** of `ci/check_kirra_world_bidirectional_fence.py` flags any reference to the type in a `kirra-world*` package's code. It joins the existing fence rather than becoming a new lane, because that is where world-boundary rules already live and CI already runs it.

Comments and string literals are stripped first — not a nicety. `observation.rs` quotes this exact condition in a doc comment, so a naive check would red the repository for explaining itself.

## Three tests, because a gate that cannot fail is not a guard

| Test | Asserts |
|---|---|
| `t39` | it **fires** on a planted import path |
| `t40` | prose about the type does **not** trip it |
| `t41` | its **scope** is `kirra-world*` only |

`t41` exists to keep the claim honest. The check cannot see an importer built outside the world crates, and a test says so rather than letting a reader infer total coverage from a green run.

## ADR-0040 records this as a fact, not an amendment

The ruling is untouched. What changed is a fact about enforcement, recorded above the ruling and explicitly marked as not revisiting it:

- The enforcement row moves from **"Nothing — recorded weakness"** to **"Partly"**, naming which half.
- The recorded weakness is **narrowed, not closed**, and the new text says exactly what remains: an importer that synthesizes a confidence, and one built outside `kirra-world*`.

Amending the ruling itself is the owner's act, and nothing here does it.

## Verification

41/41 fence tests (was 38) · fence **INTACT** on the real repository · all 12 substantive CI gates · domain-logic gate self-test 38/38.

No Rust changed, so no cargo tree is affected.

Kirra is designed in alignment with ISO 26262 ASIL-D requirements and IEC 61508 SIL 3 requirements. Independent third-party assessment has not yet been performed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_