### PR TITLE
S-1: compaction must not silently coarsen a subject summary

### DIFF
--- a/crates/kirra-world-store/src/compaction.rs
+++ b/crates/kirra-world-store/src/compaction.rs
@@ -148,6 +148,12 @@ CREATE TABLE IF NOT EXISTS compaction_summaries (
     CHECK (event_count > 0),
     CHECK (last_valid_from_ms >= first_valid_from_ms)
 );
+
+-- The PRIMARY KEY leads with `lo_generation`, so a lookup BY SUBJECT -- which
+-- is how `SummaryCoverage` is computed for every summary read -- cannot use it
+-- and would scan the whole table once per subject.
+CREATE INDEX IF NOT EXISTS idx_compaction_summaries_subject
+    ON compaction_summaries (subject);
 "#;
 
 /// The per-key summary retained when a span is compacted.

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -3376,16 +3376,25 @@ impl WorldStore {
         let retained = self.subject_summaries()?;
         let all_citations = self.summaries()?;
 
+        // Grouped once, not rescanned per subject: each citation belongs to
+        // exactly one subject, and BOTH tables grow without bound over a
+        // store's life, so a per-subject scan would be quadratic in precisely
+        // the dimension that accumulates.
+        let mut citations_by_subject: std::collections::BTreeMap<&str, Vec<DegradedSummary>> =
+            std::collections::BTreeMap::new();
+        for c in &all_citations {
+            citations_by_subject
+                .entry(c.subject.as_str())
+                .or_default()
+                .push(c.clone());
+        }
+
         let coverage_for = |subject: &str| -> SummaryCoverage {
-            let mine: Vec<_> = all_citations
-                .iter()
-                .filter(|c| c.subject == subject)
-                .cloned()
-                .collect();
-            if mine.is_empty() {
-                SummaryCoverage::Complete
-            } else {
-                SummaryCoverage::Degraded { summaries: mine }
+            match citations_by_subject.get(subject) {
+                None => SummaryCoverage::Complete,
+                Some(mine) => SummaryCoverage::Degraded {
+                    summaries: mine.clone(),
+                },
             }
         };
 

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -3357,6 +3357,72 @@ impl WorldStore {
         )
     }
 
+    /// **Every summarised subject, with how complete each one is.**
+    ///
+    /// The union of two sources, and the union is the point: rows the fold
+    /// retained, **plus** subjects known only through compaction citations.
+    /// Before this, a subject whose every event had been compacted simply
+    /// vanished from a rebuilt summary — the store went from having observed it
+    /// to never having heard of it.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::Sqlite`] on any read failure.
+    pub fn subject_summaries_with_coverage(
+        &self,
+    ) -> Result<Vec<subject_projection::SubjectSummaryAnswer>, StoreError> {
+        use subject_projection::{SubjectSummaryAnswer, SummaryCoverage, SummaryKind};
+
+        let retained = self.subject_summaries()?;
+        let all_citations = self.summaries()?;
+
+        let coverage_for = |subject: &str| -> SummaryCoverage {
+            let mine: Vec<_> = all_citations
+                .iter()
+                .filter(|c| c.subject == subject)
+                .cloned()
+                .collect();
+            if mine.is_empty() {
+                SummaryCoverage::Complete
+            } else {
+                SummaryCoverage::Degraded { summaries: mine }
+            }
+        };
+
+        let mut out: Vec<SubjectSummaryAnswer> = retained
+            .into_iter()
+            .map(|r| SubjectSummaryAnswer {
+                subject_kind: r.subject_kind,
+                subject: r.subject.clone(),
+                coverage: coverage_for(&r.subject),
+                retained: Some(r),
+            })
+            .collect();
+
+        // Subjects with NO retained row at all. `Unlabelled` is the honest kind
+        // here rather than a guess -- see the FIXME on `SubjectSummaryAnswer`:
+        // citations record no discriminant, so claiming `Entity` would be
+        // inventing one.
+        let known: std::collections::BTreeSet<&str> =
+            out.iter().map(|a| a.subject.as_str()).collect();
+        let mut cited_only: std::collections::BTreeSet<&str> = std::collections::BTreeSet::new();
+        for c in &all_citations {
+            if !known.contains(c.subject.as_str()) {
+                cited_only.insert(c.subject.as_str());
+            }
+        }
+        for subject in cited_only {
+            out.push(SubjectSummaryAnswer {
+                subject_kind: SummaryKind::Unlabelled,
+                subject: subject.to_owned(),
+                retained: None,
+                coverage: coverage_for(subject),
+            });
+        }
+        out.sort_by(|a, b| a.subject.cmp(&b.subject));
+        Ok(out)
+    }
+
     /// Every **resolved entity** this store has summarised.
     ///
     /// The query this projection was rebuilt to answer, and what entity

--- a/crates/kirra-world-store/src/subject_projection.rs
+++ b/crates/kirra-world-store/src/subject_projection.rs
@@ -580,3 +580,147 @@ mod tests {
         assert!(subject_fold_all(&[]).expect("readable kinds").is_empty());
     }
 }
