### PR TITLE
Rule Tier 2.5's consumer placement, and record what the differential proof can reuse

### DIFF
--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -1175,10 +1175,14 @@ future consumer rediscovers it after writing the same code.
 ### What the workspace already answers
 
 `kirra-world-service` is **the only crate that depends on `kirra-world*` and
-implements no `CorridorSource`** — its entire dependency list is `kirra-world`
-and `kirra-world-store`. It is outside every barred set: not a safety-closure
-member, not a corridor producer, nothing transitive to drag in. The **hosting**
-question is therefore already answered by construction.
+implements no `CorridorSource`** — its runtime dependencies are `kirra-world` and
+`kirra-world-store`, and nothing else. (It also carries one dev-dependency: the
+same `kirra-world-store` with `test-support`, for the raw-SQL escape hatch that
+plants a corrupt chain digest. Worth naming rather than eliding, because the
+§11 finding below turns entirely on how dev edges are classified — the same
+distinction, seen where it does no harm.) It is outside every barred set: not a
+safety-closure member, not a corridor producer, nothing transitive to drag in.
+The **hosting** question is therefore already answered by construction.
 
 **Hosting is not consuming, and this is the trap.** Nothing depends on
 `kirra-world-service` today except workspace membership, so it carries the same
@@ -1195,18 +1199,28 @@ the workspace manifests, not by reading crate names. What that produced:
 * The behaviour-shaping crates are **not** caught by Fence B. `kirra-planner`,
   `kirra-map`, `kirra-taj`, `kirra-sidecars` and `kirra-mick` are all outside the
   safety closure. What bars them is the *other* gate: `check_4_trait_impls`, whose
-  conjunction is *implements `CorridorSource`* ∧ *`pkg_reaches_world`*. The
-  production `CorridorSource` implementors are `kirra-core`, `kirra-map`,
-  `kirra-ros2-adapter`, `kirra-sidecars` and `kirra-taj`.
+  conjunction is *implements `CorridorSource`* ∧ *`pkg_reaches_world`*. The crates
+  carrying a non-`cfg(test)` `impl CorridorSource` — the set the gate actually
+  keys on — are `kirra-core`, `kirra-map`, `kirra-ros2-adapter`, `kirra-sidecars`
+  and `kirra-taj`. **`kirra-core` is on that list for a reason worth stating:** its
+  impl is `MockCorridorSource`, documented in place as "a straight-line test
+  stand-in, not drivable space" whose selection for a real deployment "is a
+  configuration error". It is not production drivable space — but it is not
+  `cfg(test)`-gated either, so it compiles into the library and the gate counts it.
+  The gate keys on *what ships*, not on what was intended, which is the correct
+  behaviour for a fence and the reason the list must not be read as five
+  production corridor producers.
 * **Two of the five are barred directly and three transitively**, which is worth
   separating because only the first kind is obvious from the crate itself.
   `kirra-map` and `kirra-taj` implement `CorridorSource`, so a world edge on
   either satisfies the conjunction on the spot. `kirra-planner` and `kirra-mick`
   implement nothing — they are barred because `kirra-sidecars` *does* implement it
-  and depends on both (its full list is `kirra-core`, `kirra-planner`,
-  `kirra-trajectory`, `kirra-taj`, `kirra-mick`), so a world edge added at either
-  makes `kirra-sidecars` reach world and the gate fires there. That is the
-  transitivity direction §9 relies on, confirmed rather than assumed.
+  and depends on both (its full **Kirra-internal** dependency list is `kirra-core`,
+  `kirra-planner`, `kirra-trajectory`, `kirra-taj`, `kirra-mick`; it carries
+  third-party crates besides, which the closure walk follows but which cannot
+  reach Kirra World), so a world edge added at either makes `kirra-sidecars` reach
+  world and the gate fires there. That is the transitivity direction §9 relies on,
+  confirmed rather than assumed.
 * **27 packages pass both gates mechanically.** Nearly all are harnesses, benches,
   fuzz targets or proof crates. A consumer placed in one of them would satisfy
   goal 1 *vacuously* — the fence would say yes to a crate that ships no behaviour,

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -1177,13 +1177,79 @@ future consumer rediscovers it after writing the same code.
 `kirra-world-service` is **the only crate that depends on `kirra-world*` and
 implements no `CorridorSource`** — its entire dependency list is `kirra-world`
 and `kirra-world-store`. It is outside every barred set: not a safety-closure
