### PR TITLE
RULED: Tier 1 is done — and both residues land rather than vanish

### DIFF
--- a/docs/design/WM_Q1_SEAM_BASELINE.md
+++ b/docs/design/WM_Q1_SEAM_BASELINE.md
@@ -2,6 +2,13 @@
 
 **KIRRA-WM-Q1-BASELINE-001** · recorded 2026-08-06
 
+> **Reading order.** This document is a series of **dated measurements**, each
+> standing as taken. Statements below about the trigger *not* having fired were
+> true when written and are **not** revised — see
+> [THE TRIGGER HAS FIRED — 2026-08-07](#the-trigger-has-fired--2026-08-07) at the
+> end for current state. A pointer, not an edit: a baseline you revise is not a
+> baseline, but one a reader can misquote as current is not much better.
+
 ## This is NOT the Q1 disposition, and must not be read as one
 
 [ADR-0040](../adr/0040-world-model-ownership-and-boundary.md)'s open question 1
@@ -550,6 +557,41 @@ pure, and collapsing the store into it would place `rusqlite`, `serde_json`,
 anything measured here and is untouched by it. The measurement is a second
 support for retention, not its only one — and had the number come out the other
 way, the two would have been in tension rather than the number simply winning.
+
+## THE TRIGGER HAS FIRED — 2026-08-07
+
+Appended after the fact, and deliberately not folded into the measurement above.
+
+`KIRRA-WM-TIER1-DONE-001` was adopted on 2026-08-07: **Tier 1 is done.** Both
+Tier 1 boxes are ticked and both residues were relocated to the tiers that own
+them. So the precondition this measurement was careful to say had *not* been
+met is now met — on **both** of the trigger's clauses, not only the substantive
+one, since ticking the boxes satisfies the proxy outright.
+
+**Nothing above is revised.** The measurement stands exactly as taken, including
+its own statement that the trigger had not fired, which was true when written.
+Editing it to read as though it were taken *at* the moment of firing would
+destroy the one property that makes it evidence: it was recorded and merged
+(`ed0a82e5`) **before** the criterion that fired the trigger existed, so it
+cannot have been shaped to suit it.
+
+That ordering is worth stating plainly, because the reverse is the ordinary
+failure: a measurement taken after a decision is due, by the person who wants a
+particular answer, is a justification wearing a measurement's clothes.
+
+**What this measurement puts in front of the ruling.** The two outcomes
+ADR-0040 pre-authorized, and which one the evidence selects:
+
+| Outcome | Selected? |
+|---|---|
+| The seam carries real consumption → **retained** | **yes** — 10 constructor sites, 29 variant references, 26 distinct core paths, 12 public API bindings |
+| The seam is still near-empty → **collapse it** | no — and the figures are a *lower bound*, per the monotonicity argument above |
+
+**Q1's disposition is still a separate act, and is not taken here.** The
+adopting ruling says so in its own words. What has changed is only that the
+question is now ripe, on evidence that predates the ripeness.
+
+---
 
 ## Provenance
 

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -329,12 +329,32 @@ is not about the domain model.
 
 ---
 
-## 4. Tier 1 — The domain core
+## 4. Tier 1 — The domain core — **COMPLETE, 2026-08-07**
+
+> **RULED — 2026-08-07 by Justin Looney, World Model owner. Tier 1 is DONE.**
+> Recorded under `KIRRA-WM-TIER1-DONE-001`
+> ([proposal](WM_TIER1_COMPLETION_PROPOSAL.md)), which found this tier could not
+> complete as written: §6's box was held open entirely by work its own text
+> assigned to Tier 2. Both boxes are now ticked and **both residues are listed
+> at the tiers that own them** — `entity_id` minting at Tier 2 (§5),
+> `evidence_digest`/`prev_hash` as core types at Tier 3 (§6). Neither was
+> deleted; a residue that vanishes when a box is ticked is exactly what the
+> proposal's second constraint forbids.
+>
+> **This fires ADR-0040's Q1 revisit trigger**, on both of its clauses rather
+> than only the substantive one. The measurement it asks for is already on
+> record — `KIRRA-WM-Q1-BASELINE-001` Measurement 3, taken and merged
+> (`ed0a82e5`) *before* this ruling, which is the property that makes it
+> evidence rather than justification. **Q1's own disposition remains a separate
+> act** and is not taken here.
+>
+> **One approver.** Recorded by the same person holding every role, as with
+> every other World Model ruling.
 
 `kirra-world` **was** ten unconstructible placeholders. As of 2026-08-07 it is
-**six real types and five remaining placeholders**, across six implemented
+**six real types and five remaining placeholders**, across seven implemented
 modules (`trust`, `entity`, `observation`, `relationship`, `reference`,
-`retention`) carrying 128 tests — still zero-dependency.
+`retention`, `kind`) carrying 144 tests — still zero-dependency.
 
 Six real against five remaining does not sum to ten, and should not: `EventId`
 is an addition, not one of the original ten.
