### PR TITLE
Entity lifecycle as a projection, and resolution against a real store

### DIFF
--- a/crates/kirra-world-store/src/entity_projection.rs
+++ b/crates/kirra-world-store/src/entity_projection.rs
@@ -552,3 +552,210 @@ mod tests {
         );
     }
 }
+
+/// The `projection_checkpoint` name this fold advances.
+///
+/// Its own checkpoint, not `world_current`'s: the two folds consume different
+/// row sets and advance independently, and sharing a cursor would make one
+/// fold's progress silently skip the other's input.
+pub const ENTITY_PROJECTION: &str = "entities_projection";
+
+/// Rebuild a [`Lifecycle`] from its three stored columns.
+///
+/// **Fail-closed.** Every mismatch is a corrupt row rather than a value to
+/// repair: the columns are only ever written by [`fold_adjudication`], so a
+/// `merged` row with no redirect means the file was edited underneath the
+/// store, and inventing a target would be fabricating a redirect §6.3 says is
+/// resolvable forever.
+///
+/// # Errors
+///
+/// [`EntityRowError`] naming which column disagreed with which token.
+pub fn lifecycle_from_columns(
+    token: &str,
+    redirect: Option<&str>,
+    origin: Option<&str>,
+) -> Result<Lifecycle, EntityRowError> {
+    let ids = |r: Option<&str>| -> Result<Vec<EntityId>, EntityRowError> {
+        let raw = r.ok_or(EntityRowError::MissingRedirect)?;
+        let parsed: serde_json::Value =
+            serde_json::from_str(raw).map_err(|_| EntityRowError::MalformedRedirect)?;
+        let arr = parsed.as_array().ok_or(EntityRowError::MalformedRedirect)?;
+        arr.iter()
+            .map(|v| {
+                v.as_str()
+                    .ok_or(EntityRowError::MalformedRedirect)
+                    .and_then(|s| EntityId::new(s).map_err(|_| EntityRowError::MalformedRedirect))
+            })
+            .collect()
+    };
+    match token {
+        "provisional" => Ok(Lifecycle::Provisional),
+        "established" => Ok(Lifecycle::Established),
+        "dormant" => Ok(Lifecycle::Dormant),
+        "retired" => Ok(Lifecycle::Retired),
+        "merged" => {
+            let v = ids(redirect)?;
+            match v.len() {
+                // Exactly one. A merge redirects to ONE thing -- that is the
+                // whole distinction `Superseded` exists to keep visible.
+                1 => Ok(Lifecycle::Merged {
+                    into: v.into_iter().next().expect("len checked"),
+                }),
+                n => Err(EntityRowError::WrongRedirectArity {
+                    token: "merged",
+                    found: n,
+                }),
+            }
+        }
+        "superseded" => {
+            let v = ids(redirect)?;
+            if v.is_empty() {
+                // The case `resolution` refuses outright: a supersession naming
+                // nothing is unanswerable, and reading it back would recreate
+                // the row that made an existing id report as absent.
+                return Err(EntityRowError::WrongRedirectArity {
+                    token: "superseded",
+                    found: 0,
+                });
+            }
+            Ok(Lifecycle::Superseded { by: v })
+        }
+        "split" => {
+            let from = origin.ok_or(EntityRowError::MissingOrigin)?;
+            Ok(Lifecycle::Split {
+                from: EntityId::new(from).map_err(|_| EntityRowError::MalformedOrigin)?,
+            })
+        }
+        _ => Err(EntityRowError::UnknownLifecycle {
+            token: token.to_owned(),
+        }),
+    }
+}
+
+/// Why a stored projection row could not be read back.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EntityRowError {
+    /// The lifecycle token is not one of the seven.
+    UnknownLifecycle {
+        /// The token found.
+        token: String,
+    },
+    /// A redirecting state carried no redirect.
+    MissingRedirect,
+    /// The redirect column is not a JSON array of admissible ids.
+    MalformedRedirect,
+    /// The redirect arity disagrees with the state.
+    WrongRedirectArity {
+        /// Which state.
+        token: &'static str,
+        /// How many ids were found.
+        found: usize,
+    },
+    /// A `split` row carried no origin.
+    MissingOrigin,
+    /// The origin is not an admissible entity id.
+    MalformedOrigin,
+    /// The contradiction column is not what the fold writes.
+    MalformedContradiction,
+}
+
+impl core::fmt::Display for EntityRowError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::UnknownLifecycle { token } => write!(f, "unknown lifecycle token `{token}`"),
+            Self::MissingRedirect => write!(f, "a redirecting lifecycle carried no redirect"),
+            Self::MalformedRedirect => write!(f, "the redirect column is not a JSON id array"),
+            Self::WrongRedirectArity { token, found } => {
+                write!(f, "`{token}` cannot carry {found} successors")
+            }
+            Self::MissingOrigin => write!(f, "a split row carried no origin"),
+            Self::MalformedOrigin => write!(f, "the origin is not an admissible entity id"),
+            Self::MalformedContradiction => {
+                write!(f, "the contradiction column is not what the fold writes")
+            }
+        }
+    }
+}
+
+impl std::error::Error for EntityRowError {}
+
+/// The origin of a `Split`, for the `origin` column.
+#[must_use]
+pub fn origin_of(l: &Lifecycle) -> Option<&EntityId> {
+    match l {
+        Lifecycle::Split { from } => Some(from),
+        _ => None,
+    }
+}
+
+/// The stored token for a [`LifecycleState`].
+#[must_use]
+pub fn state_token(s: LifecycleState) -> &'static str {
+    match s {
+        LifecycleState::Provisional => "provisional",
+        LifecycleState::Established => "established",
+        LifecycleState::Dormant => "dormant",
+        LifecycleState::Retired => "retired",
+        LifecycleState::Merged => "merged",
+        LifecycleState::Split => "split",
+        LifecycleState::Superseded => "superseded",
+    }
+}
+
+fn state_from_token(t: &str) -> Option<LifecycleState> {
+    Some(match t {
+        "provisional" => LifecycleState::Provisional,
+        "established" => LifecycleState::Established,
+        "dormant" => LifecycleState::Dormant,
+        "retired" => LifecycleState::Retired,
+        "merged" => LifecycleState::Merged,
+        "split" => LifecycleState::Split,
+        "superseded" => LifecycleState::Superseded,
+        _ => return None,
+    })
+}
+
+/// A contradiction as stored JSON.
+///
+/// Structured rather than a rendered sentence, so a reload returns what the
+/// fold recorded instead of a placeholder. An operator-facing sentence can be
+/// rendered from this; the reverse cannot be done without inventing the fields.
+#[must_use]
+pub fn contradiction_json(c: &Contradiction) -> String {
+    serde_json::json!({
+        "held": state_token(c.held),
+        "attempted": state_token(c.attempted),
+        "generation": c.generation,
+    })
+    .to_string()
+}
+
+/// Read a stored contradiction back.
+///
+/// # Errors
+///
+/// [`EntityRowError::MalformedContradiction`] on anything the fold would not
+/// have written — refused rather than defaulted, because a contradiction with
+/// invented fields points an operator at the wrong event.
+pub fn contradiction_from_json(raw: &str) -> Result<Contradiction, EntityRowError> {
+    let v: serde_json::Value =
+        serde_json::from_str(raw).map_err(|_| EntityRowError::MalformedContradiction)?;
+    let o = v
+        .as_object()
+        .ok_or(EntityRowError::MalformedContradiction)?;
+    let tok = |k: &str| -> Result<LifecycleState, EntityRowError> {
+        o.get(k)
+            .and_then(serde_json::Value::as_str)
+            .and_then(state_from_token)
+            .ok_or(EntityRowError::MalformedContradiction)
+    };
+    Ok(Contradiction {
+        held: tok("held")?,
+        attempted: tok("attempted")?,
+        generation: o
+            .get("generation")
+            .and_then(serde_json::Value::as_i64)
+            .ok_or(EntityRowError::MalformedContradiction)?,
+    })
+}

--- a/crates/kirra-world-store/src/entity_projection.rs
+++ b/crates/kirra-world-store/src/entity_projection.rs
@@ -101,7 +101,10 @@ CREATE TABLE IF NOT EXISTS entities_projection (
     -- The entity this one was split out of, for `split`.
     origin          TEXT,
     contradicted    INTEGER NOT NULL DEFAULT 0,
-    -- The refused transition, as `from -> attempted @ generation`.
+    -- The refused transition, as JSON:
+    --   {"held":..,"attempted":..,"generation":..}
+    -- Structured, not a rendered sentence: a reload must return what the fold
+    -- recorded rather than a placeholder. See `contradiction_json`.
     contradiction   TEXT
 );
 "#;
@@ -494,6 +497,52 @@ mod tests {
         );
     }
 
+    /// **The digest distinguishes contradiction payloads, not just the flag.**
+    ///
+    /// Two projections that refuse the same entities but name different
+    /// generations must not compare equal: the generation is what an operator
+    /// uses to find the disagreeing event, so an invariant check blind to it
+    /// would pass while pointing two stores at different history.
+    #[test]
+    fn the_digest_covers_the_contradiction_payload() {
+        let base = fold_all([(1, &merge(&["a"], "b")), (2, &merge(&["a"], "c"))]);
+        // Same entities, same lifecycles, same contradicted-ness -- only the
+        // recorded generation differs.
+        let mut shifted = base.clone();
+        shifted.get_mut("a").expect("a").contradiction = Some(Contradiction {
+            held: LifecycleState::Merged,
+            attempted: LifecycleState::Merged,
+            generation: 99,
+        });
+
+        assert_ne!(
+            state_digest_of(&base),
+            state_digest_of(&shifted),
+            "a differing contradiction generation must change the digest"
+        );
+        // Non-vacuous: identical input digests identically.
+        assert_eq!(state_digest_of(&base), state_digest_of(&base.clone()));
+    }
+
+    /// And it distinguishes a split's ORIGIN, which is otherwise invisible —
+    /// `redirect_json` is `None` for `Split`, so a digest over redirect alone
+    /// would rate two products of different parents equal.
+    #[test]
+    fn the_digest_covers_a_split_origin() {
+        let mut a = BTreeMap::new();
+        a.insert(
+            "x".to_owned(),
+            ProjectedEntity {
+                entity: eid("x"),
+                lifecycle: Lifecycle::Split { from: eid("p1") },
+                contradiction: None,
+            },
+        );
+        let mut b = a.clone();
+        b.get_mut("x").expect("x").lifecycle = Lifecycle::Split { from: eid("p2") };
+        assert_ne!(state_digest_of(&a), state_digest_of(&b));
+    }
+
     // -- Determinism ---------------------------------------------------
 
     /// **Rebuild-from-zero equals incremental** — `WM_SCOPE` §0a's Knowledge
@@ -834,4 +883,38 @@ impl kirra_world::resolution::AdjudicationGraph for IdentityView {
             .get(id.as_str())
             .is_some_and(ProjectedEntity::is_contradicted)
     }