-member, not a corridor producer, nothing transitive to drag in. The host
+member, not a corridor producer, nothing transitive to drag in. The **hosting**
 question is therefore already answered by construction.
 
 **Hosting is not consuming, and this is the trap.** Nothing depends on
 `kirra-world-service` today except workspace membership, so it carries the same
 *built for nobody* problem one level up. A service crate is a transport surface;
 this milestone needs something that turns world knowledge into behaviour.
+
+### Where a consumer could live — the survey, run rather than argued
+
+The placement question was settled by executing the fence's own predicates over
+the workspace manifests, not by reading crate names. What that produced:
+
+* **54 workspace packages.** Fence B's safety closure — the transitive
+  dependencies of the 10 `SAFETY_ROOTS` — is **19** of them; 35 sit outside it.
+* The behaviour-shaping crates are **not** caught by Fence B. `kirra-planner`,
+  `kirra-map`, `kirra-taj`, `kirra-sidecars` and `kirra-mick` are all outside the
+  safety closure. What bars them is the *other* gate: `check_4_trait_impls`, whose
+  conjunction is *implements `CorridorSource`* ∧ *`pkg_reaches_world`*. The
+  production `CorridorSource` implementors are `kirra-core`, `kirra-map`,
+  `kirra-ros2-adapter`, `kirra-sidecars` and `kirra-taj`.
+* **Two of the five are barred directly and three transitively**, which is worth
+  separating because only the first kind is obvious from the crate itself.
+  `kirra-map` and `kirra-taj` implement `CorridorSource`, so a world edge on
+  either satisfies the conjunction on the spot. `kirra-planner` and `kirra-mick`
+  implement nothing — they are barred because `kirra-sidecars` *does* implement it
+  and depends on both (its full list is `kirra-core`, `kirra-planner`,
+  `kirra-trajectory`, `kirra-taj`, `kirra-mick`), so a world edge added at either
+  makes `kirra-sidecars` reach world and the gate fires there. That is the
+  transitivity direction §9 relies on, confirmed rather than assumed.
+* **27 packages pass both gates mechanically.** Nearly all are harnesses, benches,
+  fuzz targets or proof crates. A consumer placed in one of them would satisfy
+  goal 1 *vacuously* — the fence would say yes to a crate that ships no behaviour,
+  which is precisely the acceptance that carries no information.
+
+So the survey does not converge on an existing host. Every crate that would make
+goal 4 real is barred by the corridor conjunction, and every crate that is
+mechanically clear would make goal 1 vacuous. That is not a gap in the survey; it
+is the answer the survey produced.
+
+### `KIRRA-WM-CONSUMER-PLACEMENT-001` — RULED 2026-08-10
+
+> **Tier 2.5 requires a dedicated non-authoritative consumer crate whose sole
+> role is to translate Kirra World knowledge into proposal-shaping inputs. It may
+> influence what is proposed, but it may not implement or feed `CorridorSource`,
+> checker bounds, release authority, or actuation.**
+
+The shape:
+
+```
+Kirra World → world-consumer / mission-context crate → proposal-shaping context → planner / mission logic
+```
+
+**The key is that it outputs proposal context, not bounds.** The crate sits
+upstream of the doer and downstream of nothing safety-authoritative. It is the
+named home the gap section says does not exist — created, rather than discovered,
+because the survey above shows there is nothing to discover.
+
+This restates, at crate granularity, the invariant Tier 2.5 exists to defend:
+
+> **Kirra World may change what is proposed. It may not change the inputs from
+> which the checker derives what is permitted.**
+
+Two consequences worth stating so they are not rediscovered:
+
+* **"Non-authoritative" is a dependency fact, not an intent.** The crate is
+  non-authoritative because the two gates say so with the edge present — not
+  because its documentation says it only advises.
+* **A new crate is the weaker-coupling choice, not the heavier one.** Adding the
+  world edge to an existing behaviour crate would put every *other* thing that
+  crate does inside the blast radius of a future world-authority argument. A
+  single-purpose crate keeps the surface the fence must defend equal to the
+  surface that actually consumes.
 
 ### Two consumers, proving different things
 