@@ -411,7 +431,7 @@ is **self-releasing and already released** (ADR-0042 Decision 5, recorded
       `pinned` and `failed` apart, since **`pinned` climbing while `compacted`
       stays flat is the alertable condition** and one success counter cannot
       show it.
-- [ ] **Entity taxonomy** (§6) — **structure and kinds DONE 2026-08-06**,
+- [x] **Entity taxonomy** (§6) — **structure and kinds DONE 2026-08-06**,
       `crates/kirra-world/src/entity.rs`, 18 tests, still zero-dependency.
       Delivered: the 19-kind root-closed taxonomy + `EntityGroup`, `Lifecycle`
       with validated transitions, `EntityId`/`Alias` (each alias carrying its own
@@ -454,12 +474,15 @@ is **self-releasing and already released** (ADR-0042 Decision 5, recorded
       discriminant touches `subject`, which is inside the hashed bytes, so it
       needs the append-only-when-present treatment the trust axes got — its own
       slice.
-      **Still open:** identity *adjudication* — candidate clustering, merge/split
-      events — is Tier 2. **`entity_id` generation belongs there too**, not here:
-      minting an id is deciding that something is a distinct thing, which is
+      **Moved out, 2026-08-07 by `KIRRA-WM-TIER1-DONE-001`:** identity
+      *adjudication* — candidate clustering, merge/split events — and
+      **`entity_id` generation** are Tier 2, and are now **listed there** (§5)
+      rather than sitting under a Tier 1 box they could never let tick. Minting
+      an id is deciding that something is a distinct thing, which is
       adjudication, whereas the three fields above are arithmetic over evidence
-      that already exists. This list previously grouped it with them.
-- [ ] **Observation model** (§7) — **pure half DONE 2026-08-06**,
+      that already exists. This list previously grouped it with them, and then
+      held this box open on it.
+- [x] **Observation model** (§7) — **pure half DONE 2026-08-06**,
       `crates/kirra-world/src/observation.rs`, 17 tests, still zero-dependency.
       Delivered: `Confidence`/`ConfidenceBasis` (§7.3), `SourceClass` + its
       mapping to the trust `Origin`, `SubjectRef` (including `Unbound`, which is
@@ -528,9 +551,15 @@ is **self-releasing and already released** (ADR-0042 Decision 5, recorded
       **The stored bytes are unchanged**, and the ruling explicitly did not
       authorize changing them in this slice: `NewEvent::kind` and `payload` stay
       as they are. This types the *boundary*.
-      **Still open:** `evidence_digest`/`prev_hash` as core types — the store
-      computes both today as bare hex strings, so this is a typing gap rather than
-      a missing capability.
+      **Moved out, 2026-08-07 by `KIRRA-WM-TIER1-DONE-001`:**
+      `evidence_digest`/`prev_hash` as core types — the store computes both today
+      as bare hex strings, so this is a typing gap rather than a missing
+      capability, and the tier's stated job (a real domain core the store
+      consumes) does not depend on it. **Now listed at Tier 3** (§6), which is
+      where it is first *required* rather than merely desirable: Tier 3's
+      no-bare-values rule demands every answer carry a `ProvenanceHandle`, and
+      Tier 4's `Explain` needs derivation edges to be real structure. Recorded as
+      relocated, not resolved — it is still core-crate work.
 - [x] **Relationship model** (§8) — **DONE 2026-08-06**,
       `crates/kirra-world/src/relationship.rs`, 20 tests, still zero-dependency.
       **All ten §8 record fields**, all 15 predicates across the four groups.
@@ -670,6 +699,13 @@ for Tier 2; it is not driven by anything yet.
 
 - [ ] Entity resolution — matching incoming observations to existing entities
 - [ ] `MergeEntities` / `SplitEntity` / `ForgetEntity` as **recorded events**
+- [ ] **`entity_id` minting** — moved here from §6 on 2026-08-07 by
+      `KIRRA-WM-TIER1-DONE-001`. It was always described as belonging here
+      (*"minting an id is deciding that something is a distinct thing, which is
+      adjudication"*) while being listed under Tier 1, which is what held that
+      tier's box open on Tier 2 work. Listed rather than deleted: §6's residue
+      was a real work item, and a residue that disappears when a box is ticked
+      is the failure the ruling's own second constraint names.
 
 Merge and split are *events, never destructive edits*. This is what makes an
 `EntityId` revisable, and it is precisely what a store built on a bare opaque
@@ -687,6 +723,12 @@ Eight verbs in §14.2; about five exist in partial form.
 
 - [ ] `Resolve` · [ ] `Related` (bounded graph) · [ ] `WhatIsAt` ·
       [ ] `Capabilities` · [ ] `Freshness`
+- [ ] **`evidence_digest` / `prev_hash` as core types** — moved here from §7 on
+      2026-08-07 by `KIRRA-WM-TIER1-DONE-001`. **Core-crate work, listed at the
+      tier that first requires it**, not reclassified as query work: rule 1 below
+      demands every answer carry a `ProvenanceHandle`, and a handle over two bare
+      hex strings is the thing that rule exists to prevent. Tier 4's `Explain`
+      needs the same edges as real structure.
 
 Three rules matter more than the verb count:
 

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -354,7 +354,15 @@ is not about the domain model.
 `kirra-world` **was** ten unconstructible placeholders. As of 2026-08-07 it is
 **six real types and five remaining placeholders**, across seven implemented
 modules (`trust`, `entity`, `observation`, `relationship`, `reference`,
-`retention`, `kind`) carrying 144 tests — still zero-dependency.
+`retention`, `kind`) carrying **144 unit tests + 4 doctests** — still
+zero-dependency.
+
+The counting unit is stated because this figure is quotable and the per-module
+figures below **do not sum to it**. Those are *as-landed* snapshots carrying the
+date they were recorded; the modules have since grown (summing them today gives
+124, not 144). They are left as recorded rather than restated, for the same
+reason the seam measurements are: a dated record revised to stay tidy stops being
+a record. The crate total above is the current one, read from `cargo test`.
 
 Six real against five remaining does not sum to ten, and should not: `EventId`
 is an addition, not one of the original ten.

--- a/docs/design/WM_TIER1_COMPLETION_PROPOSAL.md
+++ b/docs/design/WM_TIER1_COMPLETION_PROPOSAL.md
@@ -1,6 +1,43 @@
-# Tier 1 completion, and the clause that decides Q1's trigger
+# Tier 1 completion, and the clause that decides Q1's trigger — RULED
 
-**KIRRA-WM-TIER1-DONE-001** · drafted 2026-08-07 · **status: PROPOSED, not adopted**
+**KIRRA-WM-TIER1-DONE-001** · drafted 2026-08-07 · **status: ADOPTED, 2026-08-07**
+
+## RULED — 2026-08-07
+
+> **ADOPTED — 2026-08-07 by Justin Looney, World Model owner and architecture
+> owner: TIER 1 IS DONE.**
+>
+> This is **option B, and it carries A with it.** Ticking both Tier 1 boxes
+> satisfies the proxy clause outright, so the trigger now fires on *both* of its
+> clauses and the question of which one governs no longer has to be answered.
+> That is a stronger outcome than option A alone, which would have left the
+> checklist misreporting the tier; and it settles the recommendation for C by
+> making its A-half moot rather than by rejecting it.
+>
+> **The three constraints are honoured, and the second one did real work:**
+>
+> 1. Measurement 3 is **not re-taken**. It stands as recorded and merged
+>    (`ed0a82e5`), before this ruling existed.
+> 2. **Neither residue was deleted.** `entity_id` minting is now listed at Tier 2
+>    (§5) and `evidence_digest`/`prev_hash` as core types at Tier 3 (§6) — each
+>    with a note saying where it came from and why it moved. §7's residue was not
+>    part of the original finding and needed a home of its own; ticking that box
+>    without one would have dropped a real work item while looking like progress.
+> 3. **Q1 is not ruled here.** Adoption fires the trigger. The disposition is a
+>    separate act.
+>
+> **What this authorizes:** Tier 1 may be described as complete; ADR-0040's Q1
+> revisit trigger has fired; and `KIRRA-WM-Q1-BASELINE-001` Measurement 3 is the
+> evidence in front of that ruling. It does **not** authorize retaining or
+> collapsing the seam, editing Measurement 3, or treating *retain* as decided
+> because the measurement points there.
+>
+> **One approver.** Recorded by the same person holding every role, as with every
+> other World Model ruling — stated so nobody infers independence from a decision
+> being written down.
+
+The proposal below is kept **unamended**, so the reasoning the decision rested on
+stays legible rather than being edited into agreement with its own outcome.
 
 ## The finding
 


### PR DESCRIPTION
Adopts `KIRRA-WM-TIER1-DONE-001` (#1383). **Tier 1 — COMPLETE, 2026-08-07.**

## Recorded as option B, which carries A with it

Ticking both Tier 1 boxes satisfies the **proxy** clause outright, so ADR-0040's Q1 trigger now fires on **both** of its clauses and the question of which one governs never has to be answered.

That settles the proposal's recommendation of C by making its A-half *moot* rather than by rejecting it — stated in the ruling, because the record should show why the outcome differs from what was recommended rather than leaving a reader to wonder whether the recommendation was overlooked.

## The part that needed care: §7's residue

"Tier 1 done" ticks **both** boxes. §7's residue was never part of the original finding — that finding was entirely about §6 — so ticking §7 without giving its residue a home would have dropped a real work item while looking like progress. Which is precisely the failure the proposal's own **second constraint** names.

So both residues **landed**:

| Residue | From | Now listed at | Why there |
|---|---|---|---|
| **`entity_id` minting** | §6 | **Tier 2** (§5) | §6's own text always said it belonged there — *"minting an id is deciding that something is a distinct thing, which is adjudication"* — while being listed under Tier 1, which is exactly what held that box open on Tier 2 work |
| **`evidence_digest` / `prev_hash` as core types** | §7 | **Tier 3** (§6) | the tier that first *requires* it, not a reclassification as query work: Tier 3's no-bare-values rule demands every answer carry a `ProvenanceHandle`, and a handle over two bare hex strings is the thing that rule exists to prevent. Tier 4's `Explain` needs the same edges as real structure |

Each carries a note saying where it came from and why it moved. Neither was deleted. **`evidence_digest`/`prev_hash` is recorded as relocated, not resolved** — it is still core-crate work, and its Tier 3 placement is a judgement call that is trivially movable.

## The seam baseline is NOT revised

`WM_Q1_SEAM_BASELINE.md` still says, in two places, that the trigger has not fired. Those statements were **true when written** and stand.

A dated appendix records that it now has, plus a reading-order pointer at the top so nobody quotes an older section as current — *a pointer, not an edit*.

This matters more than tidiness. The measurement's entire value rests on having been recorded and merged (`ed0a82e5`) **before** the criterion that fired the trigger existed. Editing it to read as though taken *at* the moment of firing would destroy exactly the property that makes it evidence rather than justification.

## Q1 is still not ruled

The trigger has fired and Measurement 3 is now the evidence in front of that ruling — selecting **retain** (10 constructor sites, 29 variant references, 26 distinct core paths, 12 public API bindings, and a *lower bound*). Both outcomes were pre-authorized by ADR-0040.

The disposition remains a separate act. Nothing here takes it.

For the avoidance of doubt: ADR-0040's `Open questions 1 and 4 dispositioned` box was already satisfied on 2026-08-06 — checked, not assumed — so this closes the deferral's **revisit**, and is not blocking that ADR's ratification.

## Stale counts corrected, and a counting unit stated

The Tier 1 heading claimed **six** modules and **128** tests. Verified against the tree and corrected to **seven** (`trust`, `entity`, `observation`, `relationship`, `reference`, `retention`, `kind`) and **144 unit tests + 4 doctests**.

The unit is stated because review flagged the bare "144" as ambiguous — the repo's own #1329 rule, applied to a number introduced one commit earlier.

Checking that surfaced a second trap, now named in the document rather than left: **the per-module figures do not sum to the crate total.** They are *as-landed* snapshots carrying their recorded dates, and the modules have grown since — entity 18→23, observation 17→23, relationship 20→24, retention 15→16, trust 27→31. Summing the document today gives **124**, not 144, so a reader reconciling them would conclude one number is wrong when both are correct for what they measure. Verified by counting `#[test]` attributes per file: they do sum to 144 in the tree, just not as recorded.

The dated figures are left as recorded and the relationship stated instead — same reason the seam measurements are not revised.

## Verification

Documentation only; no Rust changed. All six Tier 1 boxes now `[x]`, no orphaned "Still open" left in the tier, both relocated items confirmed present on their receiving lists. Kirra World fence **INTACT** (19 packages from 10 roots) · 42/42 fence tests · re-export shim ratchet at 0 · `ci/measure_q1_seam.py --check-population` unchanged.

Kirra is designed in alignment with ISO 26262 ASIL-D requirements and IEC 61508 SIL 3 requirements. Independent third-party assessment has not yet been performed.