+}
+
+/// A digest over a projection accumulator, in key order.
+///
+/// Takes the accumulator rather than reading the table, so the value written
+/// into the checkpoint is the one the fold actually produced.
+///
+/// **The contradiction payload is included, not just the flag.** Digesting only
+/// *whether* an entity is contradicted would let two projections that refuse
+/// the same entities but name different generations compare equal — and the
+/// generation is the field an operator uses to find the disagreeing event, so
+/// the invariant check would pass while pointing two stores at different
+/// history.
+#[must_use]
+pub fn state_digest_of(rows: &BTreeMap<String, ProjectedEntity>) -> String {
+    let mut buf = String::new();
+    for (id, e) in rows {
+        buf.push_str(id);
+        buf.push('\u{1f}');
+        buf.push_str(lifecycle_token(&e.lifecycle));
+        buf.push('\u{1f}');
+        buf.push_str(redirect_json(&e.lifecycle).as_deref().unwrap_or(""));
+        buf.push('\u{1f}');
+        buf.push_str(origin_of(&e.lifecycle).map_or("", EntityId::as_str));
+        buf.push('\u{1f}');
+        buf.push_str(
+            &e.contradiction
+                .as_ref()
+                .map(contradiction_json)
+                .unwrap_or_default(),
+        );
+        buf.push('\u{1e}');
+    }
+    crate::sha256_hex(buf.as_bytes())
 }