@@ -1207,21 +1273,117 @@ contract it never tested.
 
 - [ ] **Name the non-authoritative host** for world knowledge, and record why it
       is outside the checker's closure rather than merely believed to be.
+      *Placement ruled* (`KIRRA-WM-CONSUMER-PLACEMENT-001`): a **new** crate,
+      because the survey found no existing one that satisfies both halves.
+      **The box stays open, and the reason is the non-vacuity condition on it:**
+      the named host must be one whose removal would change observable proposal
+      behaviour. A host that passes the fence only because it does nothing
+      satisfies the *letter* of this goal and none of its purpose. Naming is
+      therefore half of it; goal 4's differential proof is what earns the other
+      half, and this box closes when that proof runs — not when the crate exists.
 - [ ] **Define the one-way seam** from Kirra World into operational software.
+      The seam's type-level obligation: what crosses it is *proposal context*, and
+      nothing in its output type is admissible as a checker bound.
 - [ ] **Prove the consumer cannot influence the checker — mechanically.** The
       acceptance criterion is that
       `ci/check_kirra_world_bidirectional_fence.py` passes **with the new
       dependency edge present**, not an argument in a document.
+- [ ] **Prove the consumer changes proposals and only proposals — differentially.**
+      Two runs over one scenario, world-consumer off and on: the proposals must
+      differ (else goal 1 is vacuous) *and* the checker's bound-derivation inputs
+      must be bit-identical (else the invariant is breached).
 - [ ] **Exercise the Tier 3 contracts with a real caller** (the typed one).
 - [ ] **Capture every contract that breaks** before the API is expanded.
 
-### What goal 3 buys beyond itself
+### The acceptance proof — four parts, and why each is separate
 
