### PR TITLE
evidence_digest / prev_hash as core types

### DIFF
--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -762,7 +762,12 @@ pub fn schema_digest_v1() -> String {
 }
 
 /// The genesis value the first event chains from.
-pub const GENESIS: &str = "kirra-world:genesis";
+///
+/// **One definition, in the core.** This was a literal here and is now the
+/// core's [`kirra_world::evidence::GENESIS_TOKEN`], because the value is inside
+/// the hashed bytes of every first record and two definitions of a frozen
+/// constant are two chances for it to drift. The public path is unchanged.
+pub const GENESIS: &str = kirra_world::evidence::GENESIS_TOKEN;
 
 /// The append-only evidence log.
 pub struct WorldStore {

--- a/crates/kirra-world-store/tests/chain_identity_types.rs
+++ b/crates/kirra-world-store/tests/chain_identity_types.rs
@@ -1,0 +1,162 @@
+//! The core's chain-identity types against what the store actually produces.
+//!
+//! `EvidenceDigest` and `PrevHash` state a rule about the shape of a chain
+//! value. This is where that rule meets the real producer — because a type
+//! whose admission rule disagrees with the thing it is meant to type is not
+//! merely useless, it is worse than a `String`: it would refuse genuine
+//! evidence while looking like a safety improvement.
+
+use kirra_world::evidence::{DigestError, EvidenceDigest, PrevHash, DIGEST_HEX_LEN, GENESIS_TOKEN};
+use kirra_world_store::{
+    ClaimStatus, EventId, NewEvent, ObservationId, WorldStore, WriterClass, GENESIS,
+};
+
+const T0: i64 = 1_700_000_000_000;
+
+fn tmp(name: &str) -> std::path::PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "kirra-world-chainid-{}-{}.sqlite",
+        name,
+        std::process::id()
+    ));
+    for suffix in ["", "-wal", "-shm"] {
+        let mut q = p.as_os_str().to_os_string();
+        q.push(suffix);
+        let _ = std::fs::remove_file(std::path::PathBuf::from(q));
+    }
+    p
+}
+
+fn seed(store: &mut WorldStore, n: i64) {
+    let event = EventId::new(format!("evt-{n}")).unwrap();
+    let observation = ObservationId::new(format!("obs-{n}")).unwrap();
+    store
+        .append(&NewEvent {
+            event_id: &event,
+            observation_id: &observation,
+            txn_time_ms: T0 + n,
+            valid_from_ms: T0,
+            valid_to_ms: None,
+            source: "sensor-a",
+            source_version: "0.1.0",
+            writer_class: WriterClass::Sensor,
+            claim_status: ClaimStatus::Confirmed,
+            provenance: &[],
+            frame_id: None,
+            map_id: None,
+            kind: "observation",
+            subject: "cup-1",
+            predicate: Some("colour"),
+            object: Some("red"),
+            payload: r#"{"n":1}"#,
+            payload_schema: 1,
+            retention_class: "raw",
+            trust: None,
+        })
+        .expect("append");
+}
+
+/// **One definition of the genesis sentinel, not two.**
+///
+/// The store's `GENESIS` is now the core's constant. Pinned by identity so a
+/// future edit that reintroduces a local literal here is caught even if the two
+/// happen to agree on the day it is written.
+#[test]
+fn the_store_and_the_core_share_one_genesis_definition() {
+    assert_eq!(GENESIS, GENESIS_TOKEN);
+    // ...and the value itself is frozen: it is hashed into every first record,
+    // so changing it does not migrate a store, it makes existing first records
+    // unverifiable.
+    assert_eq!(GENESIS, "kirra-world:genesis");
+}
+
+/// **The seam test.** A digest the store really produced is admissible by the
+/// core type.
+///
+/// This is the assertion that makes the type worth having. `EvidenceDigest`
+/// demands exactly 64 lower-case hex characters; `compute_record_hash_v2`
+/// emits `hex::encode` of a SHA-256. If those two ever disagreed — a producer
+/// switching to upper case, a truncation, a prefix — the type would start
+/// refusing genuine evidence, and it would do so while looking like a
+/// tightening rather than a break.
+#[test]
+fn a_digest_the_store_produced_is_admissible_by_the_core_type() {
+    let mut s = WorldStore::open(&tmp("produced")).expect("open");
+    seed(&mut s, 1);
+
+    let head = s.head_chain().expect("head");
+    assert_ne!(head, GENESIS, "an appended store has moved off genesis");
+
+    let typed = EvidenceDigest::new(&head).unwrap_or_else(|e| {
+        panic!("the store's own digest was refused by the core type: {e} ({head:?})")
+    });
+    assert_eq!(typed.as_str(), head, "admitted verbatim");
+    assert_eq!(head.chars().count(), DIGEST_HEX_LEN);
+}
+
+/// The two chain positions parse as the two things they actually are.
+#[test]
+fn genesis_and_a_real_head_parse_as_their_own_variants() {
+    let mut s = WorldStore::open(&tmp("variants")).expect("open");
+
+    // Before any append, the head IS genesis -- the beginning, not a digest.
+    let before = s.head_chain().expect("head");
+    assert_eq!(
+        PrevHash::parse(&before).expect("parses"),
+        PrevHash::Genesis,
+        "an empty store's head is the beginning"
+    );
+
+    seed(&mut s, 1);
+
+    // After, it is a link.
+    let after = s.head_chain().expect("head");
+    let parsed = PrevHash::parse(&after).expect("parses");
+    assert_eq!(parsed.digest().expect("a link").as_str(), after);
+    assert_ne!(parsed, PrevHash::Genesis);
+}
+
+/// A chain advances, and every head along the way stays admissible.
+///
+/// One digest being well-formed could be luck; this walks several. It also
+/// pins that the heads actually *change*, so the test is not passing against a
+/// store that returns the same value forever.
+#[test]
+fn every_head_along_a_growing_chain_is_admissible_and_distinct() {
+    let mut s = WorldStore::open(&tmp("growing")).expect("open");
+    let mut seen: Vec<String> = Vec::new();
+
+    for n in 1..=4 {
+        seed(&mut s, n);
+        let head = s.head_chain().expect("head");
+        EvidenceDigest::new(&head).expect("each head is admissible");
+        assert!(!seen.contains(&head), "each append moves the head");
+        seen.push(head);
+    }
+    assert_eq!(seen.len(), 4);
+    s.verify_chain().expect("and the chain verifies");
+}
+
+/// The store's stored digests are lower case, which is what the type demands.
+///
+/// Asserted against the real value rather than assumed from `hex::encode`'s
+/// documentation, because the case rule is the one refusal in `EvidenceDigest`
+/// that would look like pedantry if it were not tied to a real producer.
+#[test]
+fn stored_digests_are_lower_case_so_the_case_rule_is_not_arbitrary() {
+    let mut s = WorldStore::open(&tmp("case")).expect("open");
+    seed(&mut s, 1);
+    let head = s.head_chain().expect("head");
+
+    assert!(
+        !head.chars().any(|c| c.is_ascii_uppercase()),
+        "the producer emits lower case: {head}"
+    );
+    // And the upper-cased form -- the same hash, a different string -- is
+    // refused, which is the whole point of not normalizing.
+    assert_eq!(
+        EvidenceDigest::new(head.to_uppercase()).expect_err("refused"),
+        DigestError::UppercaseHex
+    );
+}