+
+// ---------------------------------------------------------------------------
+// Coverage — S-1, the compaction/aggregate boundary
+// ---------------------------------------------------------------------------
+
+/// **Whether a materialised summary is complete with respect to retained
+/// history.**
+///
+/// Distinct from [`crate::compaction::Resolution`] on purpose, though they share
+/// the degraded vocabulary. `Resolution` answers *"was the range I queried
+/// intact?"*; this answers *"is this aggregate still backed by every event that
+/// built it?"* Two different questions about the same fact, and reusing one type
+/// would make `Resolution::Full` read as a claim about a query nobody made.
+///
+/// # Why this is computed at read time and never stored
+///
+/// The same call [`crate::WorldStore`] already makes for validity: a derived
+/// conclusion that can go stale does not get a column. A fold cannot know about
+/// a compaction that happens after it, so a stored flag would be wrong the
+/// moment anyone compacted without re-folding — and the whole failure this type
+/// exists to fix is a summary that looks complete and is not.
+///
+/// # The defect this makes visible
+///
+/// `subject_summary`'s aggregates are a MIN and a COUNT over **every**
+/// contributing event, so its dependency set is the whole log rather than a
+/// head. Compaction may therefore remove evidence it depends on, and before
+/// this type existed a rebuild silently produced different knowledge:
+/// `first_observed_ms` moved forward to the oldest *surviving* event, and
+/// `observation_count` fell. Worse, a subject whose every event was compacted
+/// **disappeared entirely** from a rebuilt summary — the store went from having
+/// observed it to never having heard of it, with the evidence sitting in
+/// `compaction_summaries` the whole time.
+///
+/// Nothing about those numbers was wrong; they were *coarser*, and presented as
+/// though they were not. That is the difference from a `world_current` head,
+/// whose removal makes an answer WRONG rather than coarser — and why head
+/// protection is the right fix there and not here.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SummaryCoverage {
+    /// Every event that contributed is still in the log.
+    Complete,
+    /// Contributing evidence was compacted away.
+    ///
+    /// The retained aggregates alongside are over **surviving evidence only**;
+    /// these summaries stand for the rest. `event_count` and `first_txn_time_ms`
+    /// across them are what a caller adds back to recover the original figures
+    /// — the reconciliation identity `assert_reconciles` checks.
+    Degraded {
+        /// Per-`(subject, predicate)` summaries retained when the span went.
+        summaries: Vec<crate::compaction::DegradedSummary>,
+    },
+}
+
+impl SummaryCoverage {
+    /// Whether any contributing evidence has been compacted.
+    #[must_use]
+    pub fn is_degraded(&self) -> bool {
+        matches!(self, Self::Degraded { .. })
+    }
+
+    /// Observations accounted for by citations rather than by surviving rows.
+    ///
+    /// Zero when [`Self::Complete`]. Added to a retained `observation_count`,
+    /// this recovers the pre-compaction total.
+    #[must_use]
+    pub fn compacted_observations(&self) -> i64 {
+        match self {
+            Self::Complete => 0,
+            Self::Degraded { summaries } => summaries.iter().map(|s| s.event_count).sum(),
+        }
+    }
+
+    /// The earliest transaction time held by a citation, if any.
+    ///
+    /// The time basis matches `subject_summary.first_observed_ms`, which the
+    /// fold takes from `txn_time_ms` — so `min` of this and a retained
+    /// `first_observed_ms` recovers the pre-compaction value.
+    #[must_use]
+    pub fn earliest_compacted_txn_ms(&self) -> Option<i64> {
+        match self {
+            Self::Complete => None,
+            Self::Degraded { summaries } => summaries.iter().map(|s| s.first_txn_time_ms).min(),
+        }
+    }
+}
+
+/// One subject's summary **and** how complete it is.
+///
+/// # Why `retained` is an `Option`
+///
+/// A subject whose every contributing event was compacted has **no retained
+/// aggregates at all**. Returning a [`ProjectedSubject`] for one would mean
+/// inventing a `first_observed_ms`, a `provenance_head` and a `last_event_id`
+/// from rows that no longer exist — and a citation cannot supply the last two,
+/// because the events they identify are gone. `None` says that plainly.
+///
+/// It is still **returned**, which is the point: before this, such a subject
+/// silently vanished from a rebuilt summary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SubjectSummaryAnswer {
+    /// Which of the three subject classes this is.
+    ///
+    /// **FIXME (step 2, `subject_kind` on `compaction_summaries`):** for a
+    /// subject known only by citation this is a best guess, because
+    /// `compaction_summaries` predates the v3 discriminant and records no kind.
+    /// An `entity` row and an `unlabelled` row sharing a subject string are
+    /// therefore indistinguishable in citations, and coverage for one may be
+    /// attributed to the other. Adding the column is step 2 and retires this.
+    pub subject_kind: SummaryKind,
+    /// The subject itself.
+    pub subject: String,
+    /// The fold's aggregates over surviving evidence, or `None` when every
+    /// contributing event was compacted.
+    pub retained: Option<ProjectedSubject>,
+    /// Whether those aggregates are backed by all the evidence that built them.
+    pub coverage: SummaryCoverage,
+}
+
+impl SubjectSummaryAnswer {
+    /// Observations over surviving rows **plus** those citations account for.
+    ///
+    /// The figure the fold would have produced before any compaction — and the
+    /// left-hand side of the reconciliation identity this PR's regression test
+    /// asserts. Step 2 makes `observation_count` equal this directly.
+    #[must_use]
+    pub fn reconciled_observation_count(&self) -> i64 {
+        self.retained.as_ref().map_or(0, |r| r.observation_count)
+            + self.coverage.compacted_observations()
+    }
+
+    /// The earliest transaction time across surviving rows and citations.
+    #[must_use]
+    pub fn reconciled_first_observed_ms(&self) -> Option<i64> {
+        match (
+            self.retained.as_ref().map(|r| r.first_observed_ms),
+            self.coverage.earliest_compacted_txn_ms(),
+        ) {
+            (Some(a), Some(b)) => Some(a.min(b)),
+            (Some(a), None) => Some(a),
+            (None, b) => b,
+        }
+    }
+}