--- a/crates/kirra-world-store/src/entity_projection.rs
+++ b/crates/kirra-world-store/src/entity_projection.rs
@@ -1,0 +1,554 @@
+//! **Entity lifecycle as a projection over adjudication rows** — §6.3, ADR-0041.
+//!
+//! §6.3: *"A query at a past instant resolves identity as it was adjudicated
+//! then — **because identity is a projection like everything else**."* This is
+//! that projection. [`crate::adjudication_record`] put the judgements in the
+//! log; this folds them into what each entity *is now*.
+//!
+//! # No DDL in the ratified surface, and no schema bump
+//!
+//! `WM2_EVENT_SCHEMA.md` §7, under *what this ruling does not decide*:
+//!
+//! > **Projection schemas.** `entities_projection` / `relationships_projection`
+//! > are rebuildable views and follow from the fold, not from this table.
+//!
+//! So this table is named in the ratified document as a **rebuildable view**,
+//! deliberately outside the schema surface. `SCHEMA_VERSION` is untouched.
+//!
+//! Like [`crate::projection::PROJECTIONS_V1`], the DDL is installed **by the
+//! first fold, never at `open`** — and that is load-bearing rather than
+//! stylistic. ADR-0041 **D-20**'s `log_only_bytes` is the on-disk size of a
+//! store holding only the event log; creating projection tables at `open` adds
+//! their root pages to *every* store, including one that never projects,
+//! silently moving that figure and invalidating the D-2 comparison the
+//! retention horizons rest on.
+//!
+//! # The reducer does not restate what a verb means
+//!
+//! [`fold_adjudication`] applies [`IdentityAdjudication::resulting_lifecycles`]
+//! — the domain's own statement of each verb's consequences, already walked
+//! against [`Lifecycle::advance_to`] from every live state by the adjudication
+//! module's seam test. A second implementation here would agree today and drift
+//! later; this cannot, because there is only one.
+//!
+//! # Contradiction poisons the ENTITY, not the fold
+//!
+//! Two individually valid events can contradict in aggregate: `a` merged into
+//! `b` (terminal), then `a` merged into `c` by another operator. Neither event
+//! can see the other, so no constructor refuses it — exactly the shape of
+//! [`crate::resolution`]'s `RedirectCycle`, which is one instance of this same
+//! problem.
+//!
+//! Three responses were available and two are worse:
+//!
+//! * **Fail the fold.** Not fail-closed — *fail-bricked*. One contradictory
+//!   pair about one entity stops identity answers for **every** entity, and the
+//!   log is append-only so the offending event cannot be removed: a rebuild
+//!   replays it and wedges again. The blast radius is unbounded in the fault.
+//! * **Skip the event.** Produces a projection that disagrees with the log while
+//!   looking healthy — the "no projection-only fact" invariant inverted, and
+//!   confidently wrong, which is the one outcome this store exists to prevent.
+//! * **Poison the entity.** The blast radius matches the fault, nothing is
+//!   invented (no winner is picked), and the caller learns at the point of
+//!   asking about *that* entity. §14.4 makes it an **outcome**, not an error;
+//!   §14.3's `ContradictionDetected` is the event it gives something to fire on.
+//!
+//! The third is taken. It also matches the precedent already set: `resolution`
+//! answers a cyclic redirect per query rather than refusing to resolve anything.
+//!
+//! ## Poison is STICKY, and recovery needs a verb that does not exist
+//!
+//! Once contradicted, an entity stays contradicted no matter what follows, and
+//! the **first** contradiction is the one retained.
+//!
+//! The justification is *diagnostic stability*, not determinism, and the
+//! difference is worth stating because the first draft of this paragraph got it
+//! wrong. It claimed stickiness is "what keeps rebuild-from-zero equal to an
+//! incremental fold". It is not: the reducer is a pure function of the event
+//! sequence either way, so a liftable poison would still replay identically
+//! from any checkpoint. Running the negative control settled it — mutating
+//! stickiness away leaves `folding_in_two_halves_equals_folding_at_once`
+//! passing, and only `poison_is_sticky_and_keeps_the_first_contradiction` fails.
+//!
+//! What stickiness actually buys: the recorded contradiction names the **first**
+//! disagreement, which is the one an operator needs, rather than whichever
+//! happened last. And a contradicted entity is not advanced by later events,
+//! because advancing from a state the projection has already declared untrusted
+//! would be picking a winner one event at a time.
+//!
+//! Stated plainly because it is a real limitation and the obvious hope is
+//! wrong: **no sequence of today's four verbs clears a contradiction.** There
+//! is no "the second merge was mistaken" verb — `ForgetEntity` retires an
+//! entity, it does not adjudicate between two prior claims. Resolution needs a
+//! fifth verb and its own ruling. What this design buys is not easy recovery;
+//! it is that the damage stays proportional to the fault while the evidence
+//! stays intact for whoever writes that verb.
+
+use std::collections::BTreeMap;
+
+use kirra_world::adjudication::IdentityAdjudication;
+use kirra_world::entity::{Lifecycle, LifecycleState};
+use kirra_world::reference::EntityId;
+
+/// The lazily-installed projection table. See the module docs for why this is
+/// not schema DDL and why it is not installed at `open`.
+pub const ENTITY_PROJECTION_V1: &str = r#"
+CREATE TABLE IF NOT EXISTS entities_projection (
+    entity_id       TEXT    PRIMARY KEY,
+    lifecycle       TEXT    NOT NULL,
+    -- JSON array. One id for `merged`, N for `superseded`, absent otherwise.
+    redirect        TEXT,
+    -- The entity this one was split out of, for `split`.
+    origin          TEXT,
+    contradicted    INTEGER NOT NULL DEFAULT 0,
+    -- The refused transition, as `from -> attempted @ generation`.
+    contradiction   TEXT
+);
+"#;
+
+/// A contradiction between two individually valid adjudications.
+///
+/// Carries the refused transition rather than a message, so an operator sees
+/// *what* disagreed rather than that something did.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Contradiction {
+    /// The state the entity was in.
+    pub held: LifecycleState,
+    /// The state an adjudication tried to move it to.
+    pub attempted: LifecycleState,
+    /// The generation of the event that tried.
+    pub generation: i64,
+}
+
+/// One entity's projected state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectedEntity {
+    /// Which entity.
+    pub entity: EntityId,
+    /// Its lifecycle as of the folded prefix.
+    ///
+    /// When [`Self::contradiction`] is `Some`, this is the state held **before**
+    /// the refused transition — the projection does not pick a winner.
+    pub lifecycle: Lifecycle,
+    /// The first contradiction seen, if any. Sticky.
+    pub contradiction: Option<Contradiction>,
+}
+
+impl ProjectedEntity {
+    /// Whether this entity's identity is self-contradictory.
+    #[must_use]
+    pub fn is_contradicted(&self) -> bool {
+        self.contradiction.is_some()
+    }
+}
+
+/// **The pure fold step.** Apply one adjudication to the accumulator.
+///
+/// `BTreeMap` rather than `HashMap` for the same reason
+/// [`crate::projection::fold_all`] uses one: the state digest is taken over
+/// iteration order, and a digest that depended on hash seeding would compare
+/// unequal to itself.
+///
+/// # Ordering
+///
+/// Callers apply this in generation order, and `generation` is recorded on a
+/// contradiction so the refusal names the event that caused it.
+///
+/// # An entity first seen in a consequence is created there
+///
+/// A merge may name a source this fold has never met — `AssertIdentity` is the
+/// newest verb, and nothing requires a log to have used it. Creating the entity
+/// directly in its resulting state keeps the redirect, which is the information
+/// §6.3 promises to hold forever; refusing would discard it to enforce an
+/// ordering the log never promised.
+pub fn fold_adjudication(
+    acc: &mut BTreeMap<String, ProjectedEntity>,
+    adjudication: &IdentityAdjudication,
+    generation: i64,
+) {
+    // `Assert` states no lifecycle consequence -- it CREATES. Handled here
+    // because `resulting_lifecycles` is empty for it, deliberately: creation is
+    // not a transition.
+    if let IdentityAdjudication::Assert(a) = adjudication {
+        let key = a.entity().as_str().to_owned();
+        match acc.get_mut(&key) {
+            None => {
+                acc.insert(
+                    key,
+                    ProjectedEntity {
+                        entity: a.entity().clone(),
+                        lifecycle: Lifecycle::Provisional,
+                        contradiction: None,
+                    },
+                );
+            }
+            // Asserting an id that already exists contradicts the mint's
+            // never-reuse guarantee: two events each claim to have brought the
+            // same identity into being.
+            Some(existing) => {
+                if existing.contradiction.is_none() {
+                    existing.contradiction = Some(Contradiction {
+                        held: existing.lifecycle.state(),
+                        attempted: LifecycleState::Provisional,
+                        generation,
+                    });
+                }
+            }
+        }
+        return;
+    }
+
+    for (entity, next) in adjudication.resulting_lifecycles() {
+        let key = entity.as_str().to_owned();
+        match acc.get_mut(&key) {
+            None => {
+                acc.insert(
+                    key,
+                    ProjectedEntity {
+                        entity,
+                        lifecycle: next,
+                        contradiction: None,
+                    },
+                );
+            }
+            Some(held) => {
+                // Sticky: a contradicted entity is not advanced further, and
+                // the FIRST contradiction is retained -- see the module docs for
+                // why that is a diagnostic choice rather than a determinism one.
+                if held.contradiction.is_some() {
+                    continue;
+                }
+                match held.lifecycle.advance_to(next.clone()) {
+                    Ok(moved) => held.lifecycle = moved,
+                    Err(_) => {
+                        held.contradiction = Some(Contradiction {
+                            held: held.lifecycle.state(),
+                            attempted: next.state(),
+                            generation,
+                        });
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Fold a whole sequence of `(generation, adjudication)` in order.
+#[must_use]
+pub fn fold_all<'a, I>(adjudications: I) -> BTreeMap<String, ProjectedEntity>
+where
+    I: IntoIterator<Item = (i64, &'a IdentityAdjudication)>,
+{
+    let mut acc = BTreeMap::new();
+    for (generation, a) in adjudications {
+        fold_adjudication(&mut acc, a, generation);
+    }
+    acc
+}
+
+/// The stored token for a lifecycle state.
+#[must_use]
+pub fn lifecycle_token(l: &Lifecycle) -> &'static str {
+    match l {
+        Lifecycle::Provisional => "provisional",
+        Lifecycle::Established => "established",
+        Lifecycle::Dormant => "dormant",
+        Lifecycle::Retired => "retired",
+        Lifecycle::Merged { .. } => "merged",
+        Lifecycle::Split { .. } => "split",
+        Lifecycle::Superseded { .. } => "superseded",
+    }
+}
+
+/// The successors a lifecycle redirects to, as stored JSON.
+///
+/// One id for `Merged`, N for `Superseded`, `None` otherwise — the shape
+/// `resolution::resolve` walks.
+#[must_use]
+pub fn redirect_json(l: &Lifecycle) -> Option<String> {
+    let ids: Vec<&str> = match l {
+        Lifecycle::Merged { into } => vec![into.as_str()],
+        Lifecycle::Superseded { by } => by.iter().map(EntityId::as_str).collect(),
+        _ => return None,
+    };
+    Some(
+        serde_json::Value::Array(
+            ids.into_iter()
+                .map(|s| serde_json::Value::String(s.to_owned()))
+                .collect(),
+        )
+        .to_string(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kirra_world::adjudication::{
+        AssertIdentity, ForgetEntity, Justification, MergeEntities, RetirementReason, SplitEntity,
+    };
+    use kirra_world::observation::{ClockDomain, DomainInstant};
+    use kirra_world::reference::ObservationId;
+
+    fn eid(s: &str) -> EntityId {
+        EntityId::new(s).expect("entity id")
+    }
+
+    fn just() -> Justification {
+        Justification::new([ObservationId::new("obs-1").expect("obs")]).expect("justification")
+    }
+
+    fn at() -> DomainInstant {
+        DomainInstant {
+            ms: 1,
+            domain: ClockDomain::System,
+        }
+    }
+
+    fn assert_id(e: &str) -> IdentityAdjudication {
+        IdentityAdjudication::Assert(AssertIdentity::new(eid(e), just(), at()))
+    }
+
+    fn merge(sources: &[&str], into: &str) -> IdentityAdjudication {
+        IdentityAdjudication::Merge(
+            MergeEntities::new(
+                sources.iter().map(|s| eid(s)).collect::<Vec<_>>(),
+                eid(into),
+                just(),
+                at(),
+            )
+            .expect("merge"),
+        )
+    }
+
+    fn partition(source: &str, into: &[&str]) -> IdentityAdjudication {
+        IdentityAdjudication::Split(
+            SplitEntity::partition(
+                eid(source),
+                into.iter().map(|s| eid(s)).collect::<Vec<_>>(),
+                just(),
+                at(),
+            )
+            .expect("partition"),
+        )
+    }
+
+    fn forget(e: &str) -> IdentityAdjudication {
+        IdentityAdjudication::Forget(ForgetEntity::new(
+            eid(e),
+            RetirementReason::new("decommissioned").expect("reason"),
+            just(),
+            at(),
+        ))
+    }
+
+    fn get<'a>(acc: &'a BTreeMap<String, ProjectedEntity>, e: &str) -> &'a ProjectedEntity {
+        acc.get(e).unwrap_or_else(|| panic!("no row for {e}"))
+    }
+
+    #[test]
+    fn an_assertion_creates_a_provisional_entity() {
+        let acc = fold_all([(1, &assert_id("e-1"))]);
+        assert_eq!(get(&acc, "e-1").lifecycle, Lifecycle::Provisional);
+        assert!(!get(&acc, "e-1").is_contradicted());
+    }
+
+    /// §6.3: the merged-away id keeps a row and answers with a redirect.
+    #[test]
+    fn a_merge_redirects_each_source_and_leaves_the_target_alone() {
+        let acc = fold_all([
+            (1, &assert_id("a")),
+            (2, &assert_id("b")),
+            (3, &assert_id("keep")),
+            (4, &merge(&["a", "b"], "keep")),
+        ]);
+        assert_eq!(
+            get(&acc, "a").lifecycle,
+            Lifecycle::Merged { into: eid("keep") }
+        );
+        assert_eq!(
+            get(&acc, "b").lifecycle,
+            Lifecycle::Merged { into: eid("keep") }
+        );
+        assert_eq!(
+            get(&acc, "keep").lifecycle,
+            Lifecycle::Provisional,
+            "a merge target takes no transition -- it is what the others became"
+        );
+    }
+
+    #[test]
+    fn a_partition_supersedes_the_source_and_marks_the_products() {
+        let acc = fold_all([(1, &assert_id("p")), (2, &partition("p", &["p1", "p2"]))]);
+        assert_eq!(
+            get(&acc, "p").lifecycle,
+            Lifecycle::Superseded {
+                by: vec![eid("p1"), eid("p2")]
+            }
+        );
+        assert_eq!(
+            get(&acc, "p1").lifecycle,
+            Lifecycle::Split { from: eid("p") }
+        );
+    }
+
+    /// An entity first met in a consequence is created there rather than
+    /// dropped — otherwise the redirect §6.3 promises would be discarded to
+    /// enforce an ordering the log never promised.
+    #[test]
+    fn a_source_never_asserted_still_gets_its_redirect() {
+        let acc = fold_all([(1, &merge(&["ghost"], "keep"))]);
+        assert_eq!(
+            get(&acc, "ghost").lifecycle,
+            Lifecycle::Merged { into: eid("keep") }
+        );
+    }
+
+    // -- Contradiction -------------------------------------------------
+
+    /// **The case no constructor can refuse.** Two operators merge `a` into
+    /// different targets; each event is individually valid.
+    #[test]
+    fn a_second_merge_of_the_same_source_contradicts_that_entity() {
+        let acc = fold_all([
+            (1, &assert_id("a")),
+            (2, &merge(&["a"], "b")),
+            (3, &merge(&["a"], "c")),
+        ]);
+        let a = get(&acc, "a");
+        assert_eq!(
+            a.contradiction,
+            Some(Contradiction {
+                held: LifecycleState::Merged,
+                attempted: LifecycleState::Merged,
+                generation: 3,
+            })
+        );
+        assert_eq!(
+            a.lifecycle,
+            Lifecycle::Merged { into: eid("b") },
+            "the projection keeps what it held and does NOT pick a winner"
+        );
+    }
+
+    /// **The blast radius matches the fault.** Everything else still folds.
+    #[test]
+    fn a_contradicted_entity_does_not_poison_the_rest_of_the_fold() {
+        let acc = fold_all([
+            (1, &merge(&["a"], "b")),
+            (2, &merge(&["a"], "c")),
+            (3, &assert_id("unrelated")),
+            (4, &forget("unrelated")),
+        ]);
+        assert!(get(&acc, "a").is_contradicted());
+        assert!(!get(&acc, "unrelated").is_contradicted());
+        assert_eq!(get(&acc, "unrelated").lifecycle, Lifecycle::Retired);
+    }
+
+    /// Sticky, and the FIRST contradiction is the one kept.
+    ///
+    /// This is the ONLY test that discriminates either half: the negative
+    /// controls for "not sticky" and "keep the last one" both leave
+    /// `folding_in_two_halves_equals_folding_at_once` passing, because the
+    /// reducer stays deterministic under both. Recorded so nobody reads that
+    /// test as covering this one.
+    #[test]
+    fn poison_is_sticky_and_keeps_the_first_contradiction() {
+        let acc = fold_all([
+            (1, &merge(&["a"], "b")),
+            (2, &merge(&["a"], "c")),
+            (3, &merge(&["a"], "d")),
+            (4, &forget("a")),
+        ]);
+        let a = get(&acc, "a");
+        assert_eq!(
+            a.contradiction.as_ref().expect("contradicted").generation,
+            2
+        );
+        assert_eq!(
+            a.lifecycle,
+            Lifecycle::Merged { into: eid("b") },
+            "no later event advances a contradicted entity"
+        );
+    }
+
+    /// Asserting an id twice contradicts the mint's never-reuse guarantee.
+    #[test]
+    fn asserting_the_same_id_twice_is_a_contradiction() {
+        let acc = fold_all([(1, &assert_id("e-1")), (2, &assert_id("e-1"))]);
+        assert!(get(&acc, "e-1").is_contradicted());
+    }
+
+    /// Retiring a merged entity is refused by `advance_to` (Merged is
+    /// terminal), so it contradicts rather than silently retiring it.
+    #[test]
+    fn a_transition_out_of_a_terminal_state_contradicts() {
+        let acc = fold_all([(1, &merge(&["a"], "b")), (2, &forget("a"))]);
+        assert_eq!(
+            get(&acc, "a").contradiction,
+            Some(Contradiction {
+                held: LifecycleState::Merged,
+                attempted: LifecycleState::Retired,
+                generation: 2,
+            })
+        );
+    }
+
+    // -- Determinism ---------------------------------------------------
+
+    /// **Rebuild-from-zero equals incremental** — `WM_SCOPE` §0a's Knowledge
+    /// tier invariant, at the level of the pure reducer.
+    ///
+    /// Folding a prefix and then the tail must equal folding the whole
+    /// sequence, *including* when a contradiction falls across the split.
+    ///
+    /// **What this does and does not catch.** It is a split-point-independence
+    /// guard: it would fail on a reducer whose result depended on where the
+    /// checkpoint fell — an accumulator read that is not part of the state, or a
+    /// nondeterministic iteration order. It does **not** discriminate the
+    /// contradiction policy: every mutation tried against it (non-sticky poison,
+    /// last-contradiction-wins, picking a winner) stays deterministic and leaves
+    /// it green. Those are `poison_is_sticky_and_keeps_the_first_contradiction`'s
+    /// job.
+    #[test]
+    fn folding_in_two_halves_equals_folding_at_once() {
+        let events: Vec<(i64, IdentityAdjudication)> = vec![
+            (1, assert_id("a")),
+            (2, assert_id("b")),
+            (3, merge(&["a"], "b")),
+            (4, merge(&["a"], "c")),
+            (5, partition("b", &["b1", "b2"])),
+            (6, forget("b1")),
+        ];
+
+        let whole = fold_all(events.iter().map(|(g, a)| (*g, a)));
+        for split in 0..=events.len() {
+            let mut acc = fold_all(events[..split].iter().map(|(g, a)| (*g, a)));
+            for (g, a) in &events[split..] {
+                fold_adjudication(&mut acc, a, *g);
+            }
+            assert_eq!(acc, whole, "incremental fold split at {split} diverged");
+        }
+    }
+
+    #[test]
+    fn the_stored_redirect_is_the_shape_resolution_walks() {
+        assert_eq!(
+            redirect_json(&Lifecycle::Merged { into: eid("b") }).as_deref(),
+            Some(r#"["b"]"#)
+        );
+        assert_eq!(
+            redirect_json(&Lifecycle::Superseded {
+                by: vec![eid("x"), eid("y")]
+            })
+            .as_deref(),
+            Some(r#"["x","y"]"#)
+        );
+        assert_eq!(redirect_json(&Lifecycle::Established), None);
+        assert_eq!(
+            redirect_json(&Lifecycle::Split { from: eid("p") }),
+            None,
+            "an origin is not a redirect -- a split product is live and is itself"
+        );
+    }
+}

--- a/crates/kirra-world-store/src/entity_projection.rs
+++ b/crates/kirra-world-store/src/entity_projection.rs
@@ -759,3 +759,79 @@ pub fn contradiction_from_json(raw: &str) -> Result<Contradiction, EntityRowErro
             .ok_or(EntityRowError::MalformedContradiction)?,
     })
 }
+
+/// **A loaded snapshot of the entity projection, resolvable in place.**
+///
+/// The bridge that makes `kirra_world::resolution::resolve` live against a real
+/// store — sub-slice 3 of the schema slice.
+///
+/// # Why a loaded view and not a `WorldStore` impl
+///
+/// [`AdjudicationGraph::lifecycle_of`] returns `Option<Lifecycle>` and has **no
+/// error channel**. Implementing it directly on `WorldStore` would mean every query
+/// doing I/O that can fail, with nowhere to report the failure — so a read
+/// error would become `None`, and `None` means *"the graph has no such
+/// entity"*. That reports an existing id as absent: exactly the bug
+/// `EmptySupersession` was added to fix in the resolver, reintroduced one layer
+/// down where the resolver cannot see it.
+///
+/// So the fallible work happens **once, at load**, and returns a `Result`:
+/// [`crate::WorldStore::identity_view`] refuses a corrupt projection rather
+/// than resolving over a partial one. What is left is a pure map, and the
+/// trait's contract is honoured by construction rather than by remembering to.
+///
+/// A snapshot also means a resolution walk sees ONE state of the world
+/// throughout — a per-query reader could observe a fold landing mid-walk and
+/// answer from two different generations at once.
+pub struct IdentityView {
+    rows: BTreeMap<String, ProjectedEntity>,
+    generation: i64,
+}
+
+impl IdentityView {
+    /// Build a view over already-loaded rows.
+    #[must_use]
+    pub fn new(rows: BTreeMap<String, ProjectedEntity>, generation: i64) -> Self {
+        Self { rows, generation }
+    }
+
+    /// The fold generation this snapshot was taken at.
+    ///
+    /// Carried so an answer can say *which* state of the world it came from —
+    /// §6.3's *"a query at a past instant resolves identity as it was
+    /// adjudicated then"* needs the instant to be nameable.
+    #[must_use]
+    pub fn generation(&self) -> i64 {
+        self.generation
+    }
+
+    /// How many entities the snapshot holds.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.rows.len()
+    }
+
+    /// Whether the snapshot is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.rows.is_empty()
+    }
+
+    /// One entity's projected state.
+    #[must_use]
+    pub fn get(&self, id: &EntityId) -> Option<&ProjectedEntity> {
+        self.rows.get(id.as_str())
+    }
+}
+
+impl kirra_world::resolution::AdjudicationGraph for IdentityView {
+    fn lifecycle_of(&self, id: &EntityId) -> Option<Lifecycle> {
+        self.rows.get(id.as_str()).map(|e| e.lifecycle.clone())
+    }
+
+    fn is_contradicted(&self, id: &EntityId) -> bool {
+        self.rows
+            .get(id.as_str())
+            .is_some_and(ProjectedEntity::is_contradicted)
+    }
+}

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -1294,12 +1294,8 @@ impl WorldStore {
     fn ensure_entity_projection(&self) -> Result<(), StoreError> {
         self.conn
             .execute_batch(entity_projection::ENTITY_PROJECTION_V1)?;
-        self.conn.execute_batch(
-            "CREATE TABLE IF NOT EXISTS projection_checkpoint (
-                 name       TEXT PRIMARY KEY,
-                 generation INTEGER NOT NULL
-             );",
-        )?;
+        self.conn
+            .execute_batch(projection::PROJECTION_CHECKPOINT_V1)?;
         Ok(())
     }
 
@@ -1447,10 +1443,22 @@ impl WorldStore {
                 ])?;
             }
 
+            // The digest is written WITH the generation, from the accumulator
+            // that produced it. A checkpoint recording only how far a fold got
+            // cannot tell a resumed fold whether the state it is resuming into
+            // is the state that fold left -- which is the divergence
+            // rebuild-equals-incremental exists to detect.
             tx.execute(
-                "INSERT INTO projection_checkpoint (name, generation) VALUES (?1, ?2)
-                 ON CONFLICT(name) DO UPDATE SET generation = excluded.generation",
-                params![entity_projection::ENTITY_PROJECTION, head],
+                "INSERT INTO projection_checkpoint (name, generation, state_digest)
+                 VALUES (?1, ?2, ?3)
+                 ON CONFLICT(name) DO UPDATE SET
+                     generation = excluded.generation,
+                     state_digest = excluded.state_digest",
+                params![
+                    entity_projection::ENTITY_PROJECTION,
+                    head,
+                    entity_projection::state_digest_of(&acc)
+                ],
             )?;
         }
         tx.commit()?;
