### PR TITLE
entity_id minting: the recorded verb, and a generator that can promise never-reuse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2618,9 +2618,11 @@ dependencies = [
  "kirra-audit-hash",
  "kirra-world",
  "kirra-world-store",
+ "rand 0.8.7",
  "rusqlite",
  "serde_json",
  "sha2 0.10.9",
+ "ulid",
 ]
 
 [[package]]
@@ -5217,6 +5219,16 @@ dependencies = [
  "rand 0.8.7",
  "serde",
  "spin 0.10.0",
+]
+
+[[package]]
+name = "ulid"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
+dependencies = [
+ "rand 0.9.4",
+ "web-time",
 ]
 
 [[package]]

--- a/crates/kirra-world-store/Cargo.toml
+++ b/crates/kirra-world-store/Cargo.toml
@@ -22,6 +22,10 @@ kirra-audit-hash = { path = "../kirra-audit-hash" }
 rusqlite = { version = "0.31", features = ["bundled"] }
 serde_json = "1"
 sha2 = "0.10"
+# WM_SCOPE §4 puts ULID generation HERE by design: "the core owns the type and
+# the layer with a clock mints the value". kirra-world stays zero-dependency.
+ulid = "1"
+rand = "0.8"
 hex = "0.4"
 
 [features]

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -229,6 +229,12 @@ pub enum StoreError {
         /// The value in the `subject` column.
         subject: String,
     },
+    /// The 80-bit random component could not be incremented further.
+    ///
+    /// Reached only after 2^80 ids inside one millisecond. Recorded as a
+    /// refusal rather than wrapped, because wrapping would hand out an id that
+    /// was already minted — the one thing the mint exists to prevent.
+    EntityIdSpaceExhausted,
     /// The database is stamped with a schema version this binary does not
     /// know. Refused rather than opened hopefully — an older binary writing
     /// into a newer store produces rows missing columns it never heard of,