--- a/crates/kirra-world-store/tests/subject_summary_coverage.rs
+++ b/crates/kirra-world-store/tests/subject_summary_coverage.rs
@@ -10,9 +10,7 @@
 //! * a projection head is refused, so a rebuild still reproduces the fold;
 //! * removed content stays **attestable** through `range_digest`.
 
-use kirra_world_store::{
-    ClaimStatus, EventId, NewEvent, ObservationId, WorldStore, WriterClass,
-};
+use kirra_world_store::{ClaimStatus, EventId, NewEvent, ObservationId, WorldStore, WriterClass};
 
 /// Owned ids for one event. [`NewEvent`] borrows its references, so they need a
 /// home that outlives it — and the two are separate types now, which is what

--- a/crates/kirra-world-store/tests/subject_summary_coverage.rs
+++ b/crates/kirra-world-store/tests/subject_summary_coverage.rs
@@ -1,0 +1,311 @@
+//! Retention enforcement: compaction-with-citation (ADR-0041 §11.3).
+//!
+//! The happy path is the least interesting thing here. What these tests are
+//! for is the set of properties that make deleting from a hash-chained log
+//! defensible at all:
+//!
+//! * a gap with **no** citation breaks the chain — you cannot delete quietly;
+//! * a **forged** citation breaks the chain — you cannot fake the admission;
+//! * a protected-class window is refused **whole**;
+//! * a projection head is refused, so a rebuild still reproduces the fold;
+//! * removed content stays **attestable** through `range_digest`.
+
+use kirra_world_store::{
+    ClaimStatus, EventId, NewEvent, ObservationId, WorldStore, WriterClass,
+};
+
+/// Owned ids for one event. [`NewEvent`] borrows its references, so they need a
+/// home that outlives it — and the two are separate types now, which is what
+/// stops them being passed in each other's place.
+struct Ids {
+    event: EventId,
+    observation: ObservationId,
+}
+
+/// One string for both ids. Fine for a fixture, and now *visibly* a conflation
+/// rather than an invisible one: the two fields have to be spelled separately.
+fn ids(s: &str) -> Ids {
+    Ids {
+        event: EventId::new(s).expect("admissible event id"),
+        observation: ObservationId::new(s).expect("admissible observation id"),
+    }
+}
+
+fn tmp(name: &str) -> std::path::PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "kirra-world-retention-{}-{}.sqlite",
+        name,
+        std::process::id()
+    ));
+    clean(&p);
+    p
+}
+
+fn clean(p: &std::path::Path) {
+    for s in ["", "-wal", "-shm"] {
+        let mut q = p.as_os_str().to_os_string();
+        q.push(s);
+        let _ = std::fs::remove_file(std::path::PathBuf::from(q));
+    }
+}
+
+const T0: i64 = 1_700_000_000_000;
+
+fn ev<'a>(id: &'a Ids, subject: &'a str, valid_from_ms: i64) -> NewEvent<'a> {
+    NewEvent {
+        event_id: &id.event,
+        observation_id: &id.observation,
+        txn_time_ms: valid_from_ms,
+        valid_from_ms,
+        valid_to_ms: None,
+        source: "sensor-a",
+        source_version: "0.1.0",
+        writer_class: WriterClass::Sensor,
+        claim_status: ClaimStatus::Confirmed,
+        provenance: &[],
+        frame_id: None,
+        map_id: None,
+        kind: "observation",
+        subject,
+        subject_ref: None,
+        predicate: Some("position"),
+        object: None,
+        payload: r#"{"n":1}"#,
+        payload_schema: 1,
+        retention_class: "raw",
+        trust: None,
+    }
+}
+
+/// 12 raw events across 3 subjects, so heads sit at the END of the log and
+/// generations 1..=6 are safely compactable.
+use kirra_world_store::subject_projection::{SummaryCoverage, SummaryKind};
+
+/// The population every case below shares.
+///
+/// Generations 1..=3 belong to `window-only` and nothing else, so compacting
+/// 1..=3 removes ALL of that subject's evidence and none of anyone else's —
+/// which is the case that used to make it disappear.
+fn seed_mixed(s: &mut WorldStore) {
+    for i in 1..=3i64 {
+        s.append(&ev(&ids(&format!("w{i}")), "window-only", T0 + i * 100))
+            .expect("append");
+    }
+    for i in 4..=6i64 {
+        s.append(&ev(&ids(&format!("p{i}")), "partly", T0 + i * 100))
+            .expect("append");
+    }
+    // A predicate-less confirmed event, which `build_summaries` keys on "".
+    {
+        let e = ids("bare-1");
+        let mut n = ev(&e, "partly", T0 + 650);
+        n.predicate = None;
+        n.object = None;
+        s.append(&n).expect("append predicate-less");
+    }
+    for i in 8..=9i64 {
+        s.append(&ev(&ids(&format!("u{i}")), "untouched", T0 + i * 100))
+            .expect("append");
+    }
+    // `partly-extra` has `partly` as a PREFIX, and is never compacted. Without
+    // it, a coverage lookup matching on prefix rather than equality would
+    // over-attribute another subject's citations and no test would notice --
+    // the negative control for that mutation fired nothing until this existed.
+    for i in 10..=11i64 {
+        s.append(&ev(&ids(&format!("x{i}")), "partly-extra", T0 + i * 100))
+            .expect("append");
+    }
+}
+
+fn answer<'a>(
+    all: &'a [kirra_world_store::subject_projection::SubjectSummaryAnswer],
+    subject: &str,
+) -> &'a kirra_world_store::subject_projection::SubjectSummaryAnswer {
+    all.iter()
+        .find(|a| a.subject == subject)
+        .unwrap_or_else(|| {
+            panic!(
+                "no answer for {subject}; got {:?}",
+                all.iter().map(|a| &a.subject).collect::<Vec<_>>()
+            )
+        })
+}
+
+/// **The reconciliation identity** — the property that replaces digest equality.
+///
+/// Digest equality cannot be the assertion here: step 1 does not restore the
+/// aggregates, so asserting it would mean either weakening the digest or
+/// asserting a falsehood. What must hold is that no evidence was lost track
+/// of, only relocated — surviving rows plus citations still add up to what the
+/// fold originally counted.
+#[test]
+fn compaction_relocates_evidence_it_does_not_lose_it() {
+    let p = tmp("reconcile");
+    let mut s = WorldStore::open(&p).expect("open");
+    seed_mixed(&mut s);
+    s.fold_subject_summary().expect("fold");
+
+    let before: Vec<(String, i64, i64)> = s
+        .subject_summaries()
+        .expect("read")
+        .into_iter()
+        .map(|r| (r.subject, r.observation_count, r.first_observed_ms))
+        .collect();
+
+    s.compact_range(1, 5, T0 + 90_000).expect("compact");
+    s.rebuild_subject_summary().expect("rebuild");
+
+    let after = s.subject_summaries_with_coverage().expect("read");
+
+    for (subject, count, first) in &before {
+        let a = answer(&after, subject);
+        assert_eq!(
+            a.reconciled_observation_count(),
+            *count,
+            "{subject}: surviving rows + citations must still account for every observation"
+        );
+        assert_eq!(
+            a.reconciled_first_observed_ms(),
+            Some(*first),
+            "{subject}: the original first-observed must be recoverable"
+        );
+    }
+    clean(&p);
+}
+
+/// A subject with both surviving and compacted evidence reports Degraded.
+#[test]
+fn a_partly_compacted_subject_is_degraded() {
+    let p = tmp("partly");
+    let mut s = WorldStore::open(&p).expect("open");
+    seed_mixed(&mut s);
+    s.fold_subject_summary().expect("fold");
+    s.compact_range(1, 5, T0 + 90_000).expect("compact");
+    s.rebuild_subject_summary().expect("rebuild");
+
+    let all = s.subject_summaries_with_coverage().expect("read");
+    let a = answer(&all, "partly");
+    assert!(
+        a.coverage.is_degraded(),
+        "partly-compacted must not read as complete"
+    );
+    assert!(a.retained.is_some(), "it still has surviving evidence");
+    assert!(a.coverage.compacted_observations() > 0);
+    clean(&p);
+}
+
+/// **The case that used to vanish.** Every contributing event compacted, so
+/// there is no retained row at all — and the subject must still be returned.
+#[test]
+fn a_subject_with_no_surviving_evidence_is_still_returned() {
+    let p = tmp("vanished");
+    let mut s = WorldStore::open(&p).expect("open");
+    seed_mixed(&mut s);
+    s.fold_subject_summary().expect("fold");
+    s.compact_range(1, 3, T0 + 90_000)
+        .expect("compact exactly window-only's evidence");
+    s.rebuild_subject_summary().expect("rebuild");
+
+    // The bare projection has genuinely lost it -- that is the defect.
+    assert!(
+        !s.subject_summaries()
+            .expect("read")
+            .iter()
+            .any(|r| r.subject == "window-only"),
+        "precondition: the raw projection really does drop it, or this proves nothing"
+    );
+
+    let all = s.subject_summaries_with_coverage().expect("read");
+    let a = answer(&all, "window-only");
+    assert!(a.retained.is_none(), "nothing survives to aggregate");
+    assert!(a.coverage.is_degraded());
+    assert_eq!(
+        a.reconciled_observation_count(),
+        3,
+        "all three observations are still accounted for by citations"
+    );
+    assert_eq!(a.reconciled_first_observed_ms(), Some(T0 + 100));
+    clean(&p);
+}
+
+/// A subject no compaction touched reports Complete — so `Degraded` means
+/// something.
+#[test]
+fn an_untouched_subject_is_complete() {
+    let p = tmp("untouched");
+    let mut s = WorldStore::open(&p).expect("open");
+    seed_mixed(&mut s);
+    s.fold_subject_summary().expect("fold");
+    s.compact_range(1, 3, T0 + 90_000).expect("compact");
+    s.rebuild_subject_summary().expect("rebuild");
+
+    let all = s.subject_summaries_with_coverage().expect("read");
+    let a = answer(&all, "untouched");
+    assert_eq!(a.coverage, SummaryCoverage::Complete);
+    assert_eq!(a.coverage.compacted_observations(), 0);
+    assert_eq!(a.coverage.earliest_compacted_txn_ms(), None);
+
+    // And the prefix neighbour: `partly` IS compacted, `partly-extra` is not.
+    // A lookup matching on prefix instead of equality would report this one
+    // degraded on evidence that belongs to a different subject.
+    let x = answer(&all, "partly-extra");
+    assert_eq!(
+        x.coverage,
+        SummaryCoverage::Complete,
+        "coverage must match subjects exactly, not by prefix"
+    );
+    assert_eq!(x.reconciled_observation_count(), 2);
+    clean(&p);
+}
+
+/// A predicate-less event participates. `build_summaries` keys it on `""`, and
+/// a coverage scheme that only matched predicated rows would under-count.
+#[test]
+fn a_predicate_less_event_is_covered() {
+    let p = tmp("bare");
+    let mut s = WorldStore::open(&p).expect("open");
+    seed_mixed(&mut s);
+    s.fold_subject_summary().expect("fold");
+    // 1..=7 includes the predicate-less event at generation 7.
+    s.compact_range(1, 7, T0 + 90_000).expect("compact");
+    s.rebuild_subject_summary().expect("rebuild");
+
+    let all = s.subject_summaries_with_coverage().expect("read");
+    let a = answer(&all, "partly");
+    let bare = match &a.coverage {
+        SummaryCoverage::Degraded { summaries } => {
+            summaries.iter().filter(|x| x.predicate.is_none()).count()
+        }
+        SummaryCoverage::Complete => 0,
+    };
+    assert_eq!(bare, 1, "the predicate-less event must appear in coverage");
+    assert_eq!(a.reconciled_observation_count(), 4, "3 predicated + 1 bare");
+    clean(&p);
+}
+
+/// **Step 2 cannot be forgotten.** `compaction_summaries` records no
+/// `subject_kind`, so a subject known only by citation is reported
+/// `Unlabelled` — honest, but a guess. This pins the current behaviour so that
+/// adding the column is a deliberate change with a failing test, not a silent
+/// improvement nobody notices.
+#[test]
+fn fixme_step2_a_cited_only_subject_has_no_recorded_kind() {
+    let p = tmp("kindgap");
+    let mut s = WorldStore::open(&p).expect("open");
+    seed_mixed(&mut s);
+    s.fold_subject_summary().expect("fold");
+    s.compact_range(1, 3, T0 + 90_000).expect("compact");
+    s.rebuild_subject_summary().expect("rebuild");
+
+    let all = s.subject_summaries_with_coverage().expect("read");
+    let a = answer(&all, "window-only");
+    assert_eq!(
+        a.subject_kind,
+        SummaryKind::Unlabelled,
+        "FIXME step 2: citations record no discriminant, so this is a guess. \
+         When `subject_kind` lands on `compaction_summaries`, this assertion \
+         should fail and be replaced by the real kind."
+    );
+    clean(&p);
+}

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -78,9 +78,20 @@ thrown away**, and that is the question that actually governs the design.
 |---|---|---|
 | **Evidence** | Immutable, hash-chained, **never deleted** — compaction *cites*, it does not erase | Incident reconstruction stays possible |
 | **Admission** | The **only** write door; writer class, confidence basis and frame requirement are all decided here | A rule with no other place to live has one |