@@ -1554,23 +1562,9 @@ impl WorldStore {
     ///
     /// As [`WorldStore::load_entity_projection`].
     pub fn entity_projection_state_digest(&self) -> Result<String, StoreError> {
-        let rows = self.load_entity_projection()?;
-        let mut buf = String::new();
-        for (id, e) in &rows {
-            buf.push_str(id);
-            buf.push('\u{1f}');
-            buf.push_str(entity_projection::lifecycle_token(&e.lifecycle));
-            buf.push('\u{1f}');
-            buf.push_str(
-                entity_projection::redirect_json(&e.lifecycle)
-                    .as_deref()
-                    .unwrap_or(""),
-            );
-            buf.push('\u{1f}');
-            buf.push_str(if e.is_contradicted() { "1" } else { "0" });
-            buf.push('\u{1e}');
-        }
-        Ok(sha256_hex(buf.as_bytes()))
+        Ok(entity_projection::state_digest_of(
+            &self.load_entity_projection()?,
+        ))
     }
 
     /// Recompute the chain from genesis and compare against what is stored.
@@ -2173,6 +2167,8 @@ impl WorldStore {
             }
         }
         self.conn.execute_batch(projection::PROJECTIONS_V1)?;
+        self.conn
+            .execute_batch(projection::PROJECTION_CHECKPOINT_V1)?;
         Ok(())
     }
 

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -205,6 +205,16 @@ pub enum StoreError {
     /// recorded, it just may not be *labelled* — and a caller who asked for a
     /// label should learn it did not get one.
     UnboundSubjectNotStorable,
+    /// A stored entity-projection row could not be read back faithfully.
+    ///
+    /// **Refused, never repaired.** The columns are written only by the fold,
+    /// so a row that disagrees with itself means the file was edited underneath
+    /// the store — and a projection is rebuildable, so the recovery is
+    /// `rebuild_entity_projection`, not a guess.
+    CorruptEntityProjectionRow {
+        /// Which row, and how it disagreed.
+        detail: String,
+    },
     /// A [`SubjectRef::Candidate`] was offered as a label.
     ///
     /// Refused by ruling `KIRRA-WM-CANDIDATE-ID-001` (2026-08-08), not by
@@ -313,6 +323,9 @@ impl std::fmt::Display for StoreError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Sqlite(e) => write!(f, "sqlite: {e}"),
+            Self::CorruptEntityProjectionRow { detail } => {
+                write!(f, "corrupt entities_projection row: {detail}")
+            }
             Self::LlmCannotConfirm => write!(
                 f,
                 "writer_class=llm_candidate may not write claim_status=confirmed \
@@ -1269,6 +1282,276 @@ impl WorldStore {
             retention_class: adjudication_record::ADJUDICATION_RETENTION_CLASS,
             trust: None,
         })
