### PR TITLE
Tier 2 box 2d: resolve identity as of a past instant

### DIFF
--- a/crates/kirra-world-store/src/entity_projection.rs
+++ b/crates/kirra-world-store/src/entity_projection.rs
@@ -885,6 +885,146 @@ impl kirra_world::resolution::AdjudicationGraph for IdentityView {
     }
 }
 
+/// **The identity graph as it stood at a past instant** — §6.3, Tier 2 box 2d.
+///
+/// §6.3: *"A query at a past instant resolves identity as it was adjudicated
+/// then — **because identity is a projection like everything else**."* An
+/// [`IdentityView`] is that projection folded over the whole log; this is the
+/// same projection folded over a **prefix** of it.
+///
+/// # It restrains the GRAPH, it does not re-answer the question
+///
+/// The distinction is the whole slice, and the cheap wrong version is easy to
+/// write: resolve against current state and label the answer with a timestamp.
+/// That answers today's question and lies about when. What happens here instead
+/// is that the fold is re-run over only the adjudications recorded by the
+/// instant, and then [`kirra_world::resolution::resolve`] — the **same**
+/// function, unmodified — walks the smaller graph.
+///
+/// So there is no historical resolver, no second set of outcome variants, and
+/// no shortcut. `KIRRA-WM-TRANSITIVITY-001` disqualified union-find and
+/// required that transitive resolution preserve the accepted path and refuse a
+/// contradictory graph rather than repairing it; a second engine here would be
+/// a second place for that to be got wrong. `resolve_at` is `resolve` over a
+/// restricted graph, and that is the entire mechanism.
+///
+/// # Which of the two clocks this cuts on
+///
+/// **Transaction time** (`txn_time_ms`) — *what had been recorded by then* —
+/// matching the `as_known_at_ms` axis of [`crate::WorldStore::as_of`].
+///
+/// Valid time is deliberately **not** consulted, and the reason is that an
+/// adjudication is not a claim about the world that holds over an interval. It
+/// is a judgement, and a judgement's effect on identity begins when it is
+/// recorded. `MergeEntities` carries a `DomainInstant` for *when the operator
+/// decided*; nothing in the model gives a merge an interval over which it
+/// stops being true, and `valid_to_ms` on an adjudication row is always NULL
+/// because [`crate::WorldStore::append_adjudication`] hardcodes it so. Filtering
+/// on an axis the writer never populates would look rigorous and do nothing.
+///
+/// Stated rather than assumed because the store IS bitemporal and the omission
+/// would otherwise read as an oversight: a genuine valid-time identity question
+/// ("who did we think this was, for the period the robot was in bay 3") is a
+/// different query and would need its own ruling.
+pub struct HistoricalIdentityView {
+    view: IdentityView,
+    as_known_at_ms: i64,
+    resolution: crate::compaction::Resolution,
+}
+
+impl HistoricalIdentityView {
+    /// Build a historical view over an already-restricted fold.
+    ///
+    /// Private to the crate: the restriction is what makes this type honest,
+    /// and a public constructor would let a caller build one from the *current*
+    /// projection and label it with any instant it liked — the precise lie the
+    /// type exists to prevent. [`crate::WorldStore::identity_view_at`] is the
+    /// only way to obtain one.
+    pub(crate) fn new(
+        view: IdentityView,
+        as_known_at_ms: i64,
+        resolution: crate::compaction::Resolution,
+    ) -> Self {
+        Self {
+            view,
+            as_known_at_ms,
+            resolution,
+        }
+    }
+
+    /// The transaction-time instant this view was cut at.
+    #[must_use]
+    pub fn as_known_at_ms(&self) -> i64 {
+        self.as_known_at_ms
+    }
+
+    /// Whether compaction could have removed an adjudication bearing on this
+    /// answer. See [`crate::WorldStore::identity_view_at`] for why this is
+    /// derived rather than asserted.
+    #[must_use]
+    pub fn resolution(&self) -> &crate::compaction::Resolution {
+        &self.resolution
+    }
+
+    /// The restricted projection itself.
+    #[must_use]
+    pub fn view(&self) -> &IdentityView {
+        &self.view
+    }
+
+    /// **Resolve an id against the graph as it stood at this instant.**
+    ///
+    /// Delegates to [`kirra_world::resolution::resolve`]. The answer carries
+    /// the instant and the resolution alongside the outcome, so a caller cannot
+    /// hold a historical answer without holding *when* it was true and whether
+    /// anything was missing from it.
+    #[must_use]
+    pub fn resolve_at(&self, id: &EntityId) -> HistoricalAnswer {
+        HistoricalAnswer {
+            outcome: kirra_world::resolution::resolve(&self.view, id),
+            as_known_at_ms: self.as_known_at_ms,
+            resolution: self.resolution.clone(),
+        }
+    }
+}
+
+impl kirra_world::resolution::AdjudicationGraph for HistoricalIdentityView {
+    fn lifecycle_of(&self, id: &EntityId) -> Option<Lifecycle> {
+        self.view.lifecycle_of(id)
+    }
+
+    fn is_contradicted(&self, id: &EntityId) -> bool {
+        self.view.is_contradicted(id)
+    }
+}
+
+/// One historical identity answer: the outcome, when it was true, and whether
+/// that is all of it.
+///
+/// The same shape as [`crate::compaction::TemporalAnswer`] and for the same
+/// stated reason — a caller cannot obtain the outcome without the resolution
+/// being in front of it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HistoricalAnswer {
+    /// What the id resolved to, from the restricted graph.
+    ///
+    /// The **same** four variants as a present-tense resolution. A historical
+    /// query has no extra answers and no missing ones.
+    pub outcome: kirra_world::resolution::ResolutionOutcome,
+    /// The transaction-time instant the graph was cut at.
+    pub as_known_at_ms: i64,
+    /// Whether a compacted span could have borne on the answer.
+    pub resolution: crate::compaction::Resolution,
+}
+
+impl HistoricalAnswer {
+    /// Shorthand for [`crate::compaction::Resolution::is_degraded`].
+    #[must_use]
+    pub fn is_degraded(&self) -> bool {
+        self.resolution.is_degraded()
+    }
+}
+
 /// A digest over a projection accumulator, in key order.
 ///
 /// Takes the accumulator rather than reading the table, so the value written

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -1650,7 +1650,7 @@ impl WorldStore {
         drop(rows);
         drop(stmt);
 
-        let resolution = self.identity_resolution_at(as_known_at_ms)?;
+        let resolution = self.identity_resolution_at()?;
         Ok(entity_projection::HistoricalIdentityView::new(
             entity_projection::IdentityView::new(acc, head),
             as_known_at_ms,
@@ -1679,8 +1679,7 @@ impl WorldStore {
         Ok(self.identity_view_at(as_known_at_ms)?.resolve_at(id))
     }
 
-    /// Whether compaction could have removed an adjudication recorded by
-    /// `as_known_at_ms`.
+    /// Whether compaction could have removed an adjudication.
     ///
     /// Derived from [`compaction::is_protected`] rather than assuming it: a
     /// citation is only ever written for a window the planner accepted, and the
@@ -1689,24 +1688,39 @@ impl WorldStore {
     /// still protected"* — and the moment that stops being true, every
     /// historical identity answer over a compacted store starts reporting
     /// `Degraded` on its own.
-    fn identity_resolution_at(&self, as_known_at_ms: i64) -> Result<Resolution, StoreError> {
+    fn identity_resolution_at(&self) -> Result<Resolution, StoreError> {
         if compaction::is_protected(adjudication_record::ADJUDICATION_RETENTION_CLASS) {
             return Ok(Resolution::Full);
         }
         // Unreachable while adjudications are protected. Kept as the honest
         // other half rather than an `unreachable!()`: if the class is ever
-        // demoted, a compacted span below the cut could have held an
-        // adjudication and the answer must say so instead of panicking.
+        // demoted, a compacted span could have held an adjudication and the
+        // answer must say so instead of panicking.
+        //
+        // EVERY citation degrades, with no attempt to narrow by time. The first
+        // version filtered on `compacted_at_ms <= as_known_at_ms` and was
+        // FAIL-OPEN, which is why the reasoning is written out rather than left
+        // to the code: `compacted_at_ms` is the wall clock at which compaction
+        // RAN, and `as_known_at_ms` is the transaction-time instant being asked
+        // ABOUT. They are different axes, and comparing them gets the common
+        // case backwards -- a compaction that ran *later* than the queried
+        // instant is exactly the one that removes evidence about it. Adjudi-
+        // cations at txn_time 1000, queried at 1000, compacted at 5000: the
+        // filter excluded the citation and reported `Full` over evidence that
+        // was gone.
+        //
+        // Nothing better is available, either: the removed rows are the only
+        // record of their own transaction times, so a span cannot be shown
+        // irrelevant to a past instant after the fact. `Resolution`'s documented
+        // asymmetry is the whole budget here -- it may say `Degraded` where a
+        // full answer would have been identical, and may never say `Full` where
+        // something was lost.
         let citations = self.load_citations()?;
-        let spans: Vec<Citation> = citations
-            .into_values()
-            .filter(|c| c.compacted_at_ms <= as_known_at_ms)
-            .collect();
-        if spans.is_empty() {
+        if citations.is_empty() {
             return Ok(Resolution::Full);
         }
         Ok(Resolution::Degraded {
-            spans,
+            spans: citations.into_values().collect(),
             summaries: Vec::new(),
         })
     }

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -1556,6 +1556,161 @@ impl WorldStore {
         ))
     }
 
+    /// **The identity graph as it stood at a past instant** — §6.3, Tier 2 2d.
+    ///
+    /// Folds the entity projection over only those adjudications recorded by
+    /// transaction time `as_known_at_ms`, and hands back a view
+    /// `kirra_world::resolution::resolve` walks exactly as it walks the current
+    /// one. See [`entity_projection::HistoricalIdentityView`] for why the cut is
+    /// on transaction time and not valid time.
+    ///
+    /// # Answered from the LOG, and folded from EMPTY
+    ///
+    /// Both halves matter and each has a wrong version that still compiles.
+    ///
+    /// The **log**, not `entities_projection`: the projection is a cache of one
+    /// point on the temporal surface — latest known — and every other point has
+    /// to be replayed. `WorldStore::as_of` carries the same note for claims;
+    /// identity is not an exception to it, because §6.3's whole argument is that
+    /// identity is a projection *like everything else*.
+    ///
+    /// From **empty**, not from the stored rows. [`WorldStore::fold_entity_range`]
+    /// seeds its accumulator from the stored projection, because an incremental
+    /// fold needs the prior lifecycle to tell a legal transition from a
+    /// contradiction. Seeding a *historical* fold that way would start it from
+    /// today's state and then apply an old prefix on top — every later merge
+    /// already present before the first historical event was read, which is the
+    /// exact failure this query exists to prevent, arriving through the one line
+    /// that looks like reuse.
+    ///
+    /// # Confirmed-only, so candidates cannot enter
+    ///
+    /// The `claim_status = 'confirmed'` predicate is inherited from the current
+    /// fold rather than restated as a new rule. `KIRRA-WM-CLUSTERING-001` holds
+    /// that clustering may propose co-reference and never confirm it, and
+    /// `KIRRA-WM-PROMOTION-001` that a candidate becomes identity only through
+    /// an authorized adjudicator; a candidate `same_as` observation is written
+    /// `claim_status = 'candidate'` and is therefore not selected here — at any
+    /// instant, past or present. The historical view cannot be the back door
+    /// into the confirmed graph that the write door refuses.
+    ///
+    /// # Why the resolution is derived and not hardcoded `Full`
+    ///
+    /// Adjudication rows carry `retention_class = 'adjudication'`, and
+    /// [`compaction::is_protected`] holds for every class except `"raw"`, so a
+    /// window containing one is refused whole. A recorded citation is therefore
+    /// *evidence* that its window held no adjudication — which is why this can
+    /// report `Full` over a compacted store without inspecting what was removed.
+    ///
+    /// That is a derivation from the protection predicate, not an assumption
+    /// about it: [`Self::identity_resolution_at`] consults `is_protected`
+    /// directly, so a future compaction mode that could remove a protected class
+    /// makes this degrade rather than silently keep claiming completeness.
+    ///
+    /// # Errors
+    ///
+    /// As [`WorldStore::identity_view`], plus
+    /// [`StoreError::CorruptEntityProjectionRow`] if a stored adjudication
+    /// cannot be decoded faithfully.
+    pub fn identity_view_at(
+        &self,
+        as_known_at_ms: i64,
+    ) -> Result<entity_projection::HistoricalIdentityView, StoreError> {
+        let mut acc = std::collections::BTreeMap::new();
+        let mut head: i64 = 0;
+
+        let mut stmt = self.conn.prepare(
+            "SELECT generation, payload, payload_schema, provenance
+             FROM world_events
+             WHERE claim_status = 'confirmed' AND kind = ?1 AND txn_time_ms <= ?2
+             ORDER BY generation ASC",
+        )?;
+        let mut rows = stmt.query(params![
+            adjudication_record::ADJUDICATION_KIND,
+            as_known_at_ms
+        ])?;
+        while let Some(r) = rows.next()? {
+            let generation: i64 = r.get(0)?;
+            let payload: String = r.get(1)?;
+            let payload_schema: i64 = r.get(2)?;
+            let provenance: String = r.get(3)?;
+            let cited: Vec<String> = serde_json::from_str(&provenance).map_err(|e| {
+                StoreError::CorruptEntityProjectionRow {
+                    detail: format!("provenance is not a JSON array: {e}"),
+                }
+            })?;
+            let adjudication =
+                adjudication_record::decode_adjudication(&payload, payload_schema, &cited)
+                    .map_err(|e| StoreError::CorruptEntityProjectionRow {
+                        detail: format!("generation {generation}: {e}"),
+                    })?;
+            entity_projection::fold_adjudication(&mut acc, &adjudication, generation);
+            head = generation;
+        }
+        drop(rows);
+        drop(stmt);
+
+        let resolution = self.identity_resolution_at(as_known_at_ms)?;
+        Ok(entity_projection::HistoricalIdentityView::new(
+            entity_projection::IdentityView::new(acc, head),
+            as_known_at_ms,
+            resolution,
+        ))
+    }
+
+    /// **Resolve an id as of a past instant.** The 2d verb, composed from the
+    /// two halves that already exist: restrict the graph, then run the one
+    /// resolver over it.
+    ///
+    /// A convenience over [`Self::identity_view_at`] followed by
+    /// [`entity_projection::HistoricalIdentityView::resolve_at`]. Resolving
+    /// several ids at one instant should build the view once and reuse it —
+    /// this re-folds per call, and a walk that spans two folds would be
+    /// answering from two states of the world.
+    ///
+    /// # Errors
+    ///
+    /// As [`Self::identity_view_at`].
+    pub fn resolve_at(
+        &self,
+        id: &kirra_world::reference::EntityId,
+        as_known_at_ms: i64,
+    ) -> Result<entity_projection::HistoricalAnswer, StoreError> {
+        Ok(self.identity_view_at(as_known_at_ms)?.resolve_at(id))
+    }
+
+    /// Whether compaction could have removed an adjudication recorded by
+    /// `as_known_at_ms`.
+    ///
+    /// Derived from [`compaction::is_protected`] rather than assuming it: a
+    /// citation is only ever written for a window the planner accepted, and the
+    /// planner refuses a window whole if it holds a protected class. So the
+    /// question this answers is *"is the class an adjudication is written with
+    /// still protected"* — and the moment that stops being true, every
+    /// historical identity answer over a compacted store starts reporting
+    /// `Degraded` on its own.
+    fn identity_resolution_at(&self, as_known_at_ms: i64) -> Result<Resolution, StoreError> {
+        if compaction::is_protected(adjudication_record::ADJUDICATION_RETENTION_CLASS) {
+            return Ok(Resolution::Full);
+        }
+        // Unreachable while adjudications are protected. Kept as the honest
+        // other half rather than an `unreachable!()`: if the class is ever
+        // demoted, a compacted span below the cut could have held an
+        // adjudication and the answer must say so instead of panicking.
+        let citations = self.load_citations()?;
+        let spans: Vec<Citation> = citations
+            .into_values()
+            .filter(|c| c.compacted_at_ms <= as_known_at_ms)
+            .collect();
+        if spans.is_empty() {
+            return Ok(Resolution::Full);
+        }
+        Ok(Resolution::Degraded {
+            spans,
+            summaries: Vec::new(),
+        })
+    }
+
     /// A digest over the entity projection, in key order.
     ///
     /// # Errors

--- a/crates/kirra-world-store/tests/historical_resolution.rs
+++ b/crates/kirra-world-store/tests/historical_resolution.rs
@@ -683,7 +683,19 @@ fn compacting_raw_observations_does_not_degrade_a_historical_identity_answer() {
         &[assert_id("a"), assert_id("b"), merge(&["a"], "b")],
     );
 
-    let outcome = s.compact_range(1, 3, T0).expect("compact the raw prefix");
+    // Compaction runs at a wall clock LATER than the instant queried below.
+    //
+    // That ordering is the point, not an arbitrary number. `compacted_at_ms` is
+    // when compaction RAN; `as_known_at_ms` is the instant asked ABOUT. A
+    // compaction that ran after the queried instant is precisely the one that
+    // can remove evidence bearing on it, so this is the direction in which a
+    // time-narrowing degradation rule fails OPEN. Raised in review on #1413,
+    // where the first version filtered citations by
+    // `compacted_at_ms <= as_known_at_ms` and would have reported `Full` here
+    // over evidence that was gone.
+    let outcome = s
+        .compact_range(1, 3, T0 + 10_000)
+        .expect("compact the raw prefix");
     assert!(
         outcome.removed > 0,
         "nothing was compacted, so the assertion below would hold vacuously"

--- a/crates/kirra-world-store/tests/historical_resolution.rs
+++ b/crates/kirra-world-store/tests/historical_resolution.rs
@@ -1,0 +1,741 @@
+//! **Tier 2 box 2d — resolving identity as of a past instant.** §6.3, §14.2.
+//!
+//! §6.3: *"A query at a past instant resolves identity as it was adjudicated
+//! then — because identity is a projection like everything else."*
+//!
+//! The cheap wrong implementation of that sentence resolves against **current**
+//! state and labels the answer with a timestamp. It passes any test that only
+//! checks the answer's shape, and it is wrong in exactly the way that matters:
+//! it reports what an id means now under the name of what it meant then. Every
+//! test below is chosen to fail against that implementation.
+//!
+//! The load-bearing one is `a_query_between_two_merges_stops_at_the_first`: with
+//! `a = b` recorded, then later `b = c`, a query at the instant between them
+//! must answer `b` and must not reach `c`. Resolving current state answers `c`
+//! whatever instant it is handed, so that single assertion separates a real
+//! temporal restriction from a decorated present-tense one.
+//!
+//! What is deliberately NOT re-tested here: the resolver's own semantics. There
+//! is one engine — `kirra_world::resolution::resolve` — and it is walked
+//! exhaustively by its own unit tests. These tests check that the *graph handed
+//! to it* is the historical one, plus the two places 2d could smuggle in a
+//! second set of rules (`KIRRA-WM-CLUSTERING-001` candidates, and the
+//! degradation contract).
+
+use kirra_world::adjudication::{
+    AssertIdentity, ForgetEntity, IdentityAdjudication, Justification, MergeEntities,
+    RetirementReason, SplitEntity,
+};
+use kirra_world::observation::{ClockDomain, DomainInstant};
+use kirra_world::resolution::{resolve, ResolutionOutcome};
+use kirra_world_store::adjudication_record::AdjudicationRow;
+use kirra_world_store::{
+    ClaimStatus, EntityId, EventId, NewEvent, ObservationId, Resolution, WorldStore, WriterClass,
+};
+
+/// The instant the first adjudication is recorded at. Every `t(n)` below is an
+/// offset from it, so a test names *when* rather than a bare epoch number.
+const T0: i64 = 1_700_000_000_000;
+
+/// Transaction time of the `n`th recorded adjudication.
+fn t(n: i64) -> i64 {
+    T0 + n
+}
+
+fn eid(s: &str) -> EntityId {
+    EntityId::new(s).expect("entity id")
+}
+
+fn just() -> Justification {
+    Justification::new([ObservationId::new("obs-1").expect("obs")]).expect("justification")
+}
+
+fn at() -> DomainInstant {
+    DomainInstant {
+        ms: 1,
+        domain: ClockDomain::System,
+    }
+}
+
+fn assert_id(e: &str) -> IdentityAdjudication {
+    IdentityAdjudication::Assert(AssertIdentity::new(eid(e), just(), at()))
+}
+
+fn merge(sources: &[&str], into: &str) -> IdentityAdjudication {
+    IdentityAdjudication::Merge(
+        MergeEntities::new(
+            sources.iter().map(|s| eid(s)).collect::<Vec<_>>(),
+            eid(into),
+            just(),
+            at(),
+        )
+        .expect("merge"),
+    )
+}
+
+fn partition(source: &str, into: &[&str]) -> IdentityAdjudication {
+    IdentityAdjudication::Split(
+        SplitEntity::partition(
+            eid(source),
+            into.iter().map(|s| eid(s)).collect::<Vec<_>>(),
+            just(),
+            at(),
+        )
+        .expect("partition"),
+    )
+}
+
+fn forget(e: &str) -> IdentityAdjudication {
+    IdentityAdjudication::Forget(ForgetEntity::new(
+        eid(e),
+        RetirementReason::new("superseded by adjudication").expect("reason"),
+        just(),
+        at(),
+    ))
+}
+
+/// Remove the database AND its WAL sidecars — a surviving `-wal` beside a
+/// recreated database of the same name is a recovery source, which can make a
+/// later run see rows it never wrote.
+fn clean(p: &std::path::Path) {
+    for suffix in ["", "-wal", "-shm"] {
+        let mut q = p.as_os_str().to_os_string();
+        q.push(suffix);
+        let _ = std::fs::remove_file(std::path::PathBuf::from(q));
+    }
+}
+
+fn tmp(name: &str) -> std::path::PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "kirra-wm-2d-{}-{}.sqlite",
+        name,
+        std::process::id()
+    ));
+    clean(&p);
+    p
+}
+
+/// Append adjudications, the `n`th recorded at transaction time `t(n)`.
+///
+/// One per millisecond so a test can name an instant strictly between any two
+/// of them, which is what the box-2d question is made of.
+fn seed(s: &mut WorldStore, adjudications: &[IdentityAdjudication]) {
+    for (i, a) in adjudications.iter().enumerate() {
+        let i = i64::try_from(i).expect("small test index");
+        let event_id = EventId::new(format!("ev-{i}")).expect("event id");
+        let observation_id = ObservationId::new(format!("obs-src-{i}")).expect("obs");
+        s.append_adjudication(
+            &AdjudicationRow {
+                event_id: &event_id,
+                observation_id: &observation_id,
+                txn_time_ms: t(i),
+                valid_from_ms: t(i),
+                source: "operator-console",
+                source_version: "1.0.0",
+                writer_class: WriterClass::Operator,
+            },
+            a,
+        )
+        .expect("append");
+    }
+    // Fold the CURRENT projection before any historical query runs.
+    //
+    // Not tidiness -- it is what makes these tests able to fail. A historical
+    // fold seeded from the stored projection instead of from empty starts at
+    // today's state and applies an old prefix on top, which is the subtlest way
+    // to get 2d wrong. On a store whose projection was never folded, that bug is
+    // INVISIBLE: the stored rows are empty, so seeding from them and seeding
+    // from empty are the same thing. Every test here would have passed against
+    // it. Found by running that exact mutation as a control.
+    s.rebuild_entity_projection()
+        .expect("fold current projection");
+}
+
+fn open(name: &str) -> (WorldStore, std::path::PathBuf) {
+    let path = tmp(name);
+    let s = WorldStore::open(&path).expect("open");
+    (s, path)
+}
+
+// ---------------------------------------------------------------------------
+// The property the whole slice rests on
+// ---------------------------------------------------------------------------
+
+/// **`a = b`, later `b = c`; ask between them.**
+///
+/// The one test that cannot pass against "resolve current state and label it
+/// historical". At `t(2)` the graph knows `a -> b` and nothing more, so `a`
+/// resolves to `b`. Resolving today's graph answers `c` no matter which instant
+/// it is handed — so this assertion, alone among the file, distinguishes a
+/// temporal restriction on the GRAPH from a present-tense answer wearing a
+/// timestamp.
+///
+/// The `hops` are asserted too, not just the entity: an implementation that
+/// resolved to `c` and then walked back to `b` would get the entity right and
+/// the path wrong, and `KIRRA-WM-TRANSITIVITY-001` requires the accepted path
+/// to be the one that existed at the instant.
+#[test]
+fn a_query_between_two_merges_stops_at_the_first() {
+    let (mut s, path) = open("between-merges");
+    seed(
+        &mut s,
+        &[
+            assert_id("a"),     // t(0)
+            assert_id("b"),     // t(1)
+            assert_id("c"),     // t(2)
+            merge(&["a"], "b"), // t(3)
+            merge(&["b"], "c"), // t(4)
+        ],
+    );
+
+    // Between the two merges: `a` is `b`, and `c` is not yet in the picture.
+    assert_eq!(
+        s.resolve_at(&eid("a"), t(3)).expect("resolve").outcome,
+        ResolutionOutcome::Located {
+            entity: eid("b"),
+            hops: 1,
+        },
+        "at t(3) the graph holds a->b only; reaching c means current state was \
+         resolved and merely labelled historical"
+    );
+
+    // After the second: the same id now means `c`, through two hops.
+    assert_eq!(
+        s.resolve_at(&eid("a"), t(4)).expect("resolve").outcome,
+        ResolutionOutcome::Located {
+            entity: eid("c"),
+            hops: 2,
+        }
+    );
+
+    // ...and the earlier answer is unchanged by having asked the later one.
+    assert_eq!(
+        s.resolve_at(&eid("a"), t(3)).expect("resolve").outcome,
+        ResolutionOutcome::Located {
+            entity: eid("b"),
+            hops: 1,
+        },
+        "a historical answer must not depend on what has been queried since"
+    );
+
+    drop(s);
+    clean(&path);
+}
+
+/// **A merge that exists today did not exist at `t`, and must not reach back.**
+///
+/// The same property from the other end: query an instant *before* any merge
+/// was recorded and the id must resolve to itself.
+#[test]
+fn a_merge_recorded_later_does_not_affect_an_earlier_instant() {
+    let (mut s, path) = open("later-merge");
+    seed(
+        &mut s,
+        &[assert_id("a"), assert_id("b"), merge(&["a"], "b")],
+    );
+
+    assert_eq!(
+        s.resolve_at(&eid("a"), t(1)).expect("resolve").outcome,
+        ResolutionOutcome::Located {
+            entity: eid("a"),
+            hops: 0,
+        },
+        "before the merge was recorded, `a` is still `a`"
+    );
+    assert_eq!(
+        s.resolve_at(&eid("a"), t(2)).expect("resolve").outcome,
+        ResolutionOutcome::Located {
+            entity: eid("b"),
+            hops: 1,
+        },
+        "and after it, `b` -- so the assertion above is not vacuous"
+    );
+
+    drop(s);
+    clean(&path);
+}
+
+/// **An entity asserted after `t` is absent at `t`, not present-and-live.**
+///
+/// `Unknown` is the resolver's "we looked and it is not there". A historical
+/// view must produce it for an id the log had not yet met, rather than
+/// inventing a `Located` from a row that exists today.
+#[test]
+fn an_entity_asserted_after_the_instant_is_unknown_at_it() {
+    let (mut s, path) = open("not-yet-born");
+    seed(&mut s, &[assert_id("a"), assert_id("b")]);
+
+    assert_eq!(
+        s.resolve_at(&eid("b"), t(0)).expect("resolve").outcome,
+        ResolutionOutcome::Unknown,
+        "`b` is asserted at t(1); at t(0) the graph has never heard of it"
+    );
+    assert_eq!(
+        s.resolve_at(&eid("b"), t(1)).expect("resolve").outcome,
+        ResolutionOutcome::Located {
+            entity: eid("b"),
+            hops: 0,
+        }
+    );
+
+    drop(s);
+    clean(&path);
+}
+
+// ---------------------------------------------------------------------------
+// Later records cannot rewrite an earlier answer
+// ---------------------------------------------------------------------------
+
+/// **A split after `t` does not retroactively make the earlier answer
+/// ambiguous.**
+///
+/// `a` merges into `b`; `b` is later partitioned. Asked before the partition,
+/// `a` is `b` — a single located answer. Asked after, it is ambiguous between
+/// the partition's products. The earlier answer must not acquire the later
+/// ambiguity.
+#[test]
+fn a_split_after_the_instant_does_not_reach_back_into_the_earlier_answer() {
+    let (mut s, path) = open("later-split");
+    seed(
+        &mut s,
+        &[
+            assert_id("a"),                // t(0)
+            assert_id("b"),                // t(1)
+            merge(&["a"], "b"),            // t(2)
+            partition("b", &["b1", "b2"]), // t(3)
+        ],
+    );
+
+    assert_eq!(
+        s.resolve_at(&eid("a"), t(2)).expect("resolve").outcome,
+        ResolutionOutcome::Located {
+            entity: eid("b"),
+            hops: 1,
+        },
+        "before the partition, `a` is unambiguously `b`"
+    );
+    assert_eq!(
+        s.resolve_at(&eid("a"), t(3)).expect("resolve").outcome,
+        ResolutionOutcome::Ambiguous {
+            successors: vec![eid("b1"), eid("b2")],
+        },
+        "after it, the same id is ambiguous -- so the instant is what decides"
+    );
+
+    drop(s);
+    clean(&path);
+}
+
+/// **A retirement after `t` does not retire the entity at `t`** — and, because
+/// retirement is not a redirect, it does not change the answer afterwards
+/// either. Both halves asserted, since the second is the one that would make
+/// the first look load-bearing when it was not.
+#[test]
+fn a_forget_after_the_instant_changes_the_state_but_never_the_earlier_answer() {
+    let (mut s, path) = open("later-forget");
+    seed(&mut s, &[assert_id("a"), forget("a")]);
+
+    let before = s.identity_view_at(t(0)).expect("view");
+    let after = s.identity_view_at(t(1)).expect("view");
+
+    assert_eq!(
+        before.resolve_at(&eid("a")).outcome,
+        ResolutionOutcome::Located {
+            entity: eid("a"),
+            hops: 0,
+        }
+    );
+    // §6.3: ForgetEntity "is not deletion" -- a retired id still answers with
+    // itself, so the OUTCOME is identical either side. What differs is the
+    // recorded lifecycle, which is where the instant actually shows.
+    assert_eq!(
+        after.resolve_at(&eid("a")).outcome,
+        ResolutionOutcome::Located {
+            entity: eid("a"),
+            hops: 0,
+        },
+        "retirement is not a redirect"
+    );
+
+    use kirra_world::entity::Lifecycle;
+    assert!(
+        !matches!(
+            before.view().get(&eid("a")).map(|e| &e.lifecycle),
+            Some(Lifecycle::Retired)
+        ),
+        "at t(0) the entity had not been retired"
+    );
+    assert!(
+        matches!(
+            after.view().get(&eid("a")).map(|e| &e.lifecycle),
+            Some(Lifecycle::Retired)
+        ),
+        "at t(1) it had -- without which the assertion above proves nothing"
+    );
+
+    drop(s);
+    clean(&path);
+}
+
+// ---------------------------------------------------------------------------
+// Agreement with the present-tense resolver
+// ---------------------------------------------------------------------------
+
+/// **`resolve_at(head)` and `resolve()` agree, over every id in a graph that
+/// uses all four verbs.**
+///
+/// The two paths fold the same events with the same reducer, so they must not
+/// be able to disagree at the head — and this is what would catch the historical
+/// fold accidentally seeding itself differently, or applying a different
+/// predicate, in the one case where the answer is independently known.
+///
+/// Every id is checked rather than a chosen one: a disagreement on a single
+/// entity is exactly what a hand-picked assertion would miss.
+#[test]
+fn resolve_at_the_head_agrees_with_the_present_tense_resolver() {
+    let (mut s, path) = open("head-agrees");
+    seed(
+        &mut s,
+        &[
+            assert_id("a"),
+            assert_id("b"),
+            assert_id("c"),
+            merge(&["a"], "b"),
+            partition("b", &["b1", "b2"]),
+            merge(&["b1"], "c"),
+            forget("c"),
+        ],
+    );
+
+    let current = s.identity_view().expect("current view");
+    let historical = s.identity_view_at(t(6)).expect("historical view");
+
+    let ids = ["a", "b", "c", "b1", "b2", "never-existed"];
+    let mut agreed_on_something_interesting = false;
+    for id in ids {
+        let e = eid(id);
+        let now = resolve(&current, &e);
+        let then = historical.resolve_at(&e).outcome;
+        assert_eq!(now, then, "disagreement on `{id}`");
+        if matches!(now, ResolutionOutcome::Located { hops, .. } if hops > 0) {
+            agreed_on_something_interesting = true;
+        }
+    }
+    assert!(
+        agreed_on_something_interesting,
+        "every id resolved to itself with zero hops, so this agreed vacuously"
+    );
+
+    drop(s);
+    clean(&path);
+}
+
+/// **An instant past the head is the head**, not an error and not an empty
+/// graph. A caller asking "as of now" with a wall-clock reading slightly ahead
+/// of the last recorded event must get the current answer.
+#[test]
+fn an_instant_after_every_record_answers_as_the_head_does() {
+    let (mut s, path) = open("past-head");
+    seed(
+        &mut s,
+        &[assert_id("a"), assert_id("b"), merge(&["a"], "b")],
+    );
+
+    let current = s.identity_view().expect("current view");
+    assert_eq!(
+        s.resolve_at(&eid("a"), t(10_000)).expect("resolve").outcome,
+        resolve(&current, &eid("a"))
+    );
+
+    drop(s);
+    clean(&path);
+}
+
+/// **An instant before every record is an empty graph**, so every id is
+/// `Unknown` — never a panic and never today's answer.
+#[test]
+fn an_instant_before_every_record_knows_nothing() {
+    let (mut s, path) = open("before-all");
+    seed(
+        &mut s,
+        &[assert_id("a"), assert_id("b"), merge(&["a"], "b")],
+    );
+
+    let view = s.identity_view_at(T0 - 1).expect("view");
+    assert!(view.view().is_empty(), "no adjudication had been recorded");
+    assert_eq!(
+        view.resolve_at(&eid("a")).outcome,
+        ResolutionOutcome::Unknown
+    );
+
+    drop(s);
+    clean(&path);
+}
+
+// ---------------------------------------------------------------------------
+// Contradiction: refused at the instant it arose, never resolved into a winner
+// ---------------------------------------------------------------------------
+
+/// **A contradictory historical graph refuses; it does not synthesize a
+/// winner.**
+///
+/// `a` merges into `b`, then `a` merges into `c` — two individually valid
+/// events, neither able to see the other. `KIRRA-WM-TRANSITIVITY-001` requires
+/// the contradictory graph to fail rather than be repaired, and the fold's
+/// poison is what carries that into the historical view exactly as it does the
+/// current one.
+///
+/// The instant *before* the second merge is asserted as well, and that is the
+/// half that matters: it proves the refusal is a property of the graph AT THE
+/// INSTANT rather than a flag inherited from today's projection.
+#[test]
+fn a_contradiction_refuses_at_and_after_it_arose_but_not_before() {
+    use kirra_world::resolution::RefusalReason;
+
+    let (mut s, path) = open("contradiction");
+    seed(
+        &mut s,
+        &[
+            assert_id("a"),     // t(0)
+            assert_id("b"),     // t(1)
+            assert_id("c"),     // t(2)
+            merge(&["a"], "b"), // t(3)
+            merge(&["a"], "c"), // t(4) -- contradicts the above
+        ],
+    );
+
+    assert_eq!(
+        s.resolve_at(&eid("a"), t(3)).expect("resolve").outcome,
+        ResolutionOutcome::Located {
+            entity: eid("b"),
+            hops: 1,
+        },
+        "before the second merge the history is consistent and answers"
+    );
+    assert_eq!(
+        s.resolve_at(&eid("a"), t(4)).expect("resolve").outcome,
+        ResolutionOutcome::Refused(RefusalReason::ContradictoryHistory { at: eid("a") }),
+        "once both merges are visible the graph contradicts itself and must \
+         refuse rather than pick one"
+    );
+
+    drop(s);
+    clean(&path);
+}
+
+// ---------------------------------------------------------------------------
+// KIRRA-WM-CLUSTERING-001 / -PROMOTION-001: candidates are not identity
+// ---------------------------------------------------------------------------
+
+/// **A candidate `same_as` observation never enters the historical confirmed
+/// graph.**
+///
+/// The rulings bar a matcher from confirming identity. The historical view must
+/// not be the back door: a `claim_status = 'candidate'` row is invisible to the
+/// fold at every instant, exactly as it is to the present-tense one.
+///
+/// Written as a raw `append` rather than through `append_adjudication`, because
+/// that helper writes `Confirmed` unconditionally — so the candidate row this
+/// test needs cannot be produced by the adjudication door at all, which is
+/// itself the enforcement. What is checked here is the READ side: that a
+/// candidate row sitting in the log is not picked up by the historical fold.
+#[test]
+fn a_candidate_same_as_row_is_invisible_to_the_historical_fold() {
+    let (mut s, path) = open("candidate-excluded");
+    seed(&mut s, &[assert_id("a"), assert_id("b")]);
+
+    // A candidate claim carrying an adjudication-shaped payload, written by a
+    // matcher. The `kind` matches what the fold selects on, so only the
+    // claim_status predicate keeps it out.
+    let event_id = EventId::new("ev-candidate").expect("event id");
+    let observation_id = ObservationId::new("obs-candidate").expect("obs");
+    let payload = kirra_world_store::adjudication_record::encode_adjudication(&merge(&["a"], "b"));
+    s.append(&NewEvent {
+        event_id: &event_id,
+        observation_id: &observation_id,
+        txn_time_ms: t(2),
+        valid_from_ms: t(2),
+        valid_to_ms: None,
+        source: "matcher",
+        source_version: "0.1.0",
+        writer_class: WriterClass::LlmCandidate,
+        claim_status: ClaimStatus::Candidate,
+        provenance: &["obs-1"],
+        frame_id: None,
+        map_id: None,
+        kind: kirra_world_store::adjudication_record::ADJUDICATION_KIND,
+        subject: "a",
+        subject_ref: None,
+        predicate: None,
+        object: None,
+        payload: &payload,
+        payload_schema: kirra_world_store::adjudication_record::ADJUDICATION_PAYLOAD_SCHEMA,
+        retention_class: "raw",
+        trust: None,
+    })
+    .expect("append candidate");
+
+    assert_eq!(
+        s.resolve_at(&eid("a"), t(2)).expect("resolve").outcome,
+        ResolutionOutcome::Located {
+            entity: eid("a"),
+            hops: 0,
+        },
+        "a candidate merge must not redirect `a` at any instant"
+    );
+    assert_eq!(
+        s.resolve_at(&eid("a"), t(10)).expect("resolve").outcome,
+        ResolutionOutcome::Located {
+            entity: eid("a"),
+            hops: 0,
+        },
+        "nor later -- a candidate does not become identity by ageing"
+    );
+
+    drop(s);
+    clean(&path);
+}
+
+// ---------------------------------------------------------------------------
+// The degradation contract
+// ---------------------------------------------------------------------------
+
+/// **The answer carries its resolution, and it is `Full` because adjudications
+/// are protected from compaction.**
+///
+/// Asserted through the compaction predicate rather than by comparing the field
+/// to a literal: what makes identity immune to compaction is that
+/// `is_protected` holds for the class adjudications are written with, and if
+/// that ever stops being true this assertion is the one that should change.
+#[test]
+fn a_historical_answer_carries_a_resolution_and_it_is_full_because_adjudications_are_protected() {
+    assert!(
+        kirra_world_store::compaction::is_protected(
+            kirra_world_store::adjudication_record::ADJUDICATION_RETENTION_CLASS
+        ),
+        "identity's immunity to compaction rests on this predicate; the \
+         resolution below is derived from it, not assumed alongside it"
+    );
+
+    let (mut s, path) = open("resolution-full");
+    seed(
+        &mut s,
+        &[assert_id("a"), assert_id("b"), merge(&["a"], "b")],
+    );
+
+    let answer = s.resolve_at(&eid("a"), t(2)).expect("resolve");
+    assert_eq!(answer.resolution, Resolution::Full);
+    assert!(!answer.is_degraded());
+    assert_eq!(
+        answer.as_known_at_ms,
+        t(2),
+        "the answer names the instant it was true at"
+    );
+
+    drop(s);
+    clean(&path);
+}
+
+/// **A compacted store still answers `Full` for identity** — because the
+/// compaction planner refuses a window holding a protected row, so a recorded
+/// citation is evidence that no adjudication was in it.
+///
+/// This is the case that would be wrong under a naive "any citation means
+/// degraded" rule: raw observations were compacted away, and identity is
+/// genuinely unaffected.
+#[test]
+fn compacting_raw_observations_does_not_degrade_a_historical_identity_answer() {
+    let (mut s, path) = open("compacted-raw");
+
+    // Raw observations first, so there is something compactable that is not an
+    // adjudication.
+    for i in 0..4 {
+        let event_id = EventId::new(format!("raw-{i}")).expect("event id");
+        let observation_id = ObservationId::new(format!("raw-obs-{i}")).expect("obs");
+        s.append(&NewEvent {
+            event_id: &event_id,
+            observation_id: &observation_id,
+            txn_time_ms: T0 - 100 + i,
+            valid_from_ms: T0 - 100 + i,
+            valid_to_ms: None,
+            source: "sensor-a",
+            source_version: "0.1.0",
+            writer_class: WriterClass::Sensor,
+            claim_status: ClaimStatus::Confirmed,
+            provenance: &[],
+            frame_id: None,
+            map_id: None,
+            kind: "observation",
+            subject: "thing",
+            subject_ref: None,
+            predicate: Some("colour"),
+            object: Some("red"),
+            payload: r#"{"n":1}"#,
+            payload_schema: 1,
+            retention_class: "raw",
+            trust: None,
+        })
+        .expect("append raw");
+    }
+    seed(
+        &mut s,
+        &[assert_id("a"), assert_id("b"), merge(&["a"], "b")],
+    );
+
+    let outcome = s.compact_range(1, 3, T0).expect("compact the raw prefix");
+    assert!(
+        outcome.removed > 0,
+        "nothing was compacted, so the assertion below would hold vacuously"
+    );
+
+    let answer = s.resolve_at(&eid("a"), t(2)).expect("resolve");
+    assert_eq!(
+        answer.resolution,
+        Resolution::Full,
+        "raw observations were removed; no adjudication could have been, so the \
+         identity answer is complete"
+    );
+    assert_eq!(
+        answer.outcome,
+        ResolutionOutcome::Located {
+            entity: eid("b"),
+            hops: 1,
+        },
+        "and the answer itself survives the compaction intact"
+    );
+
+    drop(s);
+    clean(&path);
+}
+
+// ---------------------------------------------------------------------------
+// One engine
+// ---------------------------------------------------------------------------
+
+/// **The historical view is an `AdjudicationGraph` like any other**, so the
+/// public resolver runs over it directly and gives the same answer as the
+/// convenience method.
+///
+/// This is what "one shared underlying resolution engine" means concretely: not
+/// that two implementations agree, but that there is one function and the
+/// historical path is a different argument to it.
+#[test]
+fn the_public_resolver_runs_over_the_historical_view_unchanged() {
+    let (mut s, path) = open("one-engine");
+    seed(
+        &mut s,
+        &[assert_id("a"), assert_id("b"), merge(&["a"], "b")],
+    );
+
+    let view = s.identity_view_at(t(2)).expect("view");
+    assert_eq!(
+        resolve(&view, &eid("a")),
+        view.resolve_at(&eid("a")).outcome,
+        "`resolve_at` must be `resolve` over a restricted graph, not a second \
+         implementation that happens to agree"
+    );
+
+    drop(s);
+    clean(&path);
+}

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -1001,7 +1001,13 @@ does not describe is how a residue disappears.
       a recorded citation is itself evidence its window held no adjudication. The
       derivation consults that predicate at runtime, so a future compaction mode
       that could remove a protected class makes identity answers degrade instead
-      of silently keeping their completeness claim.
+      of silently keeping their completeness claim. In that fallback **every
+      recorded citation degrades**, with no narrowing by time: `compacted_at_ms`
+      is when compaction RAN and `as_known_at_ms` is the instant asked ABOUT, so
+      a compaction running *after* the queried instant is exactly the one that
+      removes evidence bearing on it — and the removed rows are the only record
+      of their own transaction times, so a span cannot be shown irrelevant after
+      the fact.
       §6.3 makes historical identity part of the intended semantics, and the
       incident-reconstruction goal is not served by a resolver that can only
       answer "who is this *now*" — reconstruction asks who it was *then*.

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -973,14 +973,35 @@ does not describe is how a residue disappears.
       adjudication question at read time. `resolve`'s existing refusal of a
       redirect cycle is the precedent.
 
-- [ ] **2d — Historical / as-of resolution.** `resolve` is **current-state only**
-      today. **RULED 2026-08-08: as-of identity resolution stays INSIDE Tier 2
-      and gets built** — the tier is not redefined to avoid it.
-      `resolve_at(...)` / `IdentityView::at(...)` **composes an as-of
-      evidence/projection view with the existing resolver**; it does not
-      introduce a second resolution algorithm, and it does not build
-      bitemporality, because the substrate already ships in `kirra-world-store`
-      (`current` / `as_of` / `history` / `candidates` / `changed_since`, #1353).
+- [x] **2d — Historical / as-of resolution.** **DONE 2026-08-09**,
+      `WorldStore::identity_view_at` / `resolve_at` +
+      `entity_projection::HistoricalIdentityView`, 13 integration tests.
+      **RULED 2026-08-08: as-of identity resolution stays INSIDE Tier 2 and gets
+      built** — the tier is not redefined to avoid it. As built, it **composes an
+      as-of projection view with the existing resolver**: the fold is re-run over
+      the adjudications recorded by the instant, and
+      `kirra_world::resolution::resolve` — unmodified, the same function the
+      present-tense path calls — walks the smaller graph. No second resolution
+      algorithm, no historical outcome variants, no bitemporal substrate built
+      here (it already ships, #1353).
+      **The cut is on transaction time** (`txn_time_ms`), the `as_known_at_ms`
+      axis of `as_of`. Valid time is deliberately not consulted: an adjudication
+      is a judgement whose effect begins when recorded, not a claim holding over
+      an interval, and `append_adjudication` hardcodes `valid_to_ms = NULL`, so
+      filtering on that axis would look rigorous and do nothing. A genuine
+      valid-time identity question is a different query needing its own ruling.
+      **`KIRRA-WM-CLUSTERING-001` holds at every instant, not just the present:**
+      the fold's `claim_status = 'confirmed'` predicate is inherited rather than
+      restated, so a candidate `same_as` observation is invisible to the
+      historical view too — it cannot be the back door into the confirmed graph
+      that the write door refuses.
+      **Degradation is derived, not asserted.** The answer carries a
+      `Resolution`; it reads `Full` over a compacted store because
+      `compaction::is_protected` holds for the `adjudication` retention class, so
+      a recorded citation is itself evidence its window held no adjudication. The
+      derivation consults that predicate at runtime, so a future compaction mode
+      that could remove a protected class makes identity answers degrade instead
+      of silently keeping their completeness claim.
       §6.3 makes historical identity part of the intended semantics, and the
       incident-reconstruction goal is not served by a resolver that can only
       answer "who is this *now*" — reconstruction asks who it was *then*.


### PR DESCRIPTION
§6.3: *"A query at a past instant resolves identity as it was adjudicated then —
because identity is a projection like everything else."* `resolve` was
current-state only, so incident reconstruction could ask who an id **is** and
never who it **was**.

## 1. The same resolver, reused unchanged

`kirra_world::resolution::resolve` is not modified, not wrapped, and not
reimplemented. There is no historical resolver, no historical outcome variants,
and no `resolve_at` semantics of its own — `HistoricalIdentityView::resolve_at`
calls the same function the present-tense path calls, with a different graph.

That is deliberate rather than economical. `KIRRA-WM-TRANSITIVITY-001`
disqualified union-find and required a contradictory graph to resolve to
`Ambiguous`/`Refused` rather than being repaired; a second engine here would be
a second place for that to be got wrong, and the two would agree on the day they
were written and drift afterwards. `the_public_resolver_runs_over_the_historical_view_unchanged`
pins it structurally: `HistoricalIdentityView` implements `AdjudicationGraph`,
so the public `resolve` runs over it directly and must equal the convenience
method.

The four answers are the same four. A historical query has no extra outcomes and
no missing ones.

## 2. Historical state is rebuilt from empty, never seeded from the current projection

`identity_view_at` folds from an **empty** accumulator over the adjudications
recorded by the instant. `fold_entity_range` — the incremental path — seeds its
accumulator from the stored projection, because it needs the prior lifecycle to
tell a legal transition from a contradiction. Reusing that here would start the
historical fold at *today's* state and then apply an old prefix on top: every
later merge already present before the first historical event is read.

It is one line, it looks exactly like reuse, and it is the subtlest way to get
this slice wrong. See §5 — it is also the control that nearly escaped.

It is answered from the **log**, not from `entities_projection`, for the reason
`as_of` already records for claims: the projection is a cache of one point on the
temporal surface (latest known), and every other point has to be replayed.
Identity is not an exception to that — §6.3's whole argument is that identity is
a projection *like everything else*.

## 3. Transaction time is the intentional cut

The cut is `txn_time_ms <= as_known_at_ms`, the same axis `WorldStore::as_of`
calls `as_known_at_ms`: **what identity adjudication had been recorded by then.**

Valid time is deliberately not consulted, and the omission is documented in the
type rather than left to read as an oversight — the store *is* bitemporal, so
silence here would look like a gap. An adjudication is not a claim about the
world holding over an interval; it is a judgement, and a judgement's effect on
identity begins when it is recorded. `append_adjudication` hardcodes
`valid_to_ms = NULL`, so filtering on that axis would look rigorous and do
nothing. A genuine valid-time identity question ("who did we think this was, for
the period the robot was in bay 3") is a different semantic question and should
get its own ruling rather than being smuggled into `resolve_at`.

## 4. The 2-hop control: the graph is restricted *before* resolution

`a_query_between_two_merges_stops_at_the_first` is the assertion the slice rests
on. With `a = b` recorded, then later `b = c`:

* at the instant between them, `a` resolves to **`b`, 1 hop**;
* after the second merge, the same id resolves to **`c`, 2 hops**;
* asking the earlier instant again still answers `b` — a historical answer does
  not depend on what has been queried since.

Resolving current state and labelling it with a timestamp answers `c` for every
instant it is handed. This one test separates a real temporal restriction on the
graph from a decorated present-tense answer.

`hops` is asserted, not just the entity: an implementation that resolved to `c`
and walked back to `b` would get the entity right and the path wrong, and
`KIRRA-WM-TRANSITIVITY-001` requires the accepted path to be the one that
existed at the instant.

## 5. Controls run — and one of them changed the tests

| Mutation | Tests failed |
|---|---|
| Ignore the instant (fold the whole log) | **7 / 13** |
| Seed the historical fold from the stored projection | **11 / 13** |
| Drop the `claim_status = 'confirmed'` predicate | **1 / 13** (the candidate test, alone) |

The middle row is the one worth reporting. It initially failed **2 of 13** — not
because the tests were checking the wrong thing, but because most of them never
folded the current projection, and on an *empty* projection seeding from it and
seeding from empty are the same operation. The bug was invisible to them, while
production, where the projection is always populated, would have been wrong.
`seed` now folds the projection, which is the realistic state, and the control
fails 11 of 13.

## Rulings that hold at every instant, not just the present

**`KIRRA-WM-CLUSTERING-001` / `-PROMOTION-001`.** The confirmed-only predicate is
inherited from the current fold rather than restated as a new rule, so a
candidate `same_as` row is invisible to the historical view too. The historical
query cannot be the back door into the confirmed graph that the write door
refuses — checked at the queried instant and later, since a candidate does not
become identity by ageing.

**Contradiction.** `a_contradiction_refuses_at_and_after_it_arose_but_not_before`
asserts both sides: consistent history answers, and once both merges are visible
the graph refuses rather than picking a winner. Asserting the *before* case is
what proves the refusal is a property of the graph at the instant rather than a
flag inherited from today's projection.

## Degradation is derived, not hardcoded

The answer carries a `Resolution`. It reads `Full` over a compacted store because
`compaction::is_protected` holds for the `adjudication` retention class, so the
planner refuses a window containing one — which makes a recorded citation
*evidence* that its window held no adjudication.

`identity_resolution_at` consults that predicate at runtime rather than asserting
its conclusion, so `Full` is justified by the retention policy rather than by
optimism. If the class is ever demoted, historical identity answers start
reporting `Degraded` on their own instead of silently keeping a completeness
claim they no longer have. A test compacts real raw rows and pins that identity
still answers `Full`, and intact — the case a naive "any citation means degraded"
rule would get wrong in the noisy direction.

## Verification

`cargo test --workspace` and `cargo clippy --workspace --all-targets -D warnings`
both exit 0; `cargo fmt --check` clean; every `ci/check_*.py` gate passes.
13 new integration tests in `crates/kirra-world-store/tests/historical_resolution.rs`.
`WM_SCOPE.md` 2d is checked off with the as-built notes, including the two
decisions above.

## Branch note

`claude/proposal-release-token-binding-jlu018` held three stale commits (retention
policy, survey states) whose content had already landed in `main` via squash merge
and been built on since — the branch added no file `main` lacked and was missing
20+ files it has. That was verified before acting; the branch was then restarted
from `main`. No unmerged work was discarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_