### PR TITLE
The answer boundary — where "no bare values" can actually live

### DIFF
--- a/crates/kirra-world-service/src/lib.rs
+++ b/crates/kirra-world-service/src/lib.rs
@@ -1,8 +1,19 @@
-//! **Kirra World service adapter — PROTOTYPE: shape only, no service.**
+//! **Kirra World service adapter — PROTOTYPE: no service, but no longer empty.**
 //!
-//! No HTTP, no routes, no server, no runtime, no transport dependency. This
-//! crate exists so the third node of ADR-0040's proposed graph is present and
-//! checkable; it does not run.
+//! No HTTP, no routes, no server, no runtime, no transport dependency — all
+//! still true, and all still load-bearing. This crate does not run.
+//!
+//! **What changed 2026-08-07:** it now carries [`read_view`], the **answer
+//! boundary** — the one place Tier 3's "no bare values" rule can be made
+//! structural, since `ProjectedClaim` cannot carry it (see that module). It
+//! landed here because `WM_SCOPE.md` §9's consumer was refused every doer-side
+//! host by Fence B, and this is the only crate that could legally hold the shape
+//! that consumer produced.
+//!
+//! So the header below is amended rather than deleted: the crate is no longer
+//! *shape only*, but the emptiness that mattered — no transport, no runtime, no
+//! route to an actuator — is exactly as it was, and is what the section below is
+//! actually about.
 //!
 //! # Why the emptiness is the point
 //!
@@ -19,8 +30,11 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 
+pub mod read_view;
+
 // Both edges exercised, so the proposed three-node graph is genuinely built and
-// not merely described in a manifest.
+// not merely described in a manifest. The edge is no longer only exercised --
+// `read_view` consumes the core and the store in earnest.
 pub use kirra_world::ResolutionOutcome;
 pub use kirra_world_store::EntityId;
 

