### PR TITLE
ObservationKind and the per-kind body contract — Tier 1's last item

### DIFF
--- a/crates/kirra-world/src/kind.rs
+++ b/crates/kirra-world/src/kind.rs
@@ -1,0 +1,508 @@
+//! **`ObservationKind`** — what a claim asserts, and the per-kind body contract.
+//!
+//! # Ruled, not invented
+//!
+//! §7.1 names this field and the blueprint never enumerates its variants, so
+//! [`observation`](crate::observation) refused to invent a taxonomy. The list
+//! below is not this module's guess: it was proposed in
+//! `WM_OBSERVATION_KIND_PROPOSAL.md` (`KIRRA-WM-OBSKIND-001`) and **adopted
+//! 2026-08-07, option 2** — the three variants attested by what the system
+//! actually writes, plus a degrade target.
+//!
+//! `Existence` was proposed as a fourth and **deferred**, on an asymmetry
+//! rather than a preference: adding a variant later costs an additive enum
+//! change, while removing one already written into a hash-chained log would
+//! mean rewriting rows inside the chain. Its revisit trigger is a perception
+//! producer with a saw-something-claiming-nothing output.
+//!
+//! # `ObservationKind` is not `EntityKind` renamed
+//!
+//! Worth stating because the two are easy to conflate, and conflating them
+//! makes the payload vocabulary grow as 19 × *k* instead of *k*:
+//!
+//! * [`EntityKind`](crate::entity::EntityKind) answers *what is this thing* —
+//!   `Robot`, `Door`, `Room`.
+//! * `ObservationKind` answers *what does this claim assert about it*.
+//!
+//! A `Door` can be the subject of a spatial claim, an attribute claim and a
+//! relationship claim; a spatial claim can be about a `Door`, a `Robot` or a
+//! `Package`. They are orthogonal axes, not two spellings of one.
+//!
+//! # The tokens are fixed, and that is a hash constraint
+//!
+//! The storage layer's `kind` column is inside the canonically-hashed bytes
+//! **twice** — as a distinct argument to the record hash and as a field in the
+//! canonical JSON. Re-spelling `observation` as `attribute` would not be a
+//! rename; it would change the digest of every row that carried it and break
+//! chain verification on every existing store. [`ObservationKind::as_str`]
+//! returns the stored token, and those tokens are frozen.
+//!
+//! # What this module does NOT do
+//!
+//! It does not change the storage layer's `kind` field from `&str` to this
+//! enum. The ruling is explicit that doing so in the same slice is not
+//! authorized — it touches the hashed bytes and needs its own compatibility
+//! argument, exactly as the trust axes did. This types the *boundary*: a writer
+//! converts on the way in, a reader adjudicates on the way out, and the bytes
+//! are untouched.
+
+use core::fmt;
+
+/// What a claim asserts about its subject.
+///
+/// See the module docs for the ruling this list comes from, and for why it is
+/// orthogonal to [`EntityKind`](crate::entity::EntityKind).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum ObservationKind {
+    /// A property of one subject. The default, and the most-written value in
+    /// every store.
+    Attribute,
+    /// Where a subject is.
+    ///
+    /// **Carries SD-4's frame requirement.** A spatial claim with no frame is
+    /// refused by the storage schema, not by a caller's diligence, because a
+    /// frameless spatial claim cannot later be shown *not* to have become
+    /// checker geometry (ADR-0042 Decision 2).
+    Spatial,
+    /// That two subjects are related. The only kind for which the storage
+    /// layer's `predicate` and `object` columns carry meaning.
+    Relationship,
+    /// **A kind this build does not recognise.**
+    ///
+    /// The degrade target, shaped after
+    /// [`EntityKind::Unknown`](crate::entity::EntityKind::Unknown). Reached only
+    /// by [`ObservationKind::from_token`]; there is no way to *write* one,
+    /// because [`ObservationKind::as_str`] has no token for it — see that
+    /// method.
+    ///
+    /// A kind arriving from a newer writer is the ordinary case in a fleet
+    /// mid-rollout, not an exception, so degrading is the common path rather
+    /// than the error path.
+    Unrecognised,
+}
+
+impl ObservationKind {
+    /// The stored token, or `None` for [`ObservationKind::Unrecognised`].
+    ///
+    /// # Why this returns `Option` rather than a token
+    ///
+    /// There is no token for `Unrecognised` because writing one would be
+    /// claiming a vocabulary entry that does not exist. Returning `Option`
+    /// makes "this kind cannot be written" a thing the caller must handle,
+    /// rather than a placeholder string that round-trips and silently becomes
+    /// a real stored value.
+    ///
+    /// It is the same move as
+    /// [`EntityKind::group`](crate::entity::EntityKind::group) returning `None`
+    /// for `Unknown`: the degrade target has no reading to give, so the type
+    /// does not offer one.
+    ///
+    /// **These tokens are frozen** — they are inside the chain hash. See the
+    /// module docs.
+    #[must_use]
+    pub fn as_str(self) -> Option<&'static str> {
+        Some(match self {
+            Self::Attribute => "observation",
+            Self::Spatial => "spatial",
+            Self::Relationship => "relationship",
+            Self::Unrecognised => return None,
+        })
+    }
+
+    /// Parse a stored token, degrading rather than guessing.
+    ///
+    /// An unrecognised token is **not** an error and **not** silently mapped to
+    /// `Attribute`. §6.2's rule — *degrade to unknown, not a guessed supertype*
+    /// — applies with more force here than for entities, because reading a
+    /// newer writer's kind is routine during a rollout.
+    #[must_use]
+    pub fn from_token(token: &str) -> Self {
+        match token {
+            "observation" => Self::Attribute,
+            "spatial" => Self::Spatial,
+            "relationship" => Self::Relationship,
+            _ => Self::Unrecognised,
+        }
+    }
+
+    /// Whether this kind requires a coordinate frame (SD-4).
+    ///
+    /// `Unrecognised` answers **`false`**, and that is deliberate rather than
+    /// convenient: the storage `CHECK` keys on the literal token `'spatial'`,
+    /// so a kind this build cannot name is not spatial *to the schema* either.
+    /// Answering `true` here would put this type and the schema into
+    /// disagreement about the same row — and the schema is the guarantee.
+    #[must_use]
+    pub fn requires_frame(self) -> bool {
+        matches!(self, Self::Spatial)
+    }
+
+    /// Whether `predicate` and `object` carry meaning for this kind.
+    #[must_use]
+    pub fn uses_predicate_object(self) -> bool {
+        matches!(self, Self::Relationship)
+    }
+}
+
+impl fmt::Display for ObservationKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.as_str() {
+            Some(t) => f.write_str(t),
+            None => f.write_str("<unrecognised>"),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The per-kind versioned body — §7.1's TypedPayload
+// ---------------------------------------------------------------------------
+
+/// Why a body was refused.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BodyError {
+    /// The body was offered under a kind its type does not serve.
+    ///
+    /// Carries both so the message names the mismatch rather than only
+    /// reporting that one happened.
+    KindMismatch {
+        /// The kind the body type declares.
+        expected: ObservationKind,
+        /// The kind it was offered under.
+        offered: ObservationKind,
+    },
+    /// The body was offered at a schema version its type does not know.
+    ///
+    /// **Fail-closed, and specifically closed against the FUTURE.** A body
+    /// written by a newer producer may carry fields this build cannot see, so
+    /// decoding it as the version this build knows would silently drop them —
+    /// and in an evidence log a silently truncated record is worse than an
+    /// unread one.
+    UnsupportedVersion {
+        /// The version this build writes.
+        supported: u32,
+        /// The version offered.
+        offered: u32,
+    },
+    /// The body's own content was refused by its type.
+    Invalid(String),
+}
+
+impl fmt::Display for BodyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::KindMismatch { expected, offered } => write!(
+                f,
+                "body serves kind `{expected}` but was offered under `{offered}`"
+            ),
+            Self::UnsupportedVersion { supported, offered } => write!(
+                f,
+                "body is schema version {offered}, this build supports {supported}"
+            ),
+            Self::Invalid(detail) => write!(f, "body refused: {detail}"),
+        }
+    }
+}
+
+/// A payload body that knows **which kind it serves and at which version**.
+///
+/// # What this contract buys, and what it deliberately does not
+///
+/// §7.1 asks for a per-kind versioned `TypedPayload`. The two halves are the
+/// point:
+///
+/// * **Per-kind** — a body declares [`TypedBody::KIND`], so a spatial body
+///   cannot be attached to a relationship claim by mistake. That check is
+///   [`TypedBody::admit`], and it is a *function of the type*, not a
+///   convention a writer follows.
+/// * **Versioned** — a body declares [`TypedBody::SCHEMA_VERSION`], which is
+///   what the storage layer's `payload_schema` column has always held without
+///   anything defining what it meant.
+///
+/// **The stored bytes are unchanged.** This types the boundary: a writer
+/// encodes on the way in, a reader adjudicates on the way out. The ruling that
+/// authorized `ObservationKind` explicitly did not authorize changing the
+/// stored `kind` field in the same slice, and the same reasoning applies to the
+/// payload — both are inside the canonically-hashed bytes, and moving them
+/// needs its own compatibility argument.
+///
+/// # Why encoding is the implementor's job
+///
+/// This trait does not require `serde`, a wire format, or any particular
+/// encoding. `kirra-world` has **zero dependencies** by ratification criterion,
+/// so a trait demanding a serializer would either pull one in or fake one. The
+/// body owns its own `encode`/`decode`, and the contract is only about *kind*
+/// and *version* — the two things that decide whether decoding should be
+/// attempted at all.
+pub trait TypedBody: Sized {
+    /// The kind this body serves.
+    const KIND: ObservationKind;
+
+    /// The schema version this build writes and can read.
+    ///
+    /// Corresponds to the storage layer's `payload_schema` column, which held
+    /// a number with no stated meaning until now.
+    const SCHEMA_VERSION: u32;
+
+    /// Validate the body's own content.
+    ///
+    /// Default: nothing to check. A body with invariants overrides this; one
+    /// without says so by not overriding, which is a smaller lie than an empty
+    /// override that looks like a check.
+    ///
+    /// # Errors
+    ///
+    /// [`BodyError::Invalid`] with a reason the body's author chooses.
+    fn validate(&self) -> Result<(), BodyError> {
+        Ok(())
+    }
+
+    /// Admit this body under `kind` at `version`, or refuse.
+    ///
+    /// The order is deliberate: **kind, then version, then content.** A body
+    /// offered under the wrong kind is not a version problem, and reporting the
+    /// version mismatch of a body that should never have been considered would
+    /// send a reader to the wrong question.
+    ///
+    /// # Errors
+    ///
+    /// [`BodyError::KindMismatch`], [`BodyError::UnsupportedVersion`], or
+    /// whatever [`TypedBody::validate`] returns.
+    fn admit(&self, kind: ObservationKind, version: u32) -> Result<(), BodyError> {
+        if kind != Self::KIND {
+            return Err(BodyError::KindMismatch {
+                expected: Self::KIND,
+                offered: kind,
+            });
+        }
+        if version != Self::SCHEMA_VERSION {
+            return Err(BodyError::UnsupportedVersion {
+                supported: Self::SCHEMA_VERSION,
+                offered: version,
+            });
+        }
+        self.validate()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A body for each attested kind, minimal on purpose — the contract is what
+    // is under test, not any particular payload shape.
+    #[derive(Debug, PartialEq)]
+    struct Colour(&'static str);
+    impl TypedBody for Colour {
+        const KIND: ObservationKind = ObservationKind::Attribute;
+        const SCHEMA_VERSION: u32 = 1;
+        fn validate(&self) -> Result<(), BodyError> {
+            if self.0.is_empty() {
+                return Err(BodyError::Invalid("colour is empty".into()));
+            }
+            Ok(())
+        }
+    }
+
+    #[derive(Debug)]
+    struct Pose;
+    impl TypedBody for Pose {
+        const KIND: ObservationKind = ObservationKind::Spatial;
+        const SCHEMA_VERSION: u32 = 2;
+    }
+
+    // -----------------------------------------------------------------------
+    // The ruled vocabulary
+    // -----------------------------------------------------------------------
+
+    /// The three tokens are FROZEN — they are inside the chain hash twice, so
+    /// re-spelling one breaks verification on every existing store.
+    #[test]
+    fn the_stored_tokens_are_exactly_what_the_log_already_contains() {
+        assert_eq!(ObservationKind::Attribute.as_str(), Some("observation"));
+        assert_eq!(ObservationKind::Spatial.as_str(), Some("spatial"));
+        assert_eq!(ObservationKind::Relationship.as_str(), Some("relationship"));
+    }
+
+    /// The degrade target has no token, so it cannot be written.
+    #[test]
+    fn unrecognised_has_no_token_to_write() {
+        assert_eq!(ObservationKind::Unrecognised.as_str(), None);
+    }
+
+    /// An unknown token degrades rather than guessing — and specifically does
+    /// NOT become `Attribute`, which is the guess a "sensible default" would
+    /// make.
+    #[test]
+    fn an_unknown_token_degrades_rather_than_guessing() {
+        for token in ["existence", "prediction", "", "OBSERVATION", "spatial "] {
+            assert_eq!(
+                ObservationKind::from_token(token),
+                ObservationKind::Unrecognised,
+                "{token:?} must degrade"
+            );
+        }
+    }
+
+    /// Round trip for every writable variant.
+    #[test]
+    fn every_writable_kind_round_trips() {
+        for k in [
+            ObservationKind::Attribute,
+            ObservationKind::Spatial,
+            ObservationKind::Relationship,
+        ] {
+            let token = k.as_str().expect("writable");
+            assert_eq!(ObservationKind::from_token(token), k);
+        }
+    }
+
+    /// `Existence` was DEFERRED, not adopted. Its token must degrade — if
+    /// someone adds the variant without the ruling, this is what fails.
+    #[test]
+    fn the_deferred_existence_kind_is_not_in_the_vocabulary() {
+        assert_eq!(
+            ObservationKind::from_token("existence"),
+            ObservationKind::Unrecognised
+        );
+    }
+
+    /// SD-4's frame requirement rides on `Spatial` alone — and `Unrecognised`
+    /// answers `false` so this type and the schema agree about the same row.
+    #[test]
+    fn only_spatial_requires_a_frame() {
+        assert!(ObservationKind::Spatial.requires_frame());
+        assert!(!ObservationKind::Attribute.requires_frame());
+        assert!(!ObservationKind::Relationship.requires_frame());
+        assert!(
+            !ObservationKind::Unrecognised.requires_frame(),
+            "the schema CHECK keys on the literal token, so an unnameable kind \
+             is not spatial to it either"
+        );
+    }
+
+    #[test]
+    fn only_relationships_use_predicate_and_object() {
+        assert!(ObservationKind::Relationship.uses_predicate_object());
+        assert!(!ObservationKind::Attribute.uses_predicate_object());
+        assert!(!ObservationKind::Spatial.uses_predicate_object());
+        assert!(!ObservationKind::Unrecognised.uses_predicate_object());
+    }
+
+    // -----------------------------------------------------------------------
+    // The per-kind versioned body
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn a_body_is_admitted_under_its_own_kind_and_version() {
+        assert!(Colour("red").admit(ObservationKind::Attribute, 1).is_ok());
+        assert!(Pose.admit(ObservationKind::Spatial, 2).is_ok());
+    }
+
+    /// **The per-kind half.** A spatial body cannot be attached to a
+    /// relationship claim, and the refusal names both sides.
+    #[test]
+    fn a_body_offered_under_the_wrong_kind_is_refused() {
+        let err = Pose
+            .admit(ObservationKind::Relationship, 2)
+            .expect_err("must refuse");
+        assert_eq!(
+            err,
+            BodyError::KindMismatch {
+                expected: ObservationKind::Spatial,
+                offered: ObservationKind::Relationship,
+            }
+        );
+    }
+
+    /// **The versioned half, failing closed against the FUTURE.** A body from a
+    /// newer producer may carry fields this build cannot see, so decoding it as
+    /// the known version would silently drop them — and in an evidence log a
+    /// silently truncated record is worse than an unread one.
+    #[test]
+    fn a_body_from_a_newer_producer_is_refused_not_truncated() {
+        let err = Pose
+            .admit(ObservationKind::Spatial, 3)
+            .expect_err("must refuse");
+        assert_eq!(
+            err,
+            BodyError::UnsupportedVersion {
+                supported: 2,
+                offered: 3
+            }
+        );
+    }
+
+    /// An older version is refused too. Reading v1 as v2 would invent whatever
+    /// v2 added, which is the same defect pointed the other way.
+    #[test]
+    fn an_older_version_is_refused_as_well() {
+        assert!(matches!(
+            Pose.admit(ObservationKind::Spatial, 1),
+            Err(BodyError::UnsupportedVersion { .. })
+        ));
+    }
+
+    /// **Kind before version.** A body offered under the wrong kind should
+    /// never have been considered, so reporting its version mismatch would send
+    /// a reader to the wrong question.
+    #[test]
+    fn kind_is_checked_before_version() {
+        let err = Pose
+            .admit(ObservationKind::Attribute, 99)
+            .expect_err("must refuse");
+        assert!(
+            matches!(err, BodyError::KindMismatch { .. }),
+            "both are wrong; the kind is the one to report, got {err:?}"
+        );
+    }
+
+    /// …and content last, after both structural checks pass.
+    #[test]
+    fn content_is_validated_only_once_kind_and_version_agree() {
+        let err = Colour("")
+            .admit(ObservationKind::Attribute, 1)
+            .expect_err("must refuse");
+        assert_eq!(err, BodyError::Invalid("colour is empty".into()));
+
+        // Wrong kind AND empty content: the kind is reported, not the content.
+        assert!(matches!(
+            Colour("").admit(ObservationKind::Spatial, 1),
+            Err(BodyError::KindMismatch { .. })
+        ));
+    }
+
+    /// A body with no invariants says so by not overriding `validate`, rather
+    /// than by an empty override that looks like a check.
+    #[test]
+    fn a_body_without_invariants_validates_trivially() {
+        assert!(Pose.validate().is_ok());
+    }
+
+    #[test]
+    fn errors_name_the_mismatch_rather_than_only_reporting_one() {
+        assert_eq!(
+            BodyError::KindMismatch {
+                expected: ObservationKind::Spatial,
+                offered: ObservationKind::Attribute,
+            }
+            .to_string(),
+            "body serves kind `spatial` but was offered under `observation`"
+        );
+        assert_eq!(
+            BodyError::UnsupportedVersion {
+                supported: 2,
+                offered: 7
+            }
+            .to_string(),
+            "body is schema version 7, this build supports 2"
+        );
+    }
+
+    /// `Unrecognised` displays as something a reader can act on rather than as
+    /// a token that might be mistaken for a stored value.
+    #[test]
+    fn the_degrade_target_displays_as_unwritable() {
+        assert_eq!(ObservationKind::Unrecognised.to_string(), "<unrecognised>");
+        assert_eq!(ObservationKind::Attribute.to_string(), "observation");
+    }
+}

--- a/crates/kirra-world/src/kind.rs
+++ b/crates/kirra-world/src/kind.rs
@@ -5,9 +5,9 @@
 //! §7.1 names this field and the blueprint never enumerates its variants, so
 //! [`observation`](crate::observation) refused to invent a taxonomy. The list
 //! below is not this module's guess: it was proposed in
-//! `WM_OBSERVATION_KIND_PROPOSAL.md` (`KIRRA-WM-OBSKIND-001`) and **adopted
-//! 2026-08-07, option 2** — the three variants attested by what the system
-//! actually writes, plus a degrade target.
+//! `docs/design/WM_OBSERVATION_KIND_PROPOSAL.md` (`KIRRA-WM-OBSKIND-001`) and
+//! **adopted 2026-08-07, option 2** — the three variants attested by what the
+//! system actually writes, plus a degrade target.
 //!
 //! `Existence` was proposed as a fourth and **deferred**, on an asymmetry
 //! rather than a preference: adding a variant later costs an additive enum

--- a/crates/kirra-world/src/lib.rs
+++ b/crates/kirra-world/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! # What this crate contains, and what it still does not
 //!
-//! **Real** — four modules, pure functions over pure data, still zero
+//! **Real** — seven modules, pure functions over pure data, still zero
 //! dependencies:
 //!
 //! * [`mod@trust`] (§9) — the four orthogonal trust axes and the transition
@@ -26,11 +26,20 @@
 //!   store has known *how* to compact since WM-2; nothing has ever decided
 //!   *when*, which is why the horizons OQ2 ruled have gone unenforced.
 //!
+//! * [`mod@reference`] — the opaque identity and spatial-reference newtypes
+//!   (`EventId`, `ObservationId`, `FrameId`, `MapId`), which make two adjacent
+//!   pairs of same-typed strings unswappable. Validated, never normalized.
+//! * [`mod@kind`] (§7.1) — `ObservationKind` and the per-kind versioned body
+//!   contract. Ruled rather than invented (`KIRRA-WM-OBSKIND-001`, 2026-08-07):
+//!   this was a *specification* gap, not an implementation one.
+//!
 //! **Still absent:** storage, API and queries — plus the parts of §6/§7 that
-//! need a dependency (ULID identity, content hashing, frames, maps, typed
-//! payloads), which belong to the store. The remaining types below are
-//! **unconstructible placeholders**, each with a private unit field, so no logic
-//! can accrete around a name before the model that gives it meaning exists.
+//! genuinely need a dependency (ULID *generation*, content hashing, frames,
+//! maps), which belong to the store. Note the split that settled: the core owns
+//! the **type** and what makes a value admissible; the layer with a clock and a
+//! hash **mints** the value. Five types below are still **unconstructible
+//! placeholders**, each with a private unit field, so no logic can accrete
+//! around a name before the model that gives it meaning exists.
 //!
 //! The governing decision is the safety-assurance scope ruling
 //! ([ADR-0042](../../../docs/adr/0042-world-model-terminology-and-safety-boundary-scope.md)
@@ -112,6 +121,7 @@
 #![warn(missing_docs)]
 
 pub mod entity;
+pub mod kind;
 pub mod observation;
 pub mod reference;
 pub mod relationship;
@@ -173,6 +183,16 @@ pub use reference::EventId;
 
 /// Why a reference was refused. See [`mod@reference`].
 pub use reference::ReferenceError;
+
+/// What a claim asserts about its subject, and the per-kind versioned body
+/// contract — §7.1's `TypedPayload`.
+///
+/// **No longer absent.** The variant list was a *specification* gap rather than
+/// an implementation one: §7.1 named the field and the blueprint never
+/// enumerated it, so [`mod@observation`] refused to invent a taxonomy. Ruled
+/// 2026-08-07 (`KIRRA-WM-OBSKIND-001`, option 2) — three attested variants plus
+/// a degrade target, with `Existence` deferred.
+pub use kind::{BodyError, ObservationKind, TypedBody};
 
 // ---------------------------------------------------------------------------
 // Where a claim came from

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -495,14 +495,42 @@ is **self-releasing and already released** (ADR-0042 Decision 5, recorded
       has none by ratification criterion, so the core owns the *type* and the layer
       with a clock mints the *value*. No loss: an id arriving from a replayed log
       or another fleet must be admissible regardless.
-      **Still open:** `evidence_digest`/`prev_hash` as core types (the store
-      computes both today as bare hex strings), and the per-kind versioned
-      `TypedPayload` **body** — `Payload` carries that body's provenance, but the
-      body itself stays a type parameter. `ObservationKind` is absent for a
-      different reason and is **not** an implementation gap: the blueprint names
-      the field and never enumerates its variants, so writing that list is a
-      specification extension, not a derivation. `kind` stays `&str` until it
-      exists.
+      **`ObservationKind` + the per-kind versioned `TypedPayload` contract DONE
+      2026-08-07**, `crates/kirra-world/src/kind.rs`, 16 tests, still
+      zero-dependency. This was the **specification** gap, not an implementation
+      one — the blueprint named the field and never enumerated it — so it was
+      ruled rather than written: `KIRRA-WM-OBSKIND-001`, option 2, the three
+      variants **attested by what the system already writes** (`observation`,
+      `spatial`, `relationship`) plus `Unrecognised` as a degrade target.
+      `Existence` was proposed and **deferred**, on an asymmetry rather than a
+      preference: adding a variant later is an additive enum change, while
+      removing one already written into a hash-chained log would mean rewriting
+      rows inside the chain. Revisit trigger: a perception producer with a
+      saw-something-claiming-nothing output.
+      **Three rules made structural.** The tokens are FROZEN, because `kind` sits
+      inside the canonically-hashed bytes twice — re-spelling one is not a rename,
+      it breaks verification on every existing store. `Unrecognised` has **no
+      token**, so `as_str` returns `Option` and the degrade target cannot be
+      written at all. And `requires_frame()` answers `false` for `Unrecognised`
+      deliberately: SD-4's `CHECK` keys on the literal `'spatial'`, so a kind this
+      build cannot name is not spatial *to the schema* either, and answering
+      otherwise would put the type and the schema into disagreement about one row.
+      **`TypedBody`** gives §7.1 its two halves — `KIND` so a spatial body cannot
+      be attached to a relationship claim, and `SCHEMA_VERSION` so the store's
+      long-standing `payload_schema` column finally has a stated meaning. Checked
+      in the order kind → version → content, because a body offered under the
+      wrong kind should never have been considered and reporting its version
+      mismatch would send a reader to the wrong question. Fails closed against the
+      **future**: a newer producer's body is refused rather than decoded as the
+      known version, since a silently truncated record is worse than an unread one
+      in an evidence log. Encoding stays the implementor's job — a trait demanding
+      a serializer would break the crate's zero-dependency criterion.
+      **The stored bytes are unchanged**, and the ruling explicitly did not
+      authorize changing them in this slice: `NewEvent::kind` and `payload` stay
+      as they are. This types the *boundary*.
+      **Still open:** `evidence_digest`/`prev_hash` as core types — the store
+      computes both today as bare hex strings, so this is a typing gap rather than
+      a missing capability.
 - [x] **Relationship model** (§8) — **DONE 2026-08-06**,
       `crates/kirra-world/src/relationship.rs`, 20 tests, still zero-dependency.
       **All ten §8 record fields**, all 15 predicates across the four groups.


### PR DESCRIPTION
Closes Tier 1's last **implementation** item.

> **Correction, 2026-08-07.** This description originally claimed the slice *"fires ADR-0040's Q1 revisit trigger."* That overclaimed and is withdrawn. The trigger is keyed to *completion of `WM_SCOPE.md` Tier 1*, and this PR leaves both §6's and §7's Tier 1 checkboxes `- [ ]` — it ticks neither. "Every implementation item is done" and "the tier is complete" are different claims while two boxes are open, and the trigger is keyed to the second. #1382 records the measurement under the narrower reading and names this disagreement rather than leaving it to be discovered. Resolving which governs is the owner's call.

## Ruled, not invented

This was the **specification** gap, not an implementation one. §7.1 names the field and the blueprint never enumerates its variants, so `observation.rs` refused to write a taxonomy it had no basis for:

> **`ObservationKind` is also absent.** §7.1 names the field but the blueprint never enumerates its variants, and inventing a taxonomy of observation kinds would be a domain decision this module has no basis for.

The list comes from `KIRRA-WM-OBSKIND-001` (#1378), option 2, adopted 2026-08-07 — the three variants **attested by what the system already writes**, plus a degrade target. `Existence` stays deferred with its revisit trigger named.

## Three rules made structural

**The tokens are frozen.** `kind` sits inside the canonically-hashed bytes **twice** — a distinct argument to the record hash *and* a field in the canonical JSON. Re-spelling `observation` as `attribute` is not a rename; it changes the digest of every row that carried it.

**`Unrecognised` has no token.** `as_str` returns `Option` rather than a placeholder string, so the degrade target cannot be written at all — the same shape as `EntityKind::group` returning `None` for `Unknown`. A round-trippable placeholder eventually becomes a real stored value.

**`requires_frame()` answers `false` for `Unrecognised`** — deliberately, not conveniently. SD-4's `CHECK` keys on the literal token `'spatial'`, so a kind this build cannot name is not spatial *to the schema* either. Answering `true` would put this type and the schema into disagreement about the same row, and **the schema is the guarantee**.

## `TypedBody` — §7.1's two halves

| Half | What it buys |
|---|---|
| `KIND` | a spatial body cannot be attached to a relationship claim — a function of the *type*, not a convention a writer follows |
| `SCHEMA_VERSION` | the store's `payload_schema` column finally has a stated meaning; it has held a number since it was written with nothing defining what it was |

**Checked in the order kind → version → content**, and tested with a body wrong on both counts. A body offered under the wrong kind should never have been considered, so reporting its *version* mismatch would send a reader to the wrong question.

**Fails closed against the future specifically.** A newer producer's body is refused rather than decoded as the known version — it may carry fields this build cannot see, and in an evidence log a silently truncated record is worse than an unread one. An older version is refused too: reading v1 as v2 would invent whatever v2 added.

**Encoding stays the implementor's job.** A trait demanding `serde` would either pull a dependency into a crate that has none by ratification criterion, or fake one. The contract is only about kind and version — the two things that decide whether decoding should be attempted at all.

## The stored bytes are unchanged

The ruling was explicit that changing them in this slice is not authorized, and this does not. `NewEvent::kind` and `payload` stay exactly as they are. **This types the boundary**: a writer converts on the way in, a reader adjudicates on the way out. Moving the stored form needs its own compatibility argument, exactly as the trust axes did.

## Negative controls

| Guard reverted | Result |
|---|---|
| a token re-spelled | 1 test (pins all three against the log) |
| unknown token defaulted to `Attribute` instead of degrading | 1 test |
| `Unrecognised` given a writable token | 1 test |
| `requires_frame()` true for `Unrecognised` | 1 test |
| `Existence` added without a ruling | 1 test |
| kind checked after version | 1 test (wrong on both counts) |
| future version decoded rather than refused | 1 test |
| older version decoded rather than refused | 1 test |

## Also in here

The crate header still described **four** modules and called the reference types unconstructible placeholders — both stale by several slices. Now seven, and it records the split that settled across this run: **the core owns the type and what makes a value admissible; the layer with a clock and a hash mints the value.**

## Review follow-up

The ruling is now cited by its in-repo path (`docs/design/WM_OBSERVATION_KIND_PROPOSAL.md`) rather than a bare filename. Review flagged the document as missing entirely — true when that review ran, since this branch predated #1378; the rebase fixed that half. The traceability half stood on its own: in a crate whose position is that the taxonomy was *ruled rather than invented*, the citation should be followable without a grep.

## Verification

144 tests in `kirra-world` (was 128) + 4 doctests · clippy 0 warnings under `#[warn(missing_docs)]` · rustfmt clean · MSRV 1.88 against the real toolchain · `cargo check --workspace --all-targets` clean · 42/42 fence tests · all 12 substantive CI gates · both Kirra World fences INTACT.

Still zero-dependency.

## What this leaves

`evidence_digest` / `prev_hash` as core types — the store computes both today as bare hex strings, so that is a *typing* gap rather than a missing capability. It is one of the two items keeping Tier 1's boxes open.

Kirra is designed in alignment with ISO 26262 ASIL-D requirements and IEC 61508 SIL 3 requirements. Independent third-party assessment has not yet been performed.