-The fence has so far only ever been observed **refusing**. A fence that only
-refuses is indistinguishable from one that refuses everything, so its acceptances
-carry no information yet. This milestone is the first evidence it can say *yes*
-to a legitimate route — the same non-vacuity discipline this document applies to
-tests, applied to the fence.
+Each part fails in a way the other three cannot detect. That is the reason they
+are not collapsed into one criterion.
+
+1. **Fence positive control.** `check_kirra_world_bidirectional_fence.py` passes
+   with the new edge present. *Negative control:* the fence's existing refusals —
+   the 2026-08-07 attempt recorded in §9 — prove it can say no. Both directions
+   are required; the fence has so far only ever been observed refusing, and a gate
+   that only refuses is indistinguishable from one that refuses everything.
+2. **Corridor-conjunction control.** The consumer crate implements no
+   `CorridorSource` and appears in no `CorridorSource` implementor's closure. This
+   is checked by contents (gate t24's technique), not by dependency direction —
+   an inverted implementation would be invisible to a closure walk.
+3. **Behavioural non-vacuity.** Turning the consumer off changes what is proposed.
+   Without this, parts 1 and 2 are satisfied by a crate that does nothing.
+4. **Bound-derivation invariance.** Across the same two runs, the inputs the
+   checker derives its bounds from are **bit-identical**. Parts 3 and 4 are the
+   two halves of the invariant and must be asserted over the *same* pair of runs;
+   asserted separately, part 3 would pass on a run pair that also moved the bounds.
+
+### The differential proof's substrate — what `kirra-replay` does and does not give us
+
+Inspected before designing the harness, because reusing existing capture is
+strictly better than minting a new artifact if the fields are there. **The
+question asked was: does the captured record expose the checker's authoritative
+bound-derivation inputs separately enough to compare two runs bit-identically,
+independent of proposal/verdict differences?**
+
+**`kirra-replay` itself: no, and not for a fixable reason.** Its comparator is
+`VerdictImage` — `{outcome, deny_code, safe_value_bits, mrc}` — and its entire
+contract is *same inputs → same verdict*. Part 4 needs the opposite framing:
+inputs deliberately differ on the proposal axis, so `ReplayResult::Divergent`
+would fire on exactly the case the proof is designed to produce. Reusing it would
+invert the meaning of its alarm.
+
+**`kirra-capture-schema`'s `CaptureRecord`: no.** Three specific shortfalls:
+
+* **Proposal and bound-derivation inputs are commingled.** All five fields sit in
+  one `ProposedCommandSnapshot`. `linear_velocity_mps` / `steering_angle_deg` are
+  the proposal; `current_velocity_mps`, `current_steering_angle_deg` and
+  `delta_time_s` are the ego state and time base the envelope is computed against
+  (P5b's rate ceiling and P3/P4's accel bound read them directly). Splitting them
+  would be a harness-side naming convention, not a property of the record — and a
+  field added later carries no signal about which side it belongs on.
+* **The contract identity is absent entirely.** `VehicleClass` reaches the checker
+  as `contract_for(class)`, and `kirra-replay` takes it as a CLI argument. Nothing
+  in the record pins which envelope was in force, so the artifact cannot *prove*
+  two runs used the same one — which is the single most important thing part 4
+  must hold fixed.
+* **The derate cap is a bool.** `derate_enabled` records that a perception cap
+  composed, never its value. `kirra-replay` is honest about this and classifies
+  such records `NotReplayable`; that honesty is exactly why the field cannot be
+  used as evidence of an unchanged bound.
+
+**`kirra-cycle-record`'s `JoinedCycleRecord`: yes, and it is already the right
+shape.** It separates the three axes the proof needs, which is not a coincidence —
+it was built for incident review, which has the same separation problem:
+
+* **Bound-derivation inputs → `PerceptionEvent.evidence_digest`**, a SHA-256 over
+  the complete accepted safety-relevant Taj output: the corridor `left`/`right`
+  polylines, objects (id/x/y/vx/vy/coasted), pedestrians with their classification
+  and fusion reason, `clear_distance_m`, `minimum_corridor_width_m`,
+  `required_corridor_width_m`, `speed_cap_mps`, and the `profile_digest` that binds
+  evidence interpretation to the configuration that produced it. One 64-hex value,
+  bit-comparable, computed from the Taj response alone.
+* **The enforced cap → `raw_speed_cap_mps` / `stabilized_speed_cap_mps`**, carried
+  as a *pair* precisely so a review can see whether the enforced cap was
+  perception's own or the stabilizer holding a stale anchor.
+* **The proposal axis → `ProposalEvent.proposal_digest`**, distinct from the
+  evidence digest, with an existing echo-check that the planner bound the evidence
+  it claims.
+* **Cross-run alignment → `scan_sequence`**, the cycle's primary key.
+
+**The smallest extension needed, therefore, is one field, not a new artifact:**
+the **kinematic contract identity** (vehicle class, or a digest over the resolved
+`VehicleKinematicsContract`) on the record. Without it, two runs can be shown to
+have had identical perception evidence and still not be shown to have been judged
+against the same envelope. Everything else part 4 requires is already captured.
+
+Two things deliberately **not** added:
+
+* **A Kirra World provenance field on the cycle record.** The harness controls
+  which arm is which, so run identity is known out of band. Adding it would put
+  world-derived data into the transport of a safety artifact — close enough to the
+  fence that the convenience is not worth the precedent.
+* **`profile_digest` as its own field.** It is folded into `evidence_digest`, so a
+  perception-config change is *detected* (the digests differ) but not *explained*.
+  That is a diagnosability gap, not a soundness gap, and part 4 needs soundness.
 
 ---
 
@@ -1767,6 +1929,68 @@ the closure walk would not see it.
 
 But a gate can refuse a dependency. It cannot refuse an argument. Holding the
 line is part of this scope, not a footnote to it.
+
+### Finding — `parko-kirra` is a checker that the dev-edge exclusion treats as a doer
+
+Surfaced by the Tier 2.5 placement survey and recorded **here rather than in
+§5.5**, because it is not Tier 2.5's to fix and folding it in would make that
+milestone's acceptance hostage to an unrelated question.
+
+**First, the mechanism that is *not* at issue.** The fence enumerates manifests by
+`rglob` from the repo root, so it sees `parko/`'s crates despite `parko/` being a
+separate Cargo workspace — and `parko-core` is already **inside** Fence B's
+closure, reached by a normal dependency edge from the root crate. "A second
+workspace is invisible to the walk" would be a tidy explanation and it is false.
+
+The actual mechanism is the closure walk's **deliberate exclusion of
+dev-dependency edges**, whose stated rationale is load-bearing and, for its
+intended targets, correct:
+
+> the safety roots dev-depend on the DOER crates for their test harnesses. Those
+> crates are the ones that SHOULD one day depend on Kirra World — Occy consuming
+> semantic knowledge to generate a proposal is the intended design, not a breach.
+> Counting dev edges would drag them inside the safety closure and make the fence
+> fire on the architecture working as specified.
+
+That reasoning holds exactly for `kirra-planner`, `kirra-taj`, `kirra-sidecars`
+and `kirra-mick`. It names **`parko-kirra` alongside them, and `parko-kirra` is
+not a doer.** It hosts `KirraGovernor::apply_mrc_profile`
+(`parko/crates/parko-kirra/src/lib.rs:682`) — one of the four enforcement points
+of the Degraded decel-to-stop-and-HOLD envelope, and the one that additionally
+gates an independent angular-velocity channel through `STOP_EPSILON_RAD_S`
+(`:114`). A world edge added there would be a *checker* edge admitted by an
+exclusion justified for *doers*.
+
+`parko-kirra` misses the other route too, for an unrelated reason: it is not one
+of the 10 `SAFETY_ROOTS`, so it is never a closure root either. Two independent
+mechanisms, two different reasons, same blind spot. `parko-ros2` — which runs
+`run_pipeline_tick`, where governor divergence escalates the effective posture —
+is outside for a third reason: nothing in this workspace depends on it at all.
+
+**No world edge exists at any of these today and none is proposed.** The finding
+is about what the gate would fail to notice if one were added, which is the only
+kind of gap worth recording about a gate.
+
+Three ways to close it, none obviously right, which is why this is a finding and
+not a task:
+
+1. **Add `parko-kirra` to `SAFETY_ROOTS`.** Most direct: a root is walked
+   regardless of how it is reached, so this closes the gap without touching the
+   dev-edge policy at all. Cost: `parko-kirra`'s own dependency closure joins the
+   safety closure, and that set has not been reviewed for this purpose.
+2. **Replace the blanket dev-edge exclusion with an explicit doer allowlist.**
+   Turns "dev edges don't count" into "these four named doer crates don't count",
+   so a *new* dev-depended crate is caught by default rather than admitted by
+   default. This is the fail-closed shape; it costs a list that must be
+   maintained, which is the thing the manifest-computed closure exists to avoid.
+3. **Record the boundary as an assumption of use** and gate it socially. Cheapest,
+   and the weakest — this section's own argument is that a gate can refuse a
+   dependency but not an argument.
+
+**Owner: an ADR, not a tier box.** Option 2 is the one that generalizes, but it
+reopens how `parko/`'s separateness is meant to be understood — an independent
+product, or an implementation split of one — and that question predates Kirra
+World.
 
 ---
 

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -1371,9 +1371,49 @@ it was built for incident review, which has the same separation problem:
 
 **The smallest extension needed, therefore, is one field, not a new artifact:**
 the **kinematic contract identity** (vehicle class, or a digest over the resolved
-`VehicleKinematicsContract`) on the record. Without it, two runs can be shown to
-have had identical perception evidence and still not be shown to have been judged
-against the same envelope. Everything else part 4 requires is already captured.
+`VehicleKinematicsContract`). Without it, two runs can be shown to have had
+identical perception evidence and still not be shown to have been judged against
+the same envelope. Everything else part 4 requires is already captured.
+
+**Which record it goes on is decided by which witness can know it, and that is a
+narrower answer than "the record".** The stage events have three separate
+witnesses, and the contract identity is not available to the two that would be
+convenient:
+
+* The **interceptor** builds the release event by decoding the signed 176-byte V2
+  payload, and refuses anything else — a truncated payload decoded best-effort
+  "would attest fields that were never signed". The class is not in that payload.
+* **No witness on the robot can read `KIRRA_VEHICLE_CLASS`.** It lives in the
+  verifier's env (`kirra.env`, root 0600); `robot/doctor` records this explicitly
+  and infers the class was set only from the verifier being up.
+
+So a class field added to `PerceptionEvent` or `ProposalEvent` would be
+witness-*asserted*, not witness-*known* — the exact thing the release decoder
+refuses to do. **It belongs on `CaptureRecord`, which the verifier itself
+writes**, and it reaches the joined artifact through the `CaptureRecordRef` link
+that `kirra-cycle-record` already defines for precisely this division of labour:
+the joined record proves chain continuity, the verifier capture supports decision
+recomputation, and the two stay separate artifacts joined by reference. That the
+same field also closes `CaptureRecord`'s own gap above is not a coincidence — it
+is the same gap seen from two ends.
+
+**One honest cost, so step 2 is not mis-scoped: the schema change is one field,
+the wiring is not.** `gateway_capture_ref` is `Option`al and additive, and the
+Python emitter does not populate it today — the reference route exists in the Rust
+schema with no producer. Step 2 is therefore *field + producer*, and
+`CaptureRecord`'s wire shape is byte-pinned by two tests, so the pins move
+deliberately rather than incidentally. That is what a pin is for.
+
+**A cheaper route exists and is recorded as rejected-for-now rather than
+unnoticed.** `EffectiveConfig::effective_digest` is a SHA-256 over the boot-config
+snapshot that *includes* `vehicle_class`, is already committed as an
+`EffectiveConfigDigest` audit event at startup, and is already exportable through
+the auditor-tier audit export. Two arms with equal digests provably shared a
+class. It is rejected because it is too coarse in the wrong direction: the digest
+covers every captured config value, so two arms differing in anything incidental
+(a DB path, which a two-arm harness would plausibly vary) produce different
+digests and the check says *something* differed without saying what. A coarse
+check that fires on the harness's own setup trains people to ignore it.
 
 Two things deliberately **not** added:
 