--- a/crates/kirra-world-service/src/read_view.rs
+++ b/crates/kirra-world-service/src/read_view.rs
@@ -1,0 +1,270 @@
+//! **The answer boundary** — where Tier 3's "no bare values" rule can actually live.
+//!
+//! # What this is, and what it is not
+//!
+//! `WM_SCOPE.md` §9 asks for a small consumer wired **before** Tier 3, on the
+//! argument that a real caller falsifies what a design document cannot. That
+//! consumer was built, and **Fence B refused every host §9 nominates** — the
+//! planner, perception and LLM crates all implement `CorridorSource`, which is
+//! authoritative to the checker, so none of them may depend on Kirra World. §9
+//! records the refusal.
+//!
+//! So this is **not** the external doer caller §9 asked for, and it should not
+//! be read as one. What it is: the **shape that caller produced**, kept
+//! somewhere durable instead of being lost, in the one crate that can legally
+//! hold it — this one already depends on both `kirra-world` and
+//! `kirra-world-store`, implements no `CorridorSource`, and sits outside the
+//! safety closure.
+//!
+//! The falsification is already banked. What was still at risk was the *type*,
+//! and a type that has met a caller is worth more to Tier 3 than one derived
+//! from the rule alone.
+//!
+//! # The rule this exists to make structural
+//!
+//! Blueprint §14.2, rule 1:
+//!
+//! > **No API returns a bare value.** Every answer carries the value, the trust
+//! > axes, the validity at the supplied clock, and a `ProvenanceHandle`. …
+//! > *"a deliberate ergonomic cost: it makes 'I got a number and lost where it
+//! > came from' impossible to write."*
+//!
+//! **It cannot be met by [`ProjectedClaim`]**, and not for want of care. That
+//! type's fields are public, so
+//!
+//! ```ignore
+//! let payload = &store.current("robot-01", now)?[0].payload;
+//! ```
+//!
+//! compiles — no validity, no trust, no handle. `validity_at` and `grade_at` are
+//! methods a caller must *remember* to call, and forgetting is the default.
+//!
+//! That is not a defect. `ProjectedClaim` is the projection **row**, and a row
+//! is honestly a bag of columns. The rule belongs one layer out, at the boundary
+//! where a row becomes an *answer* — which is here.
+//!
+//! # What [`WorldAnswer`] buys, and the bound on it
+//!
+//! It has no constructor that omits validity, trust or provenance, and
+//! [`WorldView::ask`] is the only way to obtain one. So an answer in hand always
+//! carries them.
+//!
+//! **The honest bound, because overclaiming here would be the same failure the
+//! rule is about:** this closes the hole at *retrieval*. A caller cannot obtain
+//! the value without being handed the rest. It does **not** stop that caller
+//! destructuring and passing the value onward alone — Rust cannot prevent that
+//! without infecting every downstream signature, and a rule advertised as
+//! airtight when it is not is worse than one whose limit is written down.
+//!
+//! # Three rules, honoured deliberately
+//!
+//! 1. **No bare values** — [`WorldAnswer`], above.
+//! 2. **Queries are bounded** — [`WorldView::ask`] asks for *one subject*, never
+//!    the whole projection. D-9 measured 10.5 s p99 temporal queries at 100 000
+//!    entities, and ADR-0041 D-12 bars graph and temporal queries from any
+//!    control or safety deadline path. The bounded call is the habit to
+//!    establish before eight verbs exist.
+//! 3. **`Unknown` is a success** — [`WorldLookup::Unknown`] is a variant of the
+//!    `Ok` value. The error channel is for storage faults only. Conflating them
+//!    is how *"I don't know"* becomes an exception somebody catches and turns
+//!    into a default value.
+//!
+//! # Fence A still holds, and this is where it would erode
+//!
+//! This crate is inside Fence A's walk. A read view has no route to an actuator
+//! or an authorization: it reads a projection and returns owned data. That is
+//! the whole point of putting the boundary in a crate the fence already watches
+//! rather than in one it does not.
+
+use kirra_world_store::{ProjectedClaim, StoreError, TrustGrade, Validity, WorldStore};
+
+/// Why the world had nothing to say. **Not an error** — see rule 3.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UnknownReason {
+    /// No current claim for this subject at this clock.
+    ///
+    /// Note what this currently conflates: a subject never heard of, and one
+    /// whose claim has **expired**, arrive here identically, because
+    /// [`WorldStore::current`] filters on `holds_at` before this boundary sees
+    /// anything. An operator whose coverage merely lapsed is therefore told
+    /// "nothing known" and sent to a coverage question rather than a freshness
+    /// one. A boundary cannot reconstruct the difference; only the store can
+    /// report it, which makes it Tier 3's to fix.
+    NoClaim,
+    /// Claims exist, but none is admissible at this clock and budget.
+    ///
+    /// **Unreachable today, and deliberately kept.** Two filters — the
+    /// projection's `claim_status = 'confirmed'` fold and `current()`'s
+    /// `holds_at` — mean an inadmissible claim never reaches this boundary. That
+    /// guarantee is pinned in
+    /// `kirra-world-store/tests/inadmissible_never_read.rs`.
+    ///
+    /// Kept because neither filter is a *stated contract*. A boundary that
+    /// silently begins serving rejected or expired facts if one of them changes
+    /// is a worse outcome than a variant that never occurs.
+    NoneAdmissible,
+}
+
+/// One answer, which cannot exist without the things that make it citable.
+#[derive(Debug, Clone)]
+pub struct WorldAnswer {
+    subject: String,
+    predicate: Option<String>,
+    value: String,
+    validity: Validity,
+    grade: Option<TrustGrade>,
+    provenance: String,
+    event_id: String,
+}
+
+impl WorldAnswer {
+    /// The claim's subject.
+    #[must_use]
+    pub fn subject(&self) -> &str {
+        &self.subject
+    }
+
+    /// The claim's predicate, `None` for predicate-less claims.
+    #[must_use]
+    pub fn predicate(&self) -> Option<&str> {
+        self.predicate.as_deref()
+    }
+
+    /// The value itself.
+    ///
+    /// Reaching this requires already holding a `WorldAnswer`, which cannot be
+    /// built without validity, grade and provenance beside it. The value never
+    /// *arrives* alone — though a caller may still choose to carry it onward
+    /// alone, which is the bound named in the module docs.
+    #[must_use]
+    pub fn value(&self) -> &str {
+        &self.value
+    }
+
+    /// Validity resolved at the clock and budget the caller supplied.
+    ///
+    /// Resolved at construction rather than offered as a method, so it cannot be
+    /// the step that gets skipped. That is the entire difference between this
+    /// and [`ProjectedClaim`].
+    #[must_use]
+    pub fn validity(&self) -> Validity {
+        self.validity
+    }
+
+    /// The collapsed trust grade, or `None` when the claim carries no axes.
+    ///
+    /// `None` means *"this claim is unlabelled"*, never *"assume the default"*.
+    /// An unlabelled claim has no trust to grade, and manufacturing one is the
+    /// failure separate axes exist to prevent.
+    #[must_use]
+    pub fn grade(&self) -> Option<TrustGrade> {
+        self.grade
+    }
+
+    /// The provenance handle: the claim's chain digest.
+    ///
+    /// What makes the answer *citable* rather than merely believed — it locates
+    /// the claim in the tamper-evident log, so a reader can verify it instead of
+    /// trusting the API that served it.
+    #[must_use]
+    pub fn provenance(&self) -> &str {
+        &self.provenance
+    }
+
+    /// Identity of the event this answer came from.
+    #[must_use]
+    pub fn event_id(&self) -> &str {
+        &self.event_id
+    }
+}
+
+/// The outcome of asking the world about a subject.
+#[derive(Debug, Clone)]
+pub enum WorldLookup {
+    /// One or more admissible answers, in the store's key order.
+    Answered(Vec<WorldAnswer>),
+    /// Nothing usable, and why.
+    Unknown(UnknownReason),
+}
+
+/// A read-only view onto the world.
+///
+/// Read-only is structural, not a convention: this type holds a `&WorldStore`
+/// and offers no mutation. Kirra World is evidence; an answer boundary serves it
+/// and never adjudicates it.
+pub struct WorldView<'a> {
+    store: &'a WorldStore,
+    staleness_budget_ms: Option<u64>,
+}
+
+impl<'a> WorldView<'a> {
+    /// Bind a view with the **caller's** staleness policy.
+    ///
+    /// The budget is the caller's deliberately: how long a claim stays fresh is
+    /// a policy of the asking consumer, and a floor plan and a person's location
+    /// go stale at wildly different rates. Baking one budget into the row would
+    /// answer for every reader at once. `None` means this caller treats claims
+    /// as not going stale.
+    #[must_use]
+    pub fn new(store: &'a WorldStore, staleness_budget_ms: Option<u64>) -> Self {
+        Self {
+            store,
+            staleness_budget_ms,
+        }
+    }
+
+    /// Ask what is currently known about one subject.
+    ///
+    /// Bounded by construction — one subject, never the whole projection.
+    ///
+    /// # Errors
+    ///
+    /// Only on a storage fault. An empty or wholly-inadmissible result is
+    /// [`WorldLookup::Unknown`], which is a **success**.
+    pub fn ask(&self, subject: &str, now_ms: i64) -> Result<WorldLookup, StoreError> {
+        let claims = self.store.current(subject, now_ms)?;
+        if claims.is_empty() {
+            return Ok(WorldLookup::Unknown(UnknownReason::NoClaim));
+        }
+
+        let clock = now_ms.max(0).unsigned_abs();
+        let answers: Vec<WorldAnswer> = claims
+            .iter()
+            .filter(|c| Self::is_admissible(c, clock, self.staleness_budget_ms))
+            .map(|c| self.bind(c, clock))
+            .collect();
+
+        if answers.is_empty() {
+            return Ok(WorldLookup::Unknown(UnknownReason::NoneAdmissible));
+        }
+        Ok(WorldLookup::Answered(answers))
+    }
+
+    /// Expired, or graded `Inadmissible`, is not servable.
+    ///
+    /// An **unlabelled** claim is admitted: it has no axes to grade, and
+    /// refusing it would invent a trust judgement from the absence of one — the
+    /// mirror of manufacturing a default grade.
+    fn is_admissible(claim: &ProjectedClaim, clock: u64, budget: Option<u64>) -> bool {
+        if claim.validity_at(clock, budget) == Validity::Expired {
+            return false;
+        }
+        !matches!(
+            claim.grade_at(clock, budget),
+            Some(TrustGrade::Inadmissible)
+        )
+    }
+
+    /// The one place a `WorldAnswer` is built — every field populated together.
+    fn bind(&self, claim: &ProjectedClaim, clock: u64) -> WorldAnswer {
+        WorldAnswer {
+            subject: claim.subject.clone(),
+            predicate: claim.predicate.clone(),
+            value: claim.payload.clone(),
+            validity: claim.validity_at(clock, self.staleness_budget_ms),
+            grade: claim.grade_at(clock, self.staleness_budget_ms),
+            provenance: claim.chain_digest.clone(),
+            event_id: claim.event_id.clone(),
+        }
+    }
+}