--- a/crates/kirra-world/src/evidence.rs
+++ b/crates/kirra-world/src/evidence.rs
@@ -119,21 +119,36 @@ impl EvidenceDigest {
     /// characters of **lower-case** hex.
     pub fn new(v: impl Into<String>) -> Result<Self, DigestError> {
         let v = v.into();
-        if v.chars().count() != DIGEST_HEX_LEN {
-            return Err(DigestError::WrongLength {
-                len: v.chars().count(),
-            });
-        }
-        // Order matters: report the case problem specifically when the value is
-        // otherwise a valid digest, so "wrong case" never hides behind the
-        // blunter "not a digest".
-        if v.chars().all(|c| c.is_ascii_hexdigit()) {
-            if v.chars().any(|c| c.is_ascii_uppercase()) {
-                return Err(DigestError::UppercaseHex);
+
+        // One pass, then the decision. The loop deliberately does NOT return
+        // early on a non-hex character: length is checked first, so a short
+        // non-hex value must report its length rather than its content, and an
+        // early return would decide before the length is known.
+        let mut len = 0usize;
+        let mut all_hex = true;
+        let mut saw_upper = false;
+        for c in v.chars() {
+            len += 1;
+            if !c.is_ascii_hexdigit() {
+                all_hex = false;
+            } else if c.is_ascii_uppercase() {
+                saw_upper = true;
             }
-            return Ok(Self(v));
         }
-        Err(DigestError::NonHexCharacter)
+
+        // The precedence, in the order it is documented. "Wrong case" must not
+        // hide behind the blunter "not a digest", so the hex check comes first
+        // and the case check only sees values that are otherwise valid.
+        if len != DIGEST_HEX_LEN {
+            return Err(DigestError::WrongLength { len });
+        }
+        if !all_hex {
+            return Err(DigestError::NonHexCharacter);
+        }
+        if saw_upper {
+            return Err(DigestError::UppercaseHex);
+        }
+        Ok(Self(v))
     }
 
     /// The digest, exactly as admitted.
@@ -257,6 +272,35 @@ mod tests {
         assert_eq!(
             EvidenceDigest::new(mixed).expect_err("refused"),
             DigestError::UppercaseHex
+        );
+    }
+
+    /// **The precedence itself**, pinned with the only input that can see it.
+    ///
+    /// A value needs BOTH an upper-case hex character and a non-hex character to
+    /// distinguish "hex first" from "case first" — anything less passes under
+    /// either order. Without this test the documented precedence was decorative:
+    /// inverting the two checks left every other test green.
+    ///
+    /// `NonHexCharacter` is the right answer because it is the more fundamental
+    /// complaint. Reporting the case of a value that is not a digest at all
+    /// would send an investigator to fix the capitalisation of something that
+    /// was never going to parse.
+    #[test]
+    fn a_value_wrong_in_both_ways_reports_the_more_fundamental_one() {
+        let mut both = REAL.to_string();
+        both.replace_range(0..1, "A"); // upper-case, and a hex digit
+        both.replace_range(1..2, "z"); // not a hex digit at all
+        assert_eq!(
+            both.chars().count(),
+            DIGEST_HEX_LEN,
+            "length is not the issue"
+        );
+
+        assert_eq!(
+            EvidenceDigest::new(both).expect_err("refused"),
+            DigestError::NonHexCharacter,
+            "not-a-digest outranks wrong-case"
         );
     }
 

--- a/crates/kirra-world/src/evidence.rs
+++ b/crates/kirra-world/src/evidence.rs
@@ -1,0 +1,345 @@
+//! **Chain identity** — the digest of a record, and the link to the one before.
+//!
+//! The last of Tier 1's typing gaps, moved to Tier 3 by
+//! `KIRRA-WM-TIER1-DONE-001` because that is where it is first *required*:
+//! Tier 3's rule 1 says every answer carries a `ProvenanceHandle`, and a handle
+//! over a bare hex string is the thing that rule exists to prevent.
+//!
+//! # What these replace
+//!
+//! `String`, in both positions. The store computes a record's digest with
+//! `kirra_audit_hash::compute_record_hash_v2` and stores it as text; the link
+//! to the previous record is text too. Nothing distinguished either from a
+//! subject, a payload, or each other.
+//!
+//! # The rule this makes structural: verbatim, and lower-case
+//!
+//! [`EvidenceDigest`] admits **exactly 64 lower-case hex characters** and
+//! stores them **verbatim**. Both halves are load-bearing, and the second is
+//! the one that looks like pedantry and is not.
+//!
+//! `hex::encode` emits lower case. `verify_chain` compares digests by **string
+//! equality**, not by decoded value. So `"AB…"` and `"ab…"` are the *same hash*
+//! and *different strings* — and a type that helpfully lower-cased on the way in
+//! would produce a value that no longer matches what a tampered-with or
+//! foreign-cased row actually contains, reporting an intact chain as broken or a
+//! broken one as intact depending on which side normalized.
+//!
+//! Refusing upper case is therefore not a style rule. It is the same
+//! "validate, never normalize" discipline `reference.rs` applies for the same
+//! reason: **the stored bytes are the evidence, and a constructor that improves
+//! them is corrupting them.**
+//!
+//! `DigestError::UppercaseHex` is separate from `NonHexCharacter` deliberately.
+//! *"This is a well-formed digest in the wrong case"* and *"this is not a
+//! digest"* send an investigator to different questions — the first suggests a
+//! producer that used `HEX::encode` semantics, the second suggests the column
+//! holds something else entirely.
+//!
+//! # Why [`PrevHash`] is an enum and not a digest
+//!
+//! **The first record has no predecessor.** Its previous-hash position holds
+//! the sentinel [`GENESIS_TOKEN`] — `kirra-world:genesis`, which is not a hash
+//! of anything and is not hex.
+//!
+//! A single `EvidenceDigest` in that position would force one of two bad
+//! choices: widen the digest type to admit non-hex (destroying the invariant
+//! that makes it worth having), or **fabricate a digest for genesis** — a
+//! synthetic value in a hash-chained evidence log, which is the worse of the
+//! two by a distance.
+//!
+//! So the position gets a type that says what it is: either the beginning, or a
+//! link to a real record. A reader can no longer forget that the first case
+//! exists, because the compiler will not let them.
+//!
+//! # These do not change any stored bytes
+//!
+//! [`GENESIS_TOKEN`] is inside the hashed bytes of every first record —
+//! `compute_record_hash_v2` takes the previous hash as its first field — so its
+//! value is frozen exactly as the `kind` tokens are. The store re-exports this
+//! constant rather than defining its own, so there is one definition rather
+//! than two that could drift.
+
+use core::fmt;
+
+/// Length of a hex-encoded SHA-256 digest.
+pub const DIGEST_HEX_LEN: usize = 64;
+
+/// The previous-hash sentinel for the first record in a chain.
+///
+/// **Frozen.** It is hashed into every first record, so changing it does not
+/// migrate a store — it makes existing first records unverifiable.
+pub const GENESIS_TOKEN: &str = "kirra-world:genesis";
+
+/// Why a value was refused as an [`EvidenceDigest`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DigestError {
+    /// Not [`DIGEST_HEX_LEN`] characters.
+    WrongLength {
+        /// What was offered, in characters.
+        len: usize,
+    },
+    /// Contained a character that is not a hex digit at all.
+    NonHexCharacter,
+    /// Well-formed hex, but containing upper-case letters.
+    ///
+    /// Separate from [`Self::NonHexCharacter`] because the two mean different
+    /// things to whoever is diagnosing it, and because this is the case a
+    /// normalizing constructor would have silently "fixed" — see the module
+    /// docs for why that would corrupt chain verification rather than help it.
+    UppercaseHex,
+}
+
+impl fmt::Display for DigestError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::WrongLength { len } => {
+                write!(f, "expected {DIGEST_HEX_LEN} hex characters, got {len}")
+            }
+            Self::NonHexCharacter => f.write_str("not a hex digest"),
+            Self::UppercaseHex => {
+                f.write_str("upper-case hex: digests are compared as strings, so case is not free")
+            }
+        }
+    }
+}
+
+/// A record's position in the tamper-evident log — its SHA-256, hex-encoded.
+///
+/// Admitted verbatim. See the module docs on why nothing is normalized.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct EvidenceDigest(String);
+
+impl EvidenceDigest {
+    /// Admit a digest.
+    ///
+    /// # Errors
+    ///
+    /// [`DigestError`] if the value is not exactly [`DIGEST_HEX_LEN`]
+    /// characters of **lower-case** hex.
+    pub fn new(v: impl Into<String>) -> Result<Self, DigestError> {
+        let v = v.into();
+        if v.chars().count() != DIGEST_HEX_LEN {
+            return Err(DigestError::WrongLength {
+                len: v.chars().count(),
+            });
+        }
+        // Order matters: report the case problem specifically when the value is
+        // otherwise a valid digest, so "wrong case" never hides behind the
+        // blunter "not a digest".
+        if v.chars().all(|c| c.is_ascii_hexdigit()) {
+            if v.chars().any(|c| c.is_ascii_uppercase()) {
+                return Err(DigestError::UppercaseHex);
+            }
+            return Ok(Self(v));
+        }
+        Err(DigestError::NonHexCharacter)
+    }
+
+    /// The digest, exactly as admitted.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Consume this digest, returning the inner string.
+    #[must_use]
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+impl fmt::Display for EvidenceDigest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// What the previous-hash position holds: the beginning, or a real link.
+///
+/// See the module docs on why this is not an [`EvidenceDigest`].
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum PrevHash {
+    /// The first record in the chain. Carries [`GENESIS_TOKEN`], which is not
+    /// a hash and is not pretending to be one.
+    Genesis,
+    /// A link to the record before this one.
+    Digest(EvidenceDigest),
+}
+
+impl PrevHash {
+    /// Read a stored previous-hash value.
+    ///
+    /// # Errors
+    ///
+    /// [`DigestError`] when the value is neither [`GENESIS_TOKEN`] nor an
+    /// admissible digest. Note what this does **not** do: it never falls back
+    /// to [`Self::Genesis`] for an unparseable value. A corrupt link that read
+    /// as "the beginning" would make a truncated chain verify as a complete
+    /// one.
+    pub fn parse(v: &str) -> Result<Self, DigestError> {
+        if v == GENESIS_TOKEN {
+            return Ok(Self::Genesis);
+        }
+        EvidenceDigest::new(v).map(Self::Digest)
+    }
+
+    /// The stored form — the sentinel, or the digest.
+    ///
+    /// This is what goes into the hashed bytes, so it must round-trip
+    /// [`Self::parse`] exactly.
+    #[must_use]
+    pub fn as_token(&self) -> &str {
+        match self {
+            Self::Genesis => GENESIS_TOKEN,
+            Self::Digest(d) => d.as_str(),
+        }
+    }
+
+    /// The digest, or `None` at the beginning of the chain.
+    ///
+    /// `None` is *"there is no previous record"*, never *"the previous record
+    /// is unknown"*.
+    #[must_use]
+    pub fn digest(&self) -> Option<&EvidenceDigest> {
+        match self {
+            Self::Genesis => None,
+            Self::Digest(d) => Some(d),
+        }
+    }
+}
+
+impl fmt::Display for PrevHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_token())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const REAL: &str = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+    // -- EvidenceDigest admission ------------------------------------------
+
+    #[test]
+    fn a_real_sha256_hex_digest_is_admitted_verbatim() {
+        let d = EvidenceDigest::new(REAL).expect("admissible");
+        assert_eq!(d.as_str(), REAL, "stored exactly as offered");
+    }
+
+    /// **The load-bearing refusal.** Upper-case hex is the same *hash* and a
+    /// different *string*, and `verify_chain` compares strings.
+    ///
+    /// Revert this to a `to_lowercase()` and the type starts silently rewriting
+    /// evidence: a row stored upper-case would compare equal through the type
+    /// and unequal in SQL, so the chain would verify differently depending on
+    /// which path read it.
+    #[test]
+    fn uppercase_hex_is_refused_rather_than_lowercased() {
+        let err = EvidenceDigest::new(REAL.to_uppercase()).expect_err("refused");
+        assert_eq!(err, DigestError::UppercaseHex);
+    }
+
+    /// The two failure modes stay distinguishable.
+    #[test]
+    fn not_hex_and_wrong_case_are_different_diagnoses() {
+        let not_hex: String = "z".repeat(DIGEST_HEX_LEN);
+        assert_eq!(
+            EvidenceDigest::new(not_hex).expect_err("refused"),
+            DigestError::NonHexCharacter
+        );
+        // ...and a mixed-case value that IS hex reports the case, not the
+        // blunter "not a digest".
+        let mut mixed = REAL.to_string();
+        mixed.replace_range(0..1, "E");
+        assert_eq!(
+            EvidenceDigest::new(mixed).expect_err("refused"),
+            DigestError::UppercaseHex
+        );
+    }
+
+    #[test]
+    fn a_digest_of_the_wrong_length_is_refused_with_its_length() {
+        assert_eq!(
+            EvidenceDigest::new("abc").expect_err("refused"),
+            DigestError::WrongLength { len: 3 }
+        );
+        assert_eq!(
+            EvidenceDigest::new(String::new()).expect_err("refused"),
+            DigestError::WrongLength { len: 0 }
+        );
+        let long = format!("{REAL}0");
+        assert_eq!(
+            EvidenceDigest::new(long).expect_err("refused"),
+            DigestError::WrongLength { len: 65 }
+        );
+    }
+
+    /// Length is counted in **characters**, so a multi-byte value cannot slip
+    /// through a byte-length check and then fail somewhere further along.
+    #[test]
+    fn length_is_counted_in_characters_not_bytes() {
+        let multibyte: String = "é".repeat(DIGEST_HEX_LEN);
+        assert_eq!(
+            EvidenceDigest::new(multibyte).expect_err("refused"),
+            DigestError::NonHexCharacter,
+            "64 characters, 128 bytes -- reaches the hex check rather than the length one"
+        );
+    }
+
+    // -- PrevHash ----------------------------------------------------------
+
+    #[test]
+    fn the_genesis_token_parses_as_the_beginning_not_as_a_digest() {
+        let p = PrevHash::parse(GENESIS_TOKEN).expect("admissible");
+        assert_eq!(p, PrevHash::Genesis);
+        assert_eq!(p.digest(), None, "the beginning has no previous digest");
+        assert_eq!(p.as_token(), GENESIS_TOKEN);
+    }
+
+    #[test]
+    fn a_real_link_parses_as_a_digest() {
+        let p = PrevHash::parse(REAL).expect("admissible");
+        assert_eq!(p.digest().expect("a link").as_str(), REAL);
+        assert_eq!(p.as_token(), REAL);
+    }
+
+    /// **A corrupt link must not read as the beginning.**
+    ///
+    /// Revert `parse` to fall back to `Genesis` on an unparseable value and this
+    /// fails — which is the point. A truncated chain whose first surviving row
+    /// claimed to be the beginning would verify as a complete one, and the
+    /// missing history would be invisible.
+    #[test]
+    fn an_unparseable_link_is_refused_rather_than_read_as_genesis() {
+        for bad in ["", "kirra-world:GENESIS", "not-a-digest", "deadbeef"] {
+            let out = PrevHash::parse(bad);
+            assert!(out.is_err(), "{bad:?} must not parse");
+            assert_ne!(out.ok(), Some(PrevHash::Genesis));
+        }
+    }
+
+    /// The stored form round-trips, in both variants.
+    ///
+    /// `as_token` is what goes into the hashed bytes, so a value that did not
+    /// survive the round trip would change a record's digest.
+    #[test]
+    fn both_variants_round_trip_through_the_stored_form() {
+        for original in [PrevHash::Genesis, PrevHash::parse(REAL).unwrap()] {
+            let token = original.as_token().to_string();
+            assert_eq!(PrevHash::parse(&token).expect("round trips"), original);
+        }
+    }
+
+    /// The sentinel is pinned by value, not merely by name.
+    ///
+    /// It is hashed into every first record, so this constant is frozen the way
+    /// the `kind` tokens are: changing it does not migrate a store, it makes
+    /// existing first records unverifiable.
+    #[test]
+    fn the_genesis_token_is_frozen() {
+        assert_eq!(GENESIS_TOKEN, "kirra-world:genesis");
+    }
+}