+    }
+
+    /// Install the entity projection's DDL, lazily.
+    ///
+    /// **First fold, never `open`.** ADR-0041 D-20's `log_only_bytes` is the
+    /// on-disk size of a store holding only the event log; adding this table's
+    /// root pages at `open` would move that figure for every store, including
+    /// one that never projects, and invalidate the D-2 comparison the retention
+    /// horizons rest on.
+    fn ensure_entity_projection(&self) -> Result<(), StoreError> {
+        self.conn
+            .execute_batch(entity_projection::ENTITY_PROJECTION_V1)?;
+        self.conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS projection_checkpoint (
+                 name       TEXT PRIMARY KEY,
+                 generation INTEGER NOT NULL
+             );",
+        )?;
+        Ok(())
+    }
+
+    /// Whether the entity projection has ever been folded.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::Sqlite`] if the catalogue cannot be read.
+    pub fn has_entity_projection(&self) -> Result<bool, StoreError> {
+        let n: Option<i64> = self
+            .conn
+            .query_row(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='entities_projection'",
+                [],
+                |r| r.get(0),
+            )
+            .optional()?;
+        Ok(n.is_some())
+    }
+
+    /// How far the entity fold has consumed.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::Sqlite`] if the checkpoint cannot be read.
+    pub fn entity_projection_generation(&self) -> Result<i64, StoreError> {
+        if !self.has_entity_projection()? {
+            return Ok(0);
+        }
+        let g: Option<i64> = self
+            .conn
+            .query_row(
+                "SELECT generation FROM projection_checkpoint WHERE name = ?1",
+                params![entity_projection::ENTITY_PROJECTION],
+                |r| r.get(0),
+            )
+            .optional()?;
+        Ok(g.unwrap_or(0))
+    }
+
+    /// Fold new adjudication rows into the entity projection.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::Sqlite`] on storage failure, or
+    /// [`StoreError::CorruptEntityProjectionRow`] / the decode error if a
+    /// stored row cannot be read back faithfully. **Fail-closed**: a fold that
+    /// cannot read its own prior state does not start over from empty, because
+    /// that would silently drop every entity below the checkpoint.
+    pub fn fold_entity_projection(&mut self) -> Result<i64, StoreError> {
+        self.ensure_entity_projection()?;
+        let from = self.entity_projection_generation()?;
+        self.fold_entity_range(from)
+    }
+
+    /// Discard the entity projection and rebuild it from generation 0.
+    ///
+    /// The result must equal an incremental fold — ADR-0041's stated purity
+    /// property, checked by [`WorldStore::entity_projection_state_digest`]
+    /// rather than assumed.
+    ///
+    /// # Errors
+    ///
+    /// As [`WorldStore::fold_entity_projection`].
+    pub fn rebuild_entity_projection(&mut self) -> Result<i64, StoreError> {
+        self.ensure_entity_projection()?;
+        // The checkpoint is cleared for tidiness, NOT because leaving it would
+        // corrupt the rebuild: `fold_entity_range(0)` is passed its start
+        // explicitly and never consults the checkpoint, so a stale one is
+        // overwritten at the end either way. Said plainly because the
+        // neighbouring `subject_summary` path carries a comment about exactly
+        // that hazard -- which is real THERE, where the drop happens inside
+        // `ensure` and the next fold resumes from the checkpoint. Copying the
+        // reasoning across without checking it applied would have credited this
+        // line with preventing something it does not; the negative control
+        // (removing this DELETE) leaves every test green.
+        self.conn.execute("DELETE FROM entities_projection", [])?;
+        self.conn.execute(
+            "DELETE FROM projection_checkpoint WHERE name = ?1",
+            params![entity_projection::ENTITY_PROJECTION],
+        )?;
+        self.fold_entity_range(0)
+    }
+
+    fn fold_entity_range(&mut self, from_generation: i64) -> Result<i64, StoreError> {
+        // The accumulator is seeded from the STORED rows, not from empty: the
+        // reducer needs the prior lifecycle to decide whether an adjudication
+        // is a legal transition or a contradiction, and an incremental fold
+        // that started empty would call every first transition a creation.
+        let mut acc = self.load_entity_projection()?;
+
+        let tx = self.conn.transaction()?;
+        let mut head = from_generation;
+        {
+            let mut stmt = tx.prepare(
+                "SELECT generation, payload, payload_schema, provenance
+                 FROM world_events
+                 WHERE generation > ?1 AND claim_status = 'confirmed' AND kind = ?2
+                 ORDER BY generation ASC",
+            )?;
+            let mut rows = stmt.query(params![
+                from_generation,
+                adjudication_record::ADJUDICATION_KIND
+            ])?;
+            while let Some(r) = rows.next()? {
+                let generation: i64 = r.get(0)?;
+                let payload: String = r.get(1)?;
+                let payload_schema: i64 = r.get(2)?;
+                let provenance: String = r.get(3)?;
+                let cited: Vec<String> = serde_json::from_str(&provenance).map_err(|e| {
+                    StoreError::CorruptEntityProjectionRow {
+                        detail: format!("provenance is not a JSON array: {e}"),
+                    }
+                })?;
+                let adjudication =
+                    adjudication_record::decode_adjudication(&payload, payload_schema, &cited)
+                        .map_err(|e| StoreError::CorruptEntityProjectionRow {
+                            detail: format!("generation {generation}: {e}"),
+                        })?;
+                entity_projection::fold_adjudication(&mut acc, &adjudication, generation);
+                head = generation;
+            }
+
+            let mut upsert = tx.prepare(
+                "INSERT INTO entities_projection
+                     (entity_id, lifecycle, redirect, origin, contradicted, contradiction)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+                 ON CONFLICT(entity_id) DO UPDATE SET
+                     lifecycle = excluded.lifecycle,
+                     redirect = excluded.redirect,
+                     origin = excluded.origin,
+                     contradicted = excluded.contradicted,
+                     contradiction = excluded.contradiction",
+            )?;
+            for e in acc.values() {
+                upsert.execute(params![
+                    e.entity.as_str(),
+                    entity_projection::lifecycle_token(&e.lifecycle),
+                    entity_projection::redirect_json(&e.lifecycle),
+                    entity_projection::origin_of(&e.lifecycle).map(EntityId::as_str),
+                    i64::from(e.is_contradicted()),
+                    e.contradiction
+                        .as_ref()
+                        .map(entity_projection::contradiction_json),
+                ])?;
+            }
+
+            tx.execute(
+                "INSERT INTO projection_checkpoint (name, generation) VALUES (?1, ?2)
+                 ON CONFLICT(name) DO UPDATE SET generation = excluded.generation",
+                params![entity_projection::ENTITY_PROJECTION, head],
+            )?;
+        }
+        tx.commit()?;
+        Ok(head)
+    }
+
+    /// Every projected entity, keyed by id.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::CorruptEntityProjectionRow`] if a stored row cannot be
+    /// read back faithfully.
+    pub fn load_entity_projection(
+        &self,
+    ) -> Result<std::collections::BTreeMap<String, entity_projection::ProjectedEntity>, StoreError>
+    {
+        if !self.has_entity_projection()? {
+            return Ok(std::collections::BTreeMap::new());
+        }
+        let mut stmt = self.conn.prepare(
+            "SELECT entity_id, lifecycle, redirect, origin, contradicted, contradiction
+             FROM entities_projection ORDER BY entity_id ASC",
+        )?;
+        let mut out = std::collections::BTreeMap::new();
+        let mut rows = stmt.query([])?;
+        while let Some(r) = rows.next()? {
+            let id: String = r.get(0)?;
+            let token: String = r.get(1)?;
+            let redirect: Option<String> = r.get(2)?;
+            let origin: Option<String> = r.get(3)?;
+            let contradicted: i64 = r.get(4)?;
+            let detail: Option<String> = r.get(5)?;
+            let contradiction = match (contradicted != 0, detail.as_deref()) {
+                (false, _) => None,
+                (true, Some(raw)) => Some(
+                    entity_projection::contradiction_from_json(raw).map_err(|e| {
+                        StoreError::CorruptEntityProjectionRow {
+                            detail: format!("{id}: {e}"),
+                        }
+                    })?,
+                ),
+                // Flagged contradicted with nothing recorded: the fold always
+                // writes both, so this is a row edited underneath the store.
+                (true, None) => {
+                    return Err(StoreError::CorruptEntityProjectionRow {
+                        detail: format!("{id}: contradicted with no contradiction recorded"),
+                    })
+                }
+            };
+            let lifecycle = entity_projection::lifecycle_from_columns(
+                &token,
+                redirect.as_deref(),
+                origin.as_deref(),
+            )
+            .map_err(|e| StoreError::CorruptEntityProjectionRow {
+                detail: format!("{id}: {e}"),
+            })?;
+            let entity =
+                EntityId::new(&id).map_err(|e| StoreError::CorruptEntityProjectionRow {
+                    detail: format!("{id}: inadmissible entity id: {e:?}"),
+                })?;
+            out.insert(
+                id,
+                entity_projection::ProjectedEntity {
+                    entity,
+                    lifecycle,
+                    // Read back structurally. An earlier draft stored a
+                    // rendered sentence and rebuilt a placeholder here, which
+                    // would have pointed an operator at generation 0 for every
+                    // contradiction -- an invented value wearing a real field's
+                    // name.
+                    contradiction,
+                },
+            );
+        }
+        Ok(out)
+    }
+
+    /// A digest over the entity projection, in key order.
+    ///
+    /// # Errors
+    ///
+    /// As [`WorldStore::load_entity_projection`].
+    pub fn entity_projection_state_digest(&self) -> Result<String, StoreError> {
+        let rows = self.load_entity_projection()?;
+        let mut buf = String::new();
+        for (id, e) in &rows {
+            buf.push_str(id);
+            buf.push('\u{1f}');
+            buf.push_str(entity_projection::lifecycle_token(&e.lifecycle));
+            buf.push('\u{1f}');
+            buf.push_str(
+                entity_projection::redirect_json(&e.lifecycle)
+                    .as_deref()
+                    .unwrap_or(""),
+            );
+            buf.push('\u{1f}');
+            buf.push_str(if e.is_contradicted() { "1" } else { "0" });
+            buf.push('\u{1e}');
+        }
+        Ok(sha256_hex(buf.as_bytes()))
     }
 
     /// Recompute the chain from genesis and compare against what is stored.

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -1529,6 +1529,25 @@ impl WorldStore {
         Ok(out)
     }
 
+    /// **A snapshot of the entity projection, resolvable in place.**
+    ///
+    /// The read side of identity: pass it to
+    /// `kirra_world::resolution::resolve` to follow every redirect recorded
+    /// against an id.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::CorruptEntityProjectionRow`] if any row cannot be read
+    /// back faithfully. **The refusal happens here, once**, rather than during
+    /// the walk — see [`entity_projection::IdentityView`] for why resolving
+    /// over a per-query reader would turn a read failure into "no such entity".
+    pub fn identity_view(&self) -> Result<entity_projection::IdentityView, StoreError> {
+        Ok(entity_projection::IdentityView::new(
+            self.load_entity_projection()?,
+            self.entity_projection_generation()?,
+        ))
+    }
+
     /// A digest over the entity projection, in key order.
     ///
     /// # Errors

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -84,6 +84,7 @@ use rusqlite::{params, Connection, OptionalExtension};
 
 pub mod adjudication_record;
 pub mod compaction;
+pub mod entity_projection;
 pub mod projection;
 pub mod retention_driver;
 pub mod retention_sweeper;

--- a/crates/kirra-world-store/src/projection.rs
+++ b/crates/kirra-world-store/src/projection.rs
@@ -103,6 +103,17 @@ CREATE INDEX IF NOT EXISTS idx_current_object  ON world_current (object);
 -- How far the fold has consumed, so an incremental fold is possible at all.
 -- `state_digest` is what makes rebuild-equals-incremental checkable rather
 -- than merely believed.
+"#;
+
+/// **The checkpoint table, shared by every projection.**
+///
+/// Its own constant rather than a block inside [`PROJECTIONS_V1`], because more
+/// than one fold installs it and they must agree about its shape. They did not:
+/// the entity fold shipped a two-column `CREATE TABLE IF NOT EXISTS` of its own,
+/// which is a no-op when this three-column table already exists — and *wins*
+/// when it does not, so whichever fold ran second failed on the missing
+/// `state_digest`. One definition makes that disagreement unrepresentable.
+pub const PROJECTION_CHECKPOINT_V1: &str = r#"
 CREATE TABLE IF NOT EXISTS projection_checkpoint (
     name         TEXT    PRIMARY KEY,
     generation   INTEGER NOT NULL,

--- a/crates/kirra-world-store/tests/entity_projection.rs
+++ b/crates/kirra-world-store/tests/entity_projection.rs
@@ -442,3 +442,34 @@ fn a_corrupt_projection_refuses_before_any_resolution_happens() {
     );
     cleanup(&path);
 }
+
+/// **Both folds share `projection_checkpoint`, and must agree about its shape.**
+///
+/// `projection::PROJECTIONS_V1` creates it with a NOT NULL `state_digest`.
+/// Every test above folds only the entity projection, so this table was always
+/// created by the entity fold's own DDL — which means no test could have caught
+/// a disagreement. This one folds BOTH in one store, in both orders.
+#[test]
+fn the_two_folds_share_one_checkpoint_table() {
+    for entity_first in [true, false] {
+        let path = tmp(if entity_first { "share-e" } else { "share-w" });
+        let mut s = WorldStore::open(&path).expect("open");
+        seed(&mut s, &scenario());
+
+        if entity_first {
+            s.fold_entity_projection().expect("entity fold first");
+            s.fold().expect("world_current fold second");
+        } else {
+            s.fold().expect("world_current fold first");
+            s.fold_entity_projection().expect("entity fold second");
+        }
+
+        assert_eq!(
+            s.entity_projection_generation().expect("checkpoint"),
+            6,
+            "entity_first={entity_first}: the entity checkpoint survived the other fold"
+        );
+        assert!(s.projection_generation().expect("checkpoint") > 0);
+        cleanup(&path);
+    }
+}