--- a/crates/kirra-world-service/src/read_view.rs
+++ b/crates/kirra-world-service/src/read_view.rs
@@ -49,6 +49,16 @@
 //! [`WorldView::ask`] is the only way to obtain one. So an answer in hand always
 //! carries them.
 //!
+//! **"Trust" here means the axes, not a summary of them.** Rule 1 says *the
+//! trust axes*, and an earlier draft of this type carried only the collapsed
+//! [`TrustGrade`] while quoting the rule verbatim — which would have been the
+//! same overclaim this module exists to catch. Both are carried now:
+//! [`WorldAnswer::axes`] is what the rule requires, and [`WorldAnswer::grade`]
+//! is a convenience over it. Collapsing is fine; collapsing *and discarding the
+//! reason* is not, because `Weak` can mean uncorroborated, stale, or awaiting
+//! adjudication and a caller who needs to know which would be left with the raw
+//! log.
+//!
 //! **The honest bound, because overclaiming here would be the same failure the
 //! rule is about:** this closes the hole at *retrieval*. A caller cannot obtain
 //! the value without being handed the rest. It does **not** stop that caller
@@ -76,7 +86,7 @@
 //! the whole point of putting the boundary in a crate the fence already watches
 //! rather than in one it does not.
 
-use kirra_world_store::{ProjectedClaim, StoreError, TrustGrade, Validity, WorldStore};
+use kirra_world_store::{ProjectedClaim, StoreError, TrustAxes, TrustGrade, Validity, WorldStore};
 
 /// Why the world had nothing to say. **Not an error** — see rule 3.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -112,6 +122,7 @@ pub struct WorldAnswer {
     predicate: Option<String>,
     value: String,
     validity: Validity,