@@ -333,6 +339,11 @@ impl std::fmt::Display for StoreError {
                 "subject_ref names {reference:?} but subject is {subject:?}; \
                  both would enter the hashed bytes and nothing could say which \
                  was meant"
+            ),
+            Self::EntityIdSpaceExhausted => write!(
+                f,
+                "the entity-id space is exhausted for this millisecond; \
+                 refused rather than wrapped, because wrapping would reuse an id"
             ),
             Self::SchemaFromTheFuture { found, supported } => write!(
                 f,
@@ -886,6 +897,7 @@ pub fn schema_digest() -> String {
     let mut effective = String::from(schema::SCHEMA_V1);
     effective.push_str(schema::SCHEMA_V2_MIGRATION);
     effective.push_str(schema::SCHEMA_V3_MIGRATION);
+    effective.push_str(schema::SCHEMA_V4_MIGRATION);
     sha256_hex(effective.as_bytes())
 }
 
@@ -938,6 +950,7 @@ impl WorldStore {
             tx.execute_batch(schema::SCHEMA_V1)?;
             tx.execute_batch(schema::SCHEMA_V2_MIGRATION)?;
             tx.execute_batch(schema::SCHEMA_V3_MIGRATION)?;
+            tx.execute_batch(schema::SCHEMA_V4_MIGRATION)?;
             tx.execute(
                 "INSERT INTO world_store_meta (key, value) VALUES ('schema_version', ?1)",
                 params![SCHEMA_VERSION.to_string()],
@@ -1027,6 +1040,11 @@ impl WorldStore {
         // catch on the next open and would then be self-inflicted.
         if from < 3 {
             tx.execute_batch(schema::SCHEMA_V3_MIGRATION)?;
+        }
+        // Same shape again, and the same reason: separate `if`, so a v1 store
+        // takes every step in one transaction rather than skipping to the last.
+        if from < 4 {
+            tx.execute_batch(schema::SCHEMA_V4_MIGRATION)?;
         }
 
         // Digest before version, inside the transaction. The order no longer
@@ -3046,6 +3064,105 @@ impl WorldStore {
         self.subject_summary_query("ORDER BY subject_kind ASC, subject ASC", params![])
     }
 
+    /// **Mint a new `EntityId`** — `WM_SCOPE.md` §5.
+    ///
+    /// §6.1 requires an id to be *"stable, opaque, monotonic. Never reused,
+    /// never encodes semantics."* The type guarantees stable and opaque; this
+    /// guarantees the other two, and it needs durable state to do so — which is
+    /// why generation lives here and not in the zero-dependency core.
+    ///
+    /// # Monotonic across the clock, not merely within it
+    ///
+    /// A ULID is lexicographically ordered by its timestamp, so `>` on the
+    /// string is the monotonic check. The candidate built from `now_ms` is used
+    /// only if it exceeds every id already minted; otherwise the previous id is
+    /// **incremented** (the ULID spec's own monotonic rule, which bumps the
+    /// random component).
+    ///
+    /// That second branch is not an edge case to be waved at. Two ids minted in
+    /// the same millisecond hit it every time, and so does a clock that goes
+    /// backwards — an NTP step, a VM restore. Deriving the next id from the
+    /// durable high-water rather than from the clock alone is what makes
+    /// monotonicity a property of the *store* instead of a property of the
+    /// caller's clock being well-behaved.
+    ///
+    /// # The `<=` boundary is untested, and cannot practically be
+    ///
+    /// A control weakening `<=` to `<` fails **no test**. The two differ only on
+    /// exact equality between the candidate and the high-water, which needs an
+    /// 80-bit random collision — not reachable without forcing the RNG.
+    ///
+    /// Recorded rather than covered, because the honest reason it is still `<=`
+    /// is not "a test says so". On equality, `<` would hand back an id already
+    /// in the ledger, and the `PRIMARY KEY` below would refuse the `INSERT`. So
+    /// the weaker form fails *closed*, and `<=` turns an astronomically rare
+    /// hard error into a correct increment. That is a cheap improvement over an
+    /// already-safe failure, not a guard the design rests on.
+    ///
+    /// # Never reused is enforced by the schema, not by this function
+    ///
+    /// The `INSERT` into `entity_id_mint` is what makes reuse impossible: the
+    /// `PRIMARY KEY` refuses a second write of the same id, so a generator bug
+    /// surfaces as a constraint failure rather than two entities quietly
+    /// sharing an identity. The ledger is never swept — see
+    /// [`schema::SCHEMA_V4_MIGRATION`] for why it is not a projection.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::Sqlite`] on any storage failure;
+    /// [`StoreError::EntityIdSpaceExhausted`] if the random component cannot be
+    /// incremented further within one millisecond (2^80 ids — recorded as a
+    /// refusal rather than a wrap, because wrapping would reuse).
+    pub fn mint_entity_id(&mut self, now_ms: i64) -> Result<EntityId, StoreError> {
+        use std::str::FromStr;
+        let tx = self.conn.transaction()?;
+        let highest: Option<String> = tx
+            .query_row("SELECT MAX(entity_id) FROM entity_id_mint", [], |r| {
+                r.get(0)
+            })
+            .optional()?
+            .flatten();
+
+        let stamp = u64::try_from(now_ms).unwrap_or(0);
+        let candidate = ulid::Ulid::from_parts(stamp, rand_component());
+        let next = match highest
+            .as_deref()
+            .and_then(|h| ulid::Ulid::from_str(h).ok())
+        {
+            Some(last) if candidate <= last => {
+                last.increment().ok_or(StoreError::EntityIdSpaceExhausted)?
+            }
+            _ => candidate,
+        };
+
+        let id = next.to_string();
+        tx.execute(
+            "INSERT INTO entity_id_mint (entity_id, minted_at_ms) VALUES (?1, ?2)",
+            params![id, now_ms],
+        )?;
+        tx.commit()?;
+        // Constructed through the same validator every other caller uses, so a
+        // minted id is admissible by exactly the rule a stored one must pass.
+        EntityId::new(id).map_err(|e| StoreError::CorruptRow {
+            generation: 0,
+            detail: format!("minted an inadmissible entity id: {e}"),
+        })
+    }
+
+    /// How many ids this store has ever minted.
+    ///
+    /// The ledger's size, not the live entity count: a retired or merged entity
+    /// keeps its row, because that is what never-reuse means.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::Sqlite`] on any storage failure.
+    pub fn minted_entity_id_count(&self) -> Result<i64, StoreError> {
+        Ok(self
+            .conn
+            .query_row("SELECT COUNT(*) FROM entity_id_mint", [], |r| r.get(0))?)
+    }
+
     /// A digest over the whole subject summary, for the
     /// rebuild-equals-incremental assertion.
     ///
@@ -3109,4 +3226,19 @@ fn subject_summary_digest_of(conn: &Connection) -> Result<String, StoreError> {
         );
     }
     Ok(hex::encode(hasher.finalize()))
+}
+
+/// 80 bits of randomness for a ULID's non-timestamp half.
+///
+/// `ulid`'s own generator reads the system clock; this store takes `now_ms`
+/// from the caller instead, so only the random half is needed here — the same
+/// reason every time-dependent function in this crate is passed its clock
+/// rather than reading one.
+fn rand_component() -> u128 {
+    use rand::RngCore;
+    let mut buf = [0u8; 16];
+    rand::thread_rng().fill_bytes(&mut buf);
+    // The top 48 bits are the ULID's timestamp; mask them off so only the
+    // 80-bit random field is populated.
+    u128::from_be_bytes(buf) & ((1u128 << 80) - 1)
 }

--- a/crates/kirra-world-store/src/schema.rs
+++ b/crates/kirra-world-store/src/schema.rs
@@ -111,7 +111,8 @@ pub const CHAIN_ALGORITHM: &str = "kirra-audit-hash/compute_record_hash_v2";
 /// | 1 | the ratified baseline | `KIRRA-WM2-SCHEMA-001` |
 /// | 2 | the four orthogonal trust axes, additive | 2026-08-07 |
 /// | 3 | the `subject_kind` discriminant | `KIRRA-WM-CANDIDATE-ID-001` |
-pub const SCHEMA_VERSION: i64 = 3;
+/// | 4 | the `entity_id_mint` ledger | `WM_SCOPE.md` §5 |
+pub const SCHEMA_VERSION: i64 = 4;
 
 /// **v2 — the four orthogonal trust axes, added additively.**
 ///
@@ -283,4 +284,31 @@ pub const SCHEMA_V3_MIGRATION: &str = r#"
 ALTER TABLE world_events ADD COLUMN subject_kind TEXT
     CHECK (subject_kind IS NULL OR subject_kind IN
         ('entity','frame'));
+"#;
+
+/// **v4 — the entity-id mint ledger.**
+///
+/// `WM_SCOPE.md` §5's `entity_id` minting, and §6.1's constraint on what an id
+/// must be: *"Stable, opaque, monotonic. Never reused, never encodes
+/// semantics."* The first two are properties of the TYPE
+/// ([`kirra_world::reference::EntityId`]); the last two are properties of the
+/// **generator**, and a generator cannot promise them without durable state.
+///
+/// # Why this is a table and not a projection
+///
+/// A projection is rebuildable by folding the log, and that is exactly what
+/// never-reuse must NOT depend on. Retention can compact old events away; if
+/// the set of minted ids were derived from surviving events, a compacted id
+/// would become mintable again. This ledger is the one place that remembers an
+/// id was used, and it is never swept.
+///
+/// The `PRIMARY KEY` is the never-reuse guarantee itself rather than a check
+/// the mint performs — a second `INSERT` of the same id is refused by SQLite,
+/// so a generator bug surfaces as a constraint failure instead of a silently
+/// duplicated identity.
+pub const SCHEMA_V4_MIGRATION: &str = r#"
+CREATE TABLE IF NOT EXISTS entity_id_mint (
+    entity_id    TEXT    PRIMARY KEY,
+    minted_at_ms INTEGER NOT NULL
+);
 "#;

--- a/crates/kirra-world-store/tests/entity_id_mint.rs
+++ b/crates/kirra-world-store/tests/entity_id_mint.rs
@@ -1,0 +1,181 @@
+//! `entity_id` minting — `WM_SCOPE.md` §5, against a real store.
+//!
+//! §6.1 requires an id to be *"stable, opaque, monotonic. Never reused, never
+//! encodes semantics."* Stable and opaque are properties of the **type**; the
+//! other two are properties of the **generator**, and this is where they are
+//! tested because a generator cannot promise them without durable state.
+//!
+//! The two tests that matter are not the happy path:
+//!
+//! 1. **Monotonic across a clock that goes backwards.** An NTP step or a VM
+//!    restore is not exotic, and an id derived from the clock alone would
+//!    regress.
+//! 2. **Never reused, enforced by the schema.** The ledger's `PRIMARY KEY` is
+//!    the guarantee; the mint does not check.
+
+use kirra_world_store::{StoreError, WorldStore};
+
+const T0: i64 = 1_700_000_000_000;
+
+fn tmp(name: &str) -> std::path::PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "kirra-world-mint-{}-{}.sqlite",
+        name,
+        std::process::id()
+    ));
+    for suffix in ["", "-wal", "-shm"] {
+        let mut q = p.as_os_str().to_os_string();
+        q.push(suffix);
+        let _ = std::fs::remove_file(std::path::PathBuf::from(q));
+    }
+    p
+}
+
+/// Distinct ids, strictly increasing, and recorded.
+#[test]
+fn minted_ids_are_distinct_and_strictly_increasing() {
+    let path = tmp("basic");
+    let mut s = WorldStore::open(&path).expect("open");
+
+    let mut seen: Vec<String> = Vec::new();
+    for n in 0..25 {
+        let id = s.mint_entity_id(T0 + n).expect("mint");
+        seen.push(id.as_str().to_owned());
+    }
+
+    let mut sorted = seen.clone();
+    sorted.sort();
+    assert_eq!(sorted, seen, "ids must come out in increasing order");
+    sorted.dedup();
+    assert_eq!(sorted.len(), seen.len(), "and every one must be distinct");
+    assert_eq!(s.minted_entity_id_count().expect("count"), 25);
+    let _ = std::fs::remove_file(&path);
+}
+
+/// **The same millisecond does not repeat an id.**
+///
+/// The branch a clock-only generator gets wrong. Every id here is built from an
+/// identical `now_ms`, so the timestamp half is constant and only the ULID
+/// increment rule separates them.
+#[test]
+fn ids_minted_within_one_millisecond_still_advance() {
+    let path = tmp("same-ms");
+    let mut s = WorldStore::open(&path).expect("open");
+
+    let mut seen: Vec<String> = Vec::new();
+    for _ in 0..50 {
+        seen.push(s.mint_entity_id(T0).expect("mint").as_str().to_owned());
+    }
+
+    let mut sorted = seen.clone();
+    sorted.sort();
+    assert_eq!(sorted, seen, "strictly increasing inside one millisecond");
+    sorted.dedup();
+    assert_eq!(sorted.len(), 50, "no repeats inside one millisecond");
+    let _ = std::fs::remove_file(&path);
+}
+
+/// **A clock that goes backwards does not regress the id.**
+///
+/// An NTP step or a VM restore moves `now_ms` back. An id derived from the
+/// clock alone would then be *lower* than one already handed out — and the next
+/// reader to sort by id would see history reorder itself.
+///
+/// This is the test that makes monotonicity a property of the STORE rather than
+/// of the caller's clock being well-behaved: the mint takes its floor from the
+/// durable high-water, so the earlier timestamp is simply ignored.
+#[test]
+fn a_clock_that_goes_backwards_does_not_regress_the_id() {
+    let path = tmp("backwards");
+    let mut s = WorldStore::open(&path).expect("open");
+
+    let forward = s.mint_entity_id(T0 + 10_000).expect("mint");
+    // ...and now the clock jumps back ten seconds.
+    let after_step = s.mint_entity_id(T0).expect("mint");
+
+    assert!(
+        after_step.as_str() > forward.as_str(),
+        "an id minted after a backwards clock step must still exceed its \
+         predecessor: {} !> {}",
+        after_step.as_str(),
+        forward.as_str()
+    );
+    let _ = std::fs::remove_file(&path);
+}
+
+/// Monotonic **across a reopen**, because the floor is on disk.
+///
+/// A generator holding its high-water in memory would restart from the clock
+/// after a process restart, which is the same regression as above with a longer
+/// fuse.
+#[test]
+fn the_monotonic_floor_survives_a_reopen() {
+    let path = tmp("reopen");
+    let last = {
+        let mut s = WorldStore::open(&path).expect("open");
+        s.mint_entity_id(T0 + 10_000)
+            .expect("mint")
+            .as_str()
+            .to_owned()
+    };
+
+    let mut s = WorldStore::open(&path).expect("reopen");
+    let after = s.mint_entity_id(T0).expect("mint");
+    assert!(
+        after.as_str() > last.as_str(),
+        "the floor must come from disk, not from process memory"
+    );
+    assert_eq!(
+        s.minted_entity_id_count().expect("count"),
+        2,
+        "the ledger carried across the reopen"
+    );
+    let _ = std::fs::remove_file(&path);
+}
+
+/// **Never-reuse is the schema's guarantee, and it is real.**
+///
+/// The mint does not check for reuse; the `PRIMARY KEY` refuses it. Asserted by
+/// writing a minted id a second time and finding the constraint fire, so the
+/// guarantee is demonstrated rather than described.
+#[test]
+fn the_ledger_refuses_a_second_write_of_the_same_id() {
+    let path = tmp("reuse");
+    let mut s = WorldStore::open(&path).expect("open");
+    let id = s.mint_entity_id(T0).expect("mint");
+
+    let err = s
+        .raw_execute_for_test(&format!(
+            "INSERT INTO entity_id_mint (entity_id, minted_at_ms) VALUES ('{}', {})",
+            id.as_str(),
+            T0
+        ))
+        .expect_err("a second write of the same id must be refused");
+    assert!(
+        matches!(err, StoreError::Sqlite(_)),
+        "expected a constraint failure, got {err}"
+    );
+    assert_eq!(s.minted_entity_id_count().expect("count"), 1);
+    let _ = std::fs::remove_file(&path);
+}
+
+/// A minted id passes the same validator a stored one must.
+///
+/// The mint constructs through `EntityId::new` rather than wrapping a string,
+/// so an id it hands out is admissible by exactly the rule the read path
+/// applies — length and control characters included.
+#[test]
+fn a_minted_id_is_admissible_by_the_types_own_rule() {
+    let path = tmp("valid");
+    let mut s = WorldStore::open(&path).expect("open");
+    let id = s.mint_entity_id(T0).expect("mint");
+
+    assert_eq!(
+        kirra_world_store::EntityId::new(id.as_str()).expect("re-admits"),
+        id,
+        "a minted id must re-admit as itself"
+    );
+    assert_eq!(id.as_str().len(), 26, "a ULID is 26 Crockford base32 chars");
+    let _ = std::fs::remove_file(&path);
+}