--- a/crates/kirra-world-store/tests/entity_projection.rs
+++ b/crates/kirra-world-store/tests/entity_projection.rs
@@ -1,0 +1,337 @@
+//! Entity lifecycle folded from a real event log — `WM_SCOPE.md` §5.
+//!
+//! The reducer's own tests exercise the rule. These exercise the **wiring**:
+//! that adjudication rows in an actual `world_events` table produce the
+//! projection, that a rebuild equals an incremental fold, and that a store
+//! which never folds is left untouched on disk.
+
+use kirra_world::adjudication::{
+    AssertIdentity, ForgetEntity, IdentityAdjudication, Justification, MergeEntities,
+    RetirementReason, SplitEntity,
+};
+use kirra_world::entity::{Lifecycle, LifecycleState};
+use kirra_world::observation::{ClockDomain, DomainInstant};
+use kirra_world::reference::{EntityId, EventId, ObservationId};
+use kirra_world_store::adjudication_record::AdjudicationRow;
+use kirra_world_store::entity_projection;
+use kirra_world_store::{StoreError, WorldStore, WriterClass};
+
+const T0: i64 = 1_700_000_000_000;
+
+fn eid(s: &str) -> EntityId {
+    EntityId::new(s).expect("entity id")
+}
+
+fn just() -> Justification {
+    Justification::new([ObservationId::new("obs-1").expect("obs")]).expect("justification")
+}
+
+fn at() -> DomainInstant {
+    DomainInstant {
+        ms: 1,
+        domain: ClockDomain::System,
+    }
+}
+
+fn cleanup(path: &std::path::Path) {
+    for suffix in ["", "-wal", "-shm"] {
+        let mut q = path.as_os_str().to_os_string();
+        q.push(suffix);
+        let _ = std::fs::remove_file(std::path::PathBuf::from(q));
+    }
+}
+
+fn tmp(name: &str) -> std::path::PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "kirra-entproj-{}-{}.sqlite",
+        name,
+        std::process::id()
+    ));
+    cleanup(&p);
+    p
+}
+
+fn merge(sources: &[&str], into: &str) -> IdentityAdjudication {
+    IdentityAdjudication::Merge(
+        MergeEntities::new(
+            sources.iter().map(|s| eid(s)).collect::<Vec<_>>(),
+            eid(into),
+            just(),
+            at(),
+        )
+        .expect("merge"),
+    )
+}
+
+/// Append a sequence of adjudications, one per generation.
+fn seed(s: &mut WorldStore, adjudications: &[IdentityAdjudication]) {
+    for (i, a) in adjudications.iter().enumerate() {
+        let event_id = EventId::new(format!("ev-{i}")).expect("event id");
+        let observation_id = ObservationId::new(format!("obs-src-{i}")).expect("obs");
+        s.append_adjudication(
+            &AdjudicationRow {
+                event_id: &event_id,
+                observation_id: &observation_id,
+                txn_time_ms: T0 + i as i64,
+                valid_from_ms: T0 + i as i64,
+                source: "operator-console",
+                source_version: "1.0.0",
+                writer_class: WriterClass::Operator,
+            },
+            a,
+        )
+        .expect("append");
+    }
+}
+
+fn scenario() -> Vec<IdentityAdjudication> {
+    vec![
+        IdentityAdjudication::Assert(AssertIdentity::new(eid("a"), just(), at())),
+        IdentityAdjudication::Assert(AssertIdentity::new(eid("b"), just(), at())),
+        merge(&["a"], "b"),
+        IdentityAdjudication::Split(
+            SplitEntity::partition(eid("b"), [eid("b1"), eid("b2")], just(), at())
+                .expect("partition"),
+        ),
+        IdentityAdjudication::Forget(ForgetEntity::new(
+            eid("b1"),
+            RetirementReason::new("decommissioned").expect("reason"),
+            just(),
+            at(),
+        )),
+        // The contradiction: `a` is already Merged (terminal).
+        merge(&["a"], "c"),
+    ]
+}
+
+/// **A store that never folds is untouched.**
+///
+/// ADR-0041 D-20's `log_only_bytes` is the size of a log-only store. Installing
+/// this table at `open` would add its root pages to every store, moving that
+/// figure and invalidating the D-2 comparison the retention horizons rest on.
+#[test]
+fn open_leaves_no_entity_projection_table() {
+    let path = tmp("lazy");
+    let s = WorldStore::open(&path).expect("open");
+    assert!(
+        !s.has_entity_projection().expect("catalogue"),
+        "the projection table must not exist until the first fold"
+    );
+    assert_eq!(s.entity_projection_generation().expect("checkpoint"), 0);
+    cleanup(&path);
+}
+
+/// The fold reads adjudication rows and produces the lifecycles.
+#[test]
+fn folding_a_real_log_produces_the_lifecycles() {
+    let path = tmp("fold");
+    let mut s = WorldStore::open(&path).expect("open");
+    seed(&mut s, &scenario());
+
+    let head = s.fold_entity_projection().expect("fold");
+    assert_eq!(head, 6, "six adjudication rows");
+
+    let rows = s.load_entity_projection().expect("load");
+    assert_eq!(
+        rows["b1"].lifecycle,
+        Lifecycle::Retired,
+        "a split product is live and can then be retired"
+    );
+    assert_eq!(
+        rows["b"].lifecycle,
+        Lifecycle::Superseded {
+            by: vec![eid("b1"), eid("b2")]
+        }
+    );
+    assert_eq!(
+        rows["a"].lifecycle,
+        Lifecycle::Merged { into: eid("b") },
+        "the projection keeps what it held and picks no winner"
+    );
+    assert!(rows["a"].is_contradicted());
+    assert!(!rows["b"].is_contradicted(), "damage stays proportional");
+    cleanup(&path);
+}
+
+/// **Rebuild-from-zero equals incremental** — `WM_SCOPE` §0a's Knowledge-tier
+/// invariant, against a real store rather than the pure reducer.
+///
+/// Folded one event at a time, so every checkpoint position is exercised, and
+/// the contradiction deliberately falls in the middle.
+#[test]
+fn a_rebuild_equals_an_incremental_fold() {
+    let path = tmp("rebuild");
+    let mut s = WorldStore::open(&path).expect("open");
+    let events = scenario();
+
+    // **Genuinely incremental**: append one event, fold, repeat — so every fold
+    // after the first RESUMES from a checkpoint with prior state loaded.
+    //
+    // The first version of this test appended all six events and then folded
+    // six times. That is not incremental: the first fold consumed everything
+    // and the rest were no-ops, so it could not have caught a fold that started
+    // from an empty accumulator. The negative control proved it — mutating the
+    // accumulator seed to `BTreeMap::new()` left this test green.
+    for (i, a) in events.iter().enumerate() {
+        let event_id = EventId::new(format!("ev-{i}")).expect("event id");
+        let observation_id = ObservationId::new(format!("obs-src-{i}")).expect("obs");
+        s.append_adjudication(
+            &AdjudicationRow {
+                event_id: &event_id,
+                observation_id: &observation_id,
+                txn_time_ms: T0 + i as i64,
+                valid_from_ms: T0 + i as i64,
+                source: "operator-console",
+                source_version: "1.0.0",
+                writer_class: WriterClass::Operator,
+            },
+            a,
+        )
+        .expect("append");
+        s.fold_entity_projection().expect("fold");
+    }
+    assert_eq!(
+        s.entity_projection_generation().expect("checkpoint"),
+        events.len() as i64,
+        "each fold advanced the checkpoint, so the folds really were incremental"
+    );
+    let incremental = s.entity_projection_state_digest().expect("digest");
+
+    s.rebuild_entity_projection().expect("rebuild");
+    let rebuilt = s.entity_projection_state_digest().expect("digest");
+
+    assert_eq!(
+        incremental, rebuilt,
+        "a rebuild must equal an incremental fold"
+    );
+    // Non-vacuous: the digest actually distinguishes states.
+    assert_ne!(
+        incremental,
+        WorldStore::open(&tmp("empty"))
+            .expect("open")
+            .entity_projection_state_digest()
+            .expect("digest"),
+        "the digest must not be constant, or the equality above proves nothing"
+    );
+    cleanup(&path);
+}
+
+/// A contradiction survives a reload **with its fields**, not as a placeholder.
+#[test]
+fn a_contradiction_round_trips_through_storage() {
+    let path = tmp("contradiction");
+    let mut s = WorldStore::open(&path).expect("open");
+    seed(&mut s, &scenario());
+    s.fold_entity_projection().expect("fold");
+
+    let c = s.load_entity_projection().expect("load")["a"]
+        .contradiction
+        .clone()
+        .expect("contradicted");
+    assert_eq!(c.held, LifecycleState::Merged);
+    assert_eq!(c.attempted, LifecycleState::Merged);
+    assert_eq!(
+        c.generation, 6,
+        "the recorded generation must name the event that disagreed, not 0"
+    );
+    cleanup(&path);
+}
+
+/// **A corrupt row is refused, never repaired.**
+///
+/// The columns are written only by the fold, so a `merged` row with no redirect
+/// means the file was edited underneath the store. Reading it as anything would
+/// fabricate a redirect §6.3 says stays resolvable forever.
+#[test]
+fn a_corrupt_projection_row_is_refused() {
+    let path = tmp("corrupt");
+    let mut s = WorldStore::open(&path).expect("open");
+    seed(&mut s, &scenario());
+    s.fold_entity_projection().expect("fold");
+
+    s.raw_execute_for_test(
+        "UPDATE entities_projection SET redirect = NULL WHERE lifecycle = 'merged'",
+    )
+    .expect("tamper");
+
+    let err = s
+        .load_entity_projection()
+        .expect_err("a merged row with no redirect must be refused");
+    assert!(
+        matches!(err, StoreError::CorruptEntityProjectionRow { .. }),
+        "expected a corrupt-row refusal, got {err:?}"
+    );
+    cleanup(&path);
+}
+
+/// The recovery for a corrupt projection is a rebuild, and it works — which is
+/// what makes refusing above the right call rather than a dead end.
+#[test]
+fn a_rebuild_recovers_from_a_corrupt_projection() {
+    let path = tmp("recover");
+    let mut s = WorldStore::open(&path).expect("open");
+    seed(&mut s, &scenario());
+    s.fold_entity_projection().expect("fold");
+    let good = s.entity_projection_state_digest().expect("digest");
+
+    s.raw_execute_for_test(
+        "UPDATE entities_projection SET redirect = NULL WHERE lifecycle = 'merged'",
+    )
+    .expect("tamper");
+    assert!(s.load_entity_projection().is_err());
+
+    s.rebuild_entity_projection().expect("rebuild");
+    assert_eq!(
+        s.entity_projection_state_digest().expect("digest"),
+        good,
+        "a rebuild restores the projection from the log"
+    );
+    cleanup(&path);
+}
+
+/// Non-adjudication rows are not folded. The fold selects on `kind`, so an
+/// ordinary observation must not create an entity.
+#[test]
+fn ordinary_observations_do_not_enter_the_entity_projection() {
+    let path = tmp("kinds");
+    let mut s = WorldStore::open(&path).expect("open");
+    seed(&mut s, &[merge(&["a"], "b")]);
+
+    let event_id = EventId::new("ev-obs").expect("event id");
+    let observation_id = ObservationId::new("obs-obs").expect("obs");
+    s.append(&kirra_world_store::NewEvent {
+        event_id: &event_id,
+        observation_id: &observation_id,
+        txn_time_ms: T0 + 99,
+        valid_from_ms: T0 + 99,
+        valid_to_ms: None,
+        source: "sensor",
+        source_version: "1.0.0",
+        writer_class: WriterClass::Sensor,
+        claim_status: kirra_world_store::ClaimStatus::Confirmed,
+        provenance: &[],
+        frame_id: None,
+        map_id: None,
+        kind: "observation",
+        subject: "some-thing",
+        subject_ref: None,
+        predicate: None,
+        object: None,
+        payload: "{}",
+        payload_schema: 1,
+        retention_class: "raw",
+        trust: None,
+    })
+    .expect("append observation");
+
+    s.fold_entity_projection().expect("fold");
+    let rows = s.load_entity_projection().expect("load");
+    assert!(rows.contains_key("a"), "the adjudication folded");
+    assert!(
+        !rows.contains_key("some-thing"),
+        "an ordinary observation must not create an entity row"
+    );
+    let _ = entity_projection::ENTITY_PROJECTION;
+    cleanup(&path);
+}