+    axes: Option<TrustAxes>,
     grade: Option<TrustGrade>,
     provenance: String,
     event_id: String,
@@ -151,7 +162,31 @@ impl WorldAnswer {
         self.validity
     }
 
+    /// The three stored trust axes, or `None` when the claim is unlabelled.
+    ///
+    /// **This is what rule 1 actually requires** — *"the trust axes"*, not a
+    /// summary of them. It is carried beside [`Self::grade`] rather than instead
+    /// of it, and the distinction is not cosmetic.
+    ///
+    /// A grade is a **collapse**. `Weak` can mean uncorroborated, or stale, or
+    /// awaiting adjudication, and a boundary that returned only the grade would
+    /// have performed that collapse *and thrown away the reason* — leaving a
+    /// caller who needs to know **why** with nowhere to look but the raw log.
+    /// The store's own `grade_at` says the collapse should be "something a
+    /// caller *does*, never something they receive by default"; returning only
+    /// the result of it would invert exactly that.
+    ///
+    /// `None` is *"unlabelled"*, never *"assume the default"*.
+    #[must_use]
+    pub fn axes(&self) -> Option<TrustAxes> {
+        self.axes
+    }
+
     /// The collapsed trust grade, or `None` when the claim carries no axes.
+    ///
+    /// A convenience over [`Self::axes`] and [`Self::validity`], not a
+    /// replacement for them: every answer carries the axes it was collapsed
+    /// from, so taking the grade never costs the reason behind it.
     ///
     /// `None` means *"this claim is unlabelled"*, never *"assume the default"*.
     /// An unlabelled claim has no trust to grade, and manufacturing one is the
