### PR TITLE
SubjectRef carries validated newtypes, and EntityId moves to reference.rs

### DIFF
--- a/crates/kirra-world-service/src/lib.rs
+++ b/crates/kirra-world-service/src/lib.rs
@@ -56,6 +56,10 @@ mod tests {
         assert_eq!(id.as_str(), "e-1");
 
         // And it is the SAME type the domain model uses, not a look-alike.
-        assert_eq!(id, kirra_world::entity::EntityId::new("e-1").unwrap());
+        // The path is `reference` since 2026-08-08 — the type moved there so
+        // `observation::SubjectRef` could carry it without an entity <->
+        // observation module cycle. What this guard pins is unchanged: the
+        // crate-root name resolves to the constructible domain type.
+        assert_eq!(id, kirra_world::reference::EntityId::new("e-1").unwrap());
     }
 }

--- a/crates/kirra-world-service/src/lib.rs
+++ b/crates/kirra-world-service/src/lib.rs
@@ -56,10 +56,20 @@ mod tests {
         assert_eq!(id.as_str(), "e-1");
 
         // And it is the SAME type the domain model uses, not a look-alike.
-        // The path is `reference` since 2026-08-08 — the type moved there so
-        // `observation::SubjectRef` could carry it without an entity <->
-        // observation module cycle. What this guard pins is unchanged: the
-        // crate-root name resolves to the constructible domain type.
+        //
+        // The right-hand side is the DECLARATION SITE (`reference`, since
+        // 2026-08-08 — the type moved there so `observation::SubjectRef` could
+        // carry it without an entity <-> observation module cycle), and that is
+        // deliberate rather than incidental.
+        //
+        // `EntityId` here travels `kirra_world` (crate root) -> `kirra_world_store`
+        // -> this crate: the store re-exports the ROOT name, not the module
+        // path. So the left side already carries whatever the root resolves to,
+        // and comparing it against the declaration is what proves the root has
+        // not been shadowed by a placeholder again. Asserting against
+        // `kirra_world::EntityId` instead would put the root on BOTH sides and
+        // make the check tautological — a root regression would compare a
+        // placeholder to itself.
         assert_eq!(id, kirra_world::reference::EntityId::new("e-1").unwrap());
     }
 }

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -1122,7 +1122,11 @@ impl WorldStore {
             if matches!(r, SubjectRef::Candidate(_)) {
                 return Err(StoreError::CandidateSubjectNotStorable);
             }
-            match r.id() {
+            // `stored_id`, not the typed accessors: this comparison is the
+            // storage projection by definition -- the `subject` column is a
+            // string and the kind travels beside it in `subject_kind`. A caller
+            // making an identity decision would use `entity()` instead.
+            match r.stored_id() {
                 None => return Err(StoreError::UnboundSubjectNotStorable),
                 Some(id) if id != e.subject => {
                     return Err(StoreError::SubjectRefDisagreesWithSubject {

--- a/crates/kirra-world-store/tests/subject_discriminant.rs
+++ b/crates/kirra-world-store/tests/subject_discriminant.rs
@@ -16,8 +16,17 @@
 //!    to deny.
 
 use kirra_world_store::{
-    ClaimStatus, EventId, NewEvent, ObservationId, StoreError, SubjectRef, WorldStore, WriterClass,
+    ClaimStatus, EntityId, EventId, FrameId, NewEvent, ObservationId, StoreError, SubjectRef,
+    WorldStore, WriterClass,
 };
+
+fn eid(v: &str) -> EntityId {
+    EntityId::new(v).expect("test entity id")
+}
+
+fn fid(v: &str) -> FrameId {
+    FrameId::new(v).expect("test frame id")
+}
 
 const T0: i64 = 1_700_000_000_000;
 
@@ -95,12 +104,15 @@ fn every_storable_kind_survives_a_write_and_a_rehash() {
     let mut s = WorldStore::open(&path).expect("open");
 
     let cases = [
-        SubjectRef::Entity("cup-1".into()),
-        SubjectRef::Frame("base_link".into()),
+        SubjectRef::Entity(eid("cup-1")),
+        SubjectRef::Frame(fid("base_link")),
     ];
     for (n, r) in cases.iter().enumerate() {
         let id = ids(&format!("k{n}"));
-        let subject = r.id().expect("storable kinds carry an id").to_owned();
+        let subject = r
+            .stored_id()
+            .expect("storable kinds carry an id")
+            .to_owned();
         s.append(&ev(&id, &subject, Some(r))).expect("append");
     }
 
@@ -118,7 +130,7 @@ fn every_storable_kind_survives_a_write_and_a_rehash() {
 fn a_chain_may_mix_labelled_and_unlabelled_rows() {
     let path = tmp("mixed");
     let mut s = WorldStore::open(&path).expect("open");
-    let r = SubjectRef::Entity("cup-1".into());
+    let r = SubjectRef::Entity(eid("cup-1"));
 
     s.append(&ev(&ids("a"), "cup-1", None)).expect("unlabelled");
     s.append(&ev(&ids("b"), "cup-1", Some(&r)))
@@ -180,7 +192,7 @@ fn labelling_a_row_after_the_fact_breaks_the_chain() {
 fn relabelling_a_frame_as_an_entity_breaks_the_chain() {
     let path = tmp("relabel-change");
     let mut s = WorldStore::open(&path).expect("open");
-    let r = SubjectRef::Frame("base_link".into());
+    let r = SubjectRef::Frame(fid("base_link"));
     s.append(&ev(&ids("a"), "base_link", Some(&r)))
         .expect("labelled frame");
     s.verify_chain().expect("clean before tamper");
@@ -230,7 +242,7 @@ fn a_candidate_subject_is_not_storable() {
 fn stripping_a_label_breaks_the_chain() {
     let path = tmp("relabel-strip");
     let mut s = WorldStore::open(&path).expect("open");
-    let r = SubjectRef::Entity("cup-1".into());
+    let r = SubjectRef::Entity(eid("cup-1"));
     s.append(&ev(&ids("a"), "cup-1", Some(&r))).expect("append");
     s.verify_chain().expect("clean before tamper");
 
@@ -298,7 +310,7 @@ fn an_unbound_subject_cannot_be_labelled() {
 fn a_label_that_names_a_different_id_is_refused() {
     let path = tmp("mismatch");
     let mut s = WorldStore::open(&path).expect("open");
-    let r = SubjectRef::Entity("cup-2".into());
+    let r = SubjectRef::Entity(eid("cup-2"));
     let err = s
         .append(&ev(&ids("a"), "cup-1", Some(&r)))
         .expect_err("refused");
@@ -313,7 +325,7 @@ fn a_label_that_names_a_different_id_is_refused() {
 
     // The agreeing form of the same write is admitted, so the refusal is about
     // the disagreement and not about labelling being broken.
-    let ok = SubjectRef::Entity("cup-1".into());
+    let ok = SubjectRef::Entity(eid("cup-1"));
     s.append(&ev(&ids("a"), "cup-1", Some(&ok)))
         .expect("agreeing label");
     s.verify_chain().expect("verifies");
@@ -339,7 +351,7 @@ fn a_label_that_names_a_different_id_is_refused() {
 fn a_labelled_row_survives_compactions_rehash() {
     let path = tmp("compact");
     let mut s = WorldStore::open(&path).expect("open");
-    let r = SubjectRef::Entity("cup-1".into());
+    let r = SubjectRef::Entity(eid("cup-1"));
     for n in 0..4 {
         let id = ids(&format!("c{n}"));
         let labelled = if n % 2 == 0 { Some(&r) } else { None };

--- a/crates/kirra-world/src/adjudication.rs
+++ b/crates/kirra-world/src/adjudication.rs
@@ -101,8 +101,9 @@
 //! actuator path, no release token. Pure data and pure functions, zero
 //! dependencies, same as the rest of this crate.
 
-use crate::entity::{EntityId, Lifecycle};
+use crate::entity::Lifecycle;
 use crate::observation::DomainInstant;
+use crate::reference::EntityId;
 use crate::reference::ObservationId;
 
 // ---------------------------------------------------------------------------

--- a/crates/kirra-world/src/entity.rs
+++ b/crates/kirra-world/src/entity.rs
@@ -50,6 +50,7 @@
 //! [`EntityId`] here is an opaque validated wrapper, not a generator.
 
 use crate::observation::{Confidence, SourceClass};
+use crate::reference::EntityId;
 
 // ---------------------------------------------------------------------------
 // Identity
@@ -58,8 +59,6 @@ use crate::observation::{Confidence, SourceClass};
 /// Why an entity value could not be built.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum EntityError {
-    /// An id was empty or whitespace.
-    EmptyEntityId,
     /// An alias name was empty or whitespace.
     EmptyAliasName,
     /// The lifecycle transition is not permitted — see [`Lifecycle::advance_to`].
@@ -69,40 +68,6 @@ pub enum EntityError {
         /// The state moved to.
         to: LifecycleState,
     },
-}
-
-/// A stable, opaque entity identifier.
-///
-/// §6.1: *"Stable, opaque, monotonic. Never reused, never encodes semantics."*
-///
-/// **Opaque is enforced by construction, not by convention** — the inner value
-/// is private and there is no parsing accessor, so no consumer can come to
-/// depend on structure inside an id. Monotonicity and never-reuse are properties
-/// of the *generator*, which lives in the store; this type cannot enforce them
-/// and does not claim to.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct EntityId(String);
-
-impl EntityId {
-    /// Wrap an identifier.
-    ///
-    /// # Errors
-    ///
-    /// [`EntityError::EmptyEntityId`] if empty or whitespace.
-    pub fn new(id: impl Into<String>) -> Result<Self, EntityError> {
-        let id = id.into();
-        if id.trim().is_empty() {
-            return Err(EntityError::EmptyEntityId);
-        }
-        Ok(Self(id))
-    }
-
-    /// The identifier as text. Deliberately the only accessor — callers may
-    /// compare and display, not decompose.
-    #[must_use]
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1052,7 +1017,9 @@ mod tests {
 
     #[test]
     fn empty_identifiers_are_refused() {
-        assert_eq!(EntityId::new("  "), Err(EntityError::EmptyEntityId));
+        // `EntityId` moved to `crate::reference` on 2026-08-08 and now reports
+        // `ReferenceError`; its own emptiness/length/control-character cases are
+        // covered there. What this test still owns is the *alias* half.
         assert_eq!(
             Alias::new("", SourceClass::Operator),
             Err(EntityError::EmptyAliasName)

--- a/crates/kirra-world/src/entity.rs
+++ b/crates/kirra-world/src/entity.rs
@@ -1016,7 +1016,7 @@ mod tests {
     // -- Validation --------------------------------------------------------
 
     #[test]
-    fn empty_identifiers_are_refused() {
+    fn an_empty_alias_name_is_refused() {
         // `EntityId` moved to `crate::reference` on 2026-08-08 and now reports
         // `ReferenceError`; its own emptiness/length/control-character cases are
         // covered there. What this test still owns is the *alias* half.

--- a/crates/kirra-world/src/lib.rs
+++ b/crates/kirra-world/src/lib.rs
@@ -149,8 +149,8 @@ pub mod trust;
 
 /// Stable identity of a thing the world contains.
 ///
-/// **No longer a placeholder** — the real type is [`entity::EntityId`], and this
-/// is a re-export of it rather than a second type sharing its name.
+/// **No longer a placeholder** — the real type is [`reference::EntityId`], and
+/// this is a re-export of it rather than a second type sharing its name.
 ///
 /// # Why this is a re-export and not a struct
 ///
@@ -170,9 +170,17 @@ pub mod trust;
 /// ADR-0040's constraint on whatever this became still holds and is now the
 /// real type's to keep: identity adjudication is **revisable** — merge and split
 /// are recorded events, not destructive edits — so it cannot be a bare opaque
-/// key that loses its own history. `entity::EntityId` is opaque by construction;
-/// the *history* half is entity resolution, `WM_SCOPE.md` Tier 2.
-pub use entity::EntityId;
+/// key that loses its own history. `reference::EntityId` is opaque by
+/// construction; the *history* half is entity resolution, `WM_SCOPE.md` Tier 2.
+///
+/// **It moved out of `entity` on 2026-08-08.** `entity` imports `observation`,
+/// so an `EntityId` declared there could not be carried by
+/// [`observation::SubjectRef`] without making the two modules mutually
+/// dependent. `reference` is a leaf; both depend on it and neither on the
+/// other. The move also put the type on the shared `reference_newtype!`
+/// validation, so it now refuses over-long and control-character ids like every
+/// other reference — see [`reference::EntityId`].
+pub use reference::EntityId;
 
 /// Identity of a single recorded observation.
 ///

--- a/crates/kirra-world/src/observation.rs
+++ b/crates/kirra-world/src/observation.rs
@@ -64,6 +64,7 @@
 //! never enumerates its variants, and inventing a taxonomy of observation kinds
 //! would be a domain decision this module has no basis for.
 
+use crate::reference::{EntityId, FrameId, ReferenceError};
 use crate::trust::Origin;
 use core::cmp::Ordering;
 
@@ -343,17 +344,37 @@ impl SourceClass {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum SubjectRef {
     /// A resolved entity, by opaque id.
-    Entity(String),
+    ///
+    /// Carries an [`EntityId`] rather than a `String` since 2026-08-08. The two
+    /// naming arms were previously `Entity(String)` and `Candidate(String)` —
+    /// adjacent variants of the same type, so each accepted the other's value
+    /// and compiled. That is the exact hazard [`crate::reference`] was written
+    /// to remove from `NewEvent`'s two id pairs one day after this enum was
+    /// declared, and this enum never received it.
+    Entity(EntityId),
     /// A candidate that entity resolution has not yet adjudicated.
+    ///
+    /// **Still a `String`, and deliberately.** There is no `CandidateId`, and
+    /// `KIRRA-WM-CANDIDATE-ID-001` deferred creating one to entity resolution,
+    /// where it would be a *projection key* rather than an evidence value — a
+    /// candidate id is the output of a step the blueprint marks **pure**, so it
+    /// may not enter the hashed record at all. Minting a newtype for it here
+    /// would have implied a durability this id does not have.
     Candidate(String),
     /// A spatial frame.
-    Frame(String),
+    Frame(FrameId),
     /// **Nothing yet.**
     ///
     /// Load-bearing, not a placeholder: the model is evidence-first, so an
     /// observation may be recorded before anything decides what it is about, and
     /// re-attribution later must not rewrite it. This variant is why the
-    /// observation model does not depend on the entity taxonomy.
+    /// observation model does not depend on the entity **taxonomy**.
+    ///
+    /// That claim survived this enum gaining an [`EntityId`], and only because
+    /// the id moved to [`crate::reference`] first: a dependency on an opaque
+    /// identifier is not a dependency on `Entity`, `Lifecycle` or adjudication.
+    /// Had it stayed in `crate::entity` — which imports this module — the claim
+    /// would have become false and the two modules mutually dependent.
     Unbound,
 }
 
@@ -385,6 +406,22 @@ pub enum SubjectRefError {
     /// id attached to it is a contradiction, and admitting it would produce a
     /// value whose own `id()` disagrees with its variant.
     UnboundCarriesId,
+    /// The id was refused by the newtype that would carry it.
+    ///
+    /// Distinct from [`Self::EmptyId`], which is checked first: emptiness is
+    /// the case a reader is most likely to be diagnosing, and collapsing the
+    /// two would report an over-long id and an absent one the same way.
+    ///
+    /// Both naming arms report through one variant because both newtypes share
+    /// [`ReferenceError`] — a consequence of `EntityId` moving to
+    /// [`crate::reference`], and the reason the two arms now validate alike
+    /// rather than only appearing to.
+    InadmissibleId {
+        /// Which arm refused — the same token [`SubjectRef::as_str`] returns.
+        kind: &'static str,
+        /// What the newtype objected to.
+        source: ReferenceError,
+    },
     /// The id was empty or whitespace-only.
     ///
     /// Same rule as [`crate::reference`]: an empty identity is not a missing
@@ -404,6 +441,9 @@ impl core::fmt::Display for SubjectRefError {
                 write!(f, "an unbound subject cannot carry an id")
             }
             Self::EmptyId => write!(f, "a subject id may not be empty"),
+            Self::InadmissibleId { kind, source } => {
+                write!(f, "the {kind} id was refused: {source}")
+            }
         }
     }
 }
@@ -414,7 +454,7 @@ impl SubjectRef {
     /// Named `as_str` to match the store's existing convention, alongside
     /// [`crate::trust::Origin::as_str`] and `WriterClass`.
     ///
-    /// This is the discriminant only — the *value* is [`Self::id`]. The two are
+    /// This is the discriminant only — the *value* is [`Self::stored_id`]. The two are
     /// separate because a store already keeps the value in a `subject` column;
     /// what it has never kept is which of the four cases that value is, so a
     /// projection cannot restrict itself to resolved entities. That gap is
@@ -430,22 +470,70 @@ impl SubjectRef {
         }
     }
 
-    /// The id this reference names, if it names one.
+    /// The id as a storage layer sees it, if this reference names one.
     ///
     /// `None` **only** for [`Self::Unbound`] — and that asymmetry is the reason
     /// a storage layer cannot represent all four cases in a `NOT NULL` subject
     /// column without fabricating a value for the one case that has none.
+    ///
+    /// # Why this is not called `id`
+    ///
+    /// It was, and returning every kind through one `Option<&str>` is the
+    /// collapse `KIRRA-WM-CANDIDATE-ID-001` §2 objected to: a caller receiving
+    /// `Some("cup-1")` cannot tell whether entity resolution has adjudicated
+    /// that thing, which is the one distinction this enum exists to draw.
+    ///
+    /// The narrower name says what the value is for. A store genuinely needs
+    /// the string — it compares it against the `subject` column and carries the
+    /// kind separately in `subject_kind` — and that use is legitimate precisely
+    /// because the kind travels beside it. A caller making an **identity**
+    /// decision wants [`Self::entity`], which cannot silently accept a
+    /// candidate.
     #[must_use]
-    pub fn id(&self) -> Option<&str> {
+    pub fn stored_id(&self) -> Option<&str> {
         match self {
-            Self::Entity(id) | Self::Candidate(id) | Self::Frame(id) => Some(id),
+            Self::Entity(id) => Some(id.as_str()),
+            Self::Frame(id) => Some(id.as_str()),
+            Self::Candidate(id) => Some(id),
             Self::Unbound => None,
+        }
+    }
+
+    /// The entity this names, or `None` for every other case.
+    ///
+    /// The accessor to reach for when the answer must be a *resolved* entity: a
+    /// candidate returns `None` here rather than a string that looks the same.
+    #[must_use]
+    pub fn entity(&self) -> Option<&EntityId> {
+        match self {
+            Self::Entity(id) => Some(id),
+            _ => None,
+        }
+    }
+
+    /// The frame this names, or `None` for every other case.
+    #[must_use]
+    pub fn frame(&self) -> Option<&FrameId> {
+        match self {
+            Self::Frame(id) => Some(id),
+            _ => None,
+        }
+    }
+
+    /// The candidate this names, or `None` for every other case.
+    ///
+    /// A `&str` rather than a newtype — see [`Self::Candidate`].
+    #[must_use]
+    pub fn candidate(&self) -> Option<&str> {
+        match self {
+            Self::Candidate(id) => Some(id),
+            _ => None,
         }
     }
 
     /// Re-admit a reference from a stored token and a stored id.
     ///
-    /// The inverse of ([`Self::as_str`], [`Self::id`]), for a reader rebuilding
+    /// The inverse of ([`Self::as_str`], [`Self::stored_id`]), for a reader rebuilding
     /// a row. **Validates, never normalizes** — the id is carried verbatim, so
     /// a value stored with surrounding whitespace round-trips as written. A
     /// constructor that trimmed here would make an untampered row rehash
@@ -465,7 +553,14 @@ impl SubjectRef {
     /// [`SubjectRefError::UnknownKind`] for a token outside the four;
     /// [`SubjectRefError::KindNeedsId`] for a naming kind with no id;
     /// [`SubjectRefError::UnboundCarriesId`] for the reverse;
-    /// [`SubjectRefError::EmptyId`] for an id that is empty or whitespace.
+    /// [`SubjectRefError::EmptyId`] for an id that is empty or whitespace;
+    /// [`SubjectRefError::InadmissibleId`] for one the newtype refuses for any
+    /// other reason — over-long, or carrying an ASCII control character.
+    ///
+    /// `EmptyId` is checked **before** the kind match and so wins over
+    /// `InadmissibleId`, which a test pins: the two describe the same row
+    /// differently, and an empty id is the case a reader is most likely to be
+    /// diagnosing.
     pub fn from_stored_parts(token: &str, id: Option<&str>) -> Result<Self, SubjectRefError> {
         if let Some(v) = id {
             if v.trim().is_empty() {
@@ -476,10 +571,18 @@ impl SubjectRef {
             id.map(ToOwned::to_owned)
                 .ok_or(SubjectRefError::KindNeedsId { kind })
         };
+        let admit = |kind: &'static str, e: ReferenceError| SubjectRefError::InadmissibleId {
+            kind,
+            source: e,
+        };
         match token {
-            "entity" => Ok(Self::Entity(need("entity")?)),
+            "entity" => EntityId::new(need("entity")?)
+                .map(Self::Entity)
+                .map_err(|e| admit("entity", e)),
             "candidate" => Ok(Self::Candidate(need("candidate")?)),
-            "frame" => Ok(Self::Frame(need("frame")?)),
+            "frame" => FrameId::new(need("frame")?)
+                .map(Self::Frame)
+                .map_err(|e| admit("frame", e)),
             "unbound" => {
                 if id.is_some() {
                     return Err(SubjectRefError::UnboundCarriesId);
@@ -1070,19 +1173,27 @@ mod tests {
 
     /// Every variant round-trips through its stored form.
     ///
+    fn eid(v: &str) -> crate::reference::EntityId {
+        crate::reference::EntityId::new(v).expect("test entity id")
+    }
+
+    fn fid(v: &str) -> crate::reference::FrameId {
+        crate::reference::FrameId::new(v).expect("test frame id")
+    }
+
     /// Walked over all four rather than a sample, because the point of the
     /// discriminant is that the cases are *distinguishable*, and a round-trip
     /// that skipped one would not notice it collapsing into another.
     #[test]
     fn every_subject_kind_round_trips_through_its_stored_form() {
         let cases = [
-            SubjectRef::Entity("e-1".into()),
+            SubjectRef::Entity(eid("e-1")),
             SubjectRef::Candidate("c-1".into()),
-            SubjectRef::Frame("map/base_link".into()),
+            SubjectRef::Frame(fid("map/base_link")),
             SubjectRef::Unbound,
         ];
         for original in cases {
-            let back = SubjectRef::from_stored_parts(original.as_str(), original.id())
+            let back = SubjectRef::from_stored_parts(original.as_str(), original.stored_id())
                 .unwrap_or_else(|e| panic!("{original:?} did not re-admit: {e}"));
             assert_eq!(back, original);
         }
@@ -1098,9 +1209,9 @@ mod tests {
     #[test]
     fn the_four_kinds_have_four_distinct_tokens() {
         let tokens = [
-            SubjectRef::Entity(String::from("x")).as_str(),
+            SubjectRef::Entity(eid("x")).as_str(),
             SubjectRef::Candidate(String::from("x")).as_str(),
-            SubjectRef::Frame(String::from("x")).as_str(),
+            SubjectRef::Frame(fid("x")).as_str(),
             SubjectRef::Unbound.as_str(),
         ];
         let mut seen: Vec<&str> = Vec::new();
@@ -1119,9 +1230,9 @@ mod tests {
     /// refactor — it changes the digest of every row that carried the old one.
     #[test]
     fn the_tokens_are_the_exact_spellings_a_store_will_hash() {
-        assert_eq!(SubjectRef::Entity("x".into()).as_str(), "entity");
+        assert_eq!(SubjectRef::Entity(eid("x")).as_str(), "entity");
         assert_eq!(SubjectRef::Candidate("x".into()).as_str(), "candidate");
-        assert_eq!(SubjectRef::Frame("x".into()).as_str(), "frame");
+        assert_eq!(SubjectRef::Frame(fid("x")).as_str(), "frame");
         assert_eq!(SubjectRef::Unbound.as_str(), "unbound");
     }
 
@@ -1129,10 +1240,87 @@ mod tests {
     /// cannot represent without inventing one.
     #[test]
     fn unbound_is_the_only_kind_without_an_id() {
-        assert_eq!(SubjectRef::Entity("e-1".into()).id(), Some("e-1"));
-        assert_eq!(SubjectRef::Candidate("c-1".into()).id(), Some("c-1"));
-        assert_eq!(SubjectRef::Frame("f-1".into()).id(), Some("f-1"));
-        assert_eq!(SubjectRef::Unbound.id(), None);
+        assert_eq!(SubjectRef::Entity(eid("e-1")).stored_id(), Some("e-1"));
+        assert_eq!(SubjectRef::Candidate("c-1".into()).stored_id(), Some("c-1"));
+        assert_eq!(SubjectRef::Frame(fid("f-1")).stored_id(), Some("f-1"));
+        assert_eq!(SubjectRef::Unbound.stored_id(), None);
+    }
+
+    /// The typed accessor refuses to answer for a candidate.
+    ///
+    /// This is the whole point of the slice, and it is the assertion
+    /// [`SubjectRef::stored_id`] cannot make: `stored_id` returns a `&str` for
+    /// both kinds, so a caller reading it has to remember to check the
+    /// discriminant. `entity()` cannot be read carelessly — an unadjudicated
+    /// candidate is `None`, not a string that looks like an entity id.
+    #[test]
+    fn the_typed_accessor_does_not_answer_for_a_candidate() {
+        let candidate = SubjectRef::Candidate("c-1".into());
+        assert_eq!(candidate.entity(), None, "a candidate is not an entity");
+        assert_eq!(candidate.candidate(), Some("c-1"));
+        assert_eq!(
+            candidate.stored_id(),
+            Some("c-1"),
+            "the storage projection still answers -- which is why it is named \
+             for storage rather than called `id`"
+        );
+
+        let entity = SubjectRef::Entity(eid("e-1"));
+        assert_eq!(entity.entity().map(EntityId::as_str), Some("e-1"));
+        assert_eq!(entity.candidate(), None);
+        assert_eq!(entity.frame(), None, "an entity is not a frame either");
+    }
+
+    /// Both naming arms now refuse a control character on re-admission.
+    ///
+    /// Before `EntityId` moved to [`crate::reference`] this test could only
+    /// have been written for `frame`: the hand-written entity constructor
+    /// refused empty ids and nothing else, so an entity id carrying a newline
+    /// re-admitted happily into a value bound for canonically-hashed JSON and
+    /// audit exports. Walked over both arms deliberately — one passing and one
+    /// failing is exactly the asymmetry the move removed.
+    #[test]
+    fn both_naming_arms_refuse_a_control_character() {
+        for kind in ["entity", "frame"] {
+            let err = SubjectRef::from_stored_parts(kind, Some("we\nird"))
+                .expect_err("a control character must be refused");
+            assert_eq!(
+                err,
+                SubjectRefError::InadmissibleId {
+                    kind,
+                    source: ReferenceError::ControlCharacter,
+                },
+                "{kind} admitted a control character"
+            );
+        }
+    }
+
+    /// An over-long id is refused, and reports as inadmissible rather than empty.
+    #[test]
+    fn an_over_long_id_is_refused_by_the_newtype() {
+        let long = "e".repeat(crate::reference::MAX_REFERENCE_LEN + 1);
+        let err = SubjectRef::from_stored_parts("entity", Some(&long)).expect_err("refused");
+        assert!(matches!(
+            err,
+            SubjectRefError::InadmissibleId {
+                kind: "entity",
+                source: ReferenceError::TooLong { .. },
+            }
+        ));
+    }
+
+    /// `EmptyId` wins over `InadmissibleId` — the precedence is deliberate.
+    ///
+    /// An empty id would also be refused by the newtype, as
+    /// [`ReferenceError::Empty`]. The leading check exists so the error names
+    /// the case a reader is most likely to be diagnosing, and this pins which
+    /// of the two overlapping refusals is reported.
+    #[test]
+    fn an_empty_id_reports_as_empty_not_as_inadmissible() {
+        assert_eq!(
+            SubjectRef::from_stored_parts("entity", Some("   ")),
+            Err(SubjectRefError::EmptyId)
+        );
     }
 
     /// An unreadable kind is refused, **not** downgraded to `Unbound`.
@@ -1213,7 +1401,7 @@ mod tests {
     fn an_id_is_re_admitted_verbatim_rather_than_tidied() {
         let padded = " e-1 ";
         let back = SubjectRef::from_stored_parts("entity", Some(padded)).expect("admitted");
-        assert_eq!(back.id(), Some(padded), "not trimmed");
+        assert_eq!(back.stored_id(), Some(padded), "not trimmed");
     }
 
     // -- Evidence-first ----------------------------------------------------

--- a/crates/kirra-world/src/reference.rs
+++ b/crates/kirra-world/src/reference.rs
@@ -269,6 +269,46 @@ reference_newtype! {
 }
 
 reference_newtype! {
+    /// A resolved entity's identifier — §6.1.
+    ///
+    /// §6.1: *"Stable, opaque, monotonic. Never reused, never encodes
+    /// semantics."*
+    ///
+    /// **Opaque is enforced by construction, not by convention** — the inner
+    /// value is private and there is no parsing accessor, so no consumer can
+    /// come to depend on structure inside an id. Monotonicity and never-reuse
+    /// are properties of the *generator*, which lives in the store; this type
+    /// cannot enforce them and does not claim to.
+    ///
+    /// # Why it lives here rather than in [`crate::entity`]
+    ///
+    /// It was declared in `entity.rs` until 2026-08-08, hand-written, and
+    /// validated only against emptiness. Two problems, one move.
+    ///
+    /// **A cycle.** `entity` already imports `observation`, so
+    /// [`crate::observation::SubjectRef`] carrying an `EntityId` from `entity`
+    /// would have made the two modules mutually dependent. This module imports
+    /// no sibling — it is a leaf — so both can depend on it and neither on the
+    /// other. That also keeps `SubjectRef::Unbound`'s claim TRUE rather than
+    /// merely convenient: the observation model still does not depend on the
+    /// entity *taxonomy* — not `Entity`, not `Lifecycle`, not adjudication —
+    /// only on an opaque identifier that names one.
+    ///
+    /// **Two admission standards for one hashed column.** The hand-written
+    /// constructor refused empty ids and nothing else, while every reference
+    /// here also refuses over-long values and ASCII control characters — for a
+    /// reason that applies at least as strongly to entity ids, since they land
+    /// in the same canonically-hashed JSON and the same audit exports. See
+    /// [`ReferenceError::ControlCharacter`]. Sharing the macro makes the two
+    /// arms of `SubjectRef` validate alike instead of only appearing to.
+    ///
+    /// `EntityId::new` is therefore **stricter than it was**: an id over
+    /// [`MAX_REFERENCE_LEN`] bytes or containing a control character is now
+    /// refused where it previously passed.
+    EntityId, "entity reference"
+}
+
+reference_newtype! {
     /// Which map a spatial claim is relative to.
     ///
     /// See [`FrameId`] — same boundary, same prohibition. If Kirra World and

--- a/crates/kirra-world/src/relationship.rs
+++ b/crates/kirra-world/src/relationship.rs
@@ -47,8 +47,8 @@
 //! [`Symmetry::Unspecified`] for everything else rather than guessing — see its
 //! docs for the specific candidates, recorded as an open question.
 
-use crate::entity::EntityId;
 use crate::observation::{Confidence, DomainInstant, SourceClass, TimeError, ValidInterval};
+use crate::reference::EntityId;
 
 // ---------------------------------------------------------------------------
 // Predicates — §8's four groups


### PR DESCRIPTION
Follow-on to #1395. Closes the gap that PR's own body named: the discriminant was
typed while the id it discriminated was not.

Two commits, deliberately separable — the second is the slice, the first is what
made it possible.

## The slice was not what it looked like

`SubjectRef::Entity(EntityId)` looks like a rename. Checking first turned up two
reasons it isn't, and both changed the shape of the work.

**A module cycle.** `entity.rs` already imports `observation.rs`, so an
`EntityId` declared in `entity` could not be carried by `observation::SubjectRef`
without making the two mutually dependent. Rust permits intra-crate module
cycles, so this would have *compiled* — while falsifying `SubjectRef::Unbound`'s
documented claim that *"the observation model does not depend on the entity
taxonomy."*

**Two admission standards for one hashed column.** `FrameId` (macro-generated)
refuses empty, over-`MAX_REFERENCE_LEN`, and ASCII control characters.
`EntityId` (hand-written, older) refused only empty. The control-character rule's
own rationale is that these values *"are written into a canonically-hashed JSON
form, exported in audit trails and printed in operator diagnostics"* — which
applies at least as strongly to entity ids. Shipping `Entity(EntityId)` beside
`Frame(FrameId)` without fixing this would have produced one enum whose two arms
only *appeared* to validate alike.

## `766b2527` — the move

`EntityId` joins the other opaque references on the shared `reference_newtype!`
validation. `reference.rs` imports no sibling, so both modules can depend on it
and neither on the other — which keeps `Unbound`'s claim **true** rather than
merely convenient: depending on an opaque identifier is not depending on
`Entity`, `Lifecycle`, or adjudication.

`EntityId::new` is therefore **stricter than it was** — an id over 128 bytes or
carrying a control character is now refused where it passed. That is the point,
not a side effect.

The crate-root re-export absorbed the blast radius: `kirra_world::EntityId` is
unchanged for every consumer. `EntityError` loses `EmptyEntityId` (the alias half
keeps its own), two in-crate importers retarget, and the service's re-export
guard follows the path while pinning the same property.

An unplanned dividend: both newtypes now share `ReferenceError`, so **one**
`InadmissibleId { kind, source }` variant covers both arms instead of two.

## `c05f5ed3` — the enum

`Entity(EntityId)`, `Frame(FrameId)`. `Candidate` stays a `String` by ruling —
`KIRRA-WM-CANDIDATE-ID-001` deferred `CandidateId` to entity resolution, where it
would be a projection key; minting a newtype here would imply a durability that
id does not have.

`id()` → `stored_id()`, plus `entity()` / `frame()` / `candidate()`. Returning
every kind through one `Option<&str>` is the collapse the ruling's §2 objected
to. The storage projection is still there and still needed — the store compares
it against `subject` with the kind travelling beside it — but it is now named for
what it is, and a caller making an **identity** decision reaches for `entity()`,
which cannot silently accept a candidate.

## Verification

- `cargo test -p kirra-world` — 194 unit + 4 doctests (190 → 194).
- All three world crates — 18 suites; clippy `-D warnings`, fmt, rustdoc clean.
- Bidirectional fence INTACT (19 packages from 10 roots); domain-logic gate 38/38;
  re-export shim ratchet satisfied.
- `tools/wm2-schema-growth` built and tested **in its own workspace** — 30 tests.
  It is workspace-detached, so no `cargo test -p …` reaches it; #1395 learned that
  the hard way when CI caught a `NewEvent` site my `crates/`-scoped survey never
  covered.

**Negative controls**, each from a pristine copy:

| control | result |
|---|---|
| `EntityId` loses the control-character guard | both new arm tests fire |
| `Entity(EntityId)` reverted to `Entity(String)` | **does not compile** |

The second is the honest result and worth stating plainly: no test can catch a
candidate id being placed in the `Entity` arm, because with two `String` variants
that is a well-typed program. The newtype is the only available enforcement,
which is why this is a slice rather than a test.

## What this does not do

`Candidate` keeps its untyped id, by ruling. Nothing yet **writes** a label —
every call site still passes `None`, and `subject_summary` still folds every
subject string. Turning that projection into one that can name resolved entities
is next, and it is what entity resolution actually needs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_