### PR DESCRIPTION
Docs only. Three things, one of which corrects a claim rather than adding one.

## 1. `KIRRA-WM-CONSUMER-PLACEMENT-001`

> **Tier 2.5 requires a dedicated non-authoritative consumer crate whose sole role is to translate Kirra World knowledge into proposal-shaping inputs. It may influence what is proposed, but it may not implement or feed `CorridorSource`, checker bounds, release authority, or actuation.**

The key is that it outputs **proposal context, not bounds**:

```
Kirra World → world-consumer / mission-context crate → proposal-shaping context → planner / mission logic
```

The ruling is backed by a survey run with the fence's own predicates rather than argued from crate names — **54 workspace packages, a 19-package Fence B closure from 10 roots, 27 packages passing both gates**. The conclusion the survey produced:

> There is no existing crate that is both behaviourally meaningful and safely non-authoritative.

Every crate that would make the behavioural goal real is barred by the `CorridorSource` conjunction; every mechanically-clear crate is a harness that would satisfy the naming goal vacuously. The survey also separates the two ways a crate is barred, since only one is visible from the crate itself: `kirra-map` and `kirra-taj` implement `CorridorSource` directly, while `kirra-planner` and `kirra-mick` implement nothing and are barred because `kirra-sidecars` implements it and depends on both.

