### PR TITLE
Rule KIRRA-WM-CLAIM-SHAPES-001: an object-bearing claim requires a predicate

### DIFF
--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -926,14 +926,21 @@ fn sha256_hex(bytes: &[u8]) -> String {
 }
 
 /// SHA-256 of the **effective** schema text — [`schema::SCHEMA_V1`] followed by
-/// [`schema::SCHEMA_V2_MIGRATION`] — recorded in `world_store_meta` so a store
+/// every migration in order, currently through
+/// [`schema::SCHEMA_V5_MIGRATION`] — recorded in `world_store_meta` so a store
 /// can prove which exact schema produced it, not merely which version number
 /// someone claimed.
 ///
-/// A store migrated from v1 is re-stamped with this value, so a born-v2 store
-/// and a migrated one carry the **same** digest. That is correct and
-/// deliberate: they have the same effective schema, and a digest that
-/// distinguished them would be recording history rather than structure.
+/// **This list is part of the function's contract, so it is stated as a range
+/// rather than an enumeration that goes stale.** It named only v1 and v2 from
+/// v3 onward, and the digest it described had not matched the digest it computed
+/// for two migrations — exactly the drift the digest exists to detect, in the
+/// documentation of the thing detecting it.
+///
+/// A store migrated from an older version is re-stamped with this value, so a
+/// born-current store and a migrated one carry the **same** digest. That is
+/// correct and deliberate: they have the same effective schema, and a digest
+/// that distinguished them would be recording history rather than structure.
 /// [`schema_digest_v1`] remains available for reading a store that has not been
 /// migrated.
 #[must_use]

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -196,6 +196,28 @@ pub enum StoreError {
     LlmCannotConfirm,
     /// SD-4, refused early for the same reason.
     SpatialClaimNeedsFrame,
+    /// `KIRRA-WM-CLAIM-SHAPES-001` — an object-bearing claim requires a
+    /// predicate.
+    ///
+    /// **Why this is refused rather than tolerated.** `world_current` keys on
+    /// `(subject, predicate_key)` with `predicate_key = predicate` or `''`, so a
+    /// `predicate = NULL, object = Some(_)` claim occupies the SAME slot as a
+    /// payload-only claim about that subject. The two mean entirely different
+    /// things, and the later one silently replaces the earlier — measured, not
+    /// theorised: appending a payload-only claim and then an object-without-
+    /// predicate claim for one subject leaves exactly one row, and the
+    /// payload-only claim is gone.
+    ///
+    /// So the shape is not merely unsupported, it is **projection-destructive**:
+    /// the store would admit two semantically distinct claims that the
+    /// deterministic projection cannot tell apart. The three valid shapes are
+    /// payload-only, predicate + payload, and predicate + object + payload.
+    ObjectWithoutPredicate {
+        /// The claim's subject, so the refusal names the row.
+        subject: String,
+        /// The object that had no predicate to hang from.
+        object: String,
+    },
     /// A [`SubjectRef::Unbound`] was offered as a label.
     ///
     /// `Unbound` carries no id and `subject` is `NOT NULL`, so labelling such a
@@ -335,6 +357,13 @@ impl std::fmt::Display for StoreError {
                 f,
                 "a spatial claim requires frame_id (ADR-0042 Decision 2; \
                  KIRRA-WM2-SCHEMA-001 SD-4)"
+            ),
+            Self::ObjectWithoutPredicate { subject, object } => write!(
+                f,
+                "an object-bearing claim requires a predicate: subject={subject:?} \
+                 object={object:?} has no predicate, and would occupy the same \
+                 world_current slot as a payload-only claim about that subject \
+                 (KIRRA-WM-CLAIM-SHAPES-001)"
             ),
             Self::UnboundSubjectNotStorable => write!(
                 f,
@@ -913,6 +942,7 @@ pub fn schema_digest() -> String {
     effective.push_str(schema::SCHEMA_V2_MIGRATION);
     effective.push_str(schema::SCHEMA_V3_MIGRATION);
     effective.push_str(schema::SCHEMA_V4_MIGRATION);
+    effective.push_str(schema::SCHEMA_V5_MIGRATION);
     sha256_hex(effective.as_bytes())
 }
 
@@ -966,6 +996,7 @@ impl WorldStore {
             tx.execute_batch(schema::SCHEMA_V2_MIGRATION)?;
             tx.execute_batch(schema::SCHEMA_V3_MIGRATION)?;
             tx.execute_batch(schema::SCHEMA_V4_MIGRATION)?;
+            tx.execute_batch(schema::SCHEMA_V5_MIGRATION)?;
             tx.execute(
                 "INSERT INTO world_store_meta (key, value) VALUES ('schema_version', ?1)",
                 params![SCHEMA_VERSION.to_string()],
@@ -1061,6 +1092,13 @@ impl WorldStore {
         if from < 4 {
             tx.execute_batch(schema::SCHEMA_V4_MIGRATION)?;
         }
+        // Same shape once more. v5 installs the KIRRA-WM-CLAIM-SHAPES-001
+        // trigger; it touches no existing row, so a store carrying the invalid
+        // shape migrates cleanly and keeps it — visible via
+        // `invalid_shape_rows`, never silently coerced.
+        if from < 5 {
+            tx.execute_batch(schema::SCHEMA_V5_MIGRATION)?;
+        }
 
         // Digest before version, inside the transaction. The order no longer
         // guards a crash window — the transaction does — but it still reads in
@@ -1098,6 +1136,35 @@ impl WorldStore {
             .as_deref()
             .and_then(|v| v.parse::<i64>().ok())
             .unwrap_or(1))
+    }
+
+    /// Events carrying the `KIRRA-WM-CLAIM-SHAPES-001` invalid shape —
+    /// `object` present with no `predicate` — as `(generation, subject)`.
+    ///
+    /// **Reports; never repairs.** The v5 trigger stops new ones, but a store
+    /// written before it existed may already contain some, and coercing them
+    /// would mean rewriting a hash-chained append-only log — a much larger
+    /// decision than this migration is entitled to make. So they survive, and
+    /// this method is what makes them a *finding* rather than a silence.
+    ///
+    /// An operator seeing a non-empty result should know what it implies: each
+    /// such row shares `world_current`'s `(subject, '')` slot with any
+    /// payload-only claim about the same subject, so one of the two is already
+    /// absent from the current projection.
+    ///
+    /// Empty on any store created at v5 or later, which the trigger guarantees.
+    pub fn invalid_shape_rows(&self) -> Result<Vec<(i64, String)>, StoreError> {
+        let mut stmt = self.conn.prepare(
+            "SELECT generation, subject FROM world_events
+             WHERE object IS NOT NULL AND predicate IS NULL
+             ORDER BY generation",
+        )?;
+        let rows = stmt.query_map([], |r| Ok((r.get(0)?, r.get(1)?)))?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row?);
+        }
+        Ok(out)
     }
 
     /// The chain digest of the newest event, or [`GENESIS`].
@@ -1147,6 +1214,15 @@ impl WorldStore {
         }
         if e.kind == "spatial" && e.frame_id.is_none() {
             return Err(StoreError::SpatialClaimNeedsFrame);
+        }
+        // `KIRRA-WM-CLAIM-SHAPES-001`: an object-bearing claim requires a
+        // predicate. Refused here so the error names the RULE, and again by the
+        // v5 trigger so raw SQL cannot route around this check.
+        if e.object.is_some() && e.predicate.is_none() {
+            return Err(StoreError::ObjectWithoutPredicate {
+                subject: e.subject.to_owned(),
+                object: e.object.unwrap_or_default().to_owned(),
+            });
         }
         // The label must agree with the value it labels. Checked here rather
         // than by a `CHECK`, because SQLite cannot compare a column against a

--- a/crates/kirra-world-store/src/schema.rs
+++ b/crates/kirra-world-store/src/schema.rs
@@ -112,7 +112,7 @@ pub const CHAIN_ALGORITHM: &str = "kirra-audit-hash/compute_record_hash_v2";
 /// | 2 | the four orthogonal trust axes, additive | 2026-08-07 |
 /// | 3 | the `subject_kind` discriminant | `KIRRA-WM-CANDIDATE-ID-001` |
 /// | 4 | the `entity_id_mint` ledger | `WM_SCOPE.md` §5 |
-pub const SCHEMA_VERSION: i64 = 4;
+pub const SCHEMA_VERSION: i64 = 5;
 
 /// **v2 — the four orthogonal trust axes, added additively.**
 ///
@@ -311,4 +311,56 @@ CREATE TABLE IF NOT EXISTS entity_id_mint (
     entity_id    TEXT    PRIMARY KEY,
     minted_at_ms INTEGER NOT NULL
 );
+"#;
+
+/// **v5 — `KIRRA-WM-CLAIM-SHAPES-001`: an object-bearing claim requires a
+/// predicate.**
+///
+/// # The three valid claim shapes
+///
+/// | `predicate` | `object` | shape |
+/// |---|---|---|
+/// | `None` | `None` | payload-only claim |
+/// | `Some` | `None` | predicate + payload claim |
+/// | `Some` | `Some` | subject-predicate-object + payload claim |
+/// | `None` | `Some` | **INVALID** — refused by this trigger |
+///
+/// # Why the fourth is refused rather than merely unsupported
+///
+/// `world_current` keys on `(subject, predicate_key)` where `predicate_key` is
+/// the predicate or `''`. A `predicate = NULL, object = <x>` row therefore
+/// occupies the SAME slot as a payload-only claim about that subject, and the
+/// later of the two silently replaces the earlier. That was measured, not
+/// theorised: appending a payload-only claim and then an object-without-
+/// predicate claim for one subject leaves exactly one row, and the payload-only
+/// claim is gone.
+///
+/// So the shape is **projection-destructive** — the store would admit two
+/// semantically distinct claims that the deterministic projection cannot tell
+/// apart, and one of them disappears with no signal.
+///
+/// # Why a TRIGGER and not a `CHECK`
+///
+/// SQLite's `ALTER TABLE` cannot add a constraint to existing columns; only
+/// `ADD COLUMN` (which is how v2 and v3 carried their inline `CHECK`s). A real
+/// `CHECK` here would require the 12-step table rebuild — create, copy every
+/// row, drop, rename — on the hash-chained append-only log, which is the one
+/// table whose value is that it is never rewritten. A `BEFORE INSERT` trigger
+/// enforces the same rule at the SQL layer, so **raw SQL cannot route around
+/// it**, while remaining additive in the style of v4's `CREATE TABLE`.
+///
+/// # Historical rows are left alone, deliberately
+///
+/// A trigger constrains future inserts and touches nothing already written. Any
+/// pre-existing invalid row therefore survives migration unchanged rather than
+/// being coerced — repairing a hash-chained log is a different and much larger
+/// decision. [`super::WorldStore::invalid_shape_rows`] makes such rows visible
+/// so they are a finding rather than a silence.
+pub const SCHEMA_V5_MIGRATION: &str = r#"
+CREATE TRIGGER IF NOT EXISTS world_events_object_requires_predicate
+BEFORE INSERT ON world_events
+WHEN NEW.object IS NOT NULL AND NEW.predicate IS NULL
+BEGIN
+    SELECT RAISE(ABORT, 'KIRRA-WM-CLAIM-SHAPES-001: an object-bearing claim requires a predicate');
+END;
 "#;

--- a/crates/kirra-world-store/src/schema.rs
+++ b/crates/kirra-world-store/src/schema.rs
@@ -112,6 +112,7 @@ pub const CHAIN_ALGORITHM: &str = "kirra-audit-hash/compute_record_hash_v2";
 /// | 2 | the four orthogonal trust axes, additive | 2026-08-07 |
 /// | 3 | the `subject_kind` discriminant | `KIRRA-WM-CANDIDATE-ID-001` |
 /// | 4 | the `entity_id_mint` ledger | `WM_SCOPE.md` §5 |
+/// | 5 | the object-requires-predicate trigger | `KIRRA-WM-CLAIM-SHAPES-001` |
 pub const SCHEMA_VERSION: i64 = 5;
 
 /// **v2 — the four orthogonal trust axes, added additively.**

--- a/crates/kirra-world-store/tests/claim_shapes.rs
+++ b/crates/kirra-world-store/tests/claim_shapes.rs
@@ -1,0 +1,273 @@
+//! **`KIRRA-WM-CLAIM-SHAPES-001` — an object-bearing claim requires a predicate.**
+//!
+//! | `predicate` | `object` | shape |
+//! |---|---|---|
+//! | `None` | `None` | payload-only claim |
+//! | `Some` | `None` | predicate + payload claim |
+//! | `Some` | `Some` | subject-predicate-object + payload claim |
+//! | `None` | `Some` | **INVALID** |
+//!
+//! WHY THE FOURTH IS REFUSED, and it is not a matter of taste. `world_current`
+//! keys on `(subject, predicate_key)` where `predicate_key` is the predicate or
+//! `''`, so an object-without-predicate claim occupies the SAME slot as a
+//! payload-only claim about that subject. The later silently replaces the
+//! earlier. `the_two_predicateless_shapes_no_longer_alias` below is the measured
+//! form of that: against the pre-ruling code it leaves ONE row with the
+//! payload-only claim gone.
+//!
+//! The rule is enforced at two layers because one is not enough: the Rust
+//! admission check names the rule in its error, and the v5 trigger makes SQLite
+//! itself refuse — so a raw `INSERT` cannot route around a polite decoder.
+
+use kirra_world_store::{
+    ClaimStatus, EventId, NewEvent, ObservationId, StoreError, WorldStore, WriterClass,
+};
+
+const T0: i64 = 1_700_000_000_000;
+
+fn tmp(name: &str) -> std::path::PathBuf {
+    static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let n = NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "kirra-claim-shapes-{name}-{}-{n}.sqlite",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_file(&p);
+    p
+}
+
+#[allow(clippy::too_many_arguments)]
+fn event<'a>(
+    e: &'a EventId,
+    o: &'a ObservationId,
+    t: i64,
+    subject: &'a str,
+    predicate: Option<&'a str>,
+    object: Option<&'a str>,
+    payload: &'a str,
+) -> NewEvent<'a> {
+    NewEvent {
+        event_id: e,
+        observation_id: o,
+        txn_time_ms: t,
+        valid_from_ms: t,
+        valid_to_ms: None,
+        source: "shapes-test",
+        source_version: "1.0.0",
+        writer_class: WriterClass::Sensor,
+        claim_status: ClaimStatus::Confirmed,
+        provenance: &[],
+        frame_id: None,
+        map_id: None,
+        kind: "mission",
+        subject,
+        subject_ref: None,
+        predicate,
+        object,
+        payload,
+        payload_schema: 1,
+        retention_class: "raw",
+        trust: None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The three valid shapes are admitted
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_three_valid_shapes_are_admitted() {
+    let path = tmp("valid");
+    let mut s = WorldStore::open(&path).expect("open");
+
+    for (n, predicate, object) in [
+        (1, None, None),
+        (2, Some("holds"), None),
+        (3, Some("last_seen_at"), Some("dock_b")),
+    ] {
+        let e = EventId::new(format!("ev-{n}")).expect("id");
+        let o = ObservationId::new(format!("obs-{n}")).expect("id");
+        s.append(&event(
+            &e,
+            &o,
+            T0 + n,
+            &format!("subject-{n}"),
+            predicate,
+            object,
+            "{}",
+        ))
+        .unwrap_or_else(|err| panic!("shape {n} must be admitted, got {err}"));
+    }
+    drop(s);
+    let _ = std::fs::remove_file(&path);
+}
+
+// ---------------------------------------------------------------------------
+// The invalid shape is refused — at BOTH layers
+// ---------------------------------------------------------------------------
+
+/// Layer 1: admission names the rule rather than surfacing a constraint index.
+#[test]
+fn admission_refuses_an_object_without_a_predicate() {
+    let path = tmp("admission");
+    let mut s = WorldStore::open(&path).expect("open");
+    let e = EventId::new("ev-1").expect("id");
+    let o = ObservationId::new("obs-1").expect("id");
+
+    let err = s
+        .append(&event(&e, &o, T0, "thing", None, Some("dock_b"), "{}"))
+        .expect_err("the invalid shape must be refused");
+
+    match &err {
+        StoreError::ObjectWithoutPredicate { subject, object } => {
+            assert_eq!(subject, "thing");
+            assert_eq!(object, "dock_b");
+        }
+        other => panic!("expected ObjectWithoutPredicate, got {other:?}"),
+    }
+    // The message names the ruling, so a reader learns the rule from the error.
+    assert!(
+        err.to_string().contains("KIRRA-WM-CLAIM-SHAPES-001"),
+        "{err}"
+    );
+
+    drop(s);
+    let _ = std::fs::remove_file(&path);
+}
+
+/// Layer 2, and the one that matters: **SQLite itself refuses**, with the Rust
+/// admission check bypassed entirely.
+///
+/// A decoder-only guarantee is one `INSERT` away from being no guarantee. This
+/// reaches past `append` to the connection and writes the row directly.
+#[test]
+fn raw_sql_cannot_route_around_the_rule() {
+    let path = tmp("rawsql");
+    let mut s = WorldStore::open(&path).expect("open");
+    // A valid row first, so the failure below cannot be blamed on an empty or
+    // unusable table.
+    let e = EventId::new("ev-ok").expect("id");
+    let o = ObservationId::new("obs-ok").expect("id");
+    s.append(&event(
+        &e,
+        &o,
+        T0,
+        "thing",
+        Some("holds"),
+        Some("cup"),
+        "{}",
+    ))
+    .expect("valid append");
+
+    // `raw_execute_for_test` is the store's existing raw-SQL escape hatch — the
+    // same one used to plant a corrupt chain digest. Reaching for it here is the
+    // point: it bypasses `append` entirely, so what refuses the row is SQLite.
+    let err = s
+        .raw_execute_for_test(
+            "INSERT INTO world_events
+               (event_id, observation_id, txn_time_ms, valid_from_ms, valid_to_ms,
+                source, source_version, writer_class, claim_status, provenance,
+                frame_id, map_id, kind, subject, predicate, object,
+                payload, payload_schema, payload_digest, retention_class, chain_digest)
+             VALUES
+               ('ev-raw','obs-raw',1,1,NULL,
+                'raw','1.0.0','sensor','confirmed','[]',
+                NULL,NULL,'mission','thing',NULL,'dock_b',
+                '{}',1,'d','raw','c')",
+        )
+        .expect_err("SQLite must refuse the invalid shape");
+
+    assert!(
+        err.to_string().contains("KIRRA-WM-CLAIM-SHAPES-001"),
+        "the trigger's own message should surface: {err}"
+    );
+
+    drop(s);
+    let _ = std::fs::remove_file(&path);
+}
+
+// ---------------------------------------------------------------------------
+// The regression the ruling exists for
+// ---------------------------------------------------------------------------
+
+/// **This test fails against the pre-ruling code**, which is what makes it worth
+/// having. Before the fix, appending a payload-only claim and then an
+/// object-without-predicate claim for ONE subject left exactly one row in
+/// `world_current` — the object-bearing one — and the payload-only claim was
+/// silently gone. Now the second append is refused, so the first survives.
+#[test]
+fn the_two_predicateless_shapes_no_longer_alias() {
+    let path = tmp("alias");
+    let mut s = WorldStore::open(&path).expect("open");
+
+    let e1 = EventId::new("ev-payload-only").expect("id");
+    let o1 = ObservationId::new("obs-1").expect("id");
+    s.append(&event(
+        &e1,
+        &o1,
+        T0,
+        "thing",
+        None,
+        None,
+        r#"{"note":"payload only"}"#,
+    ))
+    .expect("payload-only claim is valid");
+
+    let e2 = EventId::new("ev-object-no-pred").expect("id");
+    let o2 = ObservationId::new("obs-2").expect("id");
+    let err = s.append(&event(
+        &e2,
+        &o2,
+        T0 + 1000,
+        "thing",
+        None,
+        Some("dock_b"),
+        "{}",
+    ));
+    assert!(
+        matches!(err, Err(StoreError::ObjectWithoutPredicate { .. })),
+        "the aliasing claim must be refused, got {err:?}"
+    );
+
+    s.fold().expect("fold");
+    let claims = s.current("thing", T0 + 5000).expect("current");
+    assert_eq!(claims.len(), 1, "{claims:?}");
+    assert_eq!(
+        claims[0].payload, r#"{"note":"payload only"}"#,
+        "the payload-only claim must SURVIVE — before the ruling it was silently \
+         replaced by a claim occupying the same (subject, '') slot"
+    );
+
+    drop(s);
+    let _ = std::fs::remove_file(&path);
+}
+
+// ---------------------------------------------------------------------------
+// Historical rows: reported, never repaired
+// ---------------------------------------------------------------------------
+
+/// A store created at v5 has no invalid rows, and the detector says so rather
+/// than being unable to tell.
+#[test]
+fn a_fresh_store_reports_no_invalid_shape_rows() {
+    let path = tmp("detector-clean");
+    let mut s = WorldStore::open(&path).expect("open");
+    let e = EventId::new("ev-1").expect("id");
+    let o = ObservationId::new("obs-1").expect("id");
+    s.append(&event(
+        &e,
+        &o,
+        T0,
+        "thing",
+        Some("holds"),
+        Some("cup"),
+        "{}",
+    ))
+    .expect("valid append");
+
+    assert!(s.invalid_shape_rows().expect("detector").is_empty());
+
+    drop(s);
+    let _ = std::fs::remove_file(&path);
+}

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -2057,6 +2057,51 @@ proving set — not on every conceivable query. The minimum set:
 
 New domain queries can then be added without changing the Tier 3 trust model.
 
+### `KIRRA-WM-CLAIM-SHAPES-001` — RULED 2026-08-10
+
+> **An object-bearing claim requires a predicate. `predicate = None,
+> object = Some(_)` is invalid and is rejected at admission and by schema
+> constraint.**
+
+| `predicate` | `object` | shape |
+|---|---|---|
+| `None` | `None` | payload-only claim |
+| `Some` | `None` | predicate + payload claim |
+| `Some` | `Some` | subject–predicate–object + payload claim |
+| `None` | `Some` | **INVALID** |
+
+**The evidence is stronger than "this shape feels odd."** `world_current` keys on
+`(subject, predicate_key)` where `predicate_key` is the predicate or `''`, so an
+object-without-predicate claim occupies the **same slot** as a payload-only claim
+about that subject. Measured, not theorised — appending a payload-only claim and
+then an object-without-predicate claim for one subject left exactly one row, and
+the payload-only claim was gone. The shape is not merely unsupported, it is
+**projection-destructive**: the store admitted two semantically distinct claims
+the deterministic projection cannot tell apart, and one vanished without a signal.
+
+**Enforced at two layers, because one is not enough.** Admission refuses it with
+an error naming the rule; the **v5 trigger** makes SQLite itself refuse, so a raw
+`INSERT` cannot route around a polite decoder. Both were mutation-verified:
+neutering the trigger fails only the raw-SQL test, and neutering the admission
+check fails only the admission and aliasing tests — so neither layer is carrying
+the other. (With admission off, the trigger still refuses the row; the *error
+type* changes, the *refusal* does not.)
+
+**A trigger rather than a `CHECK`, and the reason is not preference.** SQLite's
+`ALTER TABLE` cannot add a constraint to existing columns — only `ADD COLUMN`,
+which is how v2 and v3 carried their inline checks. A real `CHECK` would require
+the 12-step table rebuild on the hash-chained append-only log, the one table
+whose value is that it is never rewritten. A `BEFORE INSERT` trigger enforces the
+same rule at the same layer while staying additive.
+
+**Historical rows are reported, never repaired.** A trigger constrains future
+inserts and touches nothing already written, so a store carrying the invalid
+shape migrates cleanly and keeps it — repairing a hash-chained log is a far
+larger decision than a migration is entitled to make.
+`WorldStore::invalid_shape_rows` makes such rows a finding rather than a silence.
+Nothing in the workspace relied on the invalid shape: every `predicate: None`
+construction site was checked and all pair it with `object: None`.
+
 ### `KIRRA-WM-CONSUMER-WITNESS-001` — RULED 2026-08-10
 
 > **Every Tier 3 contract change must be exercised by at least one real consumer


### PR DESCRIPTION
Implements the ruling on the fourth claim shape found while scoping 3a.

> **An object-bearing claim requires a predicate. `predicate = None, object = Some(_)` is invalid and is rejected at admission and by schema constraint.**

| `predicate` | `object` | shape |
|---|---|---|
| `None` | `None` | payload-only claim |
| `Some` | `None` | predicate + payload claim |
| `Some` | `Some` | subject–predicate–object + payload claim |
| `None` | `Some` | **INVALID** |

## The evidence is stronger than "this shape feels odd"

`world_current` keys on `(subject, predicate_key)` where `predicate_key` is the predicate or `''`, so an object-without-predicate claim occupies the **same slot** as a payload-only claim about that subject. Measured, not theorised — appending a payload-only claim and then an object-without-predicate claim for one subject left exactly one row, and the payload-only claim was gone.

The shape is **projection-destructive**: two semantically distinct claims the deterministic projection cannot tell apart, one vanishing with no signal.

## Two layers, both mutation-verified

- **Admission** — `StoreError::ObjectWithoutPredicate`, naming the rule in its message.
- **v5 trigger** — SQLite itself refuses, so a raw `INSERT` cannot route around a polite decoder. The adversarial test uses the store's existing `raw_execute_for_test` hatch, bypassing `append` entirely.

Neither layer carries the other, and I checked rather than assumed: neutering the trigger fails **only** `raw_sql_cannot_route_around_the_rule`; neutering the admission check fails **only** the admission and aliasing tests. With admission off the trigger still refuses the row — the error *type* changes, the *refusal* does not.

## A trigger rather than a `CHECK`, and not by preference

SQLite's `ALTER TABLE` cannot add a constraint to existing columns — only `ADD COLUMN`, which is how v2 and v3 carried their inline checks. A real `CHECK` would require the 12-step table rebuild on the **hash-chained append-only log**, the one table whose value is that it is never rewritten. A `BEFORE INSERT` trigger enforces the same rule at the same layer while staying additive, in the style of v4's `CREATE TABLE`.

## Historical rows: reported, never repaired

The trigger touches nothing already written, so a store carrying the invalid shape migrates cleanly and keeps it — repairing a hash-chained log is a far larger decision than a migration is entitled to make. `WorldStore::invalid_shape_rows` makes such rows a **finding** rather than a silence.

Nothing in the workspace relied on the shape: every `predicate: None` construction site was checked, and all pair it with `object: None`.

## The regression that matters

`the_two_predicateless_shapes_no_longer_alias` **fails against the pre-ruling code** — that's what makes it worth having. Before, the payload-only claim was silently replaced; now the aliasing append is refused and the first claim survives.

## Verification

- `cargo test --workspace` → no failures
- `kirra-world-store` / `-service` / `-proposal-context` → 26 suites green
- clippy `-D warnings` (with `test-support`) → clean
- fence, domain-logic gate, symbolic-seam gate, quality guardrails → pass
- all **five** lockfiles verified against `--locked`
- `SCHEMA_VERSION` 4 → 5; digest, fresh-install and migration paths all wired

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_