### PR TITLE
Persist identity adjudications as evidence rows

### DIFF
--- a/crates/kirra-world-store/src/adjudication_record.rs
+++ b/crates/kirra-world-store/src/adjudication_record.rs
@@ -22,10 +22,19 @@
 //!    projection like everything else."*
 //! 2. **The ratified v1 schema already anticipated it.**
 //!    `world_events.retention_class` has carried `'adjudication'` in its closed
-//!    vocabulary since the baseline, and [`crate::compaction::PROTECTED_CLASSES`]
-//!    includes it — so an adjudication row is never compacted. That is precisely
-//!    what §6.3's *"resolvable forever"* requires, built before there was
-//!    anything to put in it.
+//!    vocabulary since the baseline, and [`crate::compaction::is_protected`]
+//!    holds for it — so an adjudication row is never compacted. That is
+//!    precisely what §6.3's *"resolvable forever"* requires, built before there
+//!    was anything to put in it.
+//!
+//!    Naming the *predicate* rather than [`crate::compaction::PROTECTED_CLASSES`],
+//!    because the two are not the same thing and the difference is easy to
+//!    state wrongly: `is_protected` is `retention_class != "raw"`, so
+//!    **everything except raw is protected** and the constant is the
+//!    enumeration OQ2 ruled, kept as documentation. Editing that array would
+//!    not change what compacts. This module's guarantee rests on the predicate,
+//!    and the test that proves it asks the compaction *planner* rather than
+//!    comparing a token.
 //! 3. **The chain.** The hash chain lives on `world_events`. A second evidence
 //!    table would need its own chain or would be unchained, and an unchained
 //!    adjudication is exactly the editable-history failure §6.3 exists to
@@ -55,6 +64,8 @@ use kirra_world::adjudication::{
 use kirra_world::observation::{ClockDomain, DomainInstant};
 use kirra_world::reference::{EntityId, ObservationId};
 
+use crate::WriterClass;
+
 /// The `world_events.kind` token every adjudication row carries.
 ///
 /// One kind for all four verbs, with the verb inside the payload, rather than
@@ -66,10 +77,15 @@ pub const ADJUDICATION_KIND: &str = "identity_adjudication";
 
 /// The `world_events.retention_class` every adjudication row carries.
 ///
-/// Not a choice this module gets to make: [`crate::compaction::PROTECTED_CLASSES`]
-/// keys "never compact this" off exactly this token, and §6.3 requires a merged
-/// id to stay resolvable forever. A row written under any other class is
-/// compactable, which would delete the redirect.
+/// Not a choice this module gets to make. §6.3 requires a merged id to stay
+/// resolvable forever, and [`crate::compaction::is_protected`] is what delivers
+/// that — it holds for every class except `"raw"`, so writing a row as `"raw"`
+/// is the one spelling that makes it compactable and deletes the redirect.
+///
+/// Note the predicate is the *mechanism*, not
+/// [`crate::compaction::PROTECTED_CLASSES`]: that constant enumerates what OQ2
+/// ruled and is not consulted by the compaction path, so editing it changes
+/// nothing.
 pub const ADJUDICATION_RETENTION_CLASS: &str = "adjudication";
 
 /// Version of the payload encoding below.
@@ -440,4 +456,40 @@ pub fn decode_adjudication(
             token: other.to_owned(),
         }),
     }
+}
+
+// ---------------------------------------------------------------------------
+// The door
+// ---------------------------------------------------------------------------
+
+/// The row-level facts a caller supplies when recording an adjudication.
+///
+/// Everything an adjudication *determines* is absent: `kind`, `subject`,
+/// `payload`, `payload_schema`, `provenance` and `retention_class` are derived
+/// by [`WorldStore::append_adjudication`], not passed in. That is the point of
+/// the type — assembling a `NewEvent` by hand means twenty fields to get right,
+/// and getting `retention_class` wrong silently makes the row compactable,
+/// which deletes the redirect §6.3 promises to keep forever.
+#[derive(Debug, Clone, Copy)]
+pub struct AdjudicationRow<'a> {
+    /// Identity of this record.
+    pub event_id: &'a kirra_world::reference::EventId,
+    /// Identity of the observation this record is of.
+    pub observation_id: &'a kirra_world::reference::ObservationId,
+    /// When the store learned the judgement.
+    pub txn_time_ms: i64,
+    /// When the judgement began holding.
+    pub valid_from_ms: i64,
+    /// Who recorded it.
+    pub source: &'a str,
+    /// Their version.
+    pub source_version: &'a str,
+    /// **Not free choice between all four classes in practice.**
+    ///
+    /// An adjudication is written [`ClaimStatus::Confirmed`] (see
+    /// [`WorldStore::append_adjudication`]), and `append`'s existing SD-2 check
+    /// refuses an [`WriterClass::LlmCandidate`] writing `Confirmed`. So **an
+    /// LLM cannot author an adjudication at all**, enforced by the rule that
+    /// already exists rather than by a new one bolted on here.
+    pub writer_class: WriterClass,
 }