## 2. Goal 1 stays open; a fourth goal is added

Naming a host is half the goal. The host must be one whose removal changes observable proposal behaviour — a host that passes the fence *because it does nothing* satisfies the letter and none of the purpose. So goal 1 closes on the differential proof, not on the crate existing.

The acceptance proof is stated as four parts, with the reason each fails in a way the other three cannot detect: fence positive control (with the existing refusals as its negative control), corridor-conjunction control, behavioural non-vacuity, and bound-derivation invariance. Parts 3 and 4 must be asserted over the **same** pair of runs; asserted separately, part 3 would pass on a run pair that also moved the bounds.

## 3. The `kirra-replay` inspection

Done before designing the harness, because reusing existing capture beats minting a new artifact if the fields are there.

| Artifact | Answer |
|---|---|
| `kirra-replay` | **No**, and not fixably. `VerdictImage` is verdict-only and its contract is *same inputs → same verdict*; the intended proposal difference would fire `ReplayResult::Divergent`, inverting the meaning of its alarm. |
| `kirra-capture-schema`'s `CaptureRecord` | **No.** Proposal and bound-derivation inputs are commingled in one `ProposedCommandSnapshot`; the contract identity is absent entirely (`VehicleClass` is a CLI argument); the derate cap is a bool, not a value. |
| `kirra-cycle-record`'s `JoinedCycleRecord` | **Yes**, and already the right shape — it was built for incident review, which has the same separation problem. |