-| **Knowledge** | Rebuild-from-zero **==** incremental; **no projection-only fact** | Every belief traces to evidence |
+| **Knowledge** | Rebuild-from-zero **==** incremental **given the evidence retained**; **no projection-only fact** | Every belief traces to evidence |
 | **Access** | Rebuildable from the tier below — **losing an index loses performance, never truth** | The test for "is this an index or a projection?" |
 | **Answer** | Every answer carries provenance; a **degraded answer says so** | `Explain` is possible at all |
+
+**"Given the evidence retained" is a clarification, not a relaxation.** Compaction
+is the one operation that changes the evidence set, so a rebuild after one is not
+folding the same log. What the invariant forbids is compaction quietly turning
+missing history into apparently complete knowledge — so where evidence has been
+removed, **the difference is reported rather than absorbed**. `SummaryCoverage`
+is that report for `subject_summary`, whose aggregates are a MIN and a COUNT over
+all contributing events and therefore depend on the whole log rather than on a
+head. Contrast `world_current`, where removing a head makes an answer *wrong*
+rather than *coarser* — which is why that one is protected outright
+(`ProjectionHeadInRange`) and this one is surfaced instead.
 
 That fourth row is the discriminator worth keeping. A flat component list puts
 spatial index, temporal index and identity resolution side by side — but two of