@@ -262,6 +297,7 @@ impl<'a> WorldView<'a> {
             predicate: claim.predicate.clone(),
             value: claim.payload.clone(),
             validity: claim.validity_at(clock, self.staleness_budget_ms),
+            axes: claim.trust,
             grade: claim.grade_at(clock, self.staleness_budget_ms),
             provenance: claim.chain_digest.clone(),
             event_id: claim.event_id.clone(),

--- a/crates/kirra-world-service/tests/read_view.rs
+++ b/crates/kirra-world-service/tests/read_view.rs
@@ -130,6 +130,93 @@ fn the_store_row_is_a_bare_value_today() {
     assert_eq!(bare, r#"{"n":1}"#);
 }
 
+/// **Rule 1 says "the trust axes", and the answer carries them** — not just the
+/// grade collapsed out of them.
+///
+/// An earlier draft carried only [`WorldAnswer::grade`] while the module docs
+/// quoted the rule verbatim, which was an overclaim. This pins the fix.
+#[test]
+fn an_answer_carries_the_axes_not_only_the_collapsed_grade() {
+    let mut s = open("axes");
+    let a = axes(Corroboration::Corroborated(2), Adjudication::Confirmed);
+    seed(&mut s, 1, "cup-1", None, Some(&a), ClaimStatus::Confirmed);
+
+    let view = WorldView::new(&s, Some(60_000));
+    let WorldLookup::Answered(answers) = view.ask("cup-1", T0).expect("ask") else {
+        panic!("expected an answer");
+    };
+    let got = answers[0]
+        .axes()
+        .expect("a labelled claim carries its axes");
+    assert_eq!(got.origin(), Origin::Observed);
+    assert_eq!(got.corroboration(), Corroboration::Corroborated(2));
+    assert_eq!(got.adjudication(), Adjudication::Confirmed);
+}
+
+/// **The reason behind a grade survives the collapse.**
+///
+/// This is why carrying both matters rather than being belt-and-braces. Two
+/// claims can grade **identically for different reasons**, and a boundary
+/// returning only the grade would make them indistinguishable — leaving a caller
+/// who needs to know why with nowhere to look but the raw log.
+///
+/// Both below grade `Strong`. One is corroborated by two sources; the other has
+/// a single source and rests entirely on its adjudication. Same summary, very
+/// different evidentiary basis, and only the axes tell them apart.
+///
+/// **Why this pairing and not a weaker one:** `Weak` is unreachable through this
+/// boundary at all. `trust_grade` yields it only when the adjudication is not
+/// `Confirmed`, and the derivation `CHECK` plus the projection's confirmed-only
+/// fold mean every *labelled* claim that gets here is `Confirmed`. So the
+/// reachable set is `Strong`, `Adequate` and `None` — the same emergent
+/// narrowing that makes `Inadmissible` unreachable, one notch less severe.
+#[test]
+fn two_claims_can_share_a_grade_for_different_reasons() {
+    let mut s = open("why");
+    let corroborated = axes(Corroboration::Corroborated(2), Adjudication::Confirmed);
+    let single_source = axes(Corroboration::Uncorroborated, Adjudication::Confirmed);
+    seed(
+        &mut s,
+        1,
+        "a",
+        None,
+        Some(&corroborated),
+        ClaimStatus::Confirmed,
+    );
+    seed(
+        &mut s,
+        2,
+        "b",
+        None,
+        Some(&single_source),
+        ClaimStatus::Confirmed,
+    );
+
+    let view = WorldView::new(&s, Some(60_000));
+
+    let WorldLookup::Answered(a1) = view.ask("a", T0).expect("ask") else {
+        panic!("expected an answer");
+    };
+    let WorldLookup::Answered(a2) = view.ask("b", T0).expect("ask") else {
+        panic!("expected an answer");
+    };
+
+    // Identical summaries.
+    assert_eq!(a1[0].grade(), Some(TrustGrade::Strong));
+    assert_eq!(a2[0].grade(), Some(TrustGrade::Strong));
+
+    // Different reasons -- recoverable ONLY from the axes. Without them the
+    // grade would have been the end of the trail.
+    assert_eq!(
+        a1[0].axes().expect("labelled").corroboration(),
+        Corroboration::Corroborated(2)
+    );
+    assert_eq!(
+        a2[0].axes().expect("labelled").corroboration(),
+        Corroboration::Uncorroborated
+    );
+}
+
 /// An unlabelled claim grades to `None`, never a manufactured default.
 ///
 /// Revert that and this fails: defaulting to any grade invents a trust
@@ -144,6 +231,11 @@ fn an_unlabelled_claim_has_no_grade_rather_than_a_default() {
         panic!("expected an answer");
     };
     assert_eq!(answers[0].grade(), None);
+    assert_eq!(
+        answers[0].axes(),
+        None,
+        "an unlabelled claim carries no axes either -- absence, not a default set"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/kirra-world-service/tests/read_view.rs
+++ b/crates/kirra-world-service/tests/read_view.rs
@@ -1,0 +1,273 @@
+//! The answer boundary's contract — the three Tier 3 rules, against a real store.
+//!
+//! Each test names the rule it pins and, where a guard is involved, what breaks
+//! if the guard is removed. The second test is the odd one: it pins the
+//! *falsification* that made this module necessary, and is meant to stop
+//! compiling once Tier 3 lands.
+
+use kirra_world_service::read_view::{UnknownReason, WorldLookup, WorldView};
+use kirra_world_store::{
+    Adjudication, ClaimStatus, Corroboration, EventId, NewEvent, ObservationId, Origin, TrustAxes,
+    TrustGrade, Validity, WorldStore, WriterClass,
+};
+
+const T0: i64 = 1_700_000_000_000;
+
+fn tmp(name: &str) -> std::path::PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "kirra-world-readview-{}-{}.sqlite",
+        name,
+        std::process::id()
+    ));
+    for suffix in ["", "-wal", "-shm"] {
+        let mut q = p.as_os_str().to_os_string();
+        q.push(suffix);
+        let _ = std::fs::remove_file(std::path::PathBuf::from(q));
+    }
+    p
+}
+
+fn axes(corr: Corroboration, adj: Adjudication) -> TrustAxes {
+    TrustAxes::new(Origin::Observed, corr, adj).expect("constructible")
+}
+
+fn seed(
+    store: &mut WorldStore,
+    n: i64,
+    subject: &str,
+    valid_to_ms: Option<i64>,
+    trust: Option<&TrustAxes>,
+    claim_status: ClaimStatus,
+) {
+    let event = EventId::new(format!("evt-{n}")).unwrap();
+    let observation = ObservationId::new(format!("obs-{n}")).unwrap();
+    store
+        .append(&NewEvent {
+            event_id: &event,
+            observation_id: &observation,
+            txn_time_ms: T0,
+            valid_from_ms: T0,
+            valid_to_ms,
+            source: "sensor-a",
+            source_version: "0.1.0",
+            writer_class: WriterClass::Sensor,
+            claim_status,
+            provenance: &[],
+            frame_id: None,
+            map_id: None,
+            kind: "observation",
+            subject,
+            predicate: Some("colour"),
+            object: Some("red"),
+            payload: r#"{"n":1}"#,
+            payload_schema: 1,
+            retention_class: "raw",
+            trust,
+        })
+        .expect("append");
+    store.rebuild_projections().expect("project");
+}
+
+fn open(name: &str) -> WorldStore {
+    WorldStore::open(&tmp(name)).expect("open")
+}
+
+// ---------------------------------------------------------------------------
+// Rule 1 — no bare values
+// ---------------------------------------------------------------------------
+
+/// An answer arrives with validity, trust and provenance already attached.
+#[test]
+fn an_answer_carries_validity_trust_and_provenance() {
+    let mut s = open("bundle");
+    let a = axes(Corroboration::Corroborated(2), Adjudication::Confirmed);
+    seed(&mut s, 1, "cup-1", None, Some(&a), ClaimStatus::Confirmed);
+
+    let view = WorldView::new(&s, Some(60_000));
+    let WorldLookup::Answered(answers) = view.ask("cup-1", T0).expect("ask") else {
+        panic!("expected an answer");
+    };
+    assert_eq!(answers.len(), 1);
+    let ans = &answers[0];
+
+    assert_eq!(ans.value(), r#"{"n":1}"#);
+    assert_eq!(ans.subject(), "cup-1");
+    assert_eq!(ans.predicate(), Some("colour"));
+
+    // The three things the rule says may never be lost. Fresh rather than
+    // Timeless because the caller supplied a budget, so this claim CAN go stale
+    // and is merely within it at now == valid_from.
+    assert_eq!(ans.validity(), Validity::Fresh);
+    assert_eq!(ans.grade(), Some(TrustGrade::Strong));
+    assert!(
+        !ans.provenance().is_empty(),
+        "the provenance handle is what makes an answer citable rather than \
+         merely believed -- an empty one degrades silently to 'trust the API'"
+    );
+    assert_eq!(ans.event_id(), "evt-1");
+}
+
+/// **The falsification this module exists to answer**, pinned so it cannot
+/// quietly stop being true.
+///
+/// `ProjectedClaim`'s fields are public, so the payload is reachable with no
+/// validity, no trust and no handle. Tier 3's rule 1 therefore cannot be met by
+/// the store's row type, and has to be met at a boundary — which is the entire
+/// argument for `read_view` existing.
+///
+/// **When Tier 3 lands and the rule holds structurally at the store, this test
+/// should FAIL TO COMPILE.** That is the intended outcome, not a regression, and
+/// whoever hits it should delete this test rather than work around it.
+#[test]
+fn the_store_row_is_a_bare_value_today() {
+    let mut s = open("bare");
+    seed(&mut s, 1, "cup-1", None, None, ClaimStatus::Confirmed);
+
+    let claims = s.current("cup-1", T0).expect("read");
+    // No validity_at. No grade_at. No chain_digest. This compiles.
+    let bare = &claims[0].payload;
+    assert_eq!(bare, r#"{"n":1}"#);
+}
+
+/// An unlabelled claim grades to `None`, never a manufactured default.
+///
+/// Revert that and this fails: defaulting to any grade invents a trust
+/// judgement from the absence of one, which is what separate axes prevent.
+#[test]
+fn an_unlabelled_claim_has_no_grade_rather_than_a_default() {
+    let mut s = open("unlabelled");
+    seed(&mut s, 1, "cup-1", None, None, ClaimStatus::Confirmed);
+
+    let view = WorldView::new(&s, Some(60_000));
+    let WorldLookup::Answered(answers) = view.ask("cup-1", T0).expect("ask") else {
+        panic!("expected an answer");
+    };
+    assert_eq!(answers[0].grade(), None);
+}
+
+// ---------------------------------------------------------------------------
+// Rule 3 — Unknown is a success
+// ---------------------------------------------------------------------------
+
+/// An unknown subject is `Ok(Unknown)`, never `Err`.
+///
+/// Revert to an error and this fails. That is the point: an error gets caught
+/// upstream and turned into a default value, which is how "I don't know"
+/// becomes a confident wrong answer.
+#[test]
+fn an_unknown_subject_is_a_success_not_an_error() {
+    let s = open("unknown");
+    let view = WorldView::new(&s, Some(60_000));
+
+    let out = view.ask("never-heard-of-it", T0);
+    assert!(
+        out.is_ok(),
+        "absence of knowledge must not use the error channel"
+    );
+    assert!(matches!(
+        out.expect("ok"),
+        WorldLookup::Unknown(UnknownReason::NoClaim)
+    ));
+}
+
+/// An expired claim is not served — and reports `NoClaim`, not `NoneAdmissible`.
+///
+/// Asserted as **observed**, not as designed. `current()` filters on `holds_at`
+/// before this boundary sees anything, so expiry and never-heard-of-it are
+/// indistinguishable here. Recorded rather than smoothed over: an operator whose
+/// coverage merely lapsed is being sent to a coverage question rather than a
+/// freshness one, and only the store can tell them apart.
+///
+/// Both sides asserted, so this pins the boundary rather than the exclusion
+/// alone — a filter that excluded everything would pass a one-sided test.
+#[test]
+fn an_expired_claim_is_not_served() {
+    let mut s = open("expired");
+    let a = axes(Corroboration::Corroborated(2), Adjudication::Confirmed);
+    seed(
+        &mut s,
+        1,
+        "cup-1",
+        Some(T0 + 1_000),
+        Some(&a),
+        ClaimStatus::Confirmed,
+    );
+
+    let view = WorldView::new(&s, Some(60_000));
+    assert!(matches!(
+        view.ask("cup-1", T0 + 500).expect("ask"),
+        WorldLookup::Answered(_)
+    ));
+    assert!(matches!(
+        view.ask("cup-1", T0 + 5_000).expect("ask"),
+        WorldLookup::Unknown(UnknownReason::NoClaim)
+    ));
+}
+
+/// An inadmissible claim cannot reach this boundary at all.
+///
+/// The store-side guarantee (pinned in
+/// `kirra-world-store/tests/inadmissible_never_read.rs`) seen from the consuming
+/// end. Worth asserting on both sides: that file proves the store never emits
+/// one, this proves the boundary never invents one on its own.
+#[test]
+fn an_inadmissible_claim_never_reaches_the_boundary() {
+    let mut s = open("inadmissible");
+    let rejected = axes(Corroboration::Contradicted(2), Adjudication::Rejected);
+    seed(
+        &mut s,
+        1,
+        "cup-1",
+        None,
+        Some(&rejected),
+        ClaimStatus::Candidate,
+    );
+
+    let view = WorldView::new(&s, Some(60_000));
+    assert!(matches!(
+        view.ask("cup-1", T0).expect("ask"),
+        WorldLookup::Unknown(UnknownReason::NoClaim)
+    ));
+}
+
+// ---------------------------------------------------------------------------
+// The staleness budget belongs to the caller
+// ---------------------------------------------------------------------------
+
+/// Two callers can disagree about the same claim at the same instant.
+///
+/// Which is why the budget is a parameter and not a column: a floor plan and a
+/// person's location go stale at wildly different rates. Both are still
+/// *served* — stale is a reportable state, not a refusal.
+#[test]
+fn the_staleness_budget_belongs_to_the_asking_caller() {
+    let mut s = open("staleness");
+    let a = axes(Corroboration::Corroborated(2), Adjudication::Confirmed);
+    seed(
+        &mut s,
+        1,
+        "cup-1",
+        Some(T0 + 10_000_000),
+        Some(&a),
+        ClaimStatus::Confirmed,
+    );
+
+    let later = T0 + 120_000;
+
+    let impatient = WorldView::new(&s, Some(60_000));
+    let WorldLookup::Answered(a1) = impatient.ask("cup-1", later).expect("ask") else {
+        panic!("expected an answer");
+    };
+    assert_eq!(a1[0].validity(), Validity::Stale);
+
+    let patient = WorldView::new(&s, Some(600_000));
+    let WorldLookup::Answered(a2) = patient.ask("cup-1", later).expect("ask") else {
+        panic!("expected an answer");
+    };
+    assert_eq!(a2[0].validity(), Validity::Fresh);
+
+    // Same claim, same instant, different verdicts -- and the same provenance,
+    // so the disagreement is about policy rather than about which claim was read.
+    assert_eq!(a1[0].provenance(), a2[0].provenance());
+}


### PR DESCRIPTION
`WM_SCOPE.md` §9 asks for a small consumer wired before Tier 3. That consumer was built, and **Fence B refused every host §9 nominates** — planner, perception and LLM crates all implement `CorridorSource`, which is authoritative to the checker, so none may depend on Kirra World. #1386 records the refusal.

## What this is, and what it is not

**Not** that external doer caller, and it says so in its own module docs rather than letting a reader assume otherwise. What it is: the **shape that caller produced**, kept somewhere durable instead of being lost when the session ends.

`kirra-world-service` is the one crate that can legally hold it, and the check was done **before** choosing it, not after:

| Requirement | Status |
|---|---|
| already depends on `kirra-world` + `kirra-world-store` | yes — no new dependency edges |
| implements `CorridorSource` | **no** — the check that refused `kirra-sidecars` |
| in Fence B's safety closure | **no** — verified with the fence's own closure walk |

Zero new dependency edges, zero new workspace members, zero fence perturbation.

**Why it was still worth doing.** The falsification is already banked. What was still at risk was the *type* — and a type that has met a caller is worth more to Tier 3 than one derived from the rule alone.

## The rule it makes structural

Rule 1 says *"no API returns a bare value — every answer carries the value, the trust **axes**, the validity at the supplied clock, and a `ProvenanceHandle`."* It **cannot be met by `ProjectedClaim`**: the fields are public, so

```rust
let payload = &store.current("robot-01", now)?[0].payload;
```

compiles — no validity, no trust, no handle. `validity_at`/`grade_at` are methods a caller must *remember* to call, and forgetting is the default.

That is not a defect. `ProjectedClaim` is the projection **row**, and a row is honestly a bag of columns. The rule belongs one layer out, where a row becomes an *answer*.

`WorldAnswer` has no constructor that omits validity, trust or provenance, and `WorldView::ask` is the only way to obtain one. **Validity is resolved at construction rather than offered as a method** — the entire difference from `ProjectedClaim`: it cannot be the step that gets skipped.

**The honest bound, stated because overclaiming here would be the same failure the rule is about:** this closes the hole at *retrieval*, not at propagation. A caller can still destructure and pass the value onward alone; Rust cannot prevent that without infecting every downstream signature.

## Review found a real gap — the axes, not just the grade

The first draft carried only the collapsed `TrustGrade` while quoting rule 1's *"trust **axes**"* verbatim. That was the same overclaim this module exists to catch, one screen below where it says so. **Fixed by exposing the axes**, rather than by documenting the shortfall.

Both are carried: `axes()` is what the rule requires, `grade()` is a convenience over it. A grade is a **collapse**, and returning only its output performs that collapse *and discards the reason* — inverting the store's own principle that collapsing should be *"something a caller does, never something they receive by default."*

**Writing the test for it surfaced another emergent narrowing.** My first draft paired two `Weak` claims and no store could produce one: `trust_grade` yields `Weak` only when adjudication isn't `Confirmed`, but the derivation `CHECK` plus the confirmed-only fold mean every *labelled* claim reaching this boundary is `Confirmed`. The reachable grade set is `Strong` / `Adequate` / `None` — the same shape as the `Inadmissible` finding (#1385), one notch less severe. Recorded in the test rather than left as a puzzle.

## Nine tests, one of which is meant to break

`the_store_row_is_a_bare_value_today` pins the **falsification** — and is meant to **stop compiling** when Tier 3 makes the rule structural at the store. That is the intended outcome, not a regression, and the test says so, so whoever hits it deletes it rather than works around it.

## Negative controls — and a correction to how I ran them

| Guard reverted | Tests that failed |
|---|---|
| validity not resolved at construction | **2** |
| unlabelled claim given a default grade | **1** |
| `Unknown` routed through the error channel | **3** |
| axes discarded, only the grade carried | **2** |

**My first attempt at the first three was invalid and the numbers were wrong.** I restored between controls with `git checkout --`, which silently does nothing to an *untracked* file — so the mutations stacked. B reported 3 failures (actually 1) and C reported 6 (actually 3), each inflated by the ones still applied underneath. Re-run from a pristine snapshot, independently. The contaminated figures would have overstated how much each guard catches.

## Crate header amended, not deleted

`kirra-world-service` described itself as *"shape only, no service"*. No HTTP, no routes, no server, no runtime, no transport is **all still true and still load-bearing** — but "shape only" no longer is, so the header says what changed and why the emptiness that mattered is unaffected.

## Verification

`cargo test -p kirra-world-service` green (9 + 1) · rustfmt clean · clippy 0 warnings · `cargo check --workspace --all-targets` clean · Kirra World fence **INTACT** (19 packages from 10 roots) · 42/42 fence tests · mick actuation fence INTACT.

Kirra is designed in alignment with ISO 26262 ASIL-D requirements and IEC 61508 SIL 3 requirements. Independent third-party assessment has not yet been performed.