--- a/crates/kirra-world/src/adjudication.rs
+++ b/crates/kirra-world/src/adjudication.rs
@@ -515,6 +515,85 @@ impl SplitEntity {
     }
 }
 
+/// **An identity was asserted** — a new entity is a distinct thing.
+///
+/// The fourth verb, added 2026-08-08. The blueprint's identity pipeline names
+/// three steps and annotates two of them:
+///
+/// ```text
+/// observations ──► candidate clustering ──► identity assertion ──► entity
+///                        (pure)              (recorded Event)
+/// ```
+///
+/// The *recorded event* it names is this one, and until now it did not exist:
+/// the module had `Merge`, `Split` and `Forget` — three verbs that all **revise**
+/// an identity — and nothing for the act of first deciding there is one.
+/// `WM_SCOPE.md` §5 puts minting at Tier 2 on exactly that reading: *"minting an
+/// id is deciding that something is a distinct thing, which is adjudication"*.
+///
+/// # This records the judgement; it does not generate the id
+///
+/// The `EntityId` arrives already minted. Generation lives in the store —
+/// `WM_SCOPE.md` §4: *"the core owns the type and the layer with a clock mints
+/// the value"* — because a monotonic, never-reused id needs a clock and durable
+/// state, and this crate has no dependencies by ratification criterion.
+///
+/// The split is not merely mechanical. A minted id that no `AssertIdentity`
+/// records is an id with no justification behind it, which is the failure the
+/// other three verbs each carry a [`Justification`] to prevent.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AssertIdentity {
+    entity: EntityId,
+    justification: Justification,
+    at: DomainInstant,
+}
+
+impl AssertIdentity {
+    /// Record that an identity was asserted.
+    ///
+    /// # Why there is no refusal here, stated rather than left to be noticed
+    ///
+    /// The other three constructors refuse a self-redirect, a too-narrow split,
+    /// duplicates. This one refuses nothing beyond what its own field types
+    /// already do: [`Justification`] is non-empty and duplicate-free by
+    /// construction, and [`EntityId`] is validated by
+    /// [`crate::reference`].
+    ///
+    /// That is a real difference, not an oversight. Those refusals are all
+    /// *relational* — they compare an entity against others named in the same
+    /// event. An assertion names ONE entity and nothing to be inconsistent
+    /// with. The one check worth wanting — that this id was never asserted
+    /// before — is not answerable here: it is a question about every other
+    /// event in the log, which is the store's to answer and is enforced there
+    /// by the mint's never-reuse guarantee.
+    #[must_use]
+    pub fn new(entity: EntityId, justification: Justification, at: DomainInstant) -> Self {
+        Self {
+            entity,
+            justification,
+            at,
+        }
+    }
+
+    /// The entity being asserted into existence.
+    #[must_use]
+    pub fn entity(&self) -> &EntityId {
+        &self.entity
+    }
+
+    /// The observations that justify the judgement.
+    #[must_use]
+    pub fn justification(&self) -> &Justification {
+        &self.justification
+    }
+
+    /// When the assertion was made.
+    #[must_use]
+    pub fn at(&self) -> DomainInstant {
+        self.at
+    }
+}
+
 /// **`ForgetEntity(EntityId, Reason)`** — §14.1.
 ///
 /// *"'forget this place' is an operator-facing lifecycle transition to `Retired`