--- a/crates/kirra-world/src/lib.rs
+++ b/crates/kirra-world/src/lib.rs
@@ -121,6 +121,7 @@
 #![warn(missing_docs)]
 
 pub mod entity;
+pub mod evidence;
 pub mod kind;
 pub mod observation;
 pub mod reference;

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -568,6 +568,8 @@ is **self-releasing and already released** (ADR-0042 Decision 5, recorded
       no-bare-values rule demands every answer carry a `ProvenanceHandle`, and
       Tier 4's `Explain` needs derivation edges to be real structure. Recorded as
       relocated, not resolved — it is still core-crate work.
+      **Since DONE, 2026-08-07** — see §6. Recorded as a pointer rather than by
+      editing the note above, which is a dated record of the move.
 - [x] **Relationship model** (§8) — **DONE 2026-08-06**,
       `crates/kirra-world/src/relationship.rs`, 20 tests, still zero-dependency.
       **All ten §8 record fields**, all 15 predicates across the four groups.
@@ -731,12 +733,47 @@ Eight verbs in §14.2; about five exist in partial form.
 
 - [ ] `Resolve` · [ ] `Related` (bounded graph) · [ ] `WhatIsAt` ·
       [ ] `Capabilities` · [ ] `Freshness`
-- [ ] **`evidence_digest` / `prev_hash` as core types** — moved here from §7 on
-      2026-08-07 by `KIRRA-WM-TIER1-DONE-001`. **Core-crate work, listed at the
-      tier that first requires it**, not reclassified as query work: rule 1 below
-      demands every answer carry a `ProvenanceHandle`, and a handle over two bare
-      hex strings is the thing that rule exists to prevent. Tier 4's `Explain`
-      needs the same edges as real structure.
+- [x] **`evidence_digest` / `prev_hash` as core types** — **DONE 2026-08-07**,
+      `crates/kirra-world/src/evidence.rs`, 10 unit tests + 5 seam tests in the
+      store, still zero-dependency.
+      Moved here from §7 the same day by `KIRRA-WM-TIER1-DONE-001`: core-crate
+      work, listed at the tier that first *requires* it, since rule 1 below
+      demands every answer carry a `ProvenanceHandle` and a handle over two bare
+      hex strings is what that rule exists to prevent.
+      **`EvidenceDigest` admits 64 lower-case hex characters, verbatim.** The
+      case rule is the load-bearing one and looks like pedantry until you see
+      why: `verify_chain` compares digests as **strings**, so an upper-case value
+      is the same *hash* and a different *string*, and a constructor that
+      helpfully lower-cased would report intact chains as broken depending on
+      which side normalized. Same "validate, never normalize" discipline as
+      `reference.rs`, for the same reason — the stored bytes are the evidence,
+      and a constructor that improves them is corrupting them. `UppercaseHex` is
+      a distinct error from `NonHexCharacter` because *"well-formed, wrong case"*
+      and *"not a digest"* send an investigator to different questions.
+      **`PrevHash` is an ENUM, not a digest**, because the first record has no
+      predecessor: its previous-hash position holds `kirra-world:genesis`, which
+      is not a hash and is not hex. A single digest type there would force either
+      widening the invariant or **fabricating a digest for genesis** — a
+      synthetic value in a hash-chained evidence log, which is much the worse.
+      `parse` never falls back to `Genesis` on a corrupt link, since a truncated
+      chain whose first surviving row claimed to be the beginning would verify as
+      a complete one.
+      **The genesis sentinel now has ONE definition.** It was a literal in both
+      the core and the store; the store re-exports the core's constant, because
+      the value is inside the hashed bytes of every first record and two
+      definitions of a frozen constant are two chances to drift.
+      **Seam-tested against the real producer** (`kirra-world-store/tests/
+      chain_identity_types.rs`): a digest the store actually emitted is
+      admissible, every head along a growing chain is admissible and distinct,
+      and stored digests really are lower case — so the case rule is tied to a
+      producer rather than to an opinion. A type whose admission rule disagreed
+      with the thing it types would refuse genuine evidence while looking like a
+      tightening.
+      **Still open:** the store's own chain path and `ProjectedClaim.chain_digest`
+      remain `String`. This types the *concept*, not yet every position that
+      holds one — the same staging the trust axes had, core first and the read
+      path after. `WorldAnswer::provenance()` returning `EvidenceDigest` is the
+      next hop and waits on #1388.
 
 Three rules matter more than the verb count:
 

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -734,7 +734,7 @@ Eight verbs in §14.2; about five exist in partial form.
 - [ ] `Resolve` · [ ] `Related` (bounded graph) · [ ] `WhatIsAt` ·
       [ ] `Capabilities` · [ ] `Freshness`
 - [x] **`evidence_digest` / `prev_hash` as core types** — **DONE 2026-08-07**,
-      `crates/kirra-world/src/evidence.rs`, 10 unit tests + 5 seam tests in the
+      `crates/kirra-world/src/evidence.rs`, 11 unit tests + 5 seam tests in the
       store, still zero-dependency.
       Moved here from §7 the same day by `KIRRA-WM-TIER1-DONE-001`: core-crate
       work, listed at the tier that first *requires* it, since rule 1 below


### PR DESCRIPTION
The last of Tier 1's typing gaps, relocated to Tier 3 by `KIRRA-WM-TIER1-DONE-001` because that is where it is first **required**: rule 1 demands every answer carry a `ProvenanceHandle`, and a handle over two bare hex strings is what that rule exists to prevent.

## `EvidenceDigest` — 64 lower-case hex characters, verbatim

**The case rule is the load-bearing one, and it looks like pedantry until you see why.**

`verify_chain` compares digests as **strings**, not by decoded value. So `"AB…"` and `"ab…"` are the *same hash* and *different strings*. A constructor that helpfully lower-cased would produce a value matching neither what a foreign-cased row actually contains nor what SQL compares — reporting intact chains as broken, or broken as intact, depending on which side normalized.

Same "validate, never normalize" discipline `reference.rs` already applies, for the same reason: **the stored bytes are the evidence, and a constructor that improves them is corrupting them.**

`UppercaseHex` is a distinct error from `NonHexCharacter` because *"well-formed digest, wrong case"* and *"this isn't a digest"* send an investigator to different questions.

## `PrevHash` is an enum, not a digest

This fell out of reading the producer rather than the plan. `compute_record_hash_v2` emits 64 hex characters — but the **first record has no predecessor**, and its previous-hash position holds `kirra-world:genesis`, which is not a hash and is not hex.

A single digest type there would force one of two bad choices: widen the invariant that makes the type worth having, or **fabricate a digest for genesis** — a synthetic value in a hash-chained evidence log, much the worse of the two.

`parse` also **never falls back to `Genesis`** on a corrupt link. A truncated chain whose first surviving row claimed to be the beginning would verify as a complete one, and the missing history would be invisible.

## One definition of the genesis sentinel

It was a literal in **both** crates. The value sits inside the hashed bytes of every first record, so two definitions of a frozen constant are two chances to drift. The store now re-exports the core's; public path unchanged, bytes unchanged — all 12 store test binaries stay green.

## Seam-tested against the real producer

This is what makes the type worth having rather than merely correct. A type whose admission rule disagreed with the thing it types would **refuse genuine evidence while looking like a tightening**.

- a digest the store actually emitted is admissible, and admitted verbatim
- every head along a growing chain is admissible **and distinct** — so the test isn't passing against a store that returns one value forever
- stored digests really are lower case, asserted against the real value rather than assumed from `hex::encode`'s docs

## Review follow-up — and a rule that turned out to be decorative

Review asked for a single-pass admission. The **efficiency** half is negligible at 64 characters and I wouldn't have changed it for that; the **readability** half was right, and there was a real wart beside it — `chars().count()` computed twice on the error path. Now one pass, then three checks reading top-to-bottom in the documented order. The loop deliberately does *not* early-return on a non-hex character: length is checked first, so a short non-hex value must report its length.

**Re-running the controls against the new shape found something the refactor did not cause.** Control A (drop the case check) still fired. Control **A2 — invert the documented precedence — did not fire.** Every test stayed green under either order.

The precedence was **unpinned**. Distinguishing "hex first" from "case first" needs a value with *both* an upper-case hex character and a non-hex character, and no test had one: the existing pair used all-non-hex and all-hex-mixed-case, each of which passes under either order. So a rule documented as load-bearing was pinned by nothing.

Added the input that can see it — `A` at index 0, `z` at index 1, length still 64 — asserting `NonHexCharacter`, since "not a digest" is the more fundamental complaint: reporting the *case* of something that was never going to parse sends an investigator to fix capitalisation on a non-digest.

## Negative controls

| Guard reverted | Result |
|---|---|
| normalize case instead of refusing it | **2 core tests + the store's seam test** |
| `parse` falls back to `Genesis` on a corrupt link | 1 core test |
| **precedence inverted (case before hex)** | **1 core test** — after the gap above was closed |

The first control failing in **both crates** is the point: it ties the case rule to a real producer rather than to my opinion.

## Stated as still open

The store's own chain path and `ProjectedClaim.chain_digest` remain `String`. **This types the concept, not yet every position that holds one** — the same staging the trust axes had. `WorldAnswer::provenance()` returning `EvidenceDigest` is written and follows in the next PR.

## A correction I made to myself

I first wrote "11 tests" in the scope doc when it was **10** — the 11th match was a pre-existing `entity::tests::no_evidence_yields_unknown_rather_than_a_guess`. A name filter is not a module. It is now genuinely 11, after the precedence test.

## Verification

`kirra-world` **155** tests + 4 doctests · 12 store test binaries green · rustfmt clean · clippy 0 on both crates · `cargo check --workspace --all-targets` clean · Kirra World fence **INTACT** (19 packages from 10 roots) · 42/42 fence tests. **Still zero-dependency.**

Kirra is designed in alignment with ISO 26262 ASIL-D requirements and IEC 61508 SIL 3 requirements. Independent third-party assessment has not yet been performed.