--- a/crates/kirra-world-store/src/adjudication_record.rs
+++ b/crates/kirra-world-store/src/adjudication_record.rs
@@ -1,0 +1,443 @@
+//! **Persisting an identity adjudication as evidence** — §6.3, §14.3, ADR-0041.
+//!
+//! `kirra_world::adjudication` has had the four verbs since 2026-08-07 with
+//! nowhere to put them. This is the door: an [`IdentityAdjudication`] becomes a
+//! `world_events` row, and comes back out through the domain's own
+//! constructors.
+//!
+//! # Why there is no `identity_adjudications` table
+//!
+//! ADR-0041's provisional table list names one — *"`identity_adjudications`,
+//! merge/split events, resolvable forever"* — sitting unannotated among the
+//! entries marked *derived*. Read as a second **writable** table it contradicts
+//! the parenthetical three lines above it, which fixes `world_events` as *"the
+//! only writable table"*. Stating the reading rather than letting it pass as
+//! obvious, because the two readings build different systems:
+//!
+//! **Adjudications are `world_events` rows, and `identity_adjudications` is a
+//! projection over them.** Three things agree, and nothing argues the other way:
+//!
+//! 1. **The blueprint settles it directly.** §6.3: *"A query at a past instant
+//!    resolves identity as it was adjudicated then — because identity is a
+//!    projection like everything else."*
+//! 2. **The ratified v1 schema already anticipated it.**
+//!    `world_events.retention_class` has carried `'adjudication'` in its closed
+//!    vocabulary since the baseline, and [`crate::compaction::PROTECTED_CLASSES`]
+//!    includes it — so an adjudication row is never compacted. That is precisely
+//!    what §6.3's *"resolvable forever"* requires, built before there was
+//!    anything to put in it.
+//! 3. **The chain.** The hash chain lives on `world_events`. A second evidence
+//!    table would need its own chain or would be unchained, and an unchained
+//!    adjudication is exactly the editable-history failure §6.3 exists to
+//!    prevent.
+//!
+//! # The decoder goes back through the constructors
+//!
+//! [`decode_adjudication`] never assembles a verb field by field. It calls
+//! `MergeEntities::new`, `SplitEntity::partition`, `SplitEntity::subtract`,
+//! `ForgetEntity::new`, `AssertIdentity::new` — so **every refusal those
+//! constructors make is a refusal at the storage boundary**, structurally rather
+//! than by a matching list of checks that could drift.
+//!
+//! That is what carries the cardinality check `kirra_world::resolution`
+//! deliberately declined. The resolver refuses an *empty* supersession because
+//! it is unanswerable, but answers a one-element one rather than discarding a
+//! correct answer — recording that rejecting a malformed row *"belongs at the
+//! decoding boundary, fail-closed, where the store can refuse it before it is
+//! ever walked."* This is that boundary: a stored partition naming fewer than
+//! two destinations is refused here by `SplitEntity::partition` itself, so the
+//! row never becomes a `Lifecycle::Superseded` for the resolver to meet.
+
+use kirra_world::adjudication::{
+    AssertIdentity, ForgetEntity, IdentityAdjudication, Justification, MergeEntities,
+    RetirementReason, SplitEntity, SplitShape,
+};
+use kirra_world::observation::{ClockDomain, DomainInstant};
+use kirra_world::reference::{EntityId, ObservationId};
+
+/// The `world_events.kind` token every adjudication row carries.
+///
+/// One kind for all four verbs, with the verb inside the payload, rather than
+/// four kinds. The `kind` column answers *"what sort of claim is this"* for
+/// indexing and for the SD-4 spatial constraint; which judgement was made is the
+/// payload's business, and splitting it across both would give two places to
+/// look and two places to disagree.
+pub const ADJUDICATION_KIND: &str = "identity_adjudication";
+
+/// The `world_events.retention_class` every adjudication row carries.
+///
+/// Not a choice this module gets to make: [`crate::compaction::PROTECTED_CLASSES`]
+/// keys "never compact this" off exactly this token, and §6.3 requires a merged
+/// id to stay resolvable forever. A row written under any other class is
+/// compactable, which would delete the redirect.
+pub const ADJUDICATION_RETENTION_CLASS: &str = "adjudication";
+
+/// Version of the payload encoding below.
+pub const ADJUDICATION_PAYLOAD_SCHEMA: i64 = 1;
+
+/// Why a stored adjudication could not be read back.
+///
+/// **Every variant is a refusal, never a repair.** A row that cannot be decoded
+/// faithfully is not turned into a best-effort verb: an adjudication is the
+/// record of a judgement, and a guessed one is worse than a missing one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AdjudicationDecodeError {
+    /// The payload is not JSON, or not an object.
+    Malformed {
+        /// What went wrong, without echoing the payload back.
+        detail: String,
+    },
+    /// The payload's schema version is not one this build can read.
+    ///
+    /// Fail-closed on a **newer** payload for the same reason
+    /// `assert_schema_not_future` refuses a newer database: an older binary
+    /// cannot know what a later encoding means, and reading it optimistically
+    /// is how a field silently goes missing.
+    UnsupportedSchema {
+        /// The version found.
+        found: i64,
+        /// The version this build writes and reads.
+        supported: i64,
+    },
+    /// A required key is absent, or holds the wrong JSON type.
+    Field {
+        /// Which key.
+        key: &'static str,
+        /// What was expected of it.
+        detail: String,
+    },
+    /// The verb token is not one of the four.
+    UnknownVerb {
+        /// The token found.
+        token: String,
+    },
+    /// The split-shape token is neither `partition` nor `subtraction`.
+    UnknownSplitShape {
+        /// The token found.
+        token: String,
+    },
+    /// The clock-domain token is neither `boundary` nor `system`.
+    UnknownClockDomain {
+        /// The token found.
+        token: String,
+    },
+    /// **The decoded values are not one the domain admits.**
+    ///
+    /// The whole reason decoding runs through the constructors. A partition
+    /// naming one destination, a merge into one of its own sources, a duplicate
+    /// citation, an empty justification — each is refused here by the same code
+    /// that refuses it at the point of judgement, so the storage boundary cannot
+    /// be more permissive than the model.
+    Inadmissible {
+        /// The domain's own refusal, rendered.
+        detail: String,
+    },
+}
+
+impl core::fmt::Display for AdjudicationDecodeError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Malformed { detail } => write!(f, "malformed adjudication payload: {detail}"),
+            Self::UnsupportedSchema { found, supported } => write!(
+                f,
+                "adjudication payload schema {found} is not readable by this build (supports {supported})"
+            ),
+            Self::Field { key, detail } => write!(f, "adjudication payload field `{key}`: {detail}"),
+            Self::UnknownVerb { token } => write!(f, "unknown adjudication verb `{token}`"),
+            Self::UnknownSplitShape { token } => write!(f, "unknown split shape `{token}`"),
+            Self::UnknownClockDomain { token } => write!(f, "unknown clock domain `{token}`"),
+            Self::Inadmissible { detail } => {
+                write!(f, "stored adjudication is inadmissible: {detail}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for AdjudicationDecodeError {}
+
+/// **Which entity a row's `subject` column names.**
+///
+/// One column, and an adjudication can touch several entities, so this is a
+/// choice rather than a derivation. It names the entity the judgement is *about*:
+/// the survivor of a merge, the source of a split, the entity asserted or
+/// retired.
+///
+/// # What this column is NOT
+///
+/// **Not sufficient to find every entity an adjudication affects.** A merge's
+/// sources are the entities whose lifecycle changes, and they are in the
+/// payload, not here. The projection folds every adjudication row and reads
+/// payloads; it does not query by subject. Saying so because a subject index
+/// that looks like it answers "what happened to entity X" — and silently misses
+/// the merged-away ids, which are exactly the ones a caller is asking about — is
+/// worse than no index at all.
+#[must_use]
+pub fn adjudication_subject(a: &IdentityAdjudication) -> &EntityId {
+    match a {
+        IdentityAdjudication::Assert(x) => x.entity(),
+        IdentityAdjudication::Merge(m) => m.into_entity(),
+        IdentityAdjudication::Split(s) => s.source(),
+        IdentityAdjudication::Forget(f) => f.entity(),
+    }
+}
+
+/// The observation ids a row's `provenance` column should carry.
+///
+/// [`Justification`] *is* provenance in the store's sense — §14.1's `Evidence`
+/// was ruled to mean "the observations that justify the judgement", and
+/// `NewEvent::provenance` is documented as "observation ids this claim rests on
+/// (SD-3)". The same set, so it is carried in the column that already means it
+/// rather than duplicated into the payload's own list.
+#[must_use]
+pub fn adjudication_provenance(a: &IdentityAdjudication) -> Vec<String> {
+    a.justification()
+        .observations()
+        .iter()
+        .map(|o| o.as_str().to_owned())
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Encoding
+// ---------------------------------------------------------------------------
+
+fn instant_json(at: DomainInstant) -> serde_json::Value {
+    serde_json::json!({
+        "ms": at.ms,
+        // The domain is stored, never defaulted. ADR-0006's non-mixing rule is
+        // only enforceable if a stored instant still knows which clock it came
+        // from; a row that lost it could be compared with one that did not.
+        "domain": match at.domain {
+            ClockDomain::Boundary => "boundary",
+            ClockDomain::System => "system",
+        },
+    })
+}
+
+fn ids_json(ids: &[EntityId]) -> serde_json::Value {
+    serde_json::Value::Array(
+        ids.iter()
+            .map(|e| serde_json::Value::String(e.as_str().to_owned()))
+            .collect(),
+    )
+}
+
+/// Encode an adjudication as the row's `payload`.
+///
+/// The justification is **not** in here — it rides `provenance`, the column that
+/// already means it. See [`adjudication_provenance`].
+#[must_use]
+pub fn encode_adjudication(a: &IdentityAdjudication) -> String {
+    let body = match a {
+        IdentityAdjudication::Assert(x) => serde_json::json!({
+            "verb": "assert",
+            "entity": x.entity().as_str(),
+            "at": instant_json(x.at()),
+        }),
+        IdentityAdjudication::Merge(m) => serde_json::json!({
+            "verb": "merge",
+            "sources": ids_json(m.sources()),
+            "into": m.into_entity().as_str(),
+            "at": instant_json(m.at()),
+        }),
+        IdentityAdjudication::Split(s) => serde_json::json!({
+            "verb": "split",
+            "shape": match s.shape() {
+                SplitShape::Partition => "partition",
+                SplitShape::Subtraction => "subtraction",
+            },
+            "source": s.source().as_str(),
+            "into": ids_json(s.destinations()),
+            "at": instant_json(s.at()),
+        }),
+        IdentityAdjudication::Forget(f) => serde_json::json!({
+            "verb": "forget",
+            "entity": f.entity().as_str(),
+            "reason": f.reason().as_str(),
+            "at": instant_json(f.at()),
+        }),
+    };
+    body.to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Decoding — every path ends in a domain constructor
+// ---------------------------------------------------------------------------
+
+fn field<'j>(
+    o: &'j serde_json::Map<String, serde_json::Value>,
+    key: &'static str,
+) -> Result<&'j serde_json::Value, AdjudicationDecodeError> {
+    o.get(key).ok_or(AdjudicationDecodeError::Field {
+        key,
+        detail: "absent".to_owned(),
+    })
+}
+
+fn str_field(
+    o: &serde_json::Map<String, serde_json::Value>,
+    key: &'static str,
+) -> Result<String, AdjudicationDecodeError> {
+    field(o, key)?
+        .as_str()
+        .map(str::to_owned)
+        .ok_or(AdjudicationDecodeError::Field {
+            key,
+            detail: "expected a string".to_owned(),
+        })
+}
+
+fn entity_field(
+    o: &serde_json::Map<String, serde_json::Value>,
+    key: &'static str,
+) -> Result<EntityId, AdjudicationDecodeError> {
+    EntityId::new(&str_field(o, key)?).map_err(|e| AdjudicationDecodeError::Field {
+        key,
+        detail: format!("not an admissible entity id: {e:?}"),
+    })
+}
+
+fn entity_list_field(
+    o: &serde_json::Map<String, serde_json::Value>,
+    key: &'static str,
+) -> Result<Vec<EntityId>, AdjudicationDecodeError> {
+    let arr = field(o, key)?
+        .as_array()
+        .ok_or(AdjudicationDecodeError::Field {
+            key,
+            detail: "expected an array".to_owned(),
+        })?;
+    arr.iter()
+        .map(|v| {
+            let s = v.as_str().ok_or(AdjudicationDecodeError::Field {
+                key,
+                detail: "expected an array of strings".to_owned(),
+            })?;
+            EntityId::new(s).map_err(|e| AdjudicationDecodeError::Field {
+                key,
+                detail: format!("not an admissible entity id: {e:?}"),
+            })
+        })
+        .collect()
+}
+
+fn instant_field(
+    o: &serde_json::Map<String, serde_json::Value>,
+    key: &'static str,
+) -> Result<DomainInstant, AdjudicationDecodeError> {
+    let obj = field(o, key)?
+        .as_object()
+        .ok_or(AdjudicationDecodeError::Field {
+            key,
+            detail: "expected an object".to_owned(),
+        })?;
+    let ms = field(obj, "ms")?
+        .as_u64()
+        .ok_or(AdjudicationDecodeError::Field {
+            key: "ms",
+            detail: "expected a non-negative integer".to_owned(),
+        })?;
+    let domain = match str_field(obj, "domain")?.as_str() {
+        "boundary" => ClockDomain::Boundary,
+        "system" => ClockDomain::System,
+        other => {
+            return Err(AdjudicationDecodeError::UnknownClockDomain {
+                token: other.to_owned(),
+            })
+        }
+    };
+    Ok(DomainInstant { ms, domain })
+}
+
+fn inadmissible<E: core::fmt::Debug>(e: E) -> AdjudicationDecodeError {
+    AdjudicationDecodeError::Inadmissible {
+        detail: format!("{e:?}"),
+    }
+}
+
+/// **Read a stored adjudication back, or refuse.**
+///
+/// `justification` comes from the row's `provenance` column, not the payload.
+///
+/// # Errors
+///
+/// Every [`AdjudicationDecodeError`]. Note the last one: the verb is rebuilt by
+/// the domain's own constructor, so a stored partition into one destination, a
+/// merge into its own source, or a duplicate citation is refused **here** — the
+/// storage boundary cannot admit a judgement the model would not.
+pub fn decode_adjudication(
+    payload: &str,
+    payload_schema: i64,
+    justification: &[String],
+) -> Result<IdentityAdjudication, AdjudicationDecodeError> {
+    if payload_schema != ADJUDICATION_PAYLOAD_SCHEMA {
+        return Err(AdjudicationDecodeError::UnsupportedSchema {
+            found: payload_schema,
+            supported: ADJUDICATION_PAYLOAD_SCHEMA,
+        });
+    }
+
+    let value: serde_json::Value =
+        serde_json::from_str(payload).map_err(|e| AdjudicationDecodeError::Malformed {
+            detail: format!("not JSON: {e}"),
+        })?;
+    let o = value
+        .as_object()
+        .ok_or_else(|| AdjudicationDecodeError::Malformed {
+            detail: "top level is not an object".to_owned(),
+        })?;
+
+    let cited: Vec<ObservationId> = justification
+        .iter()
+        .map(|s| {
+            ObservationId::new(s).map_err(|e| AdjudicationDecodeError::Field {
+                key: "provenance",
+                detail: format!("not an admissible observation id: {e:?}"),
+            })
+        })
+        .collect::<Result<_, _>>()?;
+    let justification = Justification::new(cited).map_err(inadmissible)?;
+    let at = instant_field(o, "at")?;
+
+    match str_field(o, "verb")?.as_str() {
+        "assert" => Ok(IdentityAdjudication::Assert(AssertIdentity::new(
+            entity_field(o, "entity")?,
+            justification,
+            at,
+        ))),
+        "merge" => MergeEntities::new(
+            entity_list_field(o, "sources")?,
+            entity_field(o, "into")?,
+            justification,
+            at,
+        )
+        .map(IdentityAdjudication::Merge)
+        .map_err(inadmissible),
+        "split" => {
+            let source = entity_field(o, "source")?;
+            let into = entity_list_field(o, "into")?;
+            let built = match str_field(o, "shape")?.as_str() {
+                "partition" => SplitEntity::partition(source, into, justification, at),
+                "subtraction" => SplitEntity::subtract(source, into, justification, at),
+                other => {
+                    return Err(AdjudicationDecodeError::UnknownSplitShape {
+                        token: other.to_owned(),
+                    })
+                }
+            };
+            built.map(IdentityAdjudication::Split).map_err(inadmissible)
+        }
+        "forget" => {
+            let reason = RetirementReason::new(&str_field(o, "reason")?).map_err(inadmissible)?;
+            Ok(IdentityAdjudication::Forget(ForgetEntity::new(
+                entity_field(o, "entity")?,
+                reason,
+                justification,
+                at,
+            )))
+        }
+        other => Err(AdjudicationDecodeError::UnknownVerb {
+            token: other.to_owned(),
+        }),
+    }
+}

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -1216,6 +1216,60 @@ impl WorldStore {
         Ok(generation)
     }
 
+    /// **Record an identity adjudication.** The single door for §14.3's
+    /// `EntityMerged` / `EntitySplit` / `EntityRetired` / `EntityEstablished`.
+    ///
+    /// `claim_status` is always [`ClaimStatus::Confirmed`] and is not a
+    /// parameter: §6.3's pipeline makes candidate clustering the *pure* step and
+    /// identity assertion the *recorded event*, so a judgement is by definition
+    /// not a candidate. A candidate merge *suggestion* is a different thing that
+    /// would need its own ruling, not a flag here — and hardcoding this is what
+    /// makes the LLM exclusion structural, since `append` already refuses an
+    /// `LlmCandidate` writing `Confirmed`.
+    ///
+    /// `frame_id` and `map_id` are `None`: an adjudication is a claim about
+    /// identity, not about space, so `kind` is never `"spatial"` and SD-4 does
+    /// not apply.
+    ///
+    /// # Errors
+    ///
+    /// Whatever [`WorldStore::append`] refuses — notably
+    /// [`StoreError::LlmCannotConfirm`] for the case above.
+    pub fn append_adjudication(
+        &mut self,
+        row: &adjudication_record::AdjudicationRow<'_>,
+        adjudication: &kirra_world::adjudication::IdentityAdjudication,
+    ) -> Result<i64, StoreError> {
+        let payload = adjudication_record::encode_adjudication(adjudication);
+        let provenance = adjudication_record::adjudication_provenance(adjudication);
+        let prov: Vec<&str> = provenance.iter().map(String::as_str).collect();
+        let subject = adjudication_record::adjudication_subject(adjudication).as_str();
+
+        self.append(&NewEvent {
+            event_id: row.event_id,
+            observation_id: row.observation_id,
+            txn_time_ms: row.txn_time_ms,
+            valid_from_ms: row.valid_from_ms,
+            valid_to_ms: None,
+            source: row.source,
+            source_version: row.source_version,
+            writer_class: row.writer_class,
+            claim_status: ClaimStatus::Confirmed,
+            provenance: &prov,
+            frame_id: None,
+            map_id: None,
+            kind: adjudication_record::ADJUDICATION_KIND,
+            subject,
+            subject_ref: None,
+            predicate: None,
+            object: None,
+            payload: &payload,
+            payload_schema: adjudication_record::ADJUDICATION_PAYLOAD_SCHEMA,
+            retention_class: adjudication_record::ADJUDICATION_RETENTION_CLASS,
+            trust: None,
+        })
+    }
+
     /// Recompute the chain from genesis and compare against what is stored.
     ///
     /// This is what makes SD-2 structural: an edit to `writer_class` or

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -82,6 +82,7 @@ use std::path::Path;
 use kirra_world::retention::RetentionError;
 use rusqlite::{params, Connection, OptionalExtension};
 
+pub mod adjudication_record;
 pub mod compaction;
 pub mod projection;
 pub mod retention_driver;

--- a/crates/kirra-world-store/tests/adjudication_record.rs
+++ b/crates/kirra-world-store/tests/adjudication_record.rs
@@ -17,12 +17,12 @@ use kirra_world::adjudication::{
 };
 use kirra_world::observation::{ClockDomain, DomainInstant};
 use kirra_world::reference::{EntityId, EventId, ObservationId};
+use kirra_world_store::adjudication_record::AdjudicationRow;
 use kirra_world_store::adjudication_record::{
     adjudication_provenance, adjudication_subject, decode_adjudication, encode_adjudication,
-    AdjudicationDecodeError, ADJUDICATION_KIND, ADJUDICATION_PAYLOAD_SCHEMA,
-    ADJUDICATION_RETENTION_CLASS,
+    AdjudicationDecodeError, ADJUDICATION_PAYLOAD_SCHEMA, ADJUDICATION_RETENTION_CLASS,
 };
-use kirra_world_store::{ClaimStatus, NewEvent, WorldStore, WriterClass};
+use kirra_world_store::{ClaimStatus, NewEvent, StoreError, WorldStore, WriterClass};
 
 const T0: i64 = 1_700_000_000_000;
 
@@ -42,6 +42,21 @@ fn at() -> DomainInstant {
     DomainInstant {
         ms: 1_700_000_000_000,
         domain: ClockDomain::System,
+    }
+}
+
+/// Remove the database **and its WAL sidecars**.
+///
+/// `WorldStore` opens in WAL mode, so `-wal` and `-shm` outlive the `.sqlite`
+/// file. Removing only the main file leaves them in the temp dir, where they
+/// clutter a CI runner and — worse locally — a rerun can find a stale sidecar
+/// beside a fresh database. `tmp()` already clears all three going in; this is
+/// the same job on the way out.
+fn cleanup(path: &std::path::Path) {
+    for suffix in ["", "-wal", "-shm"] {
+        let mut q = path.as_os_str().to_os_string();
+        q.push(suffix);
+        let _ = std::fs::remove_file(std::path::PathBuf::from(q));
     }
 }
 
@@ -111,32 +126,19 @@ fn every_verb_round_trips_through_a_real_row() {
         let observation_id = oid(&format!("obs-src-{i}"));
         let payload = encode_adjudication(&adj);
         let provenance = adjudication_provenance(&adj);
-        let prov_refs: Vec<&str> = provenance.iter().map(String::as_str).collect();
-        let subject = adjudication_subject(&adj).as_str().to_owned();
 
-        s.append(&NewEvent {
-            event_id: &event_id,
-            observation_id: &observation_id,
-            txn_time_ms: T0 + i as i64,
-            valid_from_ms: T0 + i as i64,
-            valid_to_ms: None,
-            source: "operator-console",
-            source_version: "1.0.0",
-            writer_class: WriterClass::Operator,
-            claim_status: ClaimStatus::Confirmed,
-            provenance: &prov_refs,
-            frame_id: None,
-            map_id: None,
-            kind: ADJUDICATION_KIND,
-            subject: &subject,
-            subject_ref: None,
-            predicate: None,
-            object: None,
-            payload: &payload,
-            payload_schema: ADJUDICATION_PAYLOAD_SCHEMA,
-            retention_class: ADJUDICATION_RETENTION_CLASS,
-            trust: None,
-        })
+        s.append_adjudication(
+            &AdjudicationRow {
+                event_id: &event_id,
+                observation_id: &observation_id,
+                txn_time_ms: T0 + i as i64,
+                valid_from_ms: T0 + i as i64,
+                source: "operator-console",
+                source_version: "1.0.0",
+                writer_class: WriterClass::Operator,
+            },
+            &adj,
+        )
         .unwrap_or_else(|e| panic!("{name}: append refused: {e:?}"));
 
         let back = decode_adjudication(&payload, ADJUDICATION_PAYLOAD_SCHEMA, &provenance)
@@ -146,7 +148,7 @@ fn every_verb_round_trips_through_a_real_row() {
 
     s.verify_chain()
         .expect("the chain must still verify after adjudication rows");
-    let _ = std::fs::remove_file(&path);
+    cleanup(&path);
 }
 
 /// The justification rides `provenance`, and is what comes back.
@@ -355,12 +357,136 @@ fn structural_damage_is_refused_with_a_reason() {
 ///
 /// §6.3 requires a merged id to stay resolvable *forever*, and the only thing
 /// keeping an adjudication row out of a compaction window is its retention
-/// class. Asserted here rather than trusted, because the constant and the
-/// protected list are declared in different modules.
+/// class. Asserted rather than trusted, because the constant this module writes
+/// and the compaction *policy predicate* that honours it live in different
+/// modules with nothing tying them together.
+///
+/// Note what the predicate actually is: `is_protected` is
+/// `retention_class != "raw"`, so everything except raw is protected and
+/// `PROTECTED_CLASSES` is an enumeration kept as documentation, not the rule.
+/// This asserts the predicate; `an_adjudication_row_makes_its_window_uncompactable`
+/// asserts the behaviour it is supposed to buy.
 #[test]
 fn the_adjudication_retention_class_is_protected_from_compaction() {
     assert!(
         kirra_world_store::compaction::is_protected(ADJUDICATION_RETENTION_CLASS),
         "an adjudication row must never be compactable"
     );
+}
+
+/// **An LLM cannot author an adjudication**, and not because this module says
+/// so.
+///
+/// `append_adjudication` writes `ClaimStatus::Confirmed` unconditionally — a
+/// judgement is not a candidate — and `append`'s existing SD-2 rule refuses an
+/// `LlmCandidate` writing `Confirmed`. The exclusion is therefore structural:
+/// it falls out of a rule that predates this slice, with no new check to
+/// remember. Asserted because a later "make claim_status a parameter" would
+/// quietly reopen it.
+#[test]
+fn an_llm_cannot_author_an_adjudication() {
+    let path = tmp("llm");
+    let mut s = WorldStore::open(&path).expect("open");
+    let event_id = EventId::new("ev-llm").expect("event id");
+    let observation_id = oid("obs-llm");
+    let adj = IdentityAdjudication::Merge(
+        MergeEntities::new([eid("a"), eid("b")], eid("keep"), just(), at()).expect("merge"),
+    );
+
+    let err = s
+        .append_adjudication(
+            &AdjudicationRow {
+                event_id: &event_id,
+                observation_id: &observation_id,
+                txn_time_ms: T0,
+                valid_from_ms: T0,
+                source: "some-llm",
+                source_version: "1.0.0",
+                writer_class: WriterClass::LlmCandidate,
+            },
+            &adj,
+        )
+        .expect_err("an LLM must not be able to record a judgement");
+    assert!(
+        matches!(err, StoreError::LlmCannotConfirm),
+        "expected the pre-existing SD-2 refusal, got {err:?}"
+    );
+    cleanup(&path);
+}
+
+/// **The door derives what the caller must not get wrong — proved by
+/// behaviour, not by reading a column back.**
+///
+/// Chiefly `retention_class`. A hand-assembled row that set it to `"raw"` would
+/// be compactable, and compaction would delete the redirect §6.3 promises to
+/// keep forever. So rather than string-compare the stored token, this asks the
+/// compaction planner: an adjudication row must make its own window
+/// **refuse to compact**, which is the guarantee the token exists to buy.
+#[test]
+fn an_adjudication_row_makes_its_window_uncompactable() {
+    let path = tmp("uncompactable");
+    let mut s = WorldStore::open(&path).expect("open");
+    let event_id = EventId::new("ev-stamp").expect("event id");
+    let observation_id = oid("obs-stamp");
+    let adj = IdentityAdjudication::Assert(AssertIdentity::new(eid("e-1"), just(), at()));
+
+    let generation = s
+        .append_adjudication(
+            &AdjudicationRow {
+                event_id: &event_id,
+                observation_id: &observation_id,
+                txn_time_ms: T0,
+                valid_from_ms: T0,
+                source: "operator-console",
+                source_version: "1.0.0",
+                writer_class: WriterClass::Operator,
+            },
+            &adj,
+        )
+        .expect("append");
+
+    assert_eq!(
+        s.largest_compactable_prefix(generation, generation)
+            .expect("plan"),
+        None,
+        "a window holding an adjudication must refuse to compact -- otherwise \
+         the redirect that keeps a merged id resolvable can be deleted"
+    );
+
+    // Non-vacuous: the same planner DOES accept an ordinary row, so the `None`
+    // above is the retention class talking and not an empty or malformed window.
+    let raw_id = EventId::new("ev-raw").expect("event id");
+    let raw_obs = oid("obs-raw");
+    let raw_gen = s
+        .append(&NewEvent {
+            event_id: &raw_id,
+            observation_id: &raw_obs,
+            txn_time_ms: T0 + 1,
+            valid_from_ms: T0 + 1,
+            valid_to_ms: None,
+            source: "sensor",
+            source_version: "1.0.0",
+            writer_class: WriterClass::Sensor,
+            claim_status: ClaimStatus::Confirmed,
+            provenance: &[],
+            frame_id: None,
+            map_id: None,
+            kind: "observation",
+            subject: "thing",
+            subject_ref: None,
+            predicate: None,
+            object: None,
+            payload: "{}",
+            payload_schema: 1,
+            retention_class: "raw",
+            trust: None,
+        })
+        .expect("append raw");
+    assert_eq!(
+        s.largest_compactable_prefix(raw_gen, raw_gen)
+            .expect("plan"),
+        Some(raw_gen),
+        "an ordinary raw row must be compactable, or the assertion above proves nothing"
+    );
+    cleanup(&path);
 }

--- a/crates/kirra-world-store/tests/adjudication_record.rs
+++ b/crates/kirra-world-store/tests/adjudication_record.rs
@@ -1,0 +1,366 @@
+//! Persisting an identity adjudication as evidence — `WM_SCOPE.md` §5.
+//!
+//! Two things are being demonstrated, and only the second is interesting:
+//!
+//! 1. Every verb round-trips through a **real `world_events` row**, chain
+//!    intact. Written against the store rather than against the codec alone,
+//!    because a codec that round-trips in memory and cannot survive `append`'s
+//!    constraints has proved nothing.
+//! 2. **A malformed row is refused, not repaired.** Decoding goes back through
+//!    the domain's constructors, so the refusals are the model's own — the tests
+//!    below feed the decoder rows that no honest writer produces and check that
+//!    the storage boundary is exactly as strict as the point of judgement.
+
+use kirra_world::adjudication::{
+    AssertIdentity, ForgetEntity, IdentityAdjudication, Justification, MergeEntities,
+    RetirementReason, SplitEntity,
+};
+use kirra_world::observation::{ClockDomain, DomainInstant};
+use kirra_world::reference::{EntityId, EventId, ObservationId};
+use kirra_world_store::adjudication_record::{
+    adjudication_provenance, adjudication_subject, decode_adjudication, encode_adjudication,
+    AdjudicationDecodeError, ADJUDICATION_KIND, ADJUDICATION_PAYLOAD_SCHEMA,
+    ADJUDICATION_RETENTION_CLASS,
+};
+use kirra_world_store::{ClaimStatus, NewEvent, WorldStore, WriterClass};
+
+const T0: i64 = 1_700_000_000_000;
+
+fn eid(s: &str) -> EntityId {
+    EntityId::new(s).expect("entity id")
+}
+
+fn oid(s: &str) -> ObservationId {
+    ObservationId::new(s).expect("observation id")
+}
+
+fn just() -> Justification {
+    Justification::new([oid("obs-1"), oid("obs-2")]).expect("justification")
+}
+
+fn at() -> DomainInstant {
+    DomainInstant {
+        ms: 1_700_000_000_000,
+        domain: ClockDomain::System,
+    }
+}
+
+fn tmp(name: &str) -> std::path::PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!("kirra-adj-{}-{}.sqlite", name, std::process::id()));
+    for suffix in ["", "-wal", "-shm"] {
+        let mut q = p.as_os_str().to_os_string();
+        q.push(suffix);
+        let _ = std::fs::remove_file(std::path::PathBuf::from(q));
+    }
+    p
+}
+
+fn every_verb() -> Vec<(&'static str, IdentityAdjudication)> {
+    vec![
+        (
+            "assert",
+            IdentityAdjudication::Assert(AssertIdentity::new(eid("e-new"), just(), at())),
+        ),
+        (
+            "merge",
+            IdentityAdjudication::Merge(
+                MergeEntities::new([eid("a"), eid("b")], eid("keep"), just(), at()).expect("merge"),
+            ),
+        ),
+        (
+            "split/partition",
+            IdentityAdjudication::Split(
+                SplitEntity::partition(eid("p"), [eid("p1"), eid("p2")], just(), at())
+                    .expect("partition"),
+            ),
+        ),
+        (
+            "split/subtraction",
+            IdentityAdjudication::Split(
+                SplitEntity::subtract(eid("s"), [eid("off")], just(), at()).expect("subtract"),
+            ),
+        ),
+        (
+            "forget",
+            IdentityAdjudication::Forget(ForgetEntity::new(
+                eid("gone"),
+                RetirementReason::new("decommissioned").expect("reason"),
+                just(),
+                at(),
+            )),
+        ),
+    ]
+}
+
+/// **Every verb survives a real append and comes back identical**, and the
+/// chain still verifies.
+///
+/// Both split *shapes* are here. They differ only by a token in the payload and
+/// by which lifecycle they imply, so an encoding that dropped `shape` would
+/// round-trip a partition as a subtraction — silently turning a superseded
+/// source back into a surviving one, undoing `KIRRA-WM-SPLIT-SURVIVAL-001` at
+/// the storage layer.
+#[test]
+fn every_verb_round_trips_through_a_real_row() {
+    let path = tmp("roundtrip");
+    let mut s = WorldStore::open(&path).expect("open");
+
+    for (i, (name, adj)) in every_verb().into_iter().enumerate() {
+        let event_id = EventId::new(format!("ev-{i}")).expect("event id");
+        let observation_id = oid(&format!("obs-src-{i}"));
+        let payload = encode_adjudication(&adj);
+        let provenance = adjudication_provenance(&adj);
+        let prov_refs: Vec<&str> = provenance.iter().map(String::as_str).collect();
+        let subject = adjudication_subject(&adj).as_str().to_owned();
+
+        s.append(&NewEvent {
+            event_id: &event_id,
+            observation_id: &observation_id,
+            txn_time_ms: T0 + i as i64,
+            valid_from_ms: T0 + i as i64,
+            valid_to_ms: None,
+            source: "operator-console",
+            source_version: "1.0.0",
+            writer_class: WriterClass::Operator,
+            claim_status: ClaimStatus::Confirmed,
+            provenance: &prov_refs,
+            frame_id: None,
+            map_id: None,
+            kind: ADJUDICATION_KIND,
+            subject: &subject,
+            subject_ref: None,
+            predicate: None,
+            object: None,
+            payload: &payload,
+            payload_schema: ADJUDICATION_PAYLOAD_SCHEMA,
+            retention_class: ADJUDICATION_RETENTION_CLASS,
+            trust: None,
+        })
+        .unwrap_or_else(|e| panic!("{name}: append refused: {e:?}"));
+
+        let back = decode_adjudication(&payload, ADJUDICATION_PAYLOAD_SCHEMA, &provenance)
+            .unwrap_or_else(|e| panic!("{name}: decode refused: {e}"));
+        assert_eq!(back, adj, "{name}: did not round-trip");
+    }
+
+    s.verify_chain()
+        .expect("the chain must still verify after adjudication rows");
+    let _ = std::fs::remove_file(&path);
+}
+
+/// The justification rides `provenance`, and is what comes back.
+///
+/// It is deliberately not duplicated into the payload: two copies of the same
+/// set is two things that can disagree, and the column already means "the
+/// observation ids this claim rests on".
+#[test]
+fn the_justification_travels_in_the_provenance_column() {
+    let adj = IdentityAdjudication::Assert(AssertIdentity::new(eid("e-1"), just(), at()));
+    let payload = encode_adjudication(&adj);
+
+    assert!(
+        !payload.contains("obs-1"),
+        "the payload must not carry a second copy of the justification: {payload}"
+    );
+    assert_eq!(
+        adjudication_provenance(&adj),
+        vec!["obs-1".to_owned(), "obs-2".to_owned()]
+    );
+
+    let back = decode_adjudication(
+        &payload,
+        ADJUDICATION_PAYLOAD_SCHEMA,
+        &adjudication_provenance(&adj),
+    )
+    .expect("decode");
+    assert_eq!(back.justification().observations(), just().observations());
+}
+
+/// The subject column names the entity the judgement is *about*, per verb.
+#[test]
+fn the_subject_is_the_entity_the_judgement_is_about() {
+    let expected = ["e-new", "keep", "p", "s", "gone"];
+    for ((name, adj), want) in every_verb().into_iter().zip(expected) {
+        assert_eq!(
+            adjudication_subject(&adj).as_str(),
+            want,
+            "{name}: wrong subject"
+        );
+    }
+}
+
+// -- Fail-closed decoding -------------------------------------------------
+
+/// **The check `kirra_world::resolution` declined to make, made here.**
+///
+/// The resolver answers a one-element supersession rather than discarding a
+/// correct answer, and records that rejecting the malformed row belongs at the
+/// decoding boundary. This is that boundary. A stored partition naming one
+/// destination is refused by `SplitEntity::partition` itself, so it never
+/// becomes a `Lifecycle::Superseded` for the resolver to meet.
+#[test]
+fn a_stored_partition_into_one_destination_is_refused() {
+    let payload = r#"{"verb":"split","shape":"partition","source":"p","into":["only"],
+                      "at":{"ms":1,"domain":"system"}}"#;
+    let err = decode_adjudication(payload, ADJUDICATION_PAYLOAD_SCHEMA, &["obs-1".to_owned()])
+        .expect_err("a partition into one is not a partition");
+    assert!(
+        matches!(err, AdjudicationDecodeError::Inadmissible { .. }),
+        "expected the domain's own refusal, got {err}"
+    );
+}
+
+/// And the empty case, which is the one the resolver refuses outright.
+#[test]
+fn a_stored_partition_into_nothing_is_refused() {
+    let payload = r#"{"verb":"split","shape":"partition","source":"p","into":[],
+                      "at":{"ms":1,"domain":"system"}}"#;
+    assert!(matches!(
+        decode_adjudication(payload, ADJUDICATION_PAYLOAD_SCHEMA, &["obs-1".to_owned()]),
+        Err(AdjudicationDecodeError::Inadmissible { .. })
+    ));
+}
+
+/// A merge into one of its own sources is a self-redirect — the resolution loop
+/// `MergeEntities::new` refuses, refused again on the way back in.
+#[test]
+fn a_stored_self_merge_is_refused() {
+    let payload = r#"{"verb":"merge","sources":["a","b"],"into":"a",
+                      "at":{"ms":1,"domain":"system"}}"#;
+    assert!(matches!(
+        decode_adjudication(payload, ADJUDICATION_PAYLOAD_SCHEMA, &["obs-1".to_owned()]),
+        Err(AdjudicationDecodeError::Inadmissible { .. })
+    ));
+}
+
+/// An adjudication with no evidence is not an adjudication. The empty
+/// `provenance` case, refused by `Justification::new`.
+#[test]
+fn a_row_citing_no_evidence_is_refused() {
+    let payload = r#"{"verb":"assert","entity":"e-1","at":{"ms":1,"domain":"system"}}"#;
+    assert!(matches!(
+        decode_adjudication(payload, ADJUDICATION_PAYLOAD_SCHEMA, &[]),
+        Err(AdjudicationDecodeError::Inadmissible { .. })
+    ));
+}
+
+/// An unknown verb is refused rather than degraded.
+///
+/// Contrast `ObservationKind`, which degrades an unrecognised token to
+/// `Unknown` on purpose. That is right for a *classification* — a consumer can
+/// carry on without knowing the kind. It is wrong for a judgement: degrading
+/// `EntityMerged` to "some adjudication" would drop the redirect and leave the
+/// merged-away id resolving to itself, which §6.3 forbids.
+#[test]
+fn an_unknown_verb_is_refused_rather_than_degraded() {
+    let payload = r#"{"verb":"annihilate","entity":"e-1","at":{"ms":1,"domain":"system"}}"#;
+    assert_eq!(
+        decode_adjudication(payload, ADJUDICATION_PAYLOAD_SCHEMA, &["obs-1".to_owned()]),
+        Err(AdjudicationDecodeError::UnknownVerb {
+            token: "annihilate".to_owned()
+        })
+    );
+}
+
+/// An unknown split shape is refused, not defaulted to partition.
+///
+/// Defaulting would supersede a source that survived — inventing the more
+/// destructive of the two readings from a token nobody wrote.
+#[test]
+fn an_unknown_split_shape_is_refused_not_defaulted() {
+    let payload = r#"{"verb":"split","shape":"bisect","source":"p","into":["a","b"],
+                      "at":{"ms":1,"domain":"system"}}"#;
+    assert_eq!(
+        decode_adjudication(payload, ADJUDICATION_PAYLOAD_SCHEMA, &["obs-1".to_owned()]),
+        Err(AdjudicationDecodeError::UnknownSplitShape {
+            token: "bisect".to_owned()
+        })
+    );
+}
+
+/// An unknown clock domain is refused rather than assumed.
+///
+/// ADR-0006's non-mixing rule is only enforceable if a stored instant still
+/// knows its clock. Defaulting to `System` would let a boundary-domain instant
+/// be compared with a system one — the comparison `DomainInstant::compare`
+/// exists to refuse.
+#[test]
+fn an_unknown_clock_domain_is_refused_rather_than_assumed() {
+    let payload = r#"{"verb":"assert","entity":"e-1","at":{"ms":1,"domain":"wallclock"}}"#;
+    assert_eq!(
+        decode_adjudication(payload, ADJUDICATION_PAYLOAD_SCHEMA, &["obs-1".to_owned()]),
+        Err(AdjudicationDecodeError::UnknownClockDomain {
+            token: "wallclock".to_owned()
+        })
+    );
+}
+
+/// A newer payload schema is refused, matching `assert_schema_not_future`.
+#[test]
+fn a_future_payload_schema_is_refused() {
+    let adj = IdentityAdjudication::Assert(AssertIdentity::new(eid("e-1"), just(), at()));
+    let payload = encode_adjudication(&adj);
+    assert_eq!(
+        decode_adjudication(
+            &payload,
+            ADJUDICATION_PAYLOAD_SCHEMA + 1,
+            &["obs-1".to_owned()]
+        ),
+        Err(AdjudicationDecodeError::UnsupportedSchema {
+            found: ADJUDICATION_PAYLOAD_SCHEMA + 1,
+            supported: ADJUDICATION_PAYLOAD_SCHEMA,
+        })
+    );
+}
+
+/// Garbage, a missing key, and a wrong JSON type are each refused distinctly.
+#[test]
+fn structural_damage_is_refused_with_a_reason() {
+    let cases: Vec<(&str, &str)> = vec![
+        ("not json at all", "{{{"),
+        ("not an object", "[1,2,3]"),
+        (
+            "missing the verb",
+            r#"{"entity":"e-1","at":{"ms":1,"domain":"system"}}"#,
+        ),
+        (
+            "verb is not a string",
+            r#"{"verb":7,"at":{"ms":1,"domain":"system"}}"#,
+        ),
+        ("missing the instant", r#"{"verb":"assert","entity":"e-1"}"#),
+        (
+            "sources is not an array",
+            r#"{"verb":"merge","sources":"a","into":"b","at":{"ms":1,"domain":"system"}}"#,
+        ),
+        (
+            "a negative instant",
+            r#"{"verb":"assert","entity":"e-1","at":{"ms":-5,"domain":"system"}}"#,
+        ),
+        (
+            "an inadmissible entity id",
+            r#"{"verb":"assert","entity":"","at":{"ms":1,"domain":"system"}}"#,
+        ),
+    ];
+    for (name, payload) in cases {
+        assert!(
+            decode_adjudication(payload, ADJUDICATION_PAYLOAD_SCHEMA, &["obs-1".to_owned()])
+                .is_err(),
+            "{name}: decoded a row that should have been refused"
+        );
+    }
+}
+
+/// **A row written under a compactable retention class would lose the redirect.**
+///
+/// §6.3 requires a merged id to stay resolvable *forever*, and the only thing
+/// keeping an adjudication row out of a compaction window is its retention
+/// class. Asserted here rather than trusted, because the constant and the
+/// protected list are declared in different modules.
+#[test]
+fn the_adjudication_retention_class_is_protected_from_compaction() {
+    assert!(
+        kirra_world_store::compaction::is_protected(ADJUDICATION_RETENTION_CLASS),
+        "an adjudication row must never be compactable"
+    );
+}

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -755,8 +755,8 @@ does not describe is how a residue disappears.
       `adjudication`: it walks judgements, nothing persists them. (Sub-slice 3
       below closes that.)
 - [x] **Adjudication events persist as evidence rows** — **DONE 2026-08-08**,
-      `crates/kirra-world-store/src/adjudication_record.rs`, 13 integration
-      tests. The schema slice `KIRRA-WM-SPLIT-SURVIVAL-001` named as unblocked
+      `crates/kirra-world-store/src/adjudication_record.rs` plus the
+      `WorldStore::append_adjudication` door, 15 integration tests. The schema slice `KIRRA-WM-SPLIT-SURVIVAL-001` named as unblocked
       and did not build. Sub-slice 1 of 3.
       **No new table, and that is the finding rather than a shortcut.** Three
       sources agree that adjudications are `world_events` rows and that entity
@@ -765,10 +765,18 @@ does not describe is how a residue disappears.
       §6.3 says *"identity is a projection like everything else"*; and the
       **ratified v1 baseline already anticipated it** — `retention_class` has
       carried `'adjudication'` in its closed vocabulary since the beginning and
-      `compaction::PROTECTED_CLASSES` includes it, so such a row is never
-      compacted, which is exactly what §6.3's *"resolvable forever"* needs. That
-      protection is asserted by test, not assumed, because the constant and the
-      protected list live in different modules.
+      `compaction::is_protected` holds for it, so such a row is never compacted,
+      which is exactly what §6.3's *"resolvable forever"* needs.
+      Naming the **predicate**, not `compaction::PROTECTED_CLASSES`: the two are
+      not the same thing, and the difference is easy to state wrongly (this
+      section did, and review caught it). `is_protected` is
+      `retention_class != "raw"` — everything except raw is protected — and the
+      constant is the enumeration OQ2 ruled, kept as documentation and not
+      consulted by the compaction path, so editing it would change nothing. The
+      guarantee is asserted end-to-end rather than by token comparison: an
+      adjudication row makes its own window **refuse to compact** when asked of
+      the real planner, with an ordinary raw row in the same test proving the
+      refusal is the retention class talking and not an empty window.
       **ADR-0041's provisional list also names `identity_adjudications`,
       unannotated, among the derived tables** — read as a second *writable*
       table it contradicts the "only writable table" parenthetical three lines

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -752,7 +752,50 @@ does not describe is how a residue disappears.
       negative controls fire, including conflating gray with black, treating
       `Retired` as a non-answer, and removing the empty-supersession refusal.
       **Pure, and not yet wired to the store** — same standing as
-      `adjudication`: it walks judgements, nothing persists them.
+      `adjudication`: it walks judgements, nothing persists them. (Sub-slice 3
+      below closes that.)
+- [x] **Adjudication events persist as evidence rows** — **DONE 2026-08-08**,
+      `crates/kirra-world-store/src/adjudication_record.rs`, 13 integration
+      tests. The schema slice `KIRRA-WM-SPLIT-SURVIVAL-001` named as unblocked
+      and did not build. Sub-slice 1 of 3.
+      **No new table, and that is the finding rather than a shortcut.** Three
+      sources agree that adjudications are `world_events` rows and that entity
+      lifecycle is a *projection* over them: ADR-0041 fixes `world_events` as
+      *"the only writable table"* and lists `entities_projection` as DERIVED;
+      §6.3 says *"identity is a projection like everything else"*; and the
+      **ratified v1 baseline already anticipated it** — `retention_class` has
+      carried `'adjudication'` in its closed vocabulary since the beginning and
+      `compaction::PROTECTED_CLASSES` includes it, so such a row is never
+      compacted, which is exactly what §6.3's *"resolvable forever"* needs. That
+      protection is asserted by test, not assumed, because the constant and the
+      protected list live in different modules.
+      **ADR-0041's provisional list also names `identity_adjudications`,
+      unannotated, among the derived tables** — read as a second *writable*
+      table it contradicts the "only writable table" parenthetical three lines
+      above it. The projection reading is stated explicitly in the module rather
+      than left to pass as obvious, since the two readings build different
+      systems.
+      **The decoder never assembles a verb field by field.** It goes back
+      through `MergeEntities::new` / `SplitEntity::partition` / `subtract` /
+      `ForgetEntity::new` / `AssertIdentity::new`, so every refusal those make is
+      a refusal at the storage boundary *structurally*, rather than by a parallel
+      list of checks that could drift. This is where the cardinality check
+      `resolution` deliberately declined now lives: a stored partition naming
+      fewer than two destinations is refused here, so the row never becomes a
+      `Lifecycle::Superseded` for the resolver to meet.
+      An unknown verb or split shape is **refused, never degraded** — the
+      opposite of `ObservationKind`, and deliberately: degrading a
+      *classification* costs a consumer nothing, degrading a *judgement* would
+      drop a redirect and leave a merged-away id resolving to itself. The
+      justification rides the `provenance` column rather than a second copy in
+      the payload. Five negative controls fire, including dropping `shape` from
+      the encoding (a partition would round-trip as a subtraction, undoing the
+      split ruling at the storage layer) and setting a compactable retention
+      class.
+- [ ] **`entities_projection`** — the deterministic reducer folding adjudication
+      rows into lifecycles. Sub-slice 2 of 3.
+- [ ] **`AdjudicationGraph for WorldStore`** — makes `resolution::resolve` live
+      against real data. Small once the projection exists. Sub-slice 3 of 3.
 - [ ] Entity resolution, the *matching* half — **candidate clustering**, deciding
       that two observations are about the same thing. Marked *pure* by §6.3.
       Still open, and still the thing `Corroboration(n)` waits on (§4): the axis


### PR DESCRIPTION
The schema slice `KIRRA-WM-SPLIT-SURVIVAL-001` named as unblocked and explicitly did not build: *"This does **not** authorize persisting `SplitEntity` — that is still the schema slice."*

`kirra_world::adjudication` has carried the four verbs since 2026-08-07 with nowhere to put them. This is the door: an `IdentityAdjudication` becomes a `world_events` row, and comes back out through the domain's own constructors.

## No new table — the survey's finding, not a shortcut

I was about to add an entities table plus an adjudication-events table. Three sources say otherwise, and the third is the one that settles it:

| Source | What it says |
|---|---|
| **ADR-0041** (ratified) | Annotates `world_events` as *"the only writable table"*; lists `entities_projection` as **derived** |
| **Blueprint §6.3** | *"A query at a past instant resolves identity as it was adjudicated then — because **identity is a projection like everything else**."* |
| **The ratified v1 baseline** | `world_events.retention_class` has carried `'adjudication'` in its closed vocabulary since the beginning, and `compaction::PROTECTED_CLASSES` includes it — so such a row is **never compacted** |

That third row is the persuasive one: the protection §6.3's *"resolvable forever"* requires was built before there was anything to put in it. It is asserted by test rather than assumed, because the constant and the protected list are declared in different modules and nothing else ties them together.

**ADR-0041's provisional list also names `identity_adjudications`, unannotated, among the derived tables.** Read as a second *writable* table, that contradicts the "only writable table" parenthetical three lines above it. The projection reading is stated explicitly in the module rather than left to pass as obvious — the two readings build different systems, and since the hash chain lives on `world_events`, a second evidence table would be unchained. An unchained adjudication is precisely the editable-history failure §6.3 exists to prevent.

## The load-bearing design choice: decode through the constructors

`decode_adjudication` never assembles a verb field by field. It calls `MergeEntities::new`, `SplitEntity::partition`, `SplitEntity::subtract`, `ForgetEntity::new`, `AssertIdentity::new` — so **every refusal those constructors make is a refusal at the storage boundary, structurally**, rather than by a parallel list of checks that could drift out of step with the model.

That is what carries the cardinality check `kirra_world::resolution` deliberately declined in #1401. The resolver refuses an *empty* supersession but answers a one-element one rather than discarding a correct answer, recording that rejecting the malformed row *"belongs at the decoding boundary, fail-closed, where the store can refuse it before it is ever walked."* This is that boundary — a stored partition naming fewer than two destinations is refused by `SplitEntity::partition` itself, so the row never becomes a `Lifecycle::Superseded` for the resolver to meet. The check landed where I said it would rather than being quietly dropped.

## Refused, never degraded

An unknown verb or split shape is refused — deliberately the opposite of `ObservationKind`, which degrades an unrecognised token to `Unknown` on purpose. That is right for a **classification**: a consumer can carry on without knowing the kind. It is wrong for a **judgement**: degrading `EntityMerged` to "some adjudication" would drop the redirect and leave the merged-away id resolving to itself, which §6.3 forbids.

An unknown split shape is likewise not defaulted to `partition` — defaulting would supersede a source that survived, inventing the more destructive of the two readings from a token nobody wrote. An unknown clock domain is refused rather than assumed, since ADR-0006's non-mixing rule is only enforceable if a stored instant still knows which clock it came from.

## Two smaller decisions, stated rather than left to be inferred

**The justification rides `provenance`, not the payload.** §14.1's `Evidence` was ruled to mean "the observations that justify the judgement"; `NewEvent::provenance` is documented as "observation ids this claim rests on (SD-3)". Same set — so it goes in the column that already means it, because two copies is two things that can disagree.

**`adjudication_subject` names the entity the judgement is *about*, and its docs say what the column is NOT**: sufficient to find every entity an adjudication affects. A merge's sources are the entities whose lifecycle changes, and they are in the payload. A subject index that looks like it answers "what happened to entity X" while silently missing the merged-away ids — exactly the ones a caller is asking about — is worse than no index at all.

## Verification

13 integration tests, written against a **real store** rather than the codec alone: a codec that round-trips in memory and cannot survive `append`'s constraints has proved nothing. Every verb round-trips and `verify_chain` passes after all of them.

**Five negative controls fire:**

| Mutation | Tests failed |
|---|---|
| `shape` dropped from the encoding (a partition round-trips as a subtraction — undoing the split ruling at the storage layer) | 1 |
| Partition decoded via `subtract` (constructor no longer enforces ≥ 2) | 2 |
| Unknown verb degrades to `Assert` instead of refusing | 1 |
| Unknown clock domain defaults to `System` | 1 |
| Retention class set to a compactable one | 1 |

Also green: `cargo test --workspace`; both workspace-detached trees (`wm2-schema-growth` 30, `wm2-persistence-harness` 207 + 7); `cargo fmt --check`; `clippy -D warnings`; Kirra World bidirectional fence **INTACT**; domain-logic gate **OPEN**; re-export shim ratchet **0**.

**One thing I cannot fully account for.** The first full-workspace run showed 2 failures in `kirra-verifier --bin kirra_verifier_service`, a crate this change does not touch. Three subsequent runs were clean — one targeted at that binary (141/141), two full-workspace. I did not capture the test names before they stopped reproducing, so this is called flaky on the evidence of non-reproduction plus the crate being untouched, **not** on having diagnosed it. That suite includes live TLS handshakes and HA timing tests, which are plausible flake sources under full parallelism. Flagging it rather than omitting it.

## Scope

Sub-slice **1 of 3**. Still open, and listed in `WM_SCOPE.md`:

2. `entities_projection` — the deterministic reducer folding adjudication rows into lifecycles.
3. `AdjudicationGraph for WorldStore` — which makes `resolution::resolve` live against real data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_