### PR DESCRIPTION
Step 1 of the S-1 fix from the deep review. Makes the divergence **visible**; step 2 restores the figures exactly.

## The defect, proven before fixing

`subject_summary`'s aggregates are a MIN and a COUNT over **every** contributing event, so its dependency set is the whole log rather than a head. Compaction removes evidence it depends on:

```
before: cup-0 first_observed=…000100  observation_count=4
after : cup-0 first_observed=…000700  observation_count=2
```

**Worse than originally filed.** A subject whose *every* contributing event is compacted does not merely change — it disappears:

```
before compaction: [("survivor", 3), ("window-only", 3)]
after  REBUILD   : [("survivor", 3)]                        ← gone
```

The store goes from having observed `window-only` three times to never having heard of it, with the evidence sitting in `compaction_summaries` the whole time. That case came from the reviewer's test list, not from the original design — which had no row left to mark.

## Why not "protect the dependencies"

That was the first instinct and it is right for `world_current`, whose head removal makes an answer **wrong**. Here the dependency set is *every confirmed event*, so protection degenerates to refusing every window and compaction becomes a no-op.

And the numbers were never wrong — they were **coarser**, presented as though they were not. The defect is the silence.

## The shape

`SummaryCoverage`, computed at **read time and never stored** — the same call already made for validity, because a fold cannot know about a compaction that happens after it, and a stored flag would be wrong the moment anyone compacted without re-folding.

