### PR TITLE
subject_summary can name resolved entities

### DIFF
--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -92,8 +92,8 @@ pub mod subject_projection;
 pub use compaction::{Citation, CompactionOutcome, DegradedSummary, Resolution, TemporalAnswer};
 pub use projection::{ProjectedClaim, CURRENT_PROJECTION};
 pub use subject_projection::{
-    subject_fold_all, subject_fold_step, ProjectedSubject, SubjectObservation,
-    SUBJECT_SUMMARY_PROJECTION,
+    subject_fold_all, subject_fold_step, ProjectedSubject, SubjectKey, SubjectObservation,
+    SummaryKind, SummaryKindError, SUBJECT_SUMMARY_PROJECTION,
 };
 
 // The domain core's types, re-exported so a caller of this crate needs only one
@@ -2713,9 +2713,46 @@ impl WorldStore {
     /// Install the subject-summary DDL. Lazy, for the D-20 reason in
     /// [`subject_projection`]'s module docs.
     fn ensure_subject_summary(&self) -> Result<(), StoreError> {
+        // A store written before `subject_kind` has a `subject_summary` whose
+        // DDL this batch will NOT correct: every statement is
+        // `CREATE ... IF NOT EXISTS`, so an existing table of the old shape is
+        // left exactly as it is and the first insert fails on a column that is
+        // not there.
+        //
+        // Dropped and rebuilt rather than migrated, because a projection IS a
+        // cache -- rebuildable from the event log by definition, which is the
+        // whole argument for it not being ratified schema. Migrating it would
+        // be inventing values for a column the old rows never had.
+        //
+        // The CHECKPOINT has to go with it. Dropping the table while leaving
+        // `projection_checkpoint` at generation N would make the next fold
+        // resume from N into an empty table and produce a projection missing
+        // everything below N -- a silent under-report that looks like a
+        // successful fold. Asserted by
+        // `an_old_shape_projection_is_rebuilt_from_zero_not_resumed`.
+        if self.has_subject_summary()? && !self.subject_summary_has_kind()? {
+            self.conn.execute_batch(
+                "DROP TABLE IF EXISTS subject_summary;
+                 DELETE FROM projection_checkpoint WHERE name = 'subject_summary';",
+            )?;
+        }
         self.conn
             .execute_batch(subject_projection::SUBJECT_PROJECTION_V1)?;
         Ok(())
+    }
+
+    /// Whether the installed `subject_summary` carries the `subject_kind`
+    /// column — i.e. whether it predates the resolved-entity projection.
+    fn subject_summary_has_kind(&self) -> Result<bool, StoreError> {
+        let mut stmt = self.conn.prepare("PRAGMA table_info(subject_summary)")?;
+        let mut rows = stmt.query([])?;
+        while let Some(r) = rows.next()? {
+            let name: String = r.get(1)?;
+            if name == "subject_kind" {
+                return Ok(true);
+            }
+        }
+        Ok(false)
     }
 
     /// Whether the subject-summary table has been installed.
@@ -2801,7 +2838,7 @@ impl WorldStore {
         let mut head = from_generation;
         {
             let mut stmt = tx.prepare(
-                "SELECT subject, txn_time_ms, generation, event_id, chain_digest
+                "SELECT subject, txn_time_ms, generation, event_id, chain_digest, subject_kind
                  FROM world_events
                  WHERE generation > ?1 AND claim_status = 'confirmed'
                  ORDER BY generation ASC",
@@ -2815,10 +2852,10 @@ impl WorldStore {
             // walks a real log through both and compares.
             let mut upsert = tx.prepare(
                 "INSERT INTO subject_summary (
-                    subject, first_observed_ms, last_observed_ms, provenance_head,
+                    subject_kind, subject, first_observed_ms, last_observed_ms, provenance_head,
                     observation_count, last_generation, last_event_id
-                 ) VALUES (?1,?2,?2,?3,1,?4,?5)
-                 ON CONFLICT (subject) DO UPDATE SET
+                 ) VALUES (?6,?1,?2,?2,?3,1,?4,?5)
+                 ON CONFLICT (subject_kind, subject) DO UPDATE SET
                     observation_count = subject_summary.observation_count + 1,
                     first_observed_ms = MIN(subject_summary.first_observed_ms, excluded.first_observed_ms),
                     last_observed_ms  = MAX(subject_summary.last_observed_ms,  excluded.last_observed_ms),
@@ -2837,13 +2874,24 @@ impl WorldStore {
                 let generation: i64 = r.get(2)?;
                 let event_id: String = r.get(3)?;
                 let chain_digest: String = r.get(4)?;
+                let stored_kind: Option<String> = r.get(5)?;
+                // Resolved HERE, at the boundary, so an unreadable token is a
+                // reported error rather than a row the fold has already
+                // classified as something.
+                let kind =
+                    subject_projection::SummaryKind::from_event_column(stored_kind.as_deref())
+                        .map_err(|e| StoreError::CorruptRow {
+                            generation,
+                            detail: e.to_string(),
+                        })?;
                 head = head.max(generation);
                 upsert.execute(params![
                     subject,
                     txn_time_ms,
                     chain_digest,
                     generation,
-                    event_id
+                    event_id,
+                    kind.as_str()
                 ])?;
             }
         }
@@ -2879,8 +2927,16 @@ impl WorldStore {
     /// # Errors
     ///
     /// [`StoreError::Sqlite`] on any storage failure.
+    /// **Takes the kind as well as the subject**, since 2026-08-08.
+    ///
+    /// A subject string no longer identifies a row: an entity and a frame may
+    /// share one. Keeping the old one-argument signature would have left this
+    /// returning whichever of the two SQLite happened to yield first — a silent
+    /// wrong answer, not an error — so the argument is required rather than
+    /// defaulted.
     pub fn subject_summary(
         &self,
+        kind: subject_projection::SummaryKind,
         subject: &str,
     ) -> Result<Option<subject_projection::ProjectedSubject>, StoreError> {
         if !self.has_subject_summary()? {
@@ -2889,24 +2945,75 @@ impl WorldStore {
         let row = self
             .conn
             .query_row(
-                "SELECT subject, first_observed_ms, last_observed_ms, provenance_head,
+                "SELECT subject_kind, subject, first_observed_ms, last_observed_ms, provenance_head,
                         observation_count, last_generation, last_event_id
-                 FROM subject_summary WHERE subject = ?1",
-                params![subject],
-                |r| {
-                    Ok(subject_projection::ProjectedSubject {
-                        subject: r.get(0)?,
-                        first_observed_ms: r.get(1)?,
-                        last_observed_ms: r.get(2)?,
-                        provenance_head: r.get(3)?,
-                        observation_count: r.get(4)?,
-                        last_generation: r.get(5)?,
-                        last_event_id: r.get(6)?,
-                    })
-                },
+                 FROM subject_summary WHERE subject_kind = ?1 AND subject = ?2",
+                params![kind.as_str(), subject],
+                map_projected_subject,
             )
             .optional()?;
         Ok(row)
+    }
+
+    /// Every summary for one subject string, across kinds.
+    ///
+    /// The honest answer to "what do you know about this string" now that one
+    /// string can name more than one thing.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::Sqlite`] on any storage failure;
+    /// [`StoreError::CorruptRow`] if a stored kind token cannot be read.
+    pub fn subject_summaries_for(
+        &self,
+        subject: &str,
+    ) -> Result<Vec<subject_projection::ProjectedSubject>, StoreError> {
+        self.subject_summary_query(
+            "WHERE subject = ?1 ORDER BY subject_kind ASC",
+            params![subject],
+        )
+    }
+
+    /// Every **resolved entity** this store has summarised.
+    ///
+    /// The query this projection was rebuilt to answer, and what entity
+    /// resolution matches an incoming observation against. Candidates cannot
+    /// appear here: `KIRRA-WM-CANDIDATE-ID-001` keeps them out of the evidence
+    /// entirely, so they are not merely filtered — there is nothing to filter.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::Sqlite`] on any storage failure;
+    /// [`StoreError::CorruptRow`] if a stored kind token cannot be read.
+    pub fn resolved_entities(
+        &self,
+    ) -> Result<Vec<subject_projection::ProjectedSubject>, StoreError> {
+        self.subject_summary_query(
+            "WHERE subject_kind = 'entity' ORDER BY subject ASC",
+            params![],
+        )
+    }
+
+    fn subject_summary_query(
+        &self,
+        tail: &str,
+        args: &[&dyn rusqlite::ToSql],
+    ) -> Result<Vec<subject_projection::ProjectedSubject>, StoreError> {
+        if !self.has_subject_summary()? {
+            return Ok(Vec::new());
+        }
+        let sql = format!(
+            "SELECT subject_kind, subject, first_observed_ms, last_observed_ms, provenance_head,
+                    observation_count, last_generation, last_event_id
+             FROM subject_summary {tail}"
+        );
+        let mut stmt = self.conn.prepare(&sql)?;
+        let rows = stmt.query_map(args, map_projected_subject)?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r?);
+        }
+        Ok(out)
     }
 
     /// Every subject summary, ordered by subject.
@@ -2920,27 +3027,7 @@ impl WorldStore {
         if !self.has_subject_summary()? {
             return Ok(Vec::new());
         }
-        let mut stmt = self.conn.prepare(
-            "SELECT subject, first_observed_ms, last_observed_ms, provenance_head,
-                    observation_count, last_generation, last_event_id
-             FROM subject_summary ORDER BY subject ASC",
-        )?;
-        let rows = stmt.query_map([], |r| {
-            Ok(subject_projection::ProjectedSubject {
-                subject: r.get(0)?,
-                first_observed_ms: r.get(1)?,
-                last_observed_ms: r.get(2)?,
-                provenance_head: r.get(3)?,
-                observation_count: r.get(4)?,
-                last_generation: r.get(5)?,
-                last_event_id: r.get(6)?,
-            })
-        })?;
-        let mut out = Vec::new();
-        for r in rows {
-            out.push(r?);
-        }
-        Ok(out)
+        self.subject_summary_query("ORDER BY subject_kind ASC, subject ASC", params![])
     }
 
     /// A digest over the whole subject summary, for the
@@ -2954,26 +3041,54 @@ impl WorldStore {
     }
 }
 
-/// Digest of the subject summary, taken in subject order so it is stable.
+/// One `subject_summary` row.
+///
+/// A stored kind outside the vocabulary is a **corrupt row**, not a row to be
+/// read as `Unlabelled`: the `CHECK` makes it unwritable through this crate, so
+/// finding one means the file was edited underneath it.
+fn map_projected_subject(
+    r: &rusqlite::Row<'_>,
+) -> rusqlite::Result<subject_projection::ProjectedSubject> {
+    let token: String = r.get(0)?;
+    let kind = subject_projection::SummaryKind::from_projection_column(&token).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(e))
+    })?;
+    Ok(subject_projection::ProjectedSubject {
+        subject_kind: kind,
+        subject: r.get(1)?,
+        first_observed_ms: r.get(2)?,
+        last_observed_ms: r.get(3)?,
+        provenance_head: r.get(4)?,
+        observation_count: r.get(5)?,
+        last_generation: r.get(6)?,
+        last_event_id: r.get(7)?,
+    })
+}
+
+/// Digest of the subject summary, taken in key order so it is stable.
 fn subject_summary_digest_of(conn: &Connection) -> Result<String, StoreError> {
     use sha2::{Digest, Sha256};
     let mut hasher = Sha256::new();
     let mut stmt = conn.prepare(
-        "SELECT subject, first_observed_ms, last_observed_ms, provenance_head,
+        "SELECT subject_kind, subject, first_observed_ms, last_observed_ms, provenance_head,
                 observation_count, last_generation, last_event_id
-         FROM subject_summary ORDER BY subject ASC",
+         FROM subject_summary ORDER BY subject_kind ASC, subject ASC",
     )?;
     let mut rows = stmt.query([])?;
     while let Some(r) = rows.next()? {
-        let subject: String = r.get(0)?;
-        let first: i64 = r.get(1)?;
-        let last: i64 = r.get(2)?;
-        let head: String = r.get(3)?;
-        let count: i64 = r.get(4)?;
-        let generation: i64 = r.get(5)?;
-        let event_id: String = r.get(6)?;
+        // The KIND is inside the digest. Two rows differing only by kind are
+        // different rows, and a digest blind to that would call a projection
+        // where `base_link` is a frame equal to one where it is an entity.
+        let kind: String = r.get(0)?;
+        let subject: String = r.get(1)?;
+        let first: i64 = r.get(2)?;
+        let last: i64 = r.get(3)?;
+        let head: String = r.get(4)?;
+        let count: i64 = r.get(5)?;
+        let generation: i64 = r.get(6)?;
+        let event_id: String = r.get(7)?;
         hasher.update(
-            format!("{subject}\u{1f}{first}\u{1f}{last}\u{1f}{head}\u{1f}{count}\u{1f}{generation}\u{1f}{event_id}\u{1e}")
+            format!("{kind}\u{1f}{subject}\u{1f}{first}\u{1f}{last}\u{1f}{head}\u{1f}{count}\u{1f}{generation}\u{1f}{event_id}\u{1e}")
                 .as_bytes(),
         );
     }

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -2731,10 +2731,21 @@ impl WorldStore {
         // successful fold. Asserted by
         // `an_old_shape_projection_is_rebuilt_from_zero_not_resumed`.
         if self.has_subject_summary()? && !self.subject_summary_has_kind()? {
-            self.conn.execute_batch(
-                "DROP TABLE IF EXISTS subject_summary;
-                 DELETE FROM projection_checkpoint WHERE name = 'subject_summary';",
+            // ONE transaction, because `execute_batch` is NOT one: SQLite
+            // autocommits each statement, so a crash between the DROP and the
+            // DELETE leaves the table gone and the checkpoint advanced -- and
+            // the next fold then rebuilds an empty table and resumes from a
+            // non-zero generation, silently omitting everything below it.
+            //
+            // That is the exact failure the comment above describes, and this
+            // code had it. Raised in review on #1398.
+            let tx = self.conn.unchecked_transaction()?;
+            tx.execute("DROP TABLE IF EXISTS subject_summary", [])?;
+            tx.execute(
+                "DELETE FROM projection_checkpoint WHERE name = ?1",
+                params![subject_projection::SUBJECT_SUMMARY_PROJECTION],
             )?;
+            tx.commit()?;
         }
         self.conn
             .execute_batch(subject_projection::SUBJECT_PROJECTION_V1)?;
@@ -3016,7 +3027,12 @@ impl WorldStore {
         Ok(out)
     }
 
-    /// Every subject summary, ordered by subject.
+    /// Every subject summary, ordered by `(subject_kind, subject)`.
+    ///
+    /// Not by subject alone — one string can now name more than one thing, so
+    /// the kind is the leading sort term. Stated because a caller relying on
+    /// the old contract would see rows for the same subject separated by every
+    /// other subject of the earlier kind.
     ///
     /// # Errors
     ///

--- a/crates/kirra-world-store/src/subject_projection.rs
+++ b/crates/kirra-world-store/src/subject_projection.rs
@@ -24,28 +24,41 @@
 //! that never projects, silently moving that figure and invalidating the
 //! comparison against D-2 that the retention horizons rest on.
 //!
-//! # What this is keyed on, and the honest limit of it
+//! # What this is keyed on
 //!
-//! **Keyed on `subject`, not on an entity id** — because the store cannot tell
-//! the difference.
+//! **Keyed on `(subject_kind, subject)`** since 2026-08-08. It was keyed on the
+//! subject string alone, and the module docs recorded why that was wrong:
 //!
-//! `kirra_world::observation::SubjectRef` distinguishes four cases:
-//! `Entity(id)` (resolved), `Candidate(id)` (not yet adjudicated), `Frame(id)`,
-//! and `Unbound` (recorded before anything decided what it was about). The
-//! storage layer flattens all four into one `subject TEXT NOT NULL` column and
-//! keeps no discriminant, so a fold here **cannot** restrict itself to resolved
-//! entities. Every distinct subject string gets a row.
+//! > The storage layer flattens all four into one `subject TEXT NOT NULL`
+//! > column and keeps no discriminant, so a fold here **cannot** restrict
+//! > itself to resolved entities. Every distinct subject string gets a row.
 //!
-//! This is the same shape as the `writer_class`-versus-`origin` finding: the
-//! core carries a type, the store carries a proxy, and the proxy cannot answer
-//! the question the type was built for. It is recorded rather than papered
-//! over, and the module is named for what it actually computes.
+//! `KIRRA-WM-CANDIDATE-ID-001` and the `subject_kind` column closed that. A
+//! fold can now restrict itself to resolved entities — see
+//! [`SummaryKind::Entity`] and `WorldStore::resolved_entities`.
 //!
-//! Fixing it means carrying `SubjectRef`'s discriminant in storage, which
-//! touches `subject` — a field inside the canonically-hashed bytes — so it
-//! needs the same append-only-when-present treatment the trust axes got, and it
-//! is a slice of its own. Entity *resolution* (deciding that two subjects are
-//! one thing) is Tier 2 regardless.
+//! ## Why the kind is part of the KEY and not merely a column
+//!
+//! An entity id and a frame id live in different namespaces but land in one
+//! `TEXT` column, so `base_link` as a frame and `base_link` as an entity are the
+//! same string. Keyed on the string alone they fold into ONE row whose counts
+//! and time bounds are summed across two different things, and whose kind would
+//! flip-flop with whichever event was seen last. That is not a summary of
+//! either of them.
+//!
+//! ## The sentinel, and the SQLite behaviour that forces it
+//!
+//! [`SummaryKind::Unlabelled`] is a **projection-only** token. It never appears
+//! in `world_events.subject_kind`, which is `NULL` for an unlabelled row — the
+//! evidence vocabulary is `entity`/`frame` and nothing else.
+//!
+//! It exists because **`NULL` never conflicts with `NULL` in SQLite**, so
+//! `ON CONFLICT (subject_kind, subject)` against a nullable column does not
+//! match an existing row: each unlabelled event INSERTs a new one. Measured
+//! before it was designed around, not recalled — two unlabelled events for one
+//! subject produced two rows of `observation_count = 1` rather than one row of
+//! 2. Every row in a store today is unlabelled, so that fold would have been
+//! wrong for all of them while looking entirely plausible.
 //!
 //! # Minting is not here either
 //!
@@ -61,6 +74,101 @@
 
 use std::collections::BTreeMap;
 
+/// Which kind of subject a summary row is about.
+///
+/// A three-token closed vocabulary, where the *evidence* has only two — see the
+/// module docs on the sentinel.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum SummaryKind {
+    /// A resolved entity. The rows entity resolution matches against.
+    Entity,
+    /// A spatial frame.
+    Frame,
+    /// No discriminant was stored on the event.
+    ///
+    /// Not a fourth evidence kind: `world_events.subject_kind` is `NULL` here.
+    /// The token exists so the projection can key on a NOT NULL column.
+    Unlabelled,
+}
+
+impl SummaryKind {
+    /// The token stored in the projection.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Entity => "entity",
+            Self::Frame => "frame",
+            Self::Unlabelled => "unlabelled",
+        }
+    }
+
+    /// Resolve the kind of an event from its stored `subject_kind` column.
+    ///
+    /// `None` — a `NULL` column — is [`Self::Unlabelled`]. That mapping is the
+    /// one place the sentinel is introduced.
+    ///
+    /// # Errors
+    ///
+    /// [`SummaryKindError`] for a token the evidence vocabulary does not
+    /// contain. **Fail-closed rather than folded into `Unlabelled`**: a row
+    /// whose kind cannot be read is a corrupt row, and summarising it as
+    /// "nothing said what this was" would file a corruption under a legitimate
+    /// case and hide it. `unlabelled` itself is refused from this direction too
+    /// — finding the projection's own sentinel in evidence means something
+    /// wrote a token that column may not hold.
+    pub fn from_event_column(token: Option<&str>) -> Result<Self, SummaryKindError> {
+        match token {
+            None => Ok(Self::Unlabelled),
+            Some("entity") => Ok(Self::Entity),
+            Some("frame") => Ok(Self::Frame),
+            Some(other) => Err(SummaryKindError::UnknownToken {
+                token: other.to_owned(),
+            }),
+        }
+    }
+
+    /// Re-admit a kind from a stored **projection** row.
+    ///
+    /// Unlike [`Self::from_event_column`] this accepts the sentinel, because
+    /// the projection is where the sentinel legitimately lives.
+    ///
+    /// # Errors
+    ///
+    /// [`SummaryKindError`] for anything outside the three tokens.
+    pub fn from_projection_column(token: &str) -> Result<Self, SummaryKindError> {
+        match token {
+            "entity" => Ok(Self::Entity),
+            "frame" => Ok(Self::Frame),
+            "unlabelled" => Ok(Self::Unlabelled),
+            other => Err(SummaryKindError::UnknownToken {
+                token: other.to_owned(),
+            }),
+        }
+    }
+}
+
+/// A kind token that could not be read.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SummaryKindError {
+    /// The token is outside the vocabulary for the column it came from.
+    UnknownToken {
+        /// The token as stored.
+        token: String,
+    },
+}
+
+impl core::fmt::Display for SummaryKindError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::UnknownToken { token } => {
+                write!(f, "unreadable subject kind {token:?}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for SummaryKindError {}
+
 /// The projection this module maintains.
 ///
 /// Named for what it computes. Calling it `entities_projection` would claim the
@@ -73,7 +181,11 @@ pub const SUBJECT_SUMMARY_PROJECTION: &str = "subject_summary";
 /// Separate DDL from `SCHEMA_V1` on purpose — see the module docs.
 pub const SUBJECT_PROJECTION_V1: &str = r#"
 CREATE TABLE IF NOT EXISTS subject_summary (
-    subject            TEXT    PRIMARY KEY,
+    -- NOT NULL, and the sentinel is why -- see the module docs. A nullable
+    -- column here makes ON CONFLICT stop matching and the fold stop folding.
+    subject_kind       TEXT    NOT NULL
+        CHECK (subject_kind IN ('entity','frame','unlabelled')),
+    subject            TEXT    NOT NULL,
 
     -- §6's three open fields, all folded rather than written.
     first_observed_ms  INTEGER NOT NULL,
@@ -91,11 +203,18 @@ CREATE TABLE IF NOT EXISTS subject_summary (
     last_event_id      TEXT    NOT NULL,
 
     CHECK (first_observed_ms <= last_observed_ms),
-    CHECK (observation_count >= 1)
+    CHECK (observation_count >= 1),
+
+    PRIMARY KEY (subject_kind, subject)
 );
 
 CREATE INDEX IF NOT EXISTS idx_subject_summary_last
     ON subject_summary (last_observed_ms);
+
+-- Resolved entities are the row set entity resolution matches against, so the
+-- one query this projection now exists to answer should not be a table scan.
+CREATE INDEX IF NOT EXISTS idx_subject_summary_kind
+    ON subject_summary (subject_kind, subject);
 
 -- The SAME checkpoint table `PROJECTIONS_V1` declares, repeated because either
 -- projection may be folded without the other and each must be able to install
@@ -119,6 +238,13 @@ CREATE TABLE IF NOT EXISTS projection_checkpoint (
 pub struct SubjectObservation {
     /// The event's subject, verbatim.
     pub subject: String,
+    /// The event's `subject_kind` column, verbatim — `None` when `NULL`.
+    ///
+    /// Deliberately the raw column rather than a [`SummaryKind`]: this struct
+    /// is what a row *said*, and resolving it is a step that can fail. Doing
+    /// that conversion at the boundary keeps an unreadable token a reported
+    /// error rather than something the fold has already swallowed.
+    pub subject_kind: Option<String>,
     /// When the store learned it.
     ///
     /// **Transaction time, not valid time.** `first_observed` and
@@ -139,6 +265,8 @@ pub struct SubjectObservation {
 /// A subject's folded summary.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProjectedSubject {
+    /// Which kind of subject this summarises — half of the key.
+    pub subject_kind: SummaryKind,
     /// The subject this summarises.
     pub subject: String,
     /// Transaction time of the earliest contributing event.
@@ -159,6 +287,13 @@ pub struct ProjectedSubject {
     pub last_event_id: String,
 }
 
+/// The accumulator key: a summary is identified by its kind AND its subject.
+///
+/// An alias rather than a bare tuple at every call site, so the ORDER of the two
+/// cannot be swapped silently — both halves are strings once flattened, and
+/// `(subject, kind)` would compile everywhere `(kind, subject)` does.
+pub type SubjectKey = (SummaryKind, String);
+
 /// Fold one observation into the accumulator. Returns whether it changed.
 ///
 /// # Ordering is not assumed
@@ -174,14 +309,17 @@ pub struct ProjectedSubject {
 /// tracked independently: transaction time is monotonic per store today, but
 /// deriving one bound from the other would bake that assumption into the data.
 pub fn subject_fold_step(
-    acc: &mut BTreeMap<String, ProjectedSubject>,
+    acc: &mut BTreeMap<SubjectKey, ProjectedSubject>,
     incoming: &SubjectObservation,
-) -> bool {
-    match acc.get_mut(&incoming.subject) {
+) -> Result<bool, SummaryKindError> {
+    let kind = SummaryKind::from_event_column(incoming.subject_kind.as_deref())?;
+    let key = (kind, incoming.subject.clone());
+    match acc.get_mut(&key) {
         None => {
             acc.insert(
-                incoming.subject.clone(),
+                key,
                 ProjectedSubject {
+                    subject_kind: kind,
                     subject: incoming.subject.clone(),
                     first_observed_ms: incoming.txn_time_ms,
                     last_observed_ms: incoming.txn_time_ms,
@@ -191,7 +329,7 @@ pub fn subject_fold_step(
                     last_event_id: incoming.event_id.clone(),
                 },
             );
-            true
+            Ok(true)
         }
         Some(held) => {
             held.observation_count += 1;
@@ -215,7 +353,7 @@ pub fn subject_fold_step(
                 held.provenance_head = incoming.chain_digest.clone();
                 held.last_event_id = incoming.event_id.clone();
             }
-            true
+            Ok(true)
         }
     }
 }
@@ -225,23 +363,83 @@ pub fn subject_fold_step(
 /// `BTreeMap` rather than `HashMap` so iteration order is deterministic — the
 /// state digest is taken over this order, and a digest that depended on hash
 /// seeding would compare unequal to itself.
-#[must_use]
+///
+/// # Errors
+///
+/// [`SummaryKindError`] if any observation carries a kind token the evidence
+/// vocabulary does not contain. The fold stops there rather than skipping the
+/// row: a projection that silently omitted rows it could not classify would
+/// under-report, and under-reporting is indistinguishable from "that subject
+/// was never observed".
 pub fn subject_fold_all<'a, I: IntoIterator<Item = &'a SubjectObservation>>(
     observations: I,
-) -> BTreeMap<String, ProjectedSubject> {
+) -> Result<BTreeMap<SubjectKey, ProjectedSubject>, SummaryKindError> {
     let mut acc = BTreeMap::new();
     for o in observations {
-        subject_fold_step(&mut acc, o);
+        subject_fold_step(&mut acc, o)?;
     }
-    acc
+    Ok(acc)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    #[test]
+    fn an_unreadable_event_token_is_refused_rather_than_folded_as_unlabelled() {
+        // Reading it as Unlabelled would file a corruption under a legitimate
+        // case -- "nothing decided what this was" -- and hide it. The two send
+        // an investigator to different places.
+        assert_eq!(
+            SummaryKind::from_event_column(Some("nonsense")),
+            Err(SummaryKindError::UnknownToken {
+                token: "nonsense".to_string()
+            })
+        );
+        // The projection's OWN sentinel is refused from the evidence direction:
+        // finding it there means something wrote a token that column may not
+        // hold.
+        assert!(SummaryKind::from_event_column(Some("unlabelled")).is_err());
+        // ...while the projection direction accepts it, because that is where
+        // it legitimately lives.
+        assert_eq!(
+            SummaryKind::from_projection_column("unlabelled"),
+            Ok(SummaryKind::Unlabelled)
+        );
+    }
+
+    #[test]
+    fn a_null_event_column_is_the_sentinel() {
+        assert_eq!(
+            SummaryKind::from_event_column(None),
+            Ok(SummaryKind::Unlabelled)
+        );
+        assert_eq!(SummaryKind::Unlabelled.as_str(), "unlabelled");
+    }
+
+    #[test]
+    fn the_three_kinds_have_three_distinct_tokens() {
+        let t = [
+            SummaryKind::Entity.as_str(),
+            SummaryKind::Frame.as_str(),
+            SummaryKind::Unlabelled.as_str(),
+        ];
+        let mut seen: Vec<&str> = Vec::new();
+        for x in t {
+            assert!(!seen.contains(&x), "token {x:?} used twice");
+            seen.push(x);
+        }
+    }
+
+    /// The accumulator key for an UNLABELLED subject — what every observation
+    /// in these tests is, since `obs` builds them without a kind.
+    fn ukey(subject: &str) -> SubjectKey {
+        (SummaryKind::Unlabelled, subject.to_string())
+    }
+
     fn obs(subject: &str, txn: i64, generation: i64) -> SubjectObservation {
         SubjectObservation {
+            subject_kind: None,
             subject: subject.to_string(),
             txn_time_ms: txn,
             generation,
@@ -252,8 +450,8 @@ mod tests {
 
     #[test]
     fn a_single_observation_bounds_itself() {
-        let got = subject_fold_all(&[obs("cup-1", 100, 1)]);
-        let s = &got["cup-1"];
+        let got = subject_fold_all(&[obs("cup-1", 100, 1)]).expect("readable kinds");
+        let s = &got[&ukey("cup-1")];
         assert_eq!(s.first_observed_ms, 100);
         assert_eq!(s.last_observed_ms, 100);
         assert_eq!(s.observation_count, 1);
@@ -262,8 +460,9 @@ mod tests {
 
     #[test]
     fn repeated_observations_widen_the_bounds_and_advance_the_head() {
-        let got = subject_fold_all(&[obs("cup-1", 100, 1), obs("cup-1", 300, 2)]);
-        let s = &got["cup-1"];
+        let got = subject_fold_all(&[obs("cup-1", 100, 1), obs("cup-1", 300, 2)])
+            .expect("readable kinds");
+        let s = &got[&ukey("cup-1")];
         assert_eq!(s.first_observed_ms, 100);
         assert_eq!(s.last_observed_ms, 300);
         assert_eq!(s.observation_count, 2);
@@ -273,10 +472,11 @@ mod tests {
 
     #[test]
     fn subjects_are_summarised_independently() {
-        let got = subject_fold_all(&[obs("cup-1", 100, 1), obs("cup-2", 200, 2)]);
+        let got = subject_fold_all(&[obs("cup-1", 100, 1), obs("cup-2", 200, 2)])
+            .expect("readable kinds");
         assert_eq!(got.len(), 2);
-        assert_eq!(got["cup-1"].observation_count, 1);
-        assert_eq!(got["cup-2"].first_observed_ms, 200);
+        assert_eq!(got[&ukey("cup-1")].observation_count, 1);
+        assert_eq!(got[&ukey("cup-2")].first_observed_ms, 200);
     }
 
     /// The fold must not depend on its input order. Generation order is the
@@ -288,11 +488,11 @@ mod tests {
             obs("cup-1", 300, 2),
             obs("cup-1", 200, 3),
         ];
-        let forward = subject_fold_all(&a);
+        let forward = subject_fold_all(&a).expect("readable kinds");
 
         let mut reversed: Vec<&SubjectObservation> = a.iter().collect();
         reversed.reverse();
-        let backward = subject_fold_all(reversed);
+        let backward = subject_fold_all(reversed).expect("readable kinds");
 
         assert_eq!(forward, backward, "reordering must not change the summary");
     }
@@ -307,8 +507,9 @@ mod tests {
             obs("cup-1", 100, 1),
             obs("cup-1", 500, 2),
             obs("cup-1", 200, 3),
-        ]);
-        let s = &got["cup-1"];
+        ])
+        .expect("readable kinds");
+        let s = &got[&ukey("cup-1")];
         assert_eq!(
             s.provenance_head, "digest-3",
             "the head is the newest chain position"
@@ -323,8 +524,9 @@ mod tests {
     /// Out-of-order arrival must still widen `first_observed` downward.
     #[test]
     fn an_earlier_time_arriving_later_moves_first_observed_back() {
-        let got = subject_fold_all(&[obs("cup-1", 300, 1), obs("cup-1", 100, 2)]);
-        assert_eq!(got["cup-1"].first_observed_ms, 100);
+        let got = subject_fold_all(&[obs("cup-1", 300, 1), obs("cup-1", 100, 2)])
+            .expect("readable kinds");
+        assert_eq!(got[&ukey("cup-1")].first_observed_ms, 100);
     }
 
     /// The bounds are tracked independently rather than one derived from the
@@ -333,17 +535,17 @@ mod tests {
     #[test]
     fn the_two_bounds_are_independent() {
         let mut acc = BTreeMap::new();
-        subject_fold_step(&mut acc, &obs("cup-1", 100, 1));
+        subject_fold_step(&mut acc, &obs("cup-1", 100, 1)).expect("readable kinds");
         assert_eq!(
-            acc["cup-1"].first_observed_ms,
-            acc["cup-1"].last_observed_ms
+            acc[&ukey("cup-1")].first_observed_ms,
+            acc[&ukey("cup-1")].last_observed_ms
         );
-        subject_fold_step(&mut acc, &obs("cup-1", 900, 2));
+        subject_fold_step(&mut acc, &obs("cup-1", 900, 2)).expect("readable kinds");
         assert_ne!(
-            acc["cup-1"].first_observed_ms,
-            acc["cup-1"].last_observed_ms
+            acc[&ukey("cup-1")].first_observed_ms,
+            acc[&ukey("cup-1")].last_observed_ms
         );
-        assert_eq!(acc["cup-1"].first_observed_ms, 100);
+        assert_eq!(acc[&ukey("cup-1")].first_observed_ms, 100);
     }
 
     /// Folding from zero must equal folding incrementally from a partial
@@ -359,11 +561,11 @@ mod tests {
             obs("cup-2", 500, 5),
         ];
 
-        let full = subject_fold_all(&all);
+        let full = subject_fold_all(&all).expect("readable kinds");
 
-        let mut incremental = subject_fold_all(&all[..2]);
+        let mut incremental = subject_fold_all(&all[..2]).expect("readable kinds");
         for o in &all[2..] {
-            subject_fold_step(&mut incremental, o);
+            subject_fold_step(&mut incremental, o).expect("readable kinds");
         }
 
         assert_eq!(full, incremental);
@@ -373,6 +575,6 @@ mod tests {
     /// answer the retention driver gives for a store never written to.
     #[test]
     fn an_empty_log_folds_to_nothing() {
-        assert!(subject_fold_all(&[]).is_empty());
+        assert!(subject_fold_all(&[]).expect("readable kinds").is_empty());
     }
 }

--- a/crates/kirra-world-store/src/subject_projection.rs
+++ b/crates/kirra-world-store/src/subject_projection.rs
@@ -211,10 +211,12 @@ CREATE TABLE IF NOT EXISTS subject_summary (
 CREATE INDEX IF NOT EXISTS idx_subject_summary_last
     ON subject_summary (last_observed_ms);
 
--- Resolved entities are the row set entity resolution matches against, so the
--- one query this projection now exists to answer should not be a table scan.
-CREATE INDEX IF NOT EXISTS idx_subject_summary_kind
-    ON subject_summary (subject_kind, subject);
+-- No index on (subject_kind, subject): the PRIMARY KEY already creates one.
+-- SQLite builds an implicit index for a non-INTEGER primary key, and
+-- `WHERE subject_kind = 'entity'` uses it as a leftmost-prefix scan. A second
+-- index over the same columns in the same order would add write amplification
+-- and pages for no plan the optimizer could not already reach. Raised in review
+-- on #1398, after this file shipped one.
 
 -- The SAME checkpoint table `PROJECTIONS_V1` declares, repeated because either
 -- projection may be folded without the other and each must be able to install

--- a/crates/kirra-world-store/tests/resolved_entities.rs
+++ b/crates/kirra-world-store/tests/resolved_entities.rs
@@ -29,12 +29,24 @@ fn tmp(name: &str) -> std::path::PathBuf {
         name,
         std::process::id()
     ));
+    clean(&p);
+    p
+}
+
+/// Remove the database AND its WAL sidecars.
+///
+/// `synchronous=FULL` in WAL mode leaves `-wal` and `-shm` beside the main file,
+/// so removing only the `.sqlite` leaks two files per test — and worse, a
+/// surviving `-wal` beside a recreated database of the same name is a recovery
+/// source, which can make a later run see rows it never wrote. The same helper
+/// and the same reasoning as `subject_summary.rs`; this file shipped without it
+/// and it was raised in review on #1398.
+fn clean(p: &std::path::Path) {
     for suffix in ["", "-wal", "-shm"] {
         let mut q = p.as_os_str().to_os_string();
         q.push(suffix);
         let _ = std::fs::remove_file(std::path::PathBuf::from(q));
     }
-    p
 }
 
 struct Ids {
@@ -119,7 +131,7 @@ fn resolved_entities_excludes_frames_and_unlabelled_subjects() {
     // fold that silently omitted rows would under-report, and under-reporting
     // is indistinguishable from "never observed".
     assert_eq!(s.subject_summaries().expect("all").len(), 3);
-    let _ = std::fs::remove_file(&path);
+    clean(&path);
 }
 
 /// **An entity and a frame with the same id string are two rows.**
@@ -164,7 +176,7 @@ fn one_id_string_under_two_kinds_is_two_summaries() {
     let resolved = s.resolved_entities().expect("read");
     assert_eq!(resolved.len(), 1);
     assert_eq!(resolved[0].subject_kind, SummaryKind::Entity);
-    let _ = std::fs::remove_file(&path);
+    clean(&path);
 }
 
 /// Unlabelled subjects still fold into ONE row per subject.
@@ -201,7 +213,7 @@ fn unlabelled_subjects_still_fold_into_one_row() {
     assert_eq!(all[0].subject_kind, SummaryKind::Unlabelled);
     assert_eq!(all[0].first_observed_ms, T0);
     assert_eq!(all[0].last_observed_ms, T0 + 2);
-    let _ = std::fs::remove_file(&path);
+    clean(&path);
 }
 
 // ---------------------------------------------------------------------------
@@ -266,7 +278,7 @@ fn an_old_shape_projection_is_rebuilt_from_zero_not_resumed() {
         all[0].observation_count, 3,
         "every event was re-scanned; a resumed fold would have found none"
     );
-    let _ = std::fs::remove_file(&path);
+    clean(&path);
 }
 
 /// The evidence `CHECK` refuses a kind token outside its vocabulary.
@@ -305,5 +317,5 @@ fn the_evidence_check_refuses_an_unreadable_kind_token() {
     // refusal is a refusal rather than damage.
     s.fold_subject_summary().expect("fold still works");
     assert_eq!(s.subject_summaries().expect("read").len(), 1);
-    let _ = std::fs::remove_file(&path);
+    clean(&path);
 }

--- a/crates/kirra-world-store/tests/resolved_entities.rs
+++ b/crates/kirra-world-store/tests/resolved_entities.rs
@@ -1,0 +1,309 @@
+//! The resolved-entity projection — `subject_summary` keyed on `(kind, subject)`.
+//!
+//! This closes the gap `subject_projection`'s own module docs recorded: the
+//! layer *"flattens all four into one `subject TEXT NOT NULL` column and keeps
+//! no discriminant, so a fold here **cannot** restrict itself to resolved
+//! entities."* It can now.
+//!
+//! Three properties carry the weight, and none of them is the happy path:
+//!
+//! 1. **An entity and a frame sharing an id string are separate rows.** That is
+//!    why the kind is half the KEY rather than a column beside it.
+//! 2. **Unlabelled rows still fold.** The key column is NOT NULL with a
+//!    sentinel, because `NULL` never conflicts with `NULL` in SQLite and a
+//!    nullable key would stop the upsert matching — for every row in a store
+//!    today, all of which are unlabelled.
+//! 3. **A projection of the old shape is rebuilt from zero, not resumed.**
+
+use kirra_world_store::{
+    ClaimStatus, EntityId, EventId, FrameId, NewEvent, ObservationId, SubjectRef, SummaryKind,
+    WorldStore, WriterClass,
+};
+
+const T0: i64 = 1_700_000_000_000;
+
+fn tmp(name: &str) -> std::path::PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "kirra-world-resolved-{}-{}.sqlite",
+        name,
+        std::process::id()
+    ));
+    for suffix in ["", "-wal", "-shm"] {
+        let mut q = p.as_os_str().to_os_string();
+        q.push(suffix);
+        let _ = std::fs::remove_file(std::path::PathBuf::from(q));
+    }
+    p
+}
+
+struct Ids {
+    event: EventId,
+    observation: ObservationId,
+}
+
+fn ids(n: &str) -> Ids {
+    Ids {
+        event: EventId::new(format!("evt-{n}")).unwrap(),
+        observation: ObservationId::new(format!("obs-{n}")).unwrap(),
+    }
+}
+
+fn ev<'a>(
+    id: &'a Ids,
+    subject: &'a str,
+    subject_ref: Option<&'a SubjectRef>,
+    txn_time_ms: i64,
+) -> NewEvent<'a> {
+    NewEvent {
+        event_id: &id.event,
+        observation_id: &id.observation,
+        txn_time_ms,
+        valid_from_ms: txn_time_ms,
+        valid_to_ms: None,
+        source: "sensor-a",
+        source_version: "0.1.0",
+        writer_class: WriterClass::Sensor,
+        claim_status: ClaimStatus::Confirmed,
+        provenance: &[],
+        frame_id: None,
+        map_id: None,
+        kind: "observation",
+        subject,
+        subject_ref,
+        predicate: Some("colour"),
+        object: Some("red"),
+        payload: r#"{"n":1}"#,
+        payload_schema: 1,
+        retention_class: "raw",
+        trust: None,
+    }
+}
+
+fn entity(id: &str) -> SubjectRef {
+    SubjectRef::Entity(EntityId::new(id).expect("entity id"))
+}
+
+fn frame(id: &str) -> SubjectRef {
+    SubjectRef::Frame(FrameId::new(id).expect("frame id"))
+}
+
+// ---------------------------------------------------------------------------
+// The query this projection was rebuilt to answer
+// ---------------------------------------------------------------------------
+
+/// `resolved_entities` returns resolved entities and nothing else.
+#[test]
+fn resolved_entities_excludes_frames_and_unlabelled_subjects() {
+    let path = tmp("resolved");
+    let mut s = WorldStore::open(&path).expect("open");
+
+    let e = entity("cup-1");
+    let f = frame("base_link");
+    s.append(&ev(&ids("a"), "cup-1", Some(&e), T0)).expect("a");
+    s.append(&ev(&ids("b"), "base_link", Some(&f), T0 + 1))
+        .expect("b");
+    s.append(&ev(&ids("c"), "mystery-1", None, T0 + 2))
+        .expect("c");
+    s.fold_subject_summary().expect("fold");
+
+    let resolved = s.resolved_entities().expect("read");
+    let names: Vec<&str> = resolved.iter().map(|r| r.subject.as_str()).collect();
+    assert_eq!(names, vec!["cup-1"], "only the resolved entity");
+    assert!(resolved
+        .iter()
+        .all(|r| r.subject_kind == SummaryKind::Entity));
+
+    // ...and the others are still SUMMARISED, just not as entities. Asserted so
+    // the filter cannot be mistaken for the projection having dropped them: a
+    // fold that silently omitted rows would under-report, and under-reporting
+    // is indistinguishable from "never observed".
+    assert_eq!(s.subject_summaries().expect("all").len(), 3);
+    let _ = std::fs::remove_file(&path);
+}
+
+/// **An entity and a frame with the same id string are two rows.**
+///
+/// The case that makes the kind part of the key rather than a column beside it.
+/// Keyed on the subject string alone these fold into one row whose counts and
+/// time bounds are summed across two different things and whose kind flip-flops
+/// with whichever event was seen last — a summary of neither.
+#[test]
+fn one_id_string_under_two_kinds_is_two_summaries() {
+    let path = tmp("collide");
+    let mut s = WorldStore::open(&path).expect("open");
+
+    let e = entity("base_link");
+    let f = frame("base_link");
+    s.append(&ev(&ids("a"), "base_link", Some(&e), T0))
+        .expect("as entity");
+    s.append(&ev(&ids("b"), "base_link", Some(&f), T0 + 5_000))
+        .expect("as frame");
+    s.fold_subject_summary().expect("fold");
+
+    let both = s.subject_summaries_for("base_link").expect("read");
+    assert_eq!(both.len(), 2, "one string, two things");
+
+    let as_entity = s
+        .subject_summary(SummaryKind::Entity, "base_link")
+        .expect("read")
+        .expect("present");
+    let as_frame = s
+        .subject_summary(SummaryKind::Frame, "base_link")
+        .expect("read")
+        .expect("present");
+
+    // Each counts ONLY its own events. A single merged row would show 2 here,
+    // which is the specific wrongness the composite key prevents.
+    assert_eq!(as_entity.observation_count, 1);
+    assert_eq!(as_frame.observation_count, 1);
+    assert_eq!(as_entity.first_observed_ms, T0);
+    assert_eq!(as_frame.first_observed_ms, T0 + 5_000);
+
+    // And the entity query returns the entity, not "whichever SQLite yielded".
+    let resolved = s.resolved_entities().expect("read");
+    assert_eq!(resolved.len(), 1);
+    assert_eq!(resolved[0].subject_kind, SummaryKind::Entity);
+    let _ = std::fs::remove_file(&path);
+}
+
+/// Unlabelled subjects still fold into ONE row per subject.
+///
+/// The regression guard for the sentinel — and it guards a narrower thing than
+/// it first appears, which is worth stating because the difference decides
+/// whether a future reader is actually protected.
+///
+/// `ON CONFLICT (subject_kind, subject)` stops matching when the stored value is
+/// `NULL`, because `NULL` never conflicts with `NULL` in SQLite. Measured before
+/// the design rather than recalled. Every row in a store today is unlabelled, so
+/// that fold would produce one row of `observation_count = 1` per EVENT while
+/// looking entirely plausible.
+///
+/// **What fires this test is writing `NULL`, not the column being nullable.**
+/// A control that only relaxed the DDL to `TEXT` (dropping `NOT NULL`) failed
+/// *nothing* — the driver still wrote the `unlabelled` token, so the fold still
+/// folded. Adding the second half, a driver that writes `None` for
+/// [`SummaryKind::Unlabelled`], fires this test and three others. So the
+/// `NOT NULL` is a belt to the driver's braces, and this test is the braces.
+#[test]
+fn unlabelled_subjects_still_fold_into_one_row() {
+    let path = tmp("sentinel");
+    let mut s = WorldStore::open(&path).expect("open");
+    for (n, t) in [("a", T0), ("b", T0 + 1), ("c", T0 + 2)] {
+        s.append(&ev(&ids(n), "mystery-1", None, t))
+            .expect("append");
+    }
+    s.fold_subject_summary().expect("fold");
+
+    let all = s.subject_summaries().expect("read");
+    assert_eq!(all.len(), 1, "three events, ONE subject, one row");
+    assert_eq!(all[0].observation_count, 3, "folded, not split");
+    assert_eq!(all[0].subject_kind, SummaryKind::Unlabelled);
+    assert_eq!(all[0].first_observed_ms, T0);
+    assert_eq!(all[0].last_observed_ms, T0 + 2);
+    let _ = std::fs::remove_file(&path);
+}
+
+// ---------------------------------------------------------------------------
+// The shape change
+// ---------------------------------------------------------------------------
+
+/// A projection installed before `subject_kind` is dropped and rebuilt, and the
+/// checkpoint goes with it.
+///
+/// Both halves matter and only one is obvious. `SUBJECT_PROJECTION_V1` is all
+/// `CREATE ... IF NOT EXISTS`, so an existing table of the old shape survives
+/// untouched — hence the drop. But dropping the table while leaving
+/// `projection_checkpoint` at generation N makes the next fold resume from N
+/// into an EMPTY table, producing a projection missing everything below N. That
+/// failure reports success and returns a plausible, short answer.
+#[test]
+fn an_old_shape_projection_is_rebuilt_from_zero_not_resumed() {
+    let path = tmp("oldshape");
+    let mut s = WorldStore::open(&path).expect("open");
+    for (n, t) in [("a", T0), ("b", T0 + 1), ("c", T0 + 2)] {
+        s.append(&ev(&ids(n), "mystery-1", None, t))
+            .expect("append");
+    }
+    s.fold_subject_summary().expect("fold");
+    assert_eq!(s.subject_summaries().expect("read").len(), 1);
+    let before = s.subject_summary_generation().expect("checkpoint");
+    assert!(
+        before > 0,
+        "the checkpoint advanced, so resuming is possible"
+    );
+
+    // Recreate the PRE-kind shape underneath the store, leaving the checkpoint
+    // exactly where a real old store's would be.
+    // One call per statement: `raw_execute_for_test` is `Connection::execute`,
+    // which runs a SINGLE statement and silently ignores everything after the
+    // first semicolon. A batch here dropped the table without recreating it,
+    // and the test then failed for that reason rather than the one it is about.
+    s.raw_execute_for_test("DROP TABLE subject_summary")
+        .expect("drop");
+    s.raw_execute_for_test(
+        "CREATE TABLE subject_summary (
+            subject            TEXT    PRIMARY KEY,
+            first_observed_ms  INTEGER NOT NULL,
+            last_observed_ms   INTEGER NOT NULL,
+            provenance_head    TEXT    NOT NULL,
+            observation_count  INTEGER NOT NULL,
+            last_generation    INTEGER NOT NULL,
+            last_event_id      TEXT    NOT NULL)",
+    )
+    .expect("stage the old shape");
+    assert_eq!(
+        s.subject_summary_generation().expect("checkpoint"),
+        before,
+        "the checkpoint is still advanced -- this is what makes the test non-vacuous"
+    );
+
+    // The next fold must notice the shape, rebuild, and re-scan from zero.
+    s.fold_subject_summary().expect("fold after shape change");
+    let all = s.subject_summaries().expect("read");
+    assert_eq!(all.len(), 1, "the subject came back");
+    assert_eq!(
+        all[0].observation_count, 3,
+        "every event was re-scanned; a resumed fold would have found none"
+    );
+    let _ = std::fs::remove_file(&path);
+}
+
+/// The evidence `CHECK` refuses a kind token outside its vocabulary.
+///
+/// # Why this is not the fail-closed fold test I first wrote
+///
+/// The fold resolves `subject_kind` at the boundary and returns
+/// `StoreError::CorruptRow` for a token it cannot read. I tried to exercise that
+/// by writing `'nonsense'` into the column and folding — and could not, because
+/// **this `CHECK` refuses the write**, which is what the failure below shows.
+///
+/// Getting past it needs `PRAGMA writable_schema` surgery on `sqlite_master`,
+/// which depends on the exact stored DDL text and is a fragile thing to pin a
+/// test to. So the honest position is recorded instead of a hack: while the
+/// `CHECK` holds, the fold's refusal is **unreachable through SQLite** and is
+/// defence-in-depth against a file corrupted outside it. The mapping itself is
+/// covered directly by `SummaryKind::from_event_column`'s unit tests; what this
+/// test owns is the line of defence that actually fires.
+#[test]
+fn the_evidence_check_refuses_an_unreadable_kind_token() {
+    let path = tmp("corrupt");
+    let mut s = WorldStore::open(&path).expect("open");
+    s.append(&ev(&ids("a"), "cup-1", None, T0)).expect("append");
+
+    let err = s
+        .raw_execute_for_test(
+            "UPDATE world_events SET subject_kind = 'nonsense' WHERE generation = 1",
+        )
+        .expect_err("the CHECK must refuse a token outside the vocabulary");
+    assert!(
+        format!("{err}").contains("CHECK"),
+        "expected a constraint failure, got {err}"
+    );
+
+    // The refused write left the store readable and the fold working, so the
+    // refusal is a refusal rather than damage.
+    s.fold_subject_summary().expect("fold still works");
+    assert_eq!(s.subject_summaries().expect("read").len(), 1);
+    let _ = std::fs::remove_file(&path);
+}

--- a/crates/kirra-world-store/tests/subject_summary.rs
+++ b/crates/kirra-world-store/tests/subject_summary.rs
@@ -7,7 +7,7 @@
 
 use kirra_world_store::{
     subject_fold_all, ClaimStatus, EventId, NewEvent, ObservationId, SubjectObservation,
-    WorldStore, WriterClass,
+    SummaryKind, WorldStore, WriterClass,
 };
 
 fn tmp(name: &str) -> std::path::PathBuf {
@@ -103,7 +103,10 @@ fn the_three_fields_are_folded_from_the_log() {
     }
     s.fold_subject_summary().expect("fold");
 
-    let got = s.subject_summary("cup-1").expect("read").expect("present");
+    let got = s
+        .subject_summary(SummaryKind::Unlabelled, "cup-1")
+        .expect("read")
+        .expect("present");
     assert_eq!(got.first_observed_ms, 100);
     assert_eq!(got.last_observed_ms, 700);
     assert_eq!(got.observation_count, 3);
@@ -148,6 +151,7 @@ fn the_sql_upsert_computes_what_the_pure_fold_computes() {
     let observations: Vec<SubjectObservation> = rows
         .iter()
         .map(|(n, subject, txn)| SubjectObservation {
+            subject_kind: None,
             subject: (*subject).to_string(),
             txn_time_ms: *txn,
             generation: *n,
@@ -158,11 +162,13 @@ fn the_sql_upsert_computes_what_the_pure_fold_computes() {
                 .map_or_else(String::new, |p| p.provenance_head.clone()),
         })
         .collect();
-    let pure = subject_fold_all(&observations);
+    let pure = subject_fold_all(&observations).expect("every kind readable");
 
     assert_eq!(stored.len(), pure.len(), "same subjects");
     for p in &stored {
-        let expected = pure.get(&p.subject).expect("subject in the pure fold");
+        let expected = pure
+            .get(&(p.subject_kind, p.subject.clone()))
+            .expect("subject in the pure fold");
         assert_eq!(p.first_observed_ms, expected.first_observed_ms, "{p:?}");
         assert_eq!(p.last_observed_ms, expected.last_observed_ms, "{p:?}");
         assert_eq!(p.observation_count, expected.observation_count, "{p:?}");
@@ -197,7 +203,10 @@ fn the_head_follows_generation_through_the_store_too() {
         .expect("c");
     s.fold_subject_summary().expect("fold");
 
-    let got = s.subject_summary("cup-1").expect("read").expect("present");
+    let got = s
+        .subject_summary(SummaryKind::Unlabelled, "cup-1")
+        .expect("read")
+        .expect("present");
     assert_eq!(got.last_generation, 3, "the head is the newest generation");
     assert_eq!(got.last_event_id, "evt-3");
     assert_eq!(
@@ -223,14 +232,19 @@ fn candidates_do_not_contribute() {
         .expect("candidate-only subject");
     s.fold_subject_summary().expect("fold");
 
-    let cup = s.subject_summary("cup-1").expect("read").expect("present");
+    let cup = s
+        .subject_summary(SummaryKind::Unlabelled, "cup-1")
+        .expect("read")
+        .expect("present");
     assert_eq!(
         cup.observation_count, 1,
         "the candidate must not count toward the summary"
     );
     assert_eq!(cup.last_observed_ms, 100);
     assert!(
-        s.subject_summary("ghost-1").expect("read").is_none(),
+        s.subject_summary(SummaryKind::Unlabelled, "ghost-1")
+            .expect("read")
+            .is_none(),
         "a candidate-only subject has no confirmed observation to summarise"
     );
     clean(&path);
@@ -306,7 +320,7 @@ fn a_second_fold_with_no_new_events_is_a_no_op() {
 
     assert_eq!(first, second, "re-folding must not double-count");
     assert_eq!(
-        s.subject_summary("cup-1")
+        s.subject_summary(SummaryKind::Unlabelled, "cup-1")
             .expect("read")
             .expect("present")
             .observation_count,


### PR DESCRIPTION
Closes the gap `subject_projection` recorded about itself:

> The storage layer flattens all four into one `subject TEXT NOT NULL` column and
> keeps no discriminant, so a fold here **cannot** restrict itself to resolved
> entities. Every distinct subject string gets a row.

It can now. `resolved_entities()` is the query, and it is what entity resolution
will match an incoming observation against.

## The kind is half the KEY, not a column beside it

An entity id and a frame id live in different namespaces but land in one `TEXT`
column, so `base_link` as a frame and `base_link` as an entity are the same
string. Keyed on the string alone they fold into **one** row whose counts and
time bounds are summed across two different things, and whose kind flip-flops
with whichever event arrived last — a summary of neither. Keyed on
`(kind, subject)` they are two rows, which is what they are.

## The sentinel, and why it is not optional

`unlabelled` is a **projection-only** token — the evidence vocabulary stays
`entity`/`frame`, and `world_events.subject_kind` is `NULL` for an unlabelled
row.

It exists because **`NULL` never conflicts with `NULL` in SQLite**, so
`ON CONFLICT` against a nullable key does not match and every unlabelled event
INSERTs a new row. Measured before designing around it, not recalled: two
unlabelled events for one subject produced two rows of `observation_count = 1`
instead of one row of 2. Every row in a store today is unlabelled, so that fold
would have been wrong for all of them while looking entirely plausible.

## The shape change needed a rebuild, and the checkpoint with it

`SUBJECT_PROJECTION_V1` is all `CREATE ... IF NOT EXISTS`, so an existing
old-shape table survives untouched and the first insert fails on a missing
column. Dropped and rebuilt rather than migrated — a projection *is* a cache,
rebuildable from the log by definition, which is the whole argument for it not
being ratified schema.

Dropping the table while leaving `projection_checkpoint` at generation N would
resume into an empty table and silently under-report everything below N. That
failure reports success and returns a plausible, short answer.

`subject_summary()` now **takes the kind**. A subject string no longer identifies
a row, so the old signature would have returned whichever of two rows SQLite
yielded first — a silent wrong answer rather than an error.
`subject_summaries_for()` answers the across-kinds question.

## What I got wrong, twice, both caught by controls rather than by care

**Two of my new tests failed for a reason I had not checked.**
`raw_execute_for_test` is `Connection::execute`, which runs a **single**
statement and silently drops everything after the first semicolon. My batches ran
their first statement only, so one test dropped a table without recreating it and
another never relaxed the `CHECK` it meant to.

**The sentinel guard guards something narrower than I wrote.** A control that
only relaxed the DDL to nullable failed **nothing** — the driver still wrote the
token, so the fold still folded. It takes the driver *also* writing `None` to
fire it. The `NOT NULL` is a belt to the driver's braces, and the test is the
braces; the doc now says so instead of implying the column carries the guarantee.

**One refusal is unreachable, and is recorded as such rather than faked.** The
fold fails closed on an unreadable kind token, but the evidence `CHECK` refuses
that write, so reaching it needs `writable_schema` surgery pinned to exact stored
DDL text. The mapping is unit-tested directly; the integration test owns the line
of defence that actually fires.

## Verification

- 19 suites across the three world crates (18 → 19, one new file); clippy
  `-D warnings`, fmt, fence (19 packages from 10 roots), domain-logic gate 38/38,
  re-export shim ratchet.
- **Both detached trees**, in their own workspaces: `wm2-schema-growth` (30),
  `wm2-persistence-harness` (207 + 7). Neither is reachable by
  `cargo test --workspace`, which is how #1395 shipped a broken `NewEvent` site to CI.

**Negative controls**, each from a pristine copy:

| control | tests fired |
|---|---|
| key on `subject` alone | all 5 new tests |
| old-shape detection removed | the rebuild test |
| checkpoint not cleared on drop | the rebuild test |
| nullable column **alone** | **nothing** — see above |
| nullable column + driver writes `NULL` | 4 tests |

Two rustdoc warnings in `kirra-world-store` are pre-existing (`projection.rs`,
`has_summaries`) and untouched here.

## What this does not do

Nothing yet **writes** a label — every call site still passes `None`, so
`resolved_entities()` is empty on real data until an integrator supplies
`EntityId`s or minting lands. `EntityId::new` is public, so the first is possible
today; minting is only needed for the no-match branch of resolution.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_