### PR TITLE
Measure the Q1 seam at the Tier 1 boundary, and commit the method

### DIFF
--- a/ci/measure_q1_seam.py
+++ b/ci/measure_q1_seam.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Q1 seam measurement instrument — ADR-0040's revisit trigger, made repeatable.
+
+ADR-0040 deferred open question 1 (the `kirra-world` / `kirra-world-store` seam)
+with a revisit trigger asking to *"measure what the seam actually carries"* on
+completion of `WM_SCOPE.md` Tier 1. Three measurements have now been taken
+against that trigger, and each re-derived the method by hand.
+
+`WM_Q1_SEAM_BASELINE.md`'s own Measurement 2 says why that is the wrong shape:
+
+    the baseline's *number* has a much shorter shelf life than its *method*,
+    and the method is what should be reused.
+
+This is that method. Running it reproduces every figure in Measurement 3 --
+including one the hand count got wrong: a constructor tally of 11 that was
+really 10, inflated by a doc-comment mention of `TrustAxes::new` that the
+by-hand pass excluded for variant references and forgot to exclude here. The
+error ran in the direction of the measurement's own conclusion, which is the
+specific way a hand-counted series goes bad.
+
+## Why this is NOT wired into CI
+
+A gate reds when a number changes. Every number here is *supposed* to change —
+the seam filling up is the outcome the trigger was written to detect, so a gate
+would red on progress and be silenced within a week. It is a reporting
+instrument, run when a measurement is being taken.
+
+The one exception is `--check-population`, which is a genuine invariant rather
+than a measurement: if a third crate starts depending on `kirra-world`, the
+independence unit has changed and the next measurement is not comparable to the
+recorded ones without saying so. That check is offered, deliberately unwired,
+for whoever decides a measurement is due.
+
+## Units
+
+Counting unit, unchanged from the baseline so the series stays comparable:
+one `use`/`pub use` item naming a `kirra_world` path, in the `src/` tree of a
+crate that depends on `kirra-world`. Independence unit: the consuming crate.
+
+The baseline's unit is insensitive to a braced list growing — `{A, B}` becoming
+`{A, B, C, D, E, F}` does not move it. So `distinct core paths named` is
+reported beside it rather than instead of it. Swapping units between
+measurements would destroy the comparison the baseline exists to enable.
+
+Test-only lines are counted separately: a seam carrying only test traffic is
+still near-empty in the sense the ruling cares about.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import signal
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+
+
+# The population as recorded by the baseline. Not a hardcoded answer to the
+# measurement -- a hardcoded record of who was measured, so a newcomer is
+# reported rather than silently averaged in.
+RECORDED_CONSUMERS = ["kirra-world-store", "kirra-world-service"]
+
+USE_ITEM = re.compile(r"^\s*(pub )?use kirra_world::")
+CFG_TEST = "#[cfg(test)]"
+
+# Core items whose appearance in a consumer means something stronger than a
+# name crossing the seam. Kept explicit rather than derived from the core's
+# public surface: a derived list would silently grow and make measurements
+# incomparable, which is the failure this whole file exists to prevent.
+CORE_TYPES = [
+    "EventId", "ObservationId", "FrameId", "MapId", "EntityId", "ReferenceError",
+    "TrustAxes", "Validity", "ValidityWindow", "Origin", "Corroboration",
+    "Adjudication", "TrustGrade", "trust_grade", "validity_at",
+    "RetentionPolicy", "RetentionDecision", "RetentionError", "RetentionSurvey",
+    "Eligibility", "Blocker", "CompactablePrefix",
+    "DomainInstant", "ClockDomain", "ResolutionOutcome",
+]
+CORE_ENUMS = [
+    "RetentionDecision", "Eligibility", "Blocker", "CompactablePrefix",
+    "Origin", "Corroboration", "Adjudication", "Validity", "TrustGrade",
+    "ResolutionOutcome", "ClockDomain",
+]
+CONSTRUCTIBLE = [
+    "EventId", "ObservationId", "FrameId", "MapId", "EntityId",
+    "TrustAxes", "ValidityWindow", "RetentionPolicy", "DomainInstant",
+]
+
+CORE_PAT = re.compile(r"\b(" + "|".join(CORE_TYPES) + r")\b")
+CTOR_PAT = re.compile(
+    r"\b(" + "|".join(CONSTRUCTIBLE) + r")::(new|try_new|from_[a-z_]+|parse)\b"
+)
+VARIANT_PAT = re.compile(r"\b(" + "|".join(CORE_ENUMS) + r")::[A-Z]")
+FIELD_PAT = re.compile(r"^\s*pub [a-z_0-9]+\s*:")
+FN_PAT = re.compile(r"^\s*pub fn ")
+
+
+def assert_repo_found() -> None:
+    """Refuse to measure a tree that is not there.
+
+    `REPO` is derived from this file's own location, so a copy run from
+    elsewhere finds no crates and every count comes out zero. Zero is not a
+    neutral result here -- "the seam is near-empty" is precisely the finding
+    that authorizes collapsing it, so a lost tree must not be reported as an
+    empty one. Fail loudly instead.
+    """
+    if not (REPO / "crates" / "kirra-world").is_dir():
+        sys.exit(
+            f"cannot find crates/kirra-world under {REPO}\n"
+            "This script locates the repository relative to itself; run it "
+            "from its place in the tree rather than from a copy.\n"
+            "Refusing to measure, because a missing tree and an empty seam "
+            "produce the same numbers and mean opposite things."
+        )
+
+
+def split_at_tests(lines: list[str]) -> tuple[list[str], list[str]]:
+    """Split a source file at its first `#[cfg(test)]`.
+
+    Crude on purpose. A real parse would be more accurate and less auditable,
+    and every file in the measured population puts its test module last.
+    """
+    for i, line in enumerate(lines):
+        if line.strip() == CFG_TEST:
+            return lines[:i], lines[i:]
+    return lines, []
+
+
+def is_comment(line: str) -> bool:
+    s = line.strip()
+    return s.startswith("//")
+
+
+def use_items(lines: list[str]) -> list[str]:
+    """Whole `use` statements, joined across line breaks at the `;`."""
+    out, i = [], 0
+    while i < len(lines):
+        if USE_ITEM.match(lines[i]):
+            stmt, j = lines[i], i
+            while ";" not in stmt and j + 1 < len(lines):
+                j += 1
+                stmt += " " + lines[j].strip()
+            out.append(stmt)
+            i = j
+        i += 1
+    return out
+
+
+def names_in(stmt: str) -> set[str]:
+    """The distinct `kirra_world` paths a single `use` item names."""
+    body = stmt.split("kirra_world::", 1)[1].rstrip().rstrip(";")
+    if "{" in body:
+        prefix = body.split("{")[0]
+        inner = body[body.index("{") + 1 : body.rindex("}")]
+        raw = [n.strip() for n in inner.split(",") if n.strip()]
+    else:
+        prefix, raw = "", [body.strip()]
+    # `X as Y` still names X; the rename is the consumer's business.
+    return {prefix + n.split(" as ")[0].strip() for n in raw if n.strip()}
+
+
+def fn_signatures(lines: list[str]) -> list[str]:
+    """Public fn signatures, joined to the opening brace."""
+    out, i = [], 0
+    while i < len(lines):
+        if FN_PAT.match(lines[i]):
+            sig, j = lines[i], i
+            while "{" not in sig and ";" not in sig and j + 1 < len(lines):
+                j += 1
+                sig += " " + lines[j].strip()
+            out.append(sig.split("{")[0])
+            i = j
+        i += 1
+    return out
+
+
+def measure(crate: str) -> dict:
+    src = REPO / "crates" / crate / "src"
+    m = {
+        "lines_non_test": 0, "lines_test": 0, "names": set(),
+        "ctors": 0, "variants": 0, "pub_fields": [], "pub_fns": [],
+    }
+    for f in sorted(src.glob("*.rs")):
+        lines = f.read_text().splitlines()
+        prod, test = split_at_tests(lines)
+
+        items = use_items(prod)
+        m["lines_non_test"] += len(items)
+        m["lines_test"] += len(use_items(test))
+        for stmt in items:
+            m["names"] |= names_in(stmt)
+
+        for n, line in enumerate(prod, start=1):
+            if is_comment(line):
+                continue
+            if CTOR_PAT.search(line):
+                m["ctors"] += 1
+            m["variants"] += len(VARIANT_PAT.findall(line))
+            if FIELD_PAT.match(line) and CORE_PAT.search(line):
+                m["pub_fields"].append(f"{f.name}:{n}")
+
+        for sig in fn_signatures(prod):
+            if CORE_PAT.search(sig):
+                m["pub_fns"].append(" ".join(sig.split())[:100])
+    return m
+
+
+def declared_consumers() -> list[str]:
+    """Crates whose manifest declares a `kirra-world` path dependency."""
+    found = []
+    for manifest in sorted((REPO / "crates").glob("*/Cargo.toml")):
+        crate = manifest.parent.name
+        if crate == "kirra-world":
+            continue
+        for line in manifest.read_text().splitlines():
+            s = line.strip()
+            if s.startswith("#"):
+                continue
+            if re.match(r"^kirra-world\s*=", s):
+                found.append(crate)
+                break
+    return found
+
+
+def main() -> int:
+    # This prints a long report and will be piped to `head`. Without this,
+    # SIGPIPE surfaces as a traceback, which reads as the measurement having
+    # failed rather than the reader having stopped early.
+    try:
+        signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+    except (AttributeError, ValueError):
+        pass  # not POSIX, or not the main thread; the traceback is cosmetic
+
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--check-population",
+        action="store_true",
+        help="exit non-zero if the set of direct kirra-world consumers has "
+             "changed since the recorded measurements",
+    )
+    args = ap.parse_args()
+
+    assert_repo_found()
+    actual = declared_consumers()
+    if args.check_population:
+        if sorted(actual) != sorted(RECORDED_CONSUMERS):
+            print("POPULATION CHANGED -- prior measurements are not comparable")
+            print(f"  recorded: {sorted(RECORDED_CONSUMERS)}")
+            print(f"  actual  : {sorted(actual)}")
+            print("Update RECORDED_CONSUMERS and say so in the measurement.")
+            return 1
+        print(f"population unchanged: {sorted(actual)}")
+        return 0
+
+    if sorted(actual) != sorted(RECORDED_CONSUMERS):
+        print("!! population differs from the recorded measurements; "
+              "see --check-population\n")
+
+    print("Q1 seam measurement -- ADR-0040 revisit trigger\n")
+    print(f"{'consumer':24} {'non-test':>9} {'test-only':>10} {'names':>7}")
+    tot_n = tot_t = 0
+    all_names: set[str] = set()
+    results = {}
+    for crate in actual:
+        m = measure(crate)
+        results[crate] = m
+        tot_n += m["lines_non_test"]
+        tot_t += m["lines_test"]
+        all_names |= m["names"]
+        print(f"{crate:24} {m['lines_non_test']:>9} {m['lines_test']:>10} "
+              f"{len(m['names']):>7}")
+    print(f"{'TOTAL':24} {tot_n:>9} {tot_t:>10} {len(all_names):>7}")
+
+    print("\nWhat the seam does (non-test, doc comments excluded):")
+    print(f"{'consumer':24} {'ctors':>7} {'variants':>9} "
+          f"{'pub fields':>11} {'pub fns':>8}")
+    for crate, m in results.items():
+        print(f"{crate:24} {m['ctors']:>7} {m['variants']:>9} "
+              f"{len(m['pub_fields']):>11} {len(m['pub_fns']):>8}")
+
+    print("\nDistinct core paths named:")
+    for n in sorted(all_names):
+        print(f"  {n}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/design/WM_Q1_SEAM_BASELINE.md
+++ b/docs/design/WM_Q1_SEAM_BASELINE.md
@@ -281,6 +281,26 @@ measurement, plus the argument for why taking it *now* is not the early answer
 [Measurement 2](#measurement-2--after-the-retention-driver-and-the-reference-types)
 warned against.
 
+### One record says otherwise, and the disagreement is worth naming
+
+#1381's pull request describes itself as firing this trigger — *"Closes Tier 1's
+last implementation item, and with it **fires ADR-0040's Q1 revisit trigger**"*.
+This document takes the narrower reading, so a reader meeting both should not
+have to guess which governs.
+
+**The durable record agrees with this document.** #1381 leaves both §6's and
+§7's checkboxes `- [ ]`; it ticks neither. `WM_SCOPE.md` is the record the
+trigger names, and by that record Tier 1 is open. The pull request's prose is
+commentary on a slice, and it is defensible on its own terms — Tier 1's
+*implementation* work is what that slice closed, and §6's residue really is
+assigned to Tier 2.
+
+The gap between the two is the word **completion**. "Every implementation item
+is done" and "the tier is complete" are not the same claim while two boxes are
+unticked, and the trigger is keyed to the second. Resolving that is the owner's
+call, not a measurement's — which is precisely why nothing here is ticked and no
+disposition is declared.
+
 ## Why measuring now is not answering early
 
 Measurement 2 closed by warning that *"answering early with a more convenient

--- a/docs/design/WM_Q1_SEAM_BASELINE.md
+++ b/docs/design/WM_Q1_SEAM_BASELINE.md
@@ -259,6 +259,13 @@ more convenient number is the failure mode it was written against.
 **recorded 2026-08-07** · `main` at `9a0712da`, with `claude/wm-typed-payload`
 (#1381) at `ff394e89`
 
+> #1381's head advanced to `230edc4f` after this was recorded — a base-branch
+> update, not new work. `ff394e89` remains an ancestor of it, so the command
+> below still resolves, and the empty-diff claim was re-verified against **both**
+> heads. Noted rather than silently restamped: this document's SHAs say which
+> tree was measured, and quietly moving them would make a later reader trust a
+> pairing nobody checked.
+
 ## The precondition, stated before the number rather than after it
 
 The revisit trigger fires on *"completion of `WM_SCOPE.md` Tier 1"*. On a strict

--- a/docs/design/WM_Q1_SEAM_BASELINE.md
+++ b/docs/design/WM_Q1_SEAM_BASELINE.md
@@ -312,10 +312,18 @@ marks §7's last implementation item done. Its diff against `main`, restricted t
 the two consumer crates, is **empty**:
 
 ```
-git diff --stat main origin/claude/wm-typed-payload \
+git fetch origin refs/pull/1381/head
+git diff --stat 9a0712da ff394e89 \
   -- crates/kirra-world-store/ crates/kirra-world-service/
 (no output)
 ```
+
+Written against the **pull request ref** rather than the branch name it was
+originally run with, because both of the obvious forms stop working. The branch
+`claude/wm-typed-payload` is deleted on merge; and #1381 is **squash**-merged, so
+`ff394e89` is not an ancestor of `main` afterwards and a fresh clone cannot
+resolve it either. `refs/pull/1381/head` outlives both. A reproduction command in
+a document about reproducibility should survive the merge it describes.
 
 It changes `crates/kirra-world/src/` and documentation only. The seam is counted
 in the *consumers*, so every number below is identical on both trees. Waiting for

--- a/docs/design/WM_Q1_SEAM_BASELINE.md
+++ b/docs/design/WM_Q1_SEAM_BASELINE.md
@@ -251,3 +251,279 @@ If anything, the direction of the trend argues for taking one further
 measurement *at* completion rather than treating this one as sufficient — the
 ruling asked for a measurement at a defined moment, and answering early with a
 more convenient number is the failure mode it was written against.
+
+---
+
+# Measurement 3 — at the Tier 1 boundary
+
+**recorded 2026-08-07** · `main` at `9a0712da`, with `claude/wm-typed-payload`
+(#1381) at `ff394e89`
+
+## The precondition, stated before the number rather than after it
+
+The revisit trigger fires on *"completion of `WM_SCOPE.md` Tier 1"*. On a strict
+reading of Tier 1's own checklist, **it has not fired**, and this document does
+not claim it has. Two boxes are unticked even with #1381 applied:
+
+| Tier 1 box | What is still open under it |
+|---|---|
+| **Entity taxonomy (§6)** | identity *adjudication* — candidate clustering, merge/split, `entity_id` minting — all of which that entry explicitly assigns to **Tier 2** |
+| **Observation model (§7)** | `evidence_digest` / `prev_hash` as core types; the store computes both today as bare hex strings |
+
+ADR-0040's own ruling on Q1 supplies the discipline for this situation, and it
+is quoted here because it cuts against the convenient reading:
+
+> Ticking on a half-satisfied conjunction is exactly the drift these rulings
+> exist to prevent.
+
+So the box is not ticked and no disposition is declared. What follows is the
+measurement, plus the argument for why taking it *now* is not the early answer
+[Measurement 2](#measurement-2--after-the-retention-driver-and-the-reference-types)
+warned against.
+
+## Why measuring now is not answering early
+
+Measurement 2 closed by warning that *"answering early with a more convenient
+number is the failure mode it was written against."* Three checks, each
+mechanical rather than argued, establish that this measurement is not that.
+
+**1 — It is invariant to the merged-pending item.** `#1381` is the slice that
+marks §7's last implementation item done. Its diff against `main`, restricted to
+the two consumer crates, is **empty**:
+
+```
+git diff --stat main origin/claude/wm-typed-payload \
+  -- crates/kirra-world-store/ crates/kirra-world-service/
+(no output)
+```
+
+It changes `crates/kirra-world/src/` and documentation only. The seam is counted
+in the *consumers*, so every number below is identical on both trees. Waiting for
+#1381 to merge would produce the same table.
+
+**2 — It is monotone in what remains.** `evidence_digest` / `prev_hash` becoming
+core types would mean the store *importing two more core types*, not fewer.
+§6's residue is Tier 2 by that entry's own assignment. Neither outstanding item
+can remove a line from the table.
+
+**3 — Therefore it is a lower bound.** Everything below is the *smallest* the
+seam will be when Tier 1 formally closes. The direction that would favour
+collapse is the one the remaining work cannot travel.
+
+That third point is what makes recording now defensible rather than premature. A
+lower bound that already clears "near-empty" by a wide margin cannot be reversed
+by finishing the tier — so the number was fixed before anyone could know whether
+it would be convenient, which is the property a baseline is supposed to have.
+
+## The measurement — the baseline's unit, unchanged
+
+Counting unit: **one `use`/`pub use` item naming a `kirra_world` path**, in the
+`src/` tree of a crate that depends on `kirra-world`. Independence unit: the
+consuming crate. Held fixed: `main` at `9a0712da`, default features, no `cfg`
+gating other than the test/non-test split, which is reported separately.
+
+**Population checked, not assumed.** Still exactly two crates depend on
+`kirra-world` directly. `tools/wm2-schema-growth` and
+`tools/wm2-persistence-harness` were inspected and are not in the population —
+the former depends on `kirra-world-store`, the latter on neither, by its own
+manifest's stated design.
+
+| Consumer | Lines (non-test) | Lines (test-only) |
+|---|---|---|
+| `kirra-world-store` | 8 | 2 |
+| `kirra-world-service` | 1 | 0 |
+| **Total** | **9** | **2** |
+
+On the baseline's own unit the trend is **2 → 8 → 9**.
+
+## The baseline's unit is the weakest thing in this document
+
+Said plainly, because the number above is the one most likely to be quoted and
+it understates the change by a wide margin.
+
+**One `use` item is insensitive to a braced list growing.** Two examples from
+this very tree:
+
+* `lib.rs:108` went from `{EntityId, ObservationId}` at baseline to
+  `{EntityId, EventId, FrameId, MapId, ObservationId, ReferenceError}` — six
+  names — and did not move the count.
+* `lib.rs:104` imports **nine** names from `kirra_world::trust` in a single item.
+
+So a second unit is reported. It is not a replacement — the first is what makes
+this comparable to the baseline, and swapping units between measurements would
+destroy the comparison the baseline exists to enable.
+
+| Unit | Baseline | Measurement 3 |
+|---|---|---|
+| `use` items naming a `kirra_world` path | 2 | **9** |
+| **distinct core paths named** | 3 | **26** |
+
+The 26 are: the six reference/identity types, nine from `trust::`, seven from
+`retention::`, two from `observation::`, `ReferenceError`, and
+`ResolutionOutcome`.
+
+## What the seam *does*, which is the part the ruling actually asked about
+
+The baseline's finding was never really "2 lines". It was this sentence:
+
+> **Neither crate calls a method, constructs a value, or matches on a variant of
+> any core type.** The dependency is declared in both manifests and, in the
+> direction that matters, carries nothing.
+
+Measurement 2 reported that sentence had become false. Measurement 3 puts
+numbers on it. All counts are non-test code, doc comments excluded:
+
+| Property | Baseline | Measurement 3 |
+|---|---|---|
+| constructor call sites (`EventId::new`, `ObservationId::new`, …) | 0 | **10** |
+| variant references in code (`RetentionDecision::…`, `Blocker::…`, …) | 0 | **29** |
+| **public struct fields typed by a core type** | 0 | **7** |
+| **public fn signatures naming a core type** | 0 | **5** |
+
+The last two rows are the ones that decide a collapse question, so they are
+listed rather than summarised.
+
+**Public fields (7)** — five of them are on `NewEvent`, which is the store's
+only write-path entry:
+
+```
+lib.rs:388               pub event_id: &'a EventId,
+lib.rs:392               pub observation_id: &'a ObservationId,
+lib.rs:411               pub frame_id: Option<&'a FrameId>,
+lib.rs:415               pub map_id: Option<&'a MapId>,
+lib.rs:442               pub trust: Option<&'a TrustAxes>,
+projection.rs:163        pub trust: Option<crate::TrustAxes>,
+retention_driver.rs:56   pub decision: RetentionDecision,
+```
+
+**Public signatures (5)**:
+
+```
+projection.rs:180        pub fn validity_at(…) -> crate::Validity
+projection.rs:199        pub fn grade_at(…) -> Option<crate::TrustGrade>
+retention_driver.rs:91   pub fn retention_survey(&self, policy: &RetentionPolicy, now: DomainInstant, …)
+retention_driver.rs:234  pub fn run_retention_pass(&mut self, policy: &RetentionPolicy, now: DomainInstant, …)
+retention_sweeper.rs:137 pub fn start(path: &Path, policy: RetentionPolicy, interval: Duration, …)
+```
+
+Reduced to one sentence: **a caller cannot append an event to the store, or run
+a retention pass over it, without constructing core values first.** A seam
+carrying re-exports dissolves by moving two lines; a seam whose consumer's write
+path is *made of* the core's types does not.
+
+## The method is now an instrument, and it immediately corrected me
+
+Measurement 2 said the method outlives the number:
+
+> the baseline's *number* has a much shorter shelf life than its *method*, and
+> the method is what should be reused.
+
+Three measurements have now re-derived that method by hand. It is committed as
+`ci/measure_q1_seam.py`, which reproduces every figure above.
+
+**Its first act was to correct this document.** The constructor count was
+hand-counted as 11; the instrument reported 10. The difference was
+`schema.rs:155` — `/// \`TrustAxes::new\` refuses it` — a doc comment. The hand
+count excluded comments when tallying variant references and forgot to when
+tallying constructors, which is exactly the kind of inconsistency that survives
+review and quietly inflates a series.
+
+Worth stating rather than silently shipping the corrected figure: the error
+inflated the number in the direction of the conclusion this measurement reaches.
+A hand-counted instrument that drifts toward its own finding is the failure the
+baseline's method discipline exists to catch, and here it took a script to catch
+it.
+
+**Its second act was to expose a fail-open in itself.** Reverting the population
+check to confirm it fires -- a guard that cannot fire is not a guard -- was run
+from a copy outside the tree. It duly reported a changed population, and also
+reported `actual: []`: finding no crates, it had measured *nothing* and rendered
+that as an empty seam.
+
+That is the wrong failure direction here, and not marginally. "The seam is
+near-empty" is the exact finding that authorizes collapsing it, so an instrument
+that returns zero when it cannot find the tree returns the collapse-authorizing
+answer on its own error. It now refuses to measure instead, because a missing
+tree and an empty seam produce identical numbers and mean opposite things.
+
+Both controls are recorded rather than merely run: the population check fires on
+a real tree with a shortened `RECORDED_CONSUMERS`, and the lost-tree guard fires
+on a copy, while the committed script passes.
+
+**It is deliberately not a CI gate.** Every figure it reports is *supposed* to
+change — the seam filling is the outcome the trigger was written to detect — so
+a gate would red on progress and be silenced. The one genuine invariant is
+offered as `--check-population`: if a third crate starts depending on
+`kirra-world`, the independence unit has changed and the recorded series is no
+longer comparable without saying so. That is a fact about the measurement, not
+about the code, so it is left for whoever takes Measurement 4 to run.
+
+## The finding the total would hide: one edge filled, the other did not
+
+Reporting "9 lines" for "the seam" would leave a reader with the impression that
+the graph filled. It did not. **8 of the 9 are one edge.**
+
+| Edge | Baseline | Measurement 3 |
+|---|---|---|
+| `kirra-world-store` → `kirra-world` | 1 line, 2 names, 0 constructions | 8 lines, 25 names, 10 constructions |
+| `kirra-world-service` → `kirra-world` | 1 line, 1 name, 0 constructions | **1 line, 1 name, 0 constructions** |
+
+The service edge is **verbatim what it was at baseline** — a single
+`pub use kirra_world::ResolutionOutcome;`.
+
+This is **not** a counter-finding against Q1, and should not be read as one. Q1
+names the `kirra-world` / `kirra-world-store` seam specifically; the service is
+outside its scope. And that crate's emptiness is deliberate and documented in
+its own module header — it exists so the fence has something to walk:
+
+> A *service* crate is where that would most plausibly erode — a transport
+> dependency added "just to publish status", a ROS handle threaded through
+> "temporarily". … A fence that arrives with the code is a fence argued with.
+> This one is already here.
+
+It is recorded here because the *aggregate* row is the one that travels, and it
+would carry a claim about the service edge that the evidence does not support.
+
+## What this selects — and what remains the owner's act
+
+ADR-0040 pre-authorized both outcomes, so the selection is mechanical:
+
+* **The seam carries real consumption** — 10 constructions, 29 variant
+  references, 12 public API bindings, and a write-path struct made of core
+  types. **Retained.**
+* *The seam is still near-empty* — not the case, by a wide margin, at a
+  measurement that is a lower bound.
+
+Two things are worth separating, because collapsing them is how a measurement
+turns into a ruling nobody made.
+
+**Recording this is low-cost, and that asymmetry is why it can be done now.**
+The outcome it selects — retain — is the one that requires *no action*. Collapse
+would be a restructuring; retention is the status quo continuing. A
+retain-pointing measurement filed before the tier formally closes therefore
+commits nothing that a later ruling could not simply override.
+
+**Closing Q1 is not this document's to do.** The trigger's precondition is two
+unticked boxes away, and Q1's disposition was recorded by the World Model owner,
+not derived from a table. What this removes is the measurement from the critical
+path: when those boxes tick, the number is already here.
+
+**One more thing the measurement does not carry.** The original ruling retained
+the seam on the **blueprint §5 layering argument** — *"the domain core must stay
+pure, and collapsing the store into it would place `rusqlite`, `serde_json`,
+`sha2` and `hex` beside the domain types."* That argument is independent of
+anything measured here and is untouched by it. The measurement is a second
+support for retention, not its only one — and had the number come out the other
+way, the two would have been in tension rather than the number simply winning.
+
+## Provenance
+
+Measured, and recorded, by the same person holding every role — as with every
+other World Model measurement. Stated so that nobody infers independence from a
+number being written down.
+
+---
+
+Kirra is designed in alignment with ISO 26262 ASIL-D requirements and IEC 61508
+SIL 3 requirements. Independent third-party assessment has not yet been
+performed.


### PR DESCRIPTION
ADR-0040 deferred open question 1 with a trigger asking to *"measure what the seam actually carries"*. This takes that measurement and, for the first time, ships the instrument.

## The trigger has NOT fired, and this does not tick it

Two Tier 1 boxes are unticked **even with #1381 applied**:

| Tier 1 box | Still open under it |
|---|---|
| **Entity taxonomy (§6)** | identity *adjudication*, `entity_id` minting — assigned to **Tier 2** by that entry itself |
| **Observation model (§7)** | `evidence_digest` / `prev_hash` as core types |

ADR-0040's own ruling supplies the discipline, quoted because it cuts against the convenient reading:

> Ticking on a half-satisfied conjunction is exactly the drift these rulings exist to prevent.

So no disposition is declared. What lands is the measurement plus the argument for why taking it now is legitimate.

## Why this is not the early answer Measurement 2 warned against

Measurement 2 closed by warning that *"answering early with a more convenient number is the failure mode it was written against."* Three checks, mechanical rather than argued:

1. **Invariant to the merged-pending item.** #1381's diff, restricted to the two consumer crates, is **empty** — it changes `crates/kirra-world/src/` and docs only. The seam is counted in *consumers*, so every number is identical on both trees.
2. **Monotone in what remains.** `evidence_digest`/`prev_hash` becoming core types means the store importing *more* core types. §6's residue is Tier 2. Neither can remove a line.
3. **Therefore a lower bound.** The direction that would favour collapse is the one the outstanding work cannot travel.

A lower bound that already clears "near-empty" cannot be reversed by finishing the tier — so the number was fixed before anyone could know whether it would be convenient.

## What the seam carries

| Unit | Baseline | M2 | **M3** |
|---|---|---|---|
| `use` items naming a `kirra_world` path | 2 | 8 | **9** |
| distinct core paths named | 3 | — | **26** |

**The baseline's unit is the weakest thing in the document, and it says so.** One `use` item is insensitive to a braced list growing: `lib.rs:108` went from `{EntityId, ObservationId}` to six names without moving the count, and `lib.rs:104` imports nine `trust::` names in one item. The second unit is reported *beside* the first, never instead — swapping units between measurements would destroy the comparison the baseline exists to enable.

**What it does** — every row zero at baseline:

| Property | Baseline | M3 |
|---|---|---|
| constructor call sites | 0 | **10** |
| variant references in code | 0 | **29** |
| public struct fields typed by a core type | 0 | **7** |
| public fn signatures naming a core type | 0 | **5** |

One sentence: **a caller cannot append an event, or run a retention pass, without constructing core values first.** A seam of re-exports dissolves by moving two lines; one whose consumer's write path is *made of* the core's types does not.

## The finding the total would hide

**8 of the 9 lines are one edge.** `kirra-world-service` is *verbatim* what it was at baseline — one re-export, zero constructions, zero public bindings.

That is not a counter-finding — Q1 names the store seam specifically, and the service's emptiness is deliberate per its own module header (it exists so the fence has something to walk). It is recorded because the aggregate row is the one that travels, and it would carry a claim about the service edge the evidence does not support.

## The method is now an instrument, and it corrected me twice

Measurement 2 said the method outlives the number — yet all three measurements re-derived it by hand. `ci/measure_q1_seam.py` reproduces every figure.

**First act: it corrected this document.** The constructor count was hand-counted as **11** and is **10** — inflated by a doc-comment mention of `TrustAxes::new` that the by-hand pass excluded for variant references and forgot to exclude here. The error ran *in the direction of the measurement's own conclusion*, which is the specific way a hand-counted series goes bad.

**Second act: the negative control exposed a fail-open in the instrument itself.** Run from outside the tree it found no crates and reported an **empty seam** — precisely the collapse-authorizing answer, produced by its own error. It now refuses to measure, because a missing tree and an empty seam produce identical numbers and mean opposite things.

**Deliberately not a CI gate.** Every figure is *supposed* to change — the seam filling is the outcome the trigger detects — so a gate would red on progress and be silenced. `--check-population` is offered unwired for the one genuine invariant: a third consumer means the independence unit changed and the series is no longer comparable.

## Verification

Both negative controls fire (population check on a real tree, lost-tree guard on a copy); the committed script passes. Fence gate INTACT, 19 packages from 10 roots; 42/42 fence tests. No Rust changed.

## What this selects, and what stays the owner's act

The measurement selects **retain** — the outcome requiring *no action*, which is why recording it before the tier formally closes commits nothing a later ruling could not override. Closing Q1 is not this document's to do.

The original ruling retained the seam on the **blueprint §5 layering argument** (`rusqlite`/`serde_json`/`sha2`/`hex` beside domain types). That is independent of anything measured here and untouched by it — the measurement is a second support, not the only one.

Measured and recorded by the same person holding every role, stated so nobody infers independence from a number being written down.

Kirra is designed in alignment with ISO 26262 ASIL-D requirements and IEC 61508 SIL 3 requirements. Independent third-party assessment has not yet been performed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_