--- a/crates/kirra-world-store/tests/entity_projection.rs
+++ b/crates/kirra-world-store/tests/entity_projection.rs
@@ -335,3 +335,110 @@ fn ordinary_observations_do_not_enter_the_entity_projection() {
     let _ = entity_projection::ENTITY_PROJECTION;
     cleanup(&path);
 }
+
+// -- Sub-slice 3: resolution against a real store -------------------------
+
+use kirra_world::resolution::{resolve, RefusalReason, ResolutionOutcome};
+
+/// **`resolve` answers from a real log.** The point of the whole slice.
+///
+/// `a` was merged into `b`, and `b` was then partitioned into `b1`/`b2`. So the
+/// merged-away id still answers — §6.3's promise — and answers with what its
+/// successor turned out to be rather than with a dead id.
+#[test]
+fn resolution_follows_a_real_logs_redirects() {
+    let path = tmp("resolve");
+    let mut s = WorldStore::open(&path).expect("open");
+    // Drop the contradiction from the scenario: this test is about the walk.
+    let events: Vec<IdentityAdjudication> = scenario().into_iter().take(5).collect();
+    seed(&mut s, &events);
+    s.fold_entity_projection().expect("fold");
+
+    let view = s.identity_view().expect("view");
+    assert_eq!(view.generation(), 5, "the snapshot names its own instant");
+
+    // b1 is Retired, b2 is a live split product -> b is ambiguous between them,
+    // and `a` inherits that by redirecting into b.
+    assert_eq!(
+        resolve(&view, &eid("a")),
+        ResolutionOutcome::Ambiguous {
+            successors: vec![eid("b1"), eid("b2")]
+        },
+        "a merged-away id resolves through its successor's partition"
+    );
+    assert_eq!(
+        resolve(&view, &eid("b2")),
+        ResolutionOutcome::Located {
+            entity: eid("b2"),
+            hops: 0,
+        }
+    );
+    cleanup(&path);
+}
+
+/// An id the log never mentions is `Unknown`, not refused.
+#[test]
+fn an_unmentioned_id_resolves_to_unknown() {
+    let path = tmp("resolve-unknown");
+    let mut s = WorldStore::open(&path).expect("open");
+    seed(&mut s, &[merge(&["a"], "b")]);
+    s.fold_entity_projection().expect("fold");
+
+    let view = s.identity_view().expect("view");
+    assert_eq!(resolve(&view, &eid("nobody")), ResolutionOutcome::Unknown);
+    cleanup(&path);
+}
+
+/// **The end-to-end contradiction path**, from two valid events in the log to a
+/// per-query refusal.
+///
+/// This is the design decision of sub-slice 2 observed from the outside: the
+/// contradicted entity refuses, and an unrelated one still answers.
+#[test]
+fn a_contradicted_entity_refuses_and_the_rest_still_resolve() {
+    let path = tmp("resolve-contradiction");
+    let mut s = WorldStore::open(&path).expect("open");
+    seed(&mut s, &scenario());
+    s.fold_entity_projection().expect("fold");
+
+    let view = s.identity_view().expect("view");
+    assert_eq!(
+        resolve(&view, &eid("a")),
+        ResolutionOutcome::Refused(RefusalReason::ContradictoryHistory { at: eid("a") }),
+        "two individually valid merges of `a` make its identity unanswerable"
+    );
+    assert!(
+        matches!(
+            resolve(&view, &eid("b2")),
+            ResolutionOutcome::Located { .. }
+        ),
+        "the damage stays proportional -- unrelated entities still answer"
+    );
+    cleanup(&path);
+}
+
+/// **A corrupt projection refuses at LOAD, not during the walk.**
+///
+/// The trait has no error channel, so a per-query reader would have to turn a
+/// read failure into `None` — reporting an existing id as absent. Doing the
+/// fallible work once, at load, is what makes that unreachable.
+#[test]
+fn a_corrupt_projection_refuses_before_any_resolution_happens() {
+    let path = tmp("resolve-corrupt");
+    let mut s = WorldStore::open(&path).expect("open");
+    seed(&mut s, &scenario());
+    s.fold_entity_projection().expect("fold");
+    s.raw_execute_for_test(
+        "UPDATE entities_projection SET redirect = NULL WHERE lifecycle = 'merged'",
+    )
+    .expect("tamper");
+
+    assert!(
+        matches!(
+            s.identity_view(),
+            Err(StoreError::CorruptEntityProjectionRow { .. })
+        ),
+        "the view must refuse to exist rather than resolve over a partial one"
+    );
+    cleanup(&path);
+}

--- a/crates/kirra-world/src/resolution.rs
+++ b/crates/kirra-world/src/resolution.rs
@@ -179,6 +179,26 @@ pub enum RefusalReason {
         /// The entity whose supersession names nothing.
         at: EntityId,
     },
+    /// **The recorded history for this entity contradicts itself.**
+    ///
+    /// Two individually valid adjudications disagreed in aggregate — `a` merged
+    /// into `b`, then `a` merged into `c` by another operator — so no
+    /// constructor could refuse either, and the projection that folded them
+    /// declined to pick a winner.
+    ///
+    /// A sibling of [`Self::RedirectCycle`] rather than a different kind of
+    /// thing: a cycle *is* one instance of this fault, caught by the walk
+    /// instead of by the fold. Both are answered per query rather than by
+    /// refusing to resolve anything, which is what keeps the damage
+    /// proportional to the contradiction.
+    ///
+    /// Reported for an entity reached **through** a redirect as much as for one
+    /// queried directly: an answer that routed through a contradicted identity
+    /// is not trustworthy just because the question named something else.
+    ContradictoryHistory {
+        /// The entity whose history disagrees with itself.
+        at: EntityId,
+    },
 }
 
 /// The graph of recorded judgements, as far as resolution needs it.
@@ -191,7 +211,31 @@ pub enum RefusalReason {
 pub trait AdjudicationGraph {
     /// The lifecycle recorded for an id, or `None` if the graph has no such
     /// entity.
+    ///
+    /// # `None` means ABSENT, never "could not look"
+    ///
+    /// There is no error channel here, and that is a constraint on
+    /// implementors rather than an oversight: an implementation backed by
+    /// storage must **not** turn a read failure into `None`, because that
+    /// reports an existing id as no-such-entity — the precise confusion
+    /// [`RefusalReason::DanglingRedirect`] and
+    /// [`RefusalReason::EmptySupersession`] exist to prevent, reintroduced one
+    /// layer down.
+    ///
+    /// The way to honour that is to do the fallible work *before* resolving:
+    /// load the state, fail closed there, and implement this over what was
+    /// loaded. `kirra_world_store::IdentityView` is that shape.
     fn lifecycle_of(&self, id: &EntityId) -> Option<Lifecycle>;
+
+    /// Whether this entity's recorded history contradicts itself.
+    ///
+    /// Defaulted to `false` so a graph with no notion of contradiction — a
+    /// test fixture, an in-memory map — is unaffected. A projection that folds
+    /// adjudications overrides it; see
+    /// [`RefusalReason::ContradictoryHistory`].
+    fn is_contradicted(&self, _id: &EntityId) -> bool {
+        false
+    }
 }
 
 /// **Resolve an identifier through every redirect recorded against it.**
@@ -273,6 +317,14 @@ impl<G: AdjudicationGraph> Walk<'_, G> {
         }
         if self.black.contains(id) {
             return Ok(());
+        }
+
+        // Checked before the lifecycle is read, and before any answer is
+        // collected: a contradicted entity has a lifecycle -- the projection
+        // keeps what it held -- so trusting it here would answer `Located` from
+        // a state the fold has already declared untrustworthy.
+        if self.graph.is_contradicted(id) {
+            return Err(RefusalReason::ContradictoryHistory { at: id.clone() });
         }
 
         let Some(lifecycle) = self.graph.lifecycle_of(id) else {
@@ -731,6 +783,75 @@ mod tests {
             ResolutionOutcome::Located {
                 entity: eid(&format!("e{MAX_REDIRECT_EDGES}")),
                 hops: MAX_REDIRECT_EDGES,
+            }
+        );
+    }
+
+    // -- Contradiction -------------------------------------------------
+
+    /// A graph that reports contradictions, for the two tests below.
+    struct Contradicting(Graph, Vec<EntityId>);
+
+    impl AdjudicationGraph for Contradicting {
+        fn lifecycle_of(&self, id: &EntityId) -> Option<Lifecycle> {
+            self.0.lifecycle_of(id)
+        }
+        fn is_contradicted(&self, id: &EntityId) -> bool {
+            self.1.contains(id)
+        }
+    }
+
+    /// **A contradicted entity refuses rather than answering from a state the
+    /// fold declined to trust.**
+    ///
+    /// The projection keeps the lifecycle it held when the contradiction
+    /// arrived, so `lifecycle_of` returns something perfectly well-formed here.
+    /// Answering `Located` from it would launder a disagreement into a
+    /// confident answer.
+    #[test]
+    fn a_contradicted_entity_refuses_instead_of_answering() {
+        let g = Contradicting(
+            graph(&[("a", merged("b")), ("b", Lifecycle::Established)]),
+            vec![eid("a")],
+        );
+        assert_eq!(
+            resolve(&g, &eid("a")),
+            ResolutionOutcome::Refused(RefusalReason::ContradictoryHistory { at: eid("a") })
+        );
+    }
+
+    /// **And it refuses for a question that merely routes through it.**
+    ///
+    /// `z` is not contradicted; `a` is, and `z` redirects to it. An answer that
+    /// travelled through a contradicted identity is not trustworthy because the
+    /// question named something else.
+    #[test]
+    fn a_redirect_through_a_contradicted_entity_also_refuses() {
+        let g = Contradicting(
+            graph(&[
+                ("z", merged("a")),
+                ("a", merged("b")),
+                ("b", Lifecycle::Established),
+            ]),
+            vec![eid("a")],
+        );
+        assert_eq!(
+            resolve(&g, &eid("z")),
+            ResolutionOutcome::Refused(RefusalReason::ContradictoryHistory { at: eid("a") }),
+            "the refusal names the contradicted entity, not the one asked about"
+        );
+    }
+
+    /// The default is `false`, so every graph that does not model
+    /// contradiction is byte-identical in behaviour.
+    #[test]
+    fn a_graph_without_contradictions_is_unaffected() {
+        let g = graph(&[("a", merged("b")), ("b", Lifecycle::Established)]);
+        assert_eq!(
+            resolve(&g, &eid("a")),
+            ResolutionOutcome::Located {
+                entity: eid("b"),
+                hops: 1,
             }
         );
     }

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -829,8 +829,28 @@ does not describe is how a residue disappears.
       Rebuild-from-zero equals incremental (`WM_SCOPE` §0a) is asserted against
       a real store with genuinely interleaved append-and-fold, and a corrupt row
       is refused rather than repaired, with a rebuild proven to recover.