Deliberately **not** a reuse of `compaction::Resolution`. That type answers *"was the range I queried intact?"*; this answers *"is this aggregate still backed by every event that built it?"*. Same vocabulary, different question — and `Resolution::Full` would read as a claim about a query nobody made.

`subject_summaries_with_coverage()` returns the **union** of retained rows and subjects known only through citations, so the vanishing case is returned rather than absent. `retained` is an `Option` because a fully-compacted subject has no aggregates at all: returning a `ProjectedSubject` would mean inventing a `provenance_head` and a `last_event_id` from rows that no longer exist, and a citation cannot supply either.

## The regression asserts reconciliation, not digest equality

Step 1 does not restore the aggregates, so asserting digest equality would mean either weakening the digest or asserting a falsehood. What must hold is that **no evidence was lost track of, only relocated**:

```
retained.observation_count + Σ(citations.event_count)          == original
MIN(retained.first_observed, MIN(citations.first_txn_time_ms)) == original
```

Both sides verified available: coverage is total (every confirmed subject in a window is summarised, including predicate-less and window-only ones), and `first_txn_time_ms` matches the time basis `first_observed_ms` folds from.

`subject_summary_state_digest()` is **untouched** — it checks the *fold*, not the *answer*, and conflating them is how a digest stops being able to fail.