`JoinedCycleRecord` separates exactly the axes the proof needs: `PerceptionEvent.evidence_digest` (a SHA-256 over the corridor polylines, objects, pedestrians, `clear_distance_m`, corridor widths, `speed_cap_mps` and the `profile_digest`, computed from the Taj response alone), the `raw`/`stabilized` cap pair, `ProposalEvent.proposal_digest` as a distinct axis, and `scan_sequence` for cross-run alignment.

**The smallest extension is therefore one field, not a new artifact: the kinematic contract identity.** Two things are deliberately *not* added — a Kirra World provenance field (it would put world-derived data into a safety artifact's transport, muddying the boundary the proof exists to establish) and `profile_digest` standalone (a diagnosability gap, not a soundness one).

## Separately — the `parko-kirra` fence finding

Filed in §11 with an ADR owner, deliberately **not** folded into Tier 2.5. The point is not that Parko is unsafe; it is that Fence B's dependency model has a blind spot around an enforcement point because of edge classification.

`parko-kirra` hosts `KirraGovernor::apply_mrc_profile` — one of the four enforcement points of the Degraded decel-to-stop-and-HOLD envelope — and sits outside Fence B because the closure walk excludes dev-dependency edges. That exclusion's stated rationale is about *doer* crates that should one day consume Kirra World, and it names `parko-kirra` among them. `parko-kirra` is not a doer. It is also not a `SAFETY_ROOT`, so it misses that route too. Three remedies are recorded.

One claim is corrected rather than added: the tidy explanation — that a second Cargo workspace is invisible to the walk — is **false**, and the section says so. The fence `rglob`s from the repo root and `parko-core` is already inside the closure via a normal dependency edge.

## Verification

- `ci/check_kirra_world_bidirectional_fence.py` → INTACT (19 packages from 10 roots)
- `ci/check_world_domain_logic_gate.py` → OPEN
- `ci/check_quality_guardrails.py` → satisfied

Every count in the doc was produced by executing the fence's own `closure()` and `check_4_trait_impls` predicates over the workspace manifests, and every code reference was read before it was cited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_