-- [ ] **`AdjudicationGraph for WorldStore`** — makes `resolution::resolve` live
-      against real data. Small now that the projection exists. Sub-slice 3 of 3.
+- [x] **Resolution against a real store** — **DONE 2026-08-08**,
+      `entity_projection::IdentityView` + `WorldStore::identity_view`. Sub-slice
+      3 of 3; the schema slice is complete and `resolution::resolve` is now live
+      against recorded evidence rather than a test fixture.
+      **Not an `AdjudicationGraph` impl on `WorldStore`, and that is the
+      finding.** `lifecycle_of` returns `Option<Lifecycle>` with **no error
+      channel**, so a per-query storage reader would have to turn a read failure
+      into `None` — and `None` means *"the graph has no such entity"*. That
+      reports an existing id as absent: precisely the bug `EmptySupersession`
+      was added to fix, reintroduced one layer down where the resolver cannot
+      see it. The fallible work therefore happens **once, at load**:
+      `identity_view()` returns a `Result` and refuses a corrupt projection
+      rather than resolving over a partial one. The trait's contract is honoured
+      by construction. A snapshot also means one walk sees ONE state of the
+      world, where a per-query reader could observe a fold landing mid-walk and
+      answer from two generations at once.
+      `RefusalReason::ContradictoryHistory` closes the loop from sub-slice 2: a
+      contradicted entity refuses **per query**, including for a question that
+      merely routes *through* it, since an answer that travelled through a
+      contradicted identity is not trustworthy because the question named
+      something else. The `is_contradicted` seam is a defaulted trait method, so
+      every graph that does not model contradiction is behaviourally unchanged.
 
 - [ ] Entity resolution, the *matching* half — **candidate clustering**, deciding
       that two observations are about the same thing. Marked *pure* by §6.3.

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -800,10 +800,38 @@ does not describe is how a residue disappears.
       the encoding (a partition would round-trip as a subtraction, undoing the
       split ruling at the storage layer) and setting a compactable retention
       class.
-- [ ] **`entities_projection`** — the deterministic reducer folding adjudication
-      rows into lifecycles. Sub-slice 2 of 3.
+- [x] **`entities_projection`** — **DONE 2026-08-08**,
+      `crates/kirra-world-store/src/entity_projection.rs` + the fold wiring on
+      `WorldStore`, 11 unit + 7 integration tests. Sub-slice 2 of 3.
+      **No migration and no schema bump**: `WM2_EVENT_SCHEMA.md` §7 rules
+      `entities_projection` a rebuildable view that *"follows from the fold, not
+      from this table"* — named in the ratified document as deliberately outside
+      the schema surface. The DDL installs on the **first fold, never at
+      `open`**, because ADR-0041 D-20's `log_only_bytes` is the size of a
+      log-only store and adding root pages at `open` would move that figure for
+      every store, invalidating the D-2 comparison the retention horizons rest
+      on.
+      The reducer does not restate what a verb means — it applies
+      `resulting_lifecycles`, already walked against `advance_to` by the
+      adjudication seam test, so there is only one implementation to drift.
+      **Contradiction poisons the ENTITY, not the fold.** Two individually valid
+      events can disagree in aggregate and no constructor can refuse either.
+      Failing the fold is not fail-closed but fail-bricked — one bad pair stops
+      identity answers for every entity, and since the log is append-only a
+      rebuild replays it and wedges again. Skipping produces a projection that
+      disagrees with the log while looking healthy. So the entity is poisoned,
+      the projection picks NO winner, and everything else folds — matching the
+      precedent `resolution` set for a redirect cycle, which is one instance of
+      the same fault. Poison is sticky and keeps the FIRST contradiction, for
+      diagnostic stability. **Stated as a real limitation: no sequence of
+      today's four verbs clears a contradiction** — resolution needs a fifth
+      verb and its own ruling.
+      Rebuild-from-zero equals incremental (`WM_SCOPE` §0a) is asserted against
+      a real store with genuinely interleaved append-and-fold, and a corrupt row
+      is refused rather than repaired, with a rebuild proven to recover.
 - [ ] **`AdjudicationGraph for WorldStore`** — makes `resolution::resolve` live
-      against real data. Small once the projection exists. Sub-slice 3 of 3.
+      against real data. Small now that the projection exists. Sub-slice 3 of 3.
+
 - [ ] Entity resolution, the *matching* half — **candidate clustering**, deciding
       that two observations are about the same thing. Marked *pure* by §6.3.
       Still open, and still the thing `Corroboration(n)` waits on (§4): the axis


### PR DESCRIPTION
Sub-slices **2 and 3** of the schema slice, shipped together. With these the slice is complete: `resolution::resolve` — landed pure in #1401 — now answers from recorded evidence instead of a test fixture.

Three commits: the pure reducer, the store wiring, then resolution.

## Two constraints the survey found before a line was written

**No migration and no schema bump.** I was about to write a v5 migration. `WM2_EVENT_SCHEMA.md` §7 rules it out under *what this ruling does not decide*:

> **Projection schemas.** `entities_projection` / `relationships_projection` are rebuildable views and follow from the fold, not from this table.

It is named in the ratified document as a rebuildable view, deliberately outside the schema surface.

**The DDL installs on the first fold, never at `open`** — load-bearing, not stylistic. ADR-0041 **D-20**'s `log_only_bytes` is the on-disk size of a store holding only the event log. Creating projection tables at `open` adds their root pages to *every* store, including one that never projects, silently moving that figure and invalidating the D-2 comparison the retention horizons rest on.

## The reducer does not restate what a verb means

It applies `IdentityAdjudication::resulting_lifecycles` — the domain's own statement of each verb's consequences, already walked against `advance_to` from every live state by the adjudication seam test. A second implementation here would agree today and drift later; this one cannot, because there is only one.

## Contradiction poisons the entity, not the fold

Two individually valid events can disagree in aggregate — `a` merged into `b`, then `a` merged into `c` by another operator — and no constructor can refuse either, since neither event can see the other. Three responses were available and two are worse:

| Response | Why not |
|---|---|
| **Fail the fold** | Not fail-closed — *fail-bricked*. One contradictory pair about one entity stops identity answers for **every** entity, and the log is append-only so the offending event cannot be removed: a rebuild replays it and wedges again |
| **Skip the event** | A projection that disagrees with the log while looking healthy — the "no projection-only fact" invariant inverted, and confidently wrong |
| **Poison the entity** ✅ | Blast radius matches the fault, nothing is invented (no winner picked), the caller learns at the point of asking about *that* entity |

This matches the precedent `resolution` already set for a redirect cycle — which is one instance of the same fault, caught by the walk instead of by the fold. Both are answered per query.

**Stated as a real limitation rather than glossed:** no sequence of today's four verbs clears a contradiction. `ForgetEntity` retires an entity; it does not adjudicate between two prior claims. Resolution needs a fifth verb and its own ruling. What this buys is proportional damage with the evidence intact — not easy recovery.

## Sub-slice 3 is not an `AdjudicationGraph` impl on `WorldStore`

`lifecycle_of` returns `Option<Lifecycle>` with **no error channel**. A per-query storage reader would therefore have to turn a read failure into `None` — and `None` means *"the graph has no such entity"*. That reports an existing id as **absent**: exactly the bug `EmptySupersession` was added to fix in #1401, reintroduced one layer down where the resolver cannot see it.

So the fallible work happens **once, at load**. `identity_view()` returns a `Result` and refuses a corrupt projection rather than resolving over a partial one; what remains is a pure map, and the trait's contract is honoured by construction. The trait docs now state that constraint on implementors, since nothing in the signature does.

A snapshot buys a second thing: one walk sees **one** state of the world. A per-query reader could observe a fold landing mid-walk and answer from two generations at once.

`RefusalReason::ContradictoryHistory` closes the loop — a contradicted entity refuses per query, including for a question that merely *routes through* it. The `is_contradicted` seam is a **defaulted** trait method, so every graph that does not model contradiction is behaviourally unchanged.

## Three things the controls caught, all mine

**The headline test was not testing what it claimed.** `a_rebuild_equals_an_incremental_fold` appended all six events and *then* folded six times — the first fold consumed everything and the rest were no-ops, so no fold ever resumed from a checkpoint with prior state. Seeding the accumulator empty instead of from stored rows left it **green**. It now interleaves append-and-fold and asserts the checkpoint advanced each time; the same control now fails it.

**`load_entity_projection` fabricated data on reload.** It stored a rendered sentence and rebuilt a placeholder contradiction with `generation: 0` — an invented value wearing a real field's name, which would have pointed an operator at the wrong event. Contradictions are now stored structurally and read back faithfully, refused if malformed.

**A comment credited a mechanism that does not apply here.** I copied `subject_summary`'s "the checkpoint must go with the table or the next fold resumes into an empty table" onto `rebuild_entity_projection`, where it is false — `fold_entity_range(0)` is passed its start explicitly and never consults the checkpoint. Removing the DELETE leaves every test green. Corrected in place, with why the hazard is real in the neighbouring path but not this one.

I also corrected an overstated justification in my own docs: stickiness of poison is a **diagnostic** choice, not a determinism one. The reducer is a pure function of the sequence either way, and the control proved it — mutating stickiness away leaves the determinism test green.

## Verification

11 unit + 11 integration tests for the projection, 3 unit + 4 integration for resolution.

**Ten negative controls fire** across the three commits: non-sticky poison, last-contradiction-wins, picking a winner, dropping an unseen entity, unfiltered `kind`, empty accumulator, corrupt row, removing the walk's contradiction check, an `IdentityView` that never reports contradiction, and an `identity_view` that swallows its load error.

Also green: `cargo test --workspace`; both workspace-detached trees; `cargo fmt --check`; `clippy -D warnings`; orphan-cores gate; Kirra World bidirectional fence **INTACT**; re-export shim ratchet **0**.

One caveat on the orphan-cores gate: it reports green partly for the wrong reason — `entity_projection::fold_all` collides by name with `projection::fold_all`, and the gate's item-name heuristic matches that anywhere. The module *is* genuinely wired, so the green is also true, but it was not earned by the check. Worth a separate fix; untouched here.

## Scope

Tier 2's remaining box is **candidate clustering** — the matching half, which `Corroboration(n)` still waits on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_