## Tests and controls

Six tests, from the reviewer's list: partly-compacted → `Degraded`; window-only with zero surviving evidence → still returned; untouched → `Complete`; the reconciliation identity; predicate-less participation; and the step-2 FIXME.

Three controls fire. **A fourth fired nothing** — matching coverage by *prefix* instead of equality — because no subject in the fixture was a prefix of another. An over-attributing lookup was invisible to the entire suite until `partly-extra` was added alongside `partly`. Worth calling out: the gap was in the test data, not the code.

## Step 2 is pinned, not noted

`compaction_summaries` predates the v3 discriminant and records no `subject_kind`, so a cited-only subject reports `Unlabelled` — honest, but a guess. `fixme_step2_a_cited_only_subject_has_no_recorded_kind` asserts that, so adding the column **fails a test** rather than being a silent improvement nobody notices.

Also: index on `compaction_summaries(subject)` — the PK leads with `lo_generation`, so the per-subject lookup this does on every read could not use it.

## Doc

`WM_SCOPE.md` §0a Knowledge-tier invariant clarified to *"rebuild == incremental **given the evidence retained**; where compaction has removed evidence, the difference is reported rather than absorbed"*, with the `world_current` contrast spelled out. Read as clarification rather than amendment: compaction is the one operation that changes the evidence set, and what the invariant forbids is missing history looking like complete knowledge.

Verified: 6/6 new tests, full store suite, `cargo test --workspace`, fmt, clippy `-D warnings`, orphan gate, fence INTACT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_