@@ -594,6 +673,8 @@ impl ForgetEntity {
 /// way to change identity should be a blueprint change first.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum IdentityAdjudication {
+    /// A new entity was asserted to be a distinct thing.
+    Assert(AssertIdentity),
     /// Several entities were one.
     Merge(MergeEntities),
     /// One entity was several.
@@ -607,6 +688,7 @@ impl IdentityAdjudication {
     #[must_use]
     pub fn at(&self) -> DomainInstant {
         match self {
+            Self::Assert(a) => a.at(),
             Self::Merge(m) => m.at(),
             Self::Split(s) => s.at(),
             Self::Forget(f) => f.at(),
@@ -617,6 +699,7 @@ impl IdentityAdjudication {
     #[must_use]
     pub fn justification(&self) -> &Justification {
         match self {
+            Self::Assert(a) => a.justification(),
             Self::Merge(m) => m.justification(),
             Self::Split(s) => s.justification(),
             Self::Forget(f) => f.justification(),
@@ -636,6 +719,21 @@ impl IdentityAdjudication {
     #[must_use]
     pub fn resulting_lifecycles(&self) -> Vec<(EntityId, Lifecycle)> {
         match self {
+            // **No lifecycle consequence, and that is not an omission.**
+            //
+            // Every entry this function returns is walked through
+            // `Lifecycle::advance_to` from every live state by
+            // `every_stated_consequence_is_a_transition_the_lifecycle_permits`.
+            // An assertion CREATES an entity: there is no prior state, so there
+            // is no transition. Its initial state comes from
+            // `Entity::provisional`, which is a constructor rather than a move.
+            //
+            // Stating `Provisional` here would be a lie the seam test correctly
+            // catches -- an established entity cannot go back to provisional,
+            // and `an_assertion_states_no_transition_because_it_creates` proves
+            // that refusal is what makes the empty vec necessary rather than
+            // convenient.
+            Self::Assert(_) => Vec::new(),
             Self::Merge(m) => m
                 .sources()
                 .iter()
@@ -685,7 +783,13 @@ impl IdentityAdjudication {
     #[must_use]
     pub fn unresolved_consequence(&self) -> Option<&EntityId> {
         match self {
-            Self::Merge(_) | Self::Forget(_) => None,
+            // An assertion has NO unresolved consequence, which is a different
+            // thing from the empty `resulting_lifecycles` above. There, the
+            // empty vec says "creation is not a transition". Here, `None` says
+            // "nothing about this event is left undecided" -- and it is true,
+            // whereas `Split` genuinely leaves its source's fate open pending
+            // KIRRA-WM-SPLIT-SURVIVAL-001.
+            Self::Assert(_) | Self::Merge(_) | Self::Forget(_) => None,
             Self::Split(s) => Some(s.source()),
         }
     }
@@ -1067,6 +1171,58 @@ mod tests {
             checked,
             5 * live.len(),
             "2 merge sources + 2 split pieces + 1 retirement, each from every live state"
+        );
+    }
+
+    /// An assertion states **no** transition, because it creates.
+    ///
+    /// The non-obvious half: this is not a gap left open like `SplitEntity`'s
+    /// source. `Provisional` is where a new entity starts, and it is reached by
+    /// `Entity::provisional` — a constructor — not by moving from somewhere.
+    ///
+    /// Proved rather than asserted: `Provisional` is *unreachable* as a
+    /// transition target from every live state, so stating it as a consequence
+    /// would make `every_stated_consequence_is_a_transition_the_lifecycle_permits`
+    /// fail. The empty vec is the only honest answer, and the walk below is why.
+    #[test]
+    fn an_assertion_states_no_transition_because_it_creates() {
+        let adj = IdentityAdjudication::Assert(AssertIdentity::new(eid("new-1"), just(), T0));
+        assert!(
+            adj.resulting_lifecycles().is_empty(),
+            "creation is not a transition"
+        );
+
+        // ...and here is why it cannot state `Provisional`.
+        for from in [
+            Lifecycle::Provisional,
+            Lifecycle::Established,
+            Lifecycle::Dormant,
+        ] {
+            assert!(
+                from.clone().advance_to(Lifecycle::Provisional).is_err(),
+                "{from:?} -> Provisional must be refused, or the empty vec above \
+                 would be a choice rather than a necessity"
+            );
+        }
+    }
+
+    /// The fourth verb carries a justification like the other three.
+    ///
+    /// Uniform on purpose: a minted id with nothing recorded behind it is an id
+    /// whose existence no one can account for, which is the failure the whole
+    /// module exists to prevent.
+    #[test]
+    fn an_assertion_rests_on_evidence_like_every_other_verb() {
+        let adj = IdentityAdjudication::Assert(AssertIdentity::new(eid("new-1"), just(), T0));
+        assert!(
+            !adj.justification().observations().is_empty(),
+            "never empty, whichever verb it is"
+        );
+        assert_eq!(adj.at(), T0);
+        assert_eq!(
+            adj.unresolved_consequence(),
+            None,
+            "nothing about an assertion is left undecided"
         );
     }
 


### PR DESCRIPTION
Closes `WM_SCOPE.md` §5's second open box. Two commits, deliberately separable —
the domain verb and the store generator.

**Based on `claude/wm-resolved-entity-projection` (#1398), not `main`**, since it
is stacked on it. Rebase target once #1398 merges.

## Why a verb at all, and not just a generator

The blueprint draws identity as three steps and annotates two:

```
observations ──► candidate clustering ──► identity assertion ──► entity
                       (pure)              (recorded Event)
```

The recorded event it names **did not exist**. The module had `Merge`, `Split`
and `Forget` — three verbs that all *revise* an identity — and nothing for the
act of first deciding there is one. `WM_SCOPE.md` §5 puts minting at Tier 2 on
exactly that reading: *"minting an id is deciding that something is a distinct
thing, which is adjudication"*. A generator with no verb would have contradicted
the argument that put the work here, and would hand out ids with no
[`Justification`] behind them.

## `766b…` `AssertIdentity` — and what it deliberately does not state

`resulting_lifecycles` returns **empty, by necessity rather than preference**.

Every entry that function returns is walked through `Lifecycle::advance_to` from
every live state by an existing seam test. An assertion **creates** an entity:
there is no prior state, so there is no transition, and its initial state comes
from `Entity::provisional` — a constructor, not a move. Stating `Provisional`
would be a lie the seam test correctly catches, and the new test proves it by
walking `Provisional` as a target from every live state and finding it refused
every time.

Distinct from `Split`'s open source, and the docs say so: the empty vec means
*creation is not a transition*; `unresolved_consequence` returning `None` means
*nothing here is undecided*. `Split` returns `Some` because its source genuinely
awaits the unruled `KIRRA-WM-SPLIT-SURVIVAL-001`.

The constructor refuses nothing beyond its field types, stated in the docs rather
than left to be noticed. The other three refuse **relational** errors —
self-redirect, too-narrow split, duplicates — all comparisons against other
entities in the same event. An assertion names one entity and nothing to
contradict. The check worth wanting, *"was this id ever asserted before"*, is a
question about the whole log and belongs to the store.

## `820b3b62` The mint

`ulid` lands exactly where `WM_SCOPE.md` §4 says it should: *"the core owns the
type and the layer with a clock mints the value"*. `kirra-world` stays
zero-dependency.

**Monotonic by the store, not by the caller's clock.** The candidate built from
`now_ms` is used only if it exceeds the durable high-water; otherwise the
previous id is incremented per the ULID monotonic rule. That branch is not an
edge case — two ids in one millisecond hit it every time, and so does a clock
that steps backwards (NTP, a VM restore). Taking the floor from disk is what
makes monotonicity a property of the *store* rather than of the clock behaving.

**Never reused by the schema, not by a check.** The `PRIMARY KEY` on
`entity_id_mint` refuses a second write, so a generator bug surfaces as a
constraint failure instead of two entities quietly sharing an identity.

The ledger is a **table and not a projection**, deliberately: a projection is
rebuilt by folding the log, and retention can compact events away — a derived set
would make a compacted id mintable again. It is never swept.

The v4 migration is wired into **both** paths, fresh-create and the `from < N`
upgrade. The second is easy to miss and would leave every existing store without
the table.

## Verification

- 196 unit + 4 doctests in `kirra-world` (194 → 196); **20 suites** across the
  three world crates (19 → 20, one new file).
- clippy `-D warnings`, fmt, rustdoc; fence INTACT (19 packages from 10 roots);
  domain-logic gate 38/38.
- **Both detached trees** in their own workspaces: `wm2-schema-growth` (30),
  `wm2-persistence-harness` (207 + 7).

**Negative controls**, each from a pristine copy:

| control | tests fired |
|---|---|
| durable floor ignored (clock alone) | 3 |
| `<=` weakened to `<` | **nothing** — see below |

**The second control is the informative one.** The two forms differ only on exact
equality with the high-water, which needs an 80-bit random collision — not
reachable without forcing the RNG. Recorded in the docs rather than covered,
because the honest reason it stays `<=` is not that a test says so: on equality
`<` would return an id already in the ledger and the `PRIMARY KEY` would refuse
the insert, so the weaker form **fails closed**. `<=` upgrades an astronomically
rare hard error into a correct increment — a cheap improvement on an already-safe
failure, not a guard the design rests on.

An earlier run of both controls silently did nothing: `cargo fmt` had reformatted
the block, so the anchors missed and two empty results looked exactly like clean
passes. Caught because a control firing *nothing* is a claim worth checking, and
re-run against the real text.

## What this does not do

`AssertIdentity` is constructible but **not persistable** — adjudication events
remain domain-only, which is gated on `KIRRA-WM-SPLIT-SURVIVAL-001`. This verb
joins the other three in that half-state rather than escaping it.

Tier 2's remaining box is **entity resolution** itself, which now has everything
it needs: a projection that names resolved entities (#1398), typed ids (#1397), a
mint for the no-match branch, and a verb to record the judgement.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_