### PR TITLE
Tier 3 box 3c: compose the world read at one coherent point, and resolve the object that names an entity

### DIFF
--- a/crates/kirra-proposal-context/src/lib.rs
+++ b/crates/kirra-proposal-context/src/lib.rs
@@ -56,8 +56,11 @@
 
 #![forbid(unsafe_code)]
 
+use kirra_world::resolution::RefusalReason;
 use kirra_world::trust::{TrustGrade, Validity};
-use kirra_world_service::read_view::{AskError, UnknownReason, WorldLookup, WorldView};
+use kirra_world_service::read_view::{
+    AskError, ObjectIdentity, UnknownReason, WorldLookup, WorldView,
+};
 use kirra_world_store::WorldStore;
 
 /// An opaque symbolic identity — a destination, a task, a package, a relation.
@@ -202,8 +205,8 @@ impl ProposalContext {
     /// collapsing them is precisely the information loss Tier 3 exists to
     /// prevent.
     #[must_use]
-    pub fn silence(&self) -> Option<WorldSilence> {
-        self.silence
+    pub fn silence(&self) -> Option<&WorldSilence> {
+        self.silence.as_ref()
     }
 
     /// The trust grade of the fact this context acted on, if it acted on one.
@@ -287,7 +290,7 @@ impl From<AskError> for ContextError {
 /// what Tier 3 exists to retain: *never heard of it* and *heard of it but not
 /// servable* are different facts about the world, and a consumer that cannot
 /// tell them apart cannot report which one it hit.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum WorldSilence {
     /// No current claim for this subject at this clock.
     NoClaim,
@@ -297,6 +300,90 @@ pub enum WorldSilence {
     /// candidates the caller offered. The world spoke; it just did not name
     /// anything on the menu.
     NoCandidateMatched,
+    /// **A claim named this relation, and its object could not be resolved to
+    /// something safe to compare** — box 3c's fail-closed arm.
+    ///
+    /// Distinct from [`Self::NoCandidateMatched`], which says the world named
+    /// something not on the menu. This says the world named something and the
+    /// identity graph could not tell us what it was: behind the log, recording a
+    /// contradiction, or resolving the object to more than one entity.
+    ObjectUnresolved(ObjectResolution),
+}
+
+/// Why a claim's object could not be turned into something safe to compare.
+///
+/// **A mirror of the world's `ObjectIdentity`, not a re-export**, for the reason
+/// [`FactGrade`] is a mirror — and here it is load-bearing rather than
+/// stylistic. The world's type carries `Resolved { hops: usize }`, and its
+/// refusal reasons carry `TraversalBudgetExceeded { limit: usize }`.
+/// Re-exporting it would put primitive numerics on this crate's public surface
+/// and give the symbolic seam somewhere to put a number, which is the one thing
+/// the seam rule exists to prevent. Those numbers are real and useful — they are
+/// simply not this seam's to carry, and they remain available at the answer
+/// boundary where an operator reads them.
+///
+/// Successors ARE carried: an entity id is a symbol, and naming which entities
+/// an object turned out to be is the difference between a usable report and
+/// "something went wrong".
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ObjectResolution {
+    /// The identity graph has not consumed every adjudication the log holds, so
+    /// any resolution would be known-stale.
+    GraphStale,
+    /// The object resolved to more than one live entity, and picking one would
+    /// be a guess.
+    Ambiguous {
+        /// The entities the object turned out to be, as the events name them.
+        successors: Vec<ContextId>,
+    },
+    /// The recorded history contradicts itself.
+    ///
+    /// CATEGORICAL — a named reason, never a magnitude, so the seam rule is
+    /// unaffected.
+    Contradictory(&'static str),
+}
+
+impl ObjectResolution {
+    /// The categorical tag for one of the world's refusal reasons.
+    ///
+    /// Public so the lock-step test can walk the real enum and assert the tags
+    /// are total and pairwise distinct. Exhaustive on purpose: adding a variant
+    /// to `RefusalReason` must break this match rather than fall into a
+    /// catch-all that silently reports the new reason as an old one — and the
+    /// test catches the half a compiler cannot, two variants quietly sharing one
+    /// tag, which compiles and then misreports forever.
+    #[must_use]
+    pub fn contradiction_tag(reason: &RefusalReason) -> &'static str {
+        match reason {
+            RefusalReason::RedirectCycle { .. } => "redirect_cycle",
+            RefusalReason::TraversalBudgetExceeded { .. } => "traversal_budget_exceeded",
+            RefusalReason::DanglingRedirect { .. } => "dangling_redirect",
+            RefusalReason::EmptySupersession { .. } => "empty_supersession",
+            RefusalReason::ContradictoryHistory { .. } => "contradictory_history",
+        }
+    }
+}
+
+/// Translate the world's `ObjectIdentity` into this seam's symbolic mirror.
+///
+/// Only the non-matchable variants can reach here — `ObjectIdentity::matchable`
+/// has already returned `Some` for the rest — so the matchable arms map to a
+/// nearest honest report rather than being unreachable-panicked. A wrong report
+/// is recoverable; a panic in a proposal producer is not.
+fn mirror_resolution(identity: &ObjectIdentity) -> ObjectResolution {
+    match identity {
+        ObjectIdentity::Unresolvable => ObjectResolution::GraphStale,
+        ObjectIdentity::Ambiguous { successors } => ObjectResolution::Ambiguous {
+            successors: successors.iter().filter_map(ContextId::new).collect(),
+        },
+        ObjectIdentity::Refused(reason) => {
+            ObjectResolution::Contradictory(ObjectResolution::contradiction_tag(reason))
+        }
+        ObjectIdentity::NoObject
+        | ObjectIdentity::Malformed
+        | ObjectIdentity::NotAnEntity
+        | ObjectIdentity::Resolved { .. } => ObjectResolution::Contradictory("unclassified"),
+    }
 }
 
 /// Derive proposal-shaping context from what Kirra World knows about `subject`.
@@ -340,7 +427,7 @@ pub fn mission_context(
 ) -> Result<ProposalContext, ContextError> {
     let view = WorldView::new(store, staleness_budget_ms);
 
-    let answers = match view.ask(subject.as_str(), now_ms)? {
+    let answers = match view.ask(subject.as_str(), now_ms)?.into_lookup() {
         WorldLookup::Answered(answers) => answers,
         WorldLookup::Unknown(reason) => {
             let silence = match reason {
@@ -351,16 +438,37 @@ pub fn mission_context(
         }
     };
 
+    // Set when a claim named this relation but its object could not be turned
+    // into something safe to compare. Tracked separately from "nothing matched"
+    // because they are different facts: the world DID answer, and the answer
+    // could not be used.
+    let mut unresolved: Option<ObjectResolution> = None;
+
     let matched = answers.iter().find_map(|a| {
         if a.predicate()? != relation.as_str() {
             return None;
         }
         // The OBJECT, not the payload: the fact is a relationship, and the
-        // object is what it points at.
-        let object = a.object()?;
+        // object is what it points at — resolved through the identity graph,
+        // because an object that names an entity is not a string. `matchable`
+        // is what makes the fail-closed cases fail closed; comparing the raw
+        // object here would silently ignore every merge the world has recorded.
+        let Some(object) = a.object_identity().matchable(a.object()) else {
+            unresolved.get_or_insert_with(|| mirror_resolution(a.object_identity()));
+            return None;
+        };
         let candidate = candidates.iter().find(|c| c.as_str() == object)?;
         Some((candidate, a))
     });
+
+    if matched.is_none() {
+        if let Some(identity) = unresolved {
+            return Ok(ProposalContext::silent(
+                candidates,
+                WorldSilence::ObjectUnresolved(identity),
+            ));
+        }
+    }
 
     let Some((preferred, answer)) = matched else {
         return Ok(ProposalContext::silent(

--- a/crates/kirra-proposal-context/tests/answer_boundary.rs
+++ b/crates/kirra-proposal-context/tests/answer_boundary.rs
@@ -129,7 +129,7 @@ fn an_unknown_subject_reports_no_claim() {
     let store = WorldStore::open(&path).expect("open");
 
     let ctx = ask(&store, T0, None);
-    assert_eq!(ctx.silence(), Some(WorldSilence::NoClaim));
+    assert_eq!(ctx.silence(), Some(&WorldSilence::NoClaim));
     assert_eq!(ctx.preferred_destination(), None);
     // Silence is not emptiness: the candidates still cross the seam, in the
     // caller's own order.
@@ -148,7 +148,7 @@ fn an_off_menu_object_reports_no_candidate_matched() {
     record(&mut store, "dock_zzz", T0, None);
 
     let ctx = ask(&store, T0, None);
-    assert_eq!(ctx.silence(), Some(WorldSilence::NoCandidateMatched));
+    assert_eq!(ctx.silence(), Some(&WorldSilence::NoCandidateMatched));
     assert_eq!(ctx.preferred_destination(), None);
 
     drop(store);
@@ -176,7 +176,7 @@ fn a_different_relation_reports_no_candidate_matched() {
         None,
     )
     .expect("context");
-    assert_eq!(ctx.silence(), Some(WorldSilence::NoCandidateMatched));
+    assert_eq!(ctx.silence(), Some(&WorldSilence::NoCandidateMatched));
 
     drop(store);
     let _ = std::fs::remove_file(&path);
@@ -224,12 +224,12 @@ fn a_rejected_claim_reports_none_admissible_not_no_claim() {
     let ctx = ask(&store, T0, None);
     assert_eq!(
         ctx.silence(),
-        Some(WorldSilence::NoneAdmissible),
+        Some(&WorldSilence::NoneAdmissible),
         "a claim the boundary refuses to serve must not read as an unknown subject"
     );
     assert_ne!(
         ctx.silence(),
-        Some(WorldSilence::NoClaim),
+        Some(&WorldSilence::NoClaim),
         "collapsing these is the information loss box 3a exists to close"
     );
     assert_eq!(ctx.preferred_destination(), None);

--- a/crates/kirra-proposal-context/tests/object_identity.rs
+++ b/crates/kirra-proposal-context/tests/object_identity.rs
@@ -1,0 +1,402 @@
+//! **Tier 3 box 3c, consumer half — an object that names an entity is not a
+//! string.**
+//!
+//! `mission_context` matches a claim's object against the candidates it was
+//! offered. Before this, it compared the STORED object literally, so every
+//! merge the world had recorded was invisible to it: a package last seen at
+//! `dock_old`, with `dock_old` since merged into `dock_b`, matched no candidate
+//! at all — the world knew the answer and the consumer could not read it.
+//!
+//! Four claims are pinned, and the fourth is the one that makes the others
+//! worth having:
+//!
+//! 1. A merged object resolves to what it became, and matches.
+//! 2. An object on a store with no adjudications matches literally — the
+//!    overwhelmingly common case must not regress.
+//! 3. A STALE identity graph refuses rather than matching the raw object.
+//! 4. An ambiguous resolution refuses rather than guessing a successor.
+//!
+//! # Why case 3 is the sharp one
+//!
+//! A first draft gated resolution on *"has the entity projection been folded"*,
+//! which is wrong in both directions and dangerous in one. It refused every
+//! object-bearing claim on a store that simply has no adjudications (case 2,
+//! which is most stores) — and it **admitted** the genuinely bad case, a
+//! projection folded once with merges recorded since, because such a projection
+//! is not unfolded. The check is now against the LOG: has identity consumed
+//! every adjudication recorded? Case 3 is what holds that line.
+
+use kirra_proposal_context::{mission_context, ContextId, ObjectResolution, WorldSilence};
+use kirra_world::adjudication::{
+    AssertIdentity, IdentityAdjudication, Justification, MergeEntities, SplitEntity,
+};
+use kirra_world::observation::{ClockDomain, DomainInstant};
+use kirra_world::reference::{EntityId, EventId, ObservationId};
+use kirra_world_store::adjudication_record::AdjudicationRow;
+use kirra_world_store::{ClaimStatus, NewEvent, WorldStore, WriterClass};
+
+const T0: i64 = 1_700_000_000_000;
+
+fn tmp(name: &str) -> std::path::PathBuf {
+    static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let n = NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "kirra-object-identity-{name}-{}-{n}.sqlite",
+        std::process::id()
+    ));
+    for suffix in ["", "-wal", "-shm"] {
+        let mut q = p.as_os_str().to_os_string();
+        q.push(suffix);
+        let _ = std::fs::remove_file(std::path::PathBuf::from(q));
+    }
+    p
+}
+
+fn id(s: &str) -> ContextId {
+    ContextId::new(s).expect("non-empty id")
+}
+
+fn eid(s: &str) -> EntityId {
+    EntityId::new(s).expect("entity id")
+}
+
+fn just() -> Justification {
+    Justification::new([ObservationId::new("obs-1").expect("obs")]).expect("justification")
+}
+
+fn at() -> DomainInstant {
+    DomainInstant {
+        ms: 1,
+        domain: ClockDomain::System,
+    }
+}
+
+fn candidates() -> Vec<ContextId> {
+    vec![id("dock_a"), id("dock_b")]
+}
+
+/// Record `package_17 last_seen_at <object>`.
+fn record_claim(store: &mut WorldStore, object: &str) {
+    store
+        .append(&NewEvent {
+            event_id: &EventId::new("ev-last-seen").expect("event id"),
+            observation_id: &ObservationId::new("obs-last-seen").expect("observation id"),
+            txn_time_ms: T0,
+            valid_from_ms: T0,
+            valid_to_ms: None,
+            source: "warehouse-scanner",
+            source_version: "1.0.0",
+            writer_class: WriterClass::Sensor,
+            claim_status: ClaimStatus::Confirmed,
+            provenance: &[],
+            frame_id: None,
+            map_id: None,
+            kind: "mission",
+            subject: "package_17",
+            subject_ref: None,
+            predicate: Some("last_seen_at"),
+            object: Some(object),
+            payload: "{}",
+            payload_schema: 1,
+            retention_class: "raw",
+            trust: None,
+        })
+        .expect("append claim");
+    store.fold().expect("fold claims");
+}
+
+fn record_adjudication(store: &mut WorldStore, tag: &str, a: &IdentityAdjudication) {
+    store
+        .append_adjudication(
+            &AdjudicationRow {
+                event_id: &EventId::new(format!("ev-adj-{tag}")).expect("event id"),
+                observation_id: &ObservationId::new(format!("obs-adj-{tag}")).expect("obs"),
+                txn_time_ms: T0 + 1,
+                valid_from_ms: T0 + 1,
+                source: "operator-console",
+                source_version: "1.0.0",
+                writer_class: WriterClass::Operator,
+            },
+            a,
+        )
+        .expect("append adjudication");
+}
+
+fn ask(store: &WorldStore) -> kirra_proposal_context::ProposalContext {
+    mission_context(
+        store,
+        &id("package_17"),
+        &id("last_seen_at"),
+        &candidates(),
+        T0,
+        None,
+    )
+    .expect("context")
+}
+
+// ---------------------------------------------------------------------------
+// 1. The positive witness
+// ---------------------------------------------------------------------------
+
+/// **A merged object resolves to what it became.**
+///
+/// The whole point of the box, in one assertion. `dock_old` is not a candidate
+/// and never will be; the world records that it merged into `dock_b`, which is.
+/// Matching the stored string finds nothing. Resolving finds the answer the
+/// world already had.
+#[test]
+fn a_merged_object_resolves_to_the_candidate_it_became() {
+    let path = tmp("merged");
+    let mut store = WorldStore::open(&path).expect("open");
+
+    record_claim(&mut store, "dock_old");
+    record_adjudication(
+        &mut store,
+        "1",
+        &IdentityAdjudication::Assert(AssertIdentity::new(eid("dock_old"), just(), at())),
+    );
+    record_adjudication(
+        &mut store,
+        "2",
+        &IdentityAdjudication::Assert(AssertIdentity::new(eid("dock_b"), just(), at())),
+    );
+    record_adjudication(
+        &mut store,
+        "3",
+        &IdentityAdjudication::Merge(
+            MergeEntities::new(vec![eid("dock_old")], eid("dock_b"), just(), at()).expect("merge"),
+        ),
+    );
+    store
+        .fold_entity_projection()
+        .expect("fold entity projection");
+
+    let ctx = ask(&store);
+    assert_eq!(
+        ctx.preferred_destination(),
+        Some(&id("dock_b")),
+        "the object merged into dock_b, so the context must prefer dock_b — \
+         matching the stored object literally finds nothing here"
+    );
+    assert_eq!(ctx.silence(), None, "the world expressed a preference");
+
+    drop(store);
+    let _ = std::fs::remove_file(&path);
+}
+
+// ---------------------------------------------------------------------------
+// 2. The common case must not regress
+// ---------------------------------------------------------------------------
+
+/// **An object on a store with no adjudications matches literally.**
+///
+/// Most stores never record an identity adjudication. Their entity projection
+/// is empty and unfolded, and that is not a fault — there are no merges to
+/// miss, so an object stands for itself. A gate that refused here would have
+/// broken every existing consumer to buy no safety at all.
+#[test]
+fn an_object_with_no_adjudications_matches_literally() {
+    let path = tmp("literal");
+    let mut store = WorldStore::open(&path).expect("open");
+    record_claim(&mut store, "dock_b");
+
+    assert!(
+        !store.has_entity_projection().expect("catalogue"),
+        "this fixture is only meaningful while the entity projection is absent"
+    );
+
+    let ctx = ask(&store);
+    assert_eq!(
+        ctx.preferred_destination(),
+        Some(&id("dock_b")),
+        "with nothing adjudicated there is nothing to resolve, and the object \
+         stands for itself"
+    );
+
+    drop(store);
+    let _ = std::fs::remove_file(&path);
+}
+
+// ---------------------------------------------------------------------------
+// 3. The sharp case: a stale graph refuses
+// ---------------------------------------------------------------------------
+
+/// **A stale identity graph refuses rather than matching the raw object.**
+///
+/// The merge is recorded and NOT folded. The stored object is `dock_b`, which
+/// is a candidate — so the pre-3c code, and any fallback-to-raw-string design,
+/// would happily prefer `dock_b`. But the log says an adjudication about this
+/// world has not been consumed, so the graph cannot support the claim that
+/// `dock_b` is still what it was. Refusing is the only honest answer.
+///
+/// Note what makes this test sharp: the literal match would SUCCEED. A refusal
+/// that only ever fired when the literal match also failed would be
+/// indistinguishable from doing nothing.
+#[test]
+fn a_stale_identity_graph_refuses_rather_than_matching_the_raw_object() {
+    let path = tmp("stale");
+    let mut store = WorldStore::open(&path).expect("open");
+
+    record_claim(&mut store, "dock_b");
+    record_adjudication(
+        &mut store,
+        "1",
+        &IdentityAdjudication::Assert(AssertIdentity::new(eid("dock_b"), just(), at())),
+    );
+    // Deliberately NOT folded: the adjudication sits in the log unconsumed.
+
+    let ctx = ask(&store);
+    assert_eq!(
+        ctx.preferred_destination(),
+        None,
+        "a stale identity graph must not shape a proposal"
+    );
+    assert_eq!(
+        ctx.silence(),
+        Some(&WorldSilence::ObjectUnresolved(
+            ObjectResolution::GraphStale
+        )),
+        "and it must say WHY — an unfolded adjudication is an operator's \
+         problem to fix, not 'the world named something off the menu'"
+    );
+
+    // Non-vacuity: fold, and the very same store answers.
+    store
+        .fold_entity_projection()
+        .expect("fold entity projection");
+    assert_eq!(
+        ask(&store).preferred_destination(),
+        Some(&id("dock_b")),
+        "once identity has caught up the same question is answerable — the \
+         refusal above is about staleness, not about this fixture"
+    );
+
+    drop(store);
+    let _ = std::fs::remove_file(&path);
+}
+
+// ---------------------------------------------------------------------------
+// 4. Ambiguity refuses rather than guessing
+// ---------------------------------------------------------------------------
+
+/// **An object that resolved to more than one entity is refused.**
+///
+/// `dock_b` is partitioned into two successors that do not reconverge. One of
+/// them could be picked — they are both live entities — and picking one would
+/// be a guess wearing an answer's clothes.
+#[test]
+fn an_ambiguous_object_refuses_rather_than_picking_a_successor() {
+    let path = tmp("ambiguous");
+    let mut store = WorldStore::open(&path).expect("open");
+
+    record_claim(&mut store, "dock_b");
+    record_adjudication(
+        &mut store,
+        "1",
+        &IdentityAdjudication::Assert(AssertIdentity::new(eid("dock_b"), just(), at())),
+    );
+    record_adjudication(
+        &mut store,
+        "2",
+        &IdentityAdjudication::Split(
+            SplitEntity::partition(
+                eid("dock_b"),
+                [eid("dock_b1"), eid("dock_b2")],
+                just(),
+                at(),
+            )
+            .expect("partition"),
+        ),
+    );
+    store
+        .fold_entity_projection()
+        .expect("fold entity projection");
+
+    let ctx = ask(&store);
+    assert_eq!(
+        ctx.preferred_destination(),
+        None,
+        "an object that turned out to be two things must not become a preference"
+    );
+    assert!(
+        matches!(
+            ctx.silence(),
+            Some(WorldSilence::ObjectUnresolved(
+                ObjectResolution::Ambiguous { .. }
+            ))
+        ),
+        "and the ambiguity must be reported as such, not as 'nothing matched': \
+         got {:?}",
+        ctx.silence()
+    );
+
+    drop(store);
+    let _ = std::fs::remove_file(&path);
+}
+
+// ---------------------------------------------------------------------------
+// 5. The mirror stays in lock-step with the world's own vocabulary
+// ---------------------------------------------------------------------------
+
+/// **Every refusal reason the world can produce has a distinct tag here.**
+///
+/// `ObjectResolution::Contradictory` carries a `&'static str` rather than the
+/// world's `RefusalReason` because that type holds
+/// `TraversalBudgetExceeded { limit: usize }` — a primitive numeric, which this
+/// crate's public surface may not carry at all. A mirror only stays honest if
+/// something walks the real enum, so this does.
+///
+/// Adding a variant to `RefusalReason` breaks `contradiction_tag`'s exhaustive
+/// match at compile time. This catches the half a compiler cannot: two variants
+/// quietly sharing one tag, which compiles and then misreports forever.
+///
+/// An earlier draft of this test compared `format!("{:?}", ..)` of the
+/// ObjectIdentity, which embeds the reason's own fields — so it would have
+/// passed with every tag set to the same string. It was testing `RefusalReason`
+/// derives `Debug`, not that the mirror is faithful.
+#[test]
+fn every_refusal_reason_has_its_own_tag() {
+    use kirra_proposal_context::ObjectResolution;
+    use kirra_world::resolution::RefusalReason;
+    use kirra_world_service::read_view::ObjectIdentity;
+
+    let all = [
+        RefusalReason::RedirectCycle { at: eid("a") },
+        RefusalReason::TraversalBudgetExceeded { limit: 64 },
+        RefusalReason::DanglingRedirect {
+            from: eid("a"),
+            to: eid("b"),
+        },
+        RefusalReason::EmptySupersession { at: eid("a") },
+        RefusalReason::ContradictoryHistory { at: eid("a") },
+    ];
+
+    let tags: Vec<&'static str> = all
+        .iter()
+        .map(ObjectResolution::contradiction_tag)
+        .collect();
+
+    let mut distinct = tags.clone();
+    distinct.sort_unstable();
+    distinct.dedup();
+    assert_eq!(
+        distinct.len(),
+        tags.len(),
+        "two refusal reasons collapsed onto one tag: {tags:?}"
+    );
+    assert!(
+        tags.iter().all(|t| !t.is_empty()),
+        "an empty tag reports nothing: {tags:?}"
+    );
+
+    // The fail-closed contract, on every reason: a refusal never yields
+    // something to match a candidate against.
+    for reason in &all {
+        assert_eq!(
+            ObjectIdentity::Refused(reason.clone()).matchable(Some("dock_b")),
+            None,
+            "a contradictory history must never yield something to match on"
+        );
+    }
+}

--- a/crates/kirra-world-service/src/read_view.rs
+++ b/crates/kirra-world-service/src/read_view.rs
@@ -87,6 +87,10 @@
 //! rather than in one it does not.
 
 use kirra_world::evidence::{DigestError, EvidenceDigest};
+use kirra_world::reference::EntityId;
+use kirra_world::resolution::{resolve, RefusalReason, ResolutionOutcome};
+use kirra_world_store::entity_projection::IdentityView;
+use kirra_world_store::snapshot::SnapshotCoordinate;
 use kirra_world_store::{ProjectedClaim, StoreError, TrustAxes, TrustGrade, Validity, WorldStore};
 
 /// Why an ask could not be answered at all.
@@ -196,6 +200,7 @@ pub struct WorldAnswer {
     subject: String,
     predicate: Option<String>,
     object: Option<String>,
+    object_identity: ObjectIdentity,
     value: String,
     validity: Validity,
     axes: Option<TrustAxes>,
@@ -232,14 +237,26 @@ impl WorldAnswer {
     /// shape aliases a payload-only claim in `world_current`'s
     /// `(subject, '')` slot and destroys it.
     ///
-    /// **This is the stored object, uninterpreted.** It is not resolved through
-    /// the identity graph, even when it names an entity: that resolution
-    /// composes two projections with independent checkpoints, which is 3c's
-    /// snapshot-consistency question and not something an answer boundary may
-    /// answer silently.
+    /// **This is the stored object, uninterpreted.** For what it resolves to
+    /// through the identity graph, see [`WorldAnswer::object_identity`] — the
+    /// two are kept separate so a caller can always see what was actually
+    /// written, not only what it now means.
     #[must_use]
     pub fn object(&self) -> Option<&str> {
         self.object.as_deref()
+    }
+
+    /// **What the object resolves to through the identity graph** — box 3c.
+    ///
+    /// Resolved in the SAME snapshot as the claim itself, so this can never
+    /// describe a different state of the world than [`WorldAnswer::object`] was
+    /// read from.
+    ///
+    /// Prefer [`ObjectIdentity::matchable`] over matching on the variants by
+    /// hand: it is what makes the fail-closed cases fail closed.
+    #[must_use]
+    pub fn object_identity(&self) -> &ObjectIdentity {
+        &self.object_identity
     }
 
     /// The claim's predicate, `None` for predicate-less claims.
@@ -329,6 +346,109 @@ pub enum WorldLookup {
     Unknown(UnknownReason),
 }
 
+/// **What a claim's object turned out to be** — Tier 3 box 3c.
+///
+/// A claim's object often names an entity, and an entity's identity is itself a
+/// projection: merges, splits and retirements are recorded as adjudications and
+/// folded into the entity graph. So comparing an object as a raw string answers
+/// the wrong question the moment anything has been merged.
+///
+/// Six variants for four caller behaviours, because collapsing them is the
+/// defect box 3a was opened for: *match literally*, *match the canonical
+/// entity*, *fail closed*, and *the graph could not be consulted at all* are
+/// four different situations, and an operator debugging the fourth needs it not
+/// to look like the first.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ObjectIdentity {
+    /// The claim carries no object. Nothing to resolve.
+    NoObject,
+    /// **The identity graph is BEHIND the log: adjudications are recorded that
+    /// it has not folded, so any resolution would be known-stale.**
+    ///
+    /// Not "the graph is empty" — an empty graph on a store with no
+    /// adjudications is perfectly current, and objects there stand for
+    /// themselves. This is the case where merges, splits or retirements *have*
+    /// been recorded and the projection has not caught up, so resolving would
+    /// answer from data already known to be superseded.
+    ///
+    /// Fail-closed rather than falling back to the raw string, because the
+    /// fallback is silent: it would look exactly like resolution succeeding and
+    /// finding nothing to redirect, which is the one answer a stale graph
+    /// cannot support.
+    Unresolvable,
+    /// The object is not a well-formed entity id, so it cannot name one.
+    Malformed,
+    /// The graph was consulted and holds no such entity.
+    ///
+    /// Nothing is wrong: not every object is an adjudicated entity. The object
+    /// stands for itself.
+    NotAnEntity,
+    /// Resolved to one live entity.
+    Resolved {
+        /// The canonical id. Equal to the stored object when nothing redirected
+        /// it.
+        entity: String,
+        /// Redirect edges traversed. `0` means nothing was followed.
+        hops: usize,
+    },
+    /// The id was partitioned and its successors did not reconverge.
+    Ambiguous {
+        /// The live entities the object turned out to be.
+        successors: Vec<String>,
+    },
+    /// The recorded history contradicts itself.
+    Refused(RefusalReason),
+}
+
+impl ObjectIdentity {
+    /// The id a consumer should match against, if matching is safe at all.
+    ///
+    /// `None` for every variant where matching would be a guess: an
+    /// unconsultable graph, a contradictory history, or an object that turned
+    /// out to be more than one thing. Fail-closed by construction — a consumer
+    /// cannot reach a candidate comparison for those cases without deliberately
+    /// going around this method.
+    pub fn matchable<'a>(&'a self, stored_object: Option<&'a str>) -> Option<&'a str> {
+        match self {
+            Self::Resolved { entity, .. } => Some(entity),
+            Self::NotAnEntity | Self::Malformed => stored_object,
+            Self::NoObject | Self::Unresolvable | Self::Ambiguous { .. } | Self::Refused(_) => None,
+        }
+    }
+}
+
+/// **A lookup and the point it was read at** — Tier 3 box 3c.
+///
+/// The coordinate is bundled rather than returned separately, on the precedent
+/// [`HistoricalAnswer`] set: a caller must not be able to hold the answer
+/// without holding which state of the world produced it. Sampling the
+/// coordinate in a second call would also reintroduce the very race this box
+/// closes — the answer would name a point it was not read at.
+///
+/// [`HistoricalAnswer`]: kirra_world_store::entity_projection::HistoricalAnswer
+#[derive(Debug, Clone)]
+pub struct ComposedLookup {
+    lookup: WorldLookup,
+    coordinate: SnapshotCoordinate,
+}
+
+impl ComposedLookup {
+    /// What was found.
+    pub fn lookup(&self) -> &WorldLookup {
+        &self.lookup
+    }
+
+    /// Take ownership of what was found.
+    pub fn into_lookup(self) -> WorldLookup {
+        self.lookup
+    }
+
+    /// Where every projection stood when this was read.
+    pub fn coordinate(&self) -> &SnapshotCoordinate {
+        &self.coordinate
+    }
+}
+
 /// A read-only view onto the world.
 ///
 /// Read-only is structural, not a convention: this type holds a `&WorldStore`
@@ -363,11 +483,41 @@ impl<'a> WorldView<'a> {
     ///
     /// Only on a storage fault. An empty or wholly-inadmissible result is
     /// [`WorldLookup::Unknown`], which is a **success**.
-    pub fn ask(&self, subject: &str, now_ms: i64) -> Result<WorldLookup, AskError> {
-        let claims = self.store.current(subject, now_ms)?;
+    /// # This is a composed read, and it is coherent by construction
+    ///
+    /// Claims and identity are two independently-folded projections. Both are
+    /// read through ONE [`ReadSnapshot`], so an answer can never pair a claim
+    /// from one state of the world with an identity resolution from another.
+    /// The point they were read at rides back on the result — see
+    /// [`ComposedLookup`].
+    ///
+    /// [`ReadSnapshot`]: kirra_world_store::snapshot::ReadSnapshot
+    ///
+    /// # The SUBJECT is deliberately not resolved
+    ///
+    /// Only the object is resolved through the identity graph. Resolving the
+    /// subject would be a regression, not an improvement: `world_current` is
+    /// keyed by the subject string **as written**, so rewriting a queried alias
+    /// to its canonical id would look up a key nothing was ever stored under and
+    /// return *fewer* claims than asking plainly. Reading the whole equivalence
+    /// class and merging it is the operation that would actually be correct, and
+    /// that is a query design of its own rather than something to slip in here.
+    pub fn ask(&self, subject: &str, now_ms: i64) -> Result<ComposedLookup, AskError> {
+        let snapshot = self.store.read_snapshot()?;
+        let coordinate = snapshot.coordinate()?;
+        let claims = snapshot.current(subject, now_ms)?;
+
         if claims.is_empty() {
-            return Ok(WorldLookup::Unknown(UnknownReason::NoClaim));
+            return Ok(ComposedLookup {
+                lookup: WorldLookup::Unknown(UnknownReason::NoClaim),
+                coordinate,
+            });
         }
+
+        // Loaded once for the whole answer, from the same snapshot as the
+        // claims. Per-claim reads would be both slower and incoherent.
+        let identity = snapshot.identity_view()?;
+        let identity_is_current = snapshot.identity_is_current()?;
 
         let clock = now_ms.max(0).unsigned_abs();
         let mut answers: Vec<WorldAnswer> = Vec::new();
@@ -375,13 +525,15 @@ impl<'a> WorldView<'a> {
             .iter()
             .filter(|c| Self::is_admissible(c, clock, self.staleness_budget_ms))
         {
-            answers.push(self.bind(c, clock)?);
+            answers.push(self.bind(c, clock, &identity, identity_is_current)?);
         }
 
-        if answers.is_empty() {
-            return Ok(WorldLookup::Unknown(UnknownReason::NoneAdmissible));
-        }
-        Ok(WorldLookup::Answered(answers))
+        let lookup = if answers.is_empty() {
+            WorldLookup::Unknown(UnknownReason::NoneAdmissible)
+        } else {
+            WorldLookup::Answered(answers)
+        };
+        Ok(ComposedLookup { lookup, coordinate })
     }
 
     /// Expired, or graded `Inadmissible`, is not servable.
@@ -403,7 +555,13 @@ impl<'a> WorldView<'a> {
     ///
     /// Fallible only on the provenance handle, which is the one field that
     /// carries an invariant the row cannot enforce.
-    fn bind(&self, claim: &ProjectedClaim, clock: u64) -> Result<WorldAnswer, AskError> {
+    fn bind(
+        &self,
+        claim: &ProjectedClaim,
+        clock: u64,
+        identity: &IdentityView,
+        identity_is_current: bool,
+    ) -> Result<WorldAnswer, AskError> {
         let provenance = EvidenceDigest::new(claim.chain_digest.clone()).map_err(|cause| {
             AskError::CorruptProvenance {
                 subject: claim.subject.clone(),
@@ -414,6 +572,11 @@ impl<'a> WorldView<'a> {
         Ok(WorldAnswer {
             subject: claim.subject.clone(),
             predicate: claim.predicate.clone(),
+            object_identity: Self::resolve_object(
+                claim.object.as_deref(),
+                identity,
+                identity_is_current,
+            ),
             object: claim.object.clone(),
             value: claim.payload.clone(),
             validity: claim.validity_at(clock, self.staleness_budget_ms),
@@ -422,5 +585,43 @@ impl<'a> WorldView<'a> {
             provenance,
             event_id: claim.event_id.clone(),
         })
+    }
+
+    /// Resolve one claim's object through the identity graph.
+    ///
+    /// The staleness check comes FIRST and is not an optimisation. `resolve`
+    /// answers `Unknown` for an id the graph does not hold — and a graph that
+    /// has not folded the adjudications naming that id does not hold it either,
+    /// so a stale graph and an honest "not an entity" are the same answer from
+    /// the resolver. Only the log can tell them apart, which is why
+    /// [`ReadSnapshot::identity_is_current`] is consulted rather than the
+    /// projection's own emptiness.
+    ///
+    /// [`ReadSnapshot::identity_is_current`]: kirra_world_store::snapshot::ReadSnapshot::identity_is_current
+    fn resolve_object(
+        object: Option<&str>,
+        identity: &IdentityView,
+        identity_is_current: bool,
+    ) -> ObjectIdentity {
+        let Some(object) = object else {
+            return ObjectIdentity::NoObject;
+        };
+        if !identity_is_current {
+            return ObjectIdentity::Unresolvable;
+        }
+        let Ok(id) = EntityId::new(object) else {
+            return ObjectIdentity::Malformed;
+        };
+        match resolve(identity, &id) {
+            ResolutionOutcome::Located { entity, hops } => ObjectIdentity::Resolved {
+                entity: entity.as_str().to_string(),
+                hops,
+            },
+            ResolutionOutcome::Ambiguous { successors } => ObjectIdentity::Ambiguous {
+                successors: successors.iter().map(|e| e.as_str().to_string()).collect(),
+            },
+            ResolutionOutcome::Unknown => ObjectIdentity::NotAnEntity,
+            ResolutionOutcome::Refused(reason) => ObjectIdentity::Refused(reason),
+        }
     }
 }

--- a/crates/kirra-world-service/tests/read_view.rs
+++ b/crates/kirra-world-service/tests/read_view.rs
@@ -129,7 +129,7 @@ fn an_answer_carries_validity_trust_and_provenance() {
     seed(&mut s, 1, "cup-1", None, Some(&a), ClaimStatus::Confirmed);
 
     let view = WorldView::new(&s, Some(60_000));
-    let WorldLookup::Answered(answers) = view.ask("cup-1", T0).expect("ask") else {
+    let WorldLookup::Answered(answers) = view.ask("cup-1", T0).expect("ask").into_lookup() else {
         panic!("expected an answer");
     };
     assert_eq!(answers.len(), 1);
@@ -192,7 +192,7 @@ fn an_answer_carries_the_axes_not_only_the_collapsed_grade() {
     seed(&mut s, 1, "cup-1", None, Some(&a), ClaimStatus::Confirmed);
 
     let view = WorldView::new(&s, Some(60_000));
-    let WorldLookup::Answered(answers) = view.ask("cup-1", T0).expect("ask") else {
+    let WorldLookup::Answered(answers) = view.ask("cup-1", T0).expect("ask").into_lookup() else {
         panic!("expected an answer");
     };
     let got = answers[0]
@@ -244,10 +244,10 @@ fn two_claims_can_share_a_grade_for_different_reasons() {
 
     let view = WorldView::new(&s, Some(60_000));
 
-    let WorldLookup::Answered(a1) = view.ask("a", T0).expect("ask") else {
+    let WorldLookup::Answered(a1) = view.ask("a", T0).expect("ask").into_lookup() else {
         panic!("expected an answer");
     };
-    let WorldLookup::Answered(a2) = view.ask("b", T0).expect("ask") else {
+    let WorldLookup::Answered(a2) = view.ask("b", T0).expect("ask").into_lookup() else {
         panic!("expected an answer");
     };
 
@@ -277,7 +277,7 @@ fn an_unlabelled_claim_has_no_grade_rather_than_a_default() {
     seed(&mut s, 1, "cup-1", None, None, ClaimStatus::Confirmed);
 
     let view = WorldView::new(&s, Some(60_000));
-    let WorldLookup::Answered(answers) = view.ask("cup-1", T0).expect("ask") else {
+    let WorldLookup::Answered(answers) = view.ask("cup-1", T0).expect("ask").into_lookup() else {
         panic!("expected an answer");
     };
     assert_eq!(answers[0].grade(), None);
@@ -308,7 +308,7 @@ fn an_unknown_subject_is_a_success_not_an_error() {
         "absence of knowledge must not use the error channel"
     );
     assert!(matches!(
-        out.expect("ok"),
+        out.expect("ok").into_lookup(),
         WorldLookup::Unknown(UnknownReason::NoClaim)
     ));
 }
@@ -338,11 +338,11 @@ fn an_expired_claim_is_not_served() {
 
     let view = WorldView::new(&s, Some(60_000));
     assert!(matches!(
-        view.ask("cup-1", T0 + 500).expect("ask"),
+        view.ask("cup-1", T0 + 500).expect("ask").into_lookup(),
         WorldLookup::Answered(_)
     ));
     assert!(matches!(
-        view.ask("cup-1", T0 + 5_000).expect("ask"),
+        view.ask("cup-1", T0 + 5_000).expect("ask").into_lookup(),
         WorldLookup::Unknown(UnknownReason::NoClaim)
     ));
 }
@@ -368,7 +368,7 @@ fn an_inadmissible_claim_never_reaches_the_boundary() {
 
     let view = WorldView::new(&s, Some(60_000));
     assert!(matches!(
-        view.ask("cup-1", T0).expect("ask"),
+        view.ask("cup-1", T0).expect("ask").into_lookup(),
         WorldLookup::Unknown(UnknownReason::NoClaim)
     ));
 }
@@ -398,13 +398,14 @@ fn the_staleness_budget_belongs_to_the_asking_caller() {
     let later = T0 + 120_000;
 
     let impatient = WorldView::new(&s, Some(60_000));
-    let WorldLookup::Answered(a1) = impatient.ask("cup-1", later).expect("ask") else {
+    let WorldLookup::Answered(a1) = impatient.ask("cup-1", later).expect("ask").into_lookup()
+    else {
         panic!("expected an answer");
     };
     assert_eq!(a1[0].validity(), Validity::Stale);
 
     let patient = WorldView::new(&s, Some(600_000));
-    let WorldLookup::Answered(a2) = patient.ask("cup-1", later).expect("ask") else {
+    let WorldLookup::Answered(a2) = patient.ask("cup-1", later).expect("ask").into_lookup() else {
         panic!("expected an answer");
     };
     assert_eq!(a2[0].validity(), Validity::Fresh);
@@ -443,7 +444,7 @@ fn an_unreadable_provenance_handle_is_refused_rather_than_served() {
     // corruption and not by the fixture never having worked.
     let view = WorldView::new(&s, Some(60_000));
     assert!(matches!(
-        view.ask("cup-1", T0).expect("ask"),
+        view.ask("cup-1", T0).expect("ask").into_lookup(),
         WorldLookup::Answered(_)
     ));
 
@@ -506,7 +507,7 @@ fn the_error_identifies_which_of_a_subject_s_rows_is_damaged() {
     // Two rows, both answerable, so the refusal below is caused by the
     // corruption rather than by a fixture that never worked.
     let view = WorldView::new(&s, Some(60_000));
-    let WorldLookup::Answered(before) = view.ask("cup-1", T0).expect("ask") else {
+    let WorldLookup::Answered(before) = view.ask("cup-1", T0).expect("ask").into_lookup() else {
         panic!("expected answers");
     };
     assert_eq!(before.len(), 2, "one row per predicate");
@@ -573,7 +574,7 @@ fn a_corrupt_handle_is_not_reported_as_absence_of_knowledge() {
     let view = WorldView::new(&s, Some(60_000));
     let out = view.ask("cup-1", T0);
     assert!(
-        !matches!(out, Ok(WorldLookup::Unknown(_))),
+        !matches!(&out, Ok(c) if matches!(c.lookup(), WorldLookup::Unknown(_))),
         "damage must not be reported as absence"
     );
     assert!(matches!(out, Err(AskError::CorruptProvenance { .. })));

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -89,6 +89,7 @@ pub mod projection;
 pub mod retention_driver;
 pub mod retention_sweeper;
 pub mod schema;
+pub mod snapshot;
 pub mod subject_projection;
 
 pub use compaction::{Citation, CompactionOutcome, DegradedSummary, Resolution, TemporalAnswer};
@@ -1558,66 +1559,7 @@ impl WorldStore {
         &self,
     ) -> Result<std::collections::BTreeMap<String, entity_projection::ProjectedEntity>, StoreError>
     {
-        if !self.has_entity_projection()? {
-            return Ok(std::collections::BTreeMap::new());
-        }
-        let mut stmt = self.conn.prepare(
-            "SELECT entity_id, lifecycle, redirect, origin, contradicted, contradiction
-             FROM entities_projection ORDER BY entity_id ASC",
-        )?;
-        let mut out = std::collections::BTreeMap::new();
-        let mut rows = stmt.query([])?;
-        while let Some(r) = rows.next()? {
-            let id: String = r.get(0)?;
-            let token: String = r.get(1)?;
-            let redirect: Option<String> = r.get(2)?;
-            let origin: Option<String> = r.get(3)?;
-            let contradicted: i64 = r.get(4)?;
-            let detail: Option<String> = r.get(5)?;
-            let contradiction = match (contradicted != 0, detail.as_deref()) {
-                (false, _) => None,
-                (true, Some(raw)) => Some(
-                    entity_projection::contradiction_from_json(raw).map_err(|e| {
-                        StoreError::CorruptEntityProjectionRow {
-                            detail: format!("{id}: {e}"),
-                        }
-                    })?,
-                ),
-                // Flagged contradicted with nothing recorded: the fold always
-                // writes both, so this is a row edited underneath the store.
-                (true, None) => {
-                    return Err(StoreError::CorruptEntityProjectionRow {
-                        detail: format!("{id}: contradicted with no contradiction recorded"),
-                    })
-                }
-            };
-            let lifecycle = entity_projection::lifecycle_from_columns(
-                &token,
-                redirect.as_deref(),
-                origin.as_deref(),
-            )
-            .map_err(|e| StoreError::CorruptEntityProjectionRow {
-                detail: format!("{id}: {e}"),
-            })?;
-            let entity =
-                EntityId::new(&id).map_err(|e| StoreError::CorruptEntityProjectionRow {
-                    detail: format!("{id}: inadmissible entity id: {e:?}"),
-                })?;
-            out.insert(
-                id,
-                entity_projection::ProjectedEntity {
-                    entity,
-                    lifecycle,
-                    // Read back structurally. An earlier draft stored a
-                    // rendered sentence and rebuilt a placeholder here, which
-                    // would have pointed an operator at generation 0 for every
-                    // contradiction -- an invented value wearing a real field's
-                    // name.
-                    contradiction,
-                },
-            );
-        }
-        Ok(out)
+        snapshot::load_entity_projection_on(&self.conn)
     }
 
     /// **A snapshot of the entity projection, resolvable in place.**
@@ -1632,11 +1574,19 @@ impl WorldStore {
     /// back faithfully. **The refusal happens here, once**, rather than during
     /// the walk — see [`entity_projection::IdentityView`] for why resolving
     /// over a per-query reader would turn a read failure into "no such entity".
+    ///
+    /// # The rows and the label come from one snapshot
+    ///
+    /// This used to read the rows and then the generation in two unrelated
+    /// statements, so a fold landing between them stamped the view with a
+    /// generation newer than the rows it held — a snapshot mislabelled as a
+    /// later state of the world, which is precisely what
+    /// [`IdentityView::generation`] is relied upon to mean. It now takes both
+    /// from one read transaction.
+    ///
+    /// [`IdentityView::generation`]: entity_projection::IdentityView::generation
     pub fn identity_view(&self) -> Result<entity_projection::IdentityView, StoreError> {
-        Ok(entity_projection::IdentityView::new(
-            self.load_entity_projection()?,
-            self.entity_projection_generation()?,
-        ))
+        self.read_snapshot()?.identity_view()
     }
 
     /// **The identity graph as it stood at a past instant** — §6.3, Tier 2 2d.
@@ -2629,21 +2579,33 @@ impl WorldStore {
     /// state survives retention**, so a device that has compacted its way back
     /// under budget still knows where everything is.
     pub fn current(&self, subject: &str, now_ms: i64) -> Result<Vec<ProjectedClaim>, StoreError> {
-        if !self.has_projections()? {
-            return Ok(Vec::new());
-        }
-        let mut stmt = self.conn.prepare(&format!(
-            "SELECT {CLAIM_COLUMNS} FROM world_current WHERE subject = ?1 ORDER BY predicate_key"
-        ))?;
-        let rows = stmt.query_map(params![subject], claim_from_row)?;
-        let mut out = Vec::new();
-        for c in rows {
-            let c = c?;
-            if c.holds_at(now_ms) {
-                out.push(c);
-            }
-        }
-        Ok(out)
+        snapshot::current_on(&self.conn, subject, now_ms)
+    }
+
+    /// **A coherent read across every projection** — Tier 3 box 3c.
+    ///
+    /// Composing an answer from more than one projection through the ordinary
+    /// `&self` readers can observe a fold landing between two calls and answer
+    /// from two states of the world. Reads taken through the returned
+    /// [`snapshot::ReadSnapshot`] cannot: it holds one SQLite read transaction,
+    /// so every projection is seen at the same set of commits.
+    ///
+    /// Drop it as soon as the composed read is done — see
+    /// [`snapshot::ReadSnapshot`] on the WAL read-mark it holds.
+    pub fn read_snapshot(&self) -> Result<snapshot::ReadSnapshot<'_>, StoreError> {
+        Ok(snapshot::ReadSnapshot::new(
+            self.conn.unchecked_transaction()?,
+        ))
+    }
+
+    /// Where every projection stands right now, read outside any snapshot.
+    ///
+    /// For reporting and diagnostics. A composed ANSWER should carry the
+    /// coordinate of the snapshot it was read from
+    /// ([`snapshot::ReadSnapshot::coordinate`]), not one sampled separately —
+    /// sampling separately is the two-statement race this box exists to close.
+    pub fn projection_coordinate(&self) -> Result<snapshot::SnapshotCoordinate, StoreError> {
+        snapshot::coordinate_on(&self.conn)
     }
 
     /// The whole projected state at `now_ms`, in key order.

--- a/crates/kirra-world-store/src/snapshot.rs
+++ b/crates/kirra-world-store/src/snapshot.rs
@@ -1,0 +1,383 @@
+//! **Tier 3 box 3c — one coherent point across several projections.**
+//!
+//! An answer that composes projections must read them at ONE coherent point, or
+//! report each coordinate explicitly. This module provides the first arm, and
+//! carries the second alongside it.
+//!
+//! # Why this exists as a type rather than as discipline
+//!
+//! Identity, claims and subject summaries are three independently-folded
+//! projections. Each advances its own checkpoint row when its own fold commits,
+//! and nothing coordinates them. A composed read that calls
+//! [`WorldStore::current`] and then [`WorldStore::identity_view`] can therefore
+//! observe a fold landing between the two calls and answer from two different
+//! states of the world — the exact failure [`IdentityView`]'s own docs rule out
+//! *within* a walk, reappearing *between* walks.
+//!
+//! [`IdentityView`]: crate::entity_projection::IdentityView
+//!
+//! # The mechanism, and why it is a guarantee rather than a detector
+//!
+//! Every projection is a table in ONE SQLite database, and every fold commits
+//! atomically. So a single read transaction — which in WAL mode holds one
+//! snapshot of the whole database for its lifetime — sees each projection at a
+//! committed fold boundary, and sees *the same set of commits* for all of them.
+//! That is coherence by construction, not drift detection after the fact.
+//!
+//! This matters for what the box is allowed to claim. Detecting drift and
+//! refusing would also satisfy 3c's fallback arm, but it is strictly weaker: it
+//! turns a concurrent fold into a refused answer, where a snapshot turns it into
+//! a correct one.
+//!
+//! # What this is NOT
+//!
+//! It is **not** the generation-pinned read that `KIRRA-WM-ANSWER-IDENTITY-001`
+//! needs, and [`SnapshotCoordinate`] is **not** an `AnswerRef`. A snapshot is
+//! coherent for as long as it is held and cannot be re-entered once dropped;
+//! re-executing a query against a *recorded* coordinate needs a way to read
+//! `world_current` as of a generation, which does not exist. That gap has its
+//! own open box in `docs/design/WM_SCOPE.md`, and
+//! `KIRRA-WM-ANSWERREF-NAMING-001` reserves the name `AnswerRef` for the day it
+//! closes. Naming this type `AnswerRef` would put the ruled guarantee's name on
+//! a mechanism that cannot honour it.
+
+use std::collections::BTreeMap;
+
+use rusqlite::{params, Connection, OptionalExtension};
+
+use crate::entity_projection::{self, IdentityView, ProjectedEntity};
+use crate::projection::{self, ProjectedClaim};
+use crate::subject_projection;
+use crate::{claim_from_row, StoreError, CLAIM_COLUMNS};
+
+/// Where ONE projection stood when a snapshot observed it.
+///
+/// Carries the `state_digest` as well as the generation because a generation
+/// alone cannot distinguish a fold that advanced from a rebuild that landed on
+/// the same head — the pair is what the fold itself commits, so it is what an
+/// observer should record.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectionCoordinate {
+    name: &'static str,
+    generation: i64,
+    state_digest: String,
+}
+
+impl ProjectionCoordinate {
+    /// The projection's checkpoint name, as the fold writes it.
+    pub fn name(&self) -> &'static str {
+        self.name
+    }
+
+    /// How far this projection's fold has consumed.
+    ///
+    /// **Not comparable to another projection's generation.** See
+    /// [`SnapshotCoordinate`] for why that comparison is meaningless rather than
+    /// merely unreliable.
+    pub fn generation(&self) -> i64 {
+        self.generation
+    }
+
+    /// The digest of the state the fold left, or `""` if never folded.
+    pub fn state_digest(&self) -> &str {
+        &self.state_digest
+    }
+
+    /// Whether this projection has ever been folded.
+    ///
+    /// A projection whose table has not been installed reports generation 0,
+    /// matching [`WorldStore::projection_generation`]'s existing convention —
+    /// so "absent" and "folded nothing" are deliberately the same observation.
+    /// They have the same consequence for a reader: there is nothing there.
+    pub fn is_unfolded(&self) -> bool {
+        self.generation == 0
+    }
+}
+
+/// Where EVERY projection stood, observed at one coherent point.
+///
+/// # These numbers are not comparable to each other
+///
+/// The obvious check — assert two projections sit at the same generation — is
+/// wrong, and wrong in the direction that looks like rigour. `world_current`
+/// and `subject_summary` advance their checkpoint past every event *considered*,
+/// including events they adopt nothing from; the entity fold advances only to
+/// the generation of the last *adjudication* it folded. So appending any
+/// non-adjudication event leaves the entity checkpoint legitimately behind the
+/// other two, with all three fully folded and nothing wrong.
+///
+/// An equality check would therefore report constant false drift, and the fix
+/// someone reaches for under deadline is to delete the check. Coherence here
+/// comes from the snapshot, not from comparing these numbers; they are recorded
+/// so an answer can say *which* state it came from, which is 3c's second arm.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SnapshotCoordinate {
+    world_current: ProjectionCoordinate,
+    entities: ProjectionCoordinate,
+    subject_summary: ProjectionCoordinate,
+}
+
+impl SnapshotCoordinate {
+    /// The claims projection's coordinate.
+    pub fn world_current(&self) -> &ProjectionCoordinate {
+        &self.world_current
+    }
+
+    /// The identity projection's coordinate.
+    pub fn entities(&self) -> &ProjectionCoordinate {
+        &self.entities
+    }
+
+    /// The subject-summary projection's coordinate.
+    pub fn subject_summary(&self) -> &ProjectionCoordinate {
+        &self.subject_summary
+    }
+
+    /// Every coordinate, in a stable order.
+    ///
+    /// All three are recorded even when a read touched one, deliberately: a
+    /// coordinate that listed only the projections a particular read happened to
+    /// consult would be a record that changes shape with the query, and a reader
+    /// comparing two of them could not tell "this projection was not read" from
+    /// "this projection did not exist".
+    pub fn all(&self) -> [&ProjectionCoordinate; 3] {
+        [&self.world_current, &self.entities, &self.subject_summary]
+    }
+}
+
+/// **A coherent multi-projection read.**
+///
+/// Holds one SQLite read transaction for its lifetime, so every read taken
+/// through it observes one state of the database — and therefore one state of
+/// every projection in it.
+///
+/// # The snapshot begins at the first read, not at construction
+///
+/// The transaction is DEFERRED, so SQLite establishes the snapshot when the
+/// first statement runs. This does not weaken coherence — every read still
+/// agrees with every other — but it does mean a snapshot held open and unused
+/// is not "as of" the moment it was created. Stated because the alternative
+/// reading is the one that produces a stale-data bug report years later.
+///
+/// # Holding one open is not free
+///
+/// A read transaction holds a WAL read-mark, which prevents checkpointing from
+/// reclaiming WAL frames beyond it. Take one for a composed read and drop it;
+/// do not park one across a request loop.
+pub struct ReadSnapshot<'a> {
+    tx: rusqlite::Transaction<'a>,
+}
+
+impl<'a> ReadSnapshot<'a> {
+    pub(crate) fn new(tx: rusqlite::Transaction<'a>) -> Self {
+        Self { tx }
+    }
+
+    /// The current claims for `subject`, holding at `now_ms`.
+    ///
+    /// Identical in result to [`WorldStore::current`] — the same code answers
+    /// both — except that it is bound to this snapshot.
+    ///
+    /// [`WorldStore::current`]: crate::WorldStore::current
+    pub fn current(&self, subject: &str, now_ms: i64) -> Result<Vec<ProjectedClaim>, StoreError> {
+        current_on(&self.tx, subject, now_ms)
+    }
+
+    /// The identity graph, loaded from this snapshot.
+    ///
+    /// Unlike [`WorldStore::identity_view`] before 3c, the rows and the
+    /// generation label are read from ONE state: the view cannot be stamped
+    /// with a generation newer than the rows it holds.
+    ///
+    /// [`WorldStore::identity_view`]: crate::WorldStore::identity_view
+    pub fn identity_view(&self) -> Result<IdentityView, StoreError> {
+        Ok(IdentityView::new(
+            load_entity_projection_on(&self.tx)?,
+            checkpoint_on(&self.tx, entity_projection::ENTITY_PROJECTION)?.0,
+        ))
+    }
+
+    /// Where every projection stood in this snapshot.
+    pub fn coordinate(&self) -> Result<SnapshotCoordinate, StoreError> {
+        coordinate_on(&self.tx)
+    }
+
+    /// **Has the identity graph consumed every adjudication the log holds?**
+    ///
+    /// The question a composed read must ask before trusting a resolution, and
+    /// it is deliberately *not* "has the entity projection been folded".
+    ///
+    /// Those differ in both directions, which is why the cheap check is the
+    /// wrong one:
+    ///
+    /// - A store that has **never** folded the entity projection because it has
+    ///   **no adjudications at all** is perfectly current. There are no merges
+    ///   to miss, so an object stands for itself. Treating that as unresolvable
+    ///   would refuse every object-bearing claim on the overwhelmingly common
+    ///   store — an availability failure bought for no safety.
+    /// - A store folded once, with merges recorded **since**, has a projection
+    ///   that exists and is *stale*. A folded-or-not check calls that fine and
+    ///   resolves against data known to be out of date — the dangerous case,
+    ///   waved through.
+    ///
+    /// Answered from the same snapshot as everything else, so a fold committing
+    /// concurrently cannot make this answer disagree with the view it describes.
+    pub fn identity_is_current(&self) -> Result<bool, StoreError> {
+        if !table_exists(&self.tx, "world_events")? {
+            return Ok(true);
+        }
+        let checkpoint = checkpoint_on(&self.tx, entity_projection::ENTITY_PROJECTION)?.0;
+        let pending: Option<i64> = self
+            .tx
+            .query_row(
+                "SELECT 1 FROM world_events
+                 WHERE kind = ?1 AND claim_status = 'confirmed' AND generation > ?2
+                 LIMIT 1",
+                params![crate::adjudication_record::ADJUDICATION_KIND, checkpoint],
+                |r| r.get(0),
+            )
+            .optional()?;
+        Ok(pending.is_none())
+    }
+}
+
+/// Read one projection's checkpoint row: `(generation, state_digest)`.
+///
+/// A missing checkpoint table or a missing row is `(0, "")` rather than an
+/// error, matching the existing generation readers: a projection that has never
+/// folded has consumed nothing, which is a fact and not a fault.
+pub(crate) fn checkpoint_on(conn: &Connection, name: &str) -> Result<(i64, String), StoreError> {
+    let installed: Option<i64> = conn
+        .query_row(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='projection_checkpoint'",
+            [],
+            |r| r.get(0),
+        )
+        .optional()?;
+    if installed.is_none() {
+        return Ok((0, String::new()));
+    }
+    let row: Option<(i64, String)> = conn
+        .query_row(
+            "SELECT generation, state_digest FROM projection_checkpoint WHERE name = ?1",
+            params![name],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .optional()?;
+    Ok(row.unwrap_or((0, String::new())))
+}
+
+pub(crate) fn coordinate_on(conn: &Connection) -> Result<SnapshotCoordinate, StoreError> {
+    let one = |name: &'static str| -> Result<ProjectionCoordinate, StoreError> {
+        let (generation, state_digest) = checkpoint_on(conn, name)?;
+        Ok(ProjectionCoordinate {
+            name,
+            generation,
+            state_digest,
+        })
+    };
+    Ok(SnapshotCoordinate {
+        world_current: one(projection::CURRENT_PROJECTION)?,
+        entities: one(entity_projection::ENTITY_PROJECTION)?,
+        subject_summary: one(subject_projection::SUBJECT_SUMMARY_PROJECTION)?,
+    })
+}
+
+/// The body of `WorldStore::current`, over any connection or transaction.
+///
+/// Extracted rather than duplicated so a snapshot read and a direct read cannot
+/// drift apart: two copies of a `holds_at` filter is exactly the kind of
+/// divergence that shows up as "the composed answer disagrees with the simple
+/// one" long after the copy was made.
+pub(crate) fn current_on(
+    conn: &Connection,
+    subject: &str,
+    now_ms: i64,
+) -> Result<Vec<ProjectedClaim>, StoreError> {
+    if !table_exists(conn, "world_current")? {
+        return Ok(Vec::new());
+    }
+    let mut stmt = conn.prepare(&format!(
+        "SELECT {CLAIM_COLUMNS} FROM world_current WHERE subject = ?1 ORDER BY predicate_key"
+    ))?;
+    let rows = stmt.query_map(params![subject], claim_from_row)?;
+    let mut out = Vec::new();
+    for c in rows {
+        let c = c?;
+        if c.holds_at(now_ms) {
+            out.push(c);
+        }
+    }
+    Ok(out)
+}
+
+/// The body of `WorldStore::load_entity_projection`, over any connection.
+pub(crate) fn load_entity_projection_on(
+    conn: &Connection,
+) -> Result<BTreeMap<String, ProjectedEntity>, StoreError> {
+    if !table_exists(conn, "entities_projection")? {
+        return Ok(BTreeMap::new());
+    }
+    let mut stmt = conn.prepare(
+        "SELECT entity_id, lifecycle, redirect, origin, contradicted, contradiction
+         FROM entities_projection ORDER BY entity_id ASC",
+    )?;
+    let mut out = BTreeMap::new();
+    let mut rows = stmt.query([])?;
+    while let Some(r) = rows.next()? {
+        let id: String = r.get(0)?;
+        let token: String = r.get(1)?;
+        let redirect: Option<String> = r.get(2)?;
+        let origin: Option<String> = r.get(3)?;
+        let contradicted: i64 = r.get(4)?;
+        let detail: Option<String> = r.get(5)?;
+        let contradiction = match (contradicted != 0, detail.as_deref()) {
+            (false, _) => None,
+            (true, Some(raw)) => Some(entity_projection::contradiction_from_json(raw).map_err(
+                |e| StoreError::CorruptEntityProjectionRow {
+                    detail: format!("{id}: {e}"),
+                },
+            )?),
+            // Flagged contradicted with nothing recorded: the fold always
+            // writes both, so this is a row edited underneath the store.
+            (true, None) => {
+                return Err(StoreError::CorruptEntityProjectionRow {
+                    detail: format!("{id}: contradicted with no contradiction recorded"),
+                })
+            }
+        };
+        let lifecycle = entity_projection::lifecycle_from_columns(
+            &token,
+            redirect.as_deref(),
+            origin.as_deref(),
+        )
+        .map_err(|e| StoreError::CorruptEntityProjectionRow {
+            detail: format!("{id}: {e}"),
+        })?;
+        let entity = kirra_world::reference::EntityId::new(&id).map_err(|e| {
+            StoreError::CorruptEntityProjectionRow {
+                detail: format!("{id}: inadmissible entity id: {e:?}"),
+            }
+        })?;
+        out.insert(
+            id,
+            ProjectedEntity {
+                entity,
+                lifecycle,
+                contradiction,
+            },
+        );
+    }
+    Ok(out)
+}
+
+pub(crate) fn table_exists(conn: &Connection, name: &str) -> Result<bool, StoreError> {
+    let n: Option<i64> = conn
+        .query_row(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name = ?1",
+            params![name],
+            |r| r.get(0),
+        )
+        .optional()?;
+    Ok(n.is_some())
+}

--- a/crates/kirra-world-store/tests/snapshot_coherence.rs
+++ b/crates/kirra-world-store/tests/snapshot_coherence.rs
@@ -1,0 +1,373 @@
+//! **Tier 3 box 3c — a composed read cannot mix projection states.**
+//!
+//! The box asks that an answer composing several projections read them at ONE
+//! coherent point, or report each coordinate explicitly. Two claims are pinned
+//! here, and they are different claims:
+//!
+//! 1. **The snapshot is real.** A fold that commits after a snapshot was
+//!    established is invisible to it — for BOTH projections — so a composed
+//!    read cannot see identity's new state beside claims' old one. The
+//!    non-vacuity guard matters more than usual: a test that only asserts the
+//!    snapshot still shows the old rows would also pass if the concurrent write
+//!    silently failed, so each case also proves the write LANDED by reading it
+//!    through a fresh reader.
+//!
+//! 2. **The two generations are not comparable, and must never be compared.**
+//!    `world_current` advances its checkpoint past every event *considered*;
+//!    the entity fold advances only to the last *adjudication* it folded. A
+//!    store with both projections fully folded therefore sits at two different
+//!    generations, legitimately. This is pinned as a fact so that anyone who
+//!    later "tightens" coherence into an equality check gets a red test naming
+//!    the reason instead of a mystery.
+//!
+//! # Why a second `WorldStore` on the same file
+//!
+//! The concurrent fold has to come from another connection: `read_snapshot`
+//! borrows the store, and a fold needs `&mut`. That is not a test artifact —
+//! it is the situation the box is about, one reader composing an answer while
+//! something else advances the projections underneath.
+
+use kirra_world::adjudication::{AssertIdentity, IdentityAdjudication, Justification};
+use kirra_world::observation::{ClockDomain, DomainInstant};
+use kirra_world::reference::{EntityId, EventId, ObservationId};
+use kirra_world_store::adjudication_record::AdjudicationRow;
+use kirra_world_store::{ClaimStatus, NewEvent, WorldStore, WriterClass};
+
+const T0: i64 = 1_700_000_000_000;
+
+fn tmp(name: &str) -> std::path::PathBuf {
+    static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let n = NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "kirra-snapshot-coherence-{name}-{}-{n}.sqlite",
+        std::process::id()
+    ));
+    cleanup(&p);
+    p
+}
+
+fn cleanup(path: &std::path::Path) {
+    for suffix in ["", "-wal", "-shm"] {
+        let mut q = path.as_os_str().to_os_string();
+        q.push(suffix);
+        let _ = std::fs::remove_file(std::path::PathBuf::from(q));
+    }
+}
+
+fn eid(s: &str) -> EntityId {
+    EntityId::new(s).expect("entity id")
+}
+
+fn assert_identity(s: &mut WorldStore, tag: &str, entity: &str, at_ms: i64) {
+    let event_id = EventId::new(format!("ev-adj-{tag}")).expect("event id");
+    let observation_id = ObservationId::new(format!("obs-adj-{tag}")).expect("obs");
+    let justification =
+        Justification::new([ObservationId::new("obs-1").expect("obs")]).expect("justification");
+    let at = DomainInstant {
+        ms: 1,
+        domain: ClockDomain::System,
+    };
+    s.append_adjudication(
+        &AdjudicationRow {
+            event_id: &event_id,
+            observation_id: &observation_id,
+            txn_time_ms: at_ms,
+            valid_from_ms: at_ms,
+            source: "operator-console",
+            source_version: "1.0.0",
+            writer_class: WriterClass::Operator,
+        },
+        &IdentityAdjudication::Assert(AssertIdentity::new(eid(entity), justification, at)),
+    )
+    .expect("append adjudication");
+}
+
+fn claim(s: &mut WorldStore, tag: &str, subject: &str, object: &str, at_ms: i64) {
+    let event_id = EventId::new(format!("ev-claim-{tag}")).expect("event id");
+    let observation_id = ObservationId::new(format!("obs-claim-{tag}")).expect("obs");
+    s.append(&NewEvent {
+        event_id: &event_id,
+        observation_id: &observation_id,
+        txn_time_ms: at_ms,
+        valid_from_ms: at_ms,
+        valid_to_ms: None,
+        source: "warehouse-scanner",
+        source_version: "1.0.0",
+        writer_class: WriterClass::Sensor,
+        claim_status: ClaimStatus::Confirmed,
+        provenance: &[],
+        frame_id: None,
+        map_id: None,
+        kind: "mission",
+        subject,
+        subject_ref: None,
+        predicate: Some("last_seen_at"),
+        object: Some(object),
+        payload: "{}",
+        payload_schema: 1,
+        retention_class: "raw",
+        trust: None,
+    })
+    .expect("append claim");
+}
+
+fn fold_both(s: &mut WorldStore) {
+    s.fold().expect("fold claims");
+    s.fold_entity_projection().expect("fold entities");
+}
+
+// ---------------------------------------------------------------------------
+// 1. The snapshot is real
+// ---------------------------------------------------------------------------
+
+/// **A concurrent fold is invisible to a snapshot — on both projections.**
+///
+/// This is the whole box in one test. The composed read takes claims and
+/// identity through one snapshot; between those two reads, another connection
+/// appends and folds BOTH projections. If the snapshot were not real, the
+/// second read would see the new state and the answer would be composed from
+/// two different worlds.
+#[test]
+fn a_fold_landing_mid_composition_is_invisible_to_both_halves() {
+    let path = tmp("midcomposition");
+
+    let mut writer = WorldStore::open(&path).expect("open writer");
+    claim(&mut writer, "1", "package_17", "dock_b", T0);
+    assert_identity(&mut writer, "1", "dock_b", T0);
+    fold_both(&mut writer);
+    drop(writer);
+
+    let reader = WorldStore::open(&path).expect("open reader");
+    let snap = reader.read_snapshot().expect("snapshot");
+
+    // First half of the composed read. This establishes the snapshot.
+    let before_claims = snap.current("package_17", T0).expect("claims");
+    assert_eq!(before_claims.len(), 1, "the seeded claim is visible");
+    let coordinate_before = snap.coordinate().expect("coordinate");
+
+    // Something else advances BOTH projections, and commits.
+    let mut other = WorldStore::open(&path).expect("open second writer");
+    claim(&mut other, "2", "package_17", "dock_c", T0 + 1);
+    assert_identity(&mut other, "2", "dock_c", T0 + 1);
+    fold_both(&mut other);
+
+    // Non-vacuity: the write really landed. Without this, every assertion
+    // below would also hold if the concurrent fold had silently done nothing.
+    let fresh = WorldStore::open(&path).expect("open fresh reader");
+    assert!(
+        fresh
+            .identity_view()
+            .expect("fresh identity")
+            .get(&eid("dock_c"))
+            .is_some(),
+        "the concurrent fold must have landed, or this test proves nothing"
+    );
+    assert_ne!(
+        fresh.projection_coordinate().expect("fresh coordinate"),
+        coordinate_before,
+        "the store moved on, or this test proves nothing"
+    );
+
+    // Second half of the composed read, through the SAME snapshot.
+    let view = snap.identity_view().expect("identity");
+    assert!(
+        view.get(&eid("dock_c")).is_none(),
+        "the snapshot must not see an entity folded after it was established"
+    );
+    assert!(
+        view.get(&eid("dock_b")).is_some(),
+        "the snapshot must still see what it was established with"
+    );
+
+    // And the claims half has not moved either.
+    let after_claims = snap.current("package_17", T0).expect("claims again");
+    assert_eq!(
+        after_claims.len(),
+        before_claims.len(),
+        "the claims half of the composed read must not move under the reader"
+    );
+    assert_eq!(
+        snap.coordinate().expect("coordinate again"),
+        coordinate_before,
+        "one snapshot reports one coordinate for its whole lifetime"
+    );
+
+    drop(snap);
+    drop(reader);
+    drop(other);
+    drop(fresh);
+    cleanup(&path);
+}
+
+/// **NEGATIVE CONTROL — the unguarded path really does mix states.**
+///
+/// The test above is only worth something if the interleaving it survives is one
+/// that would otherwise bite. So this runs the identical scenario through the
+/// ordinary `&self` readers — the pre-3c composition — and asserts it observes
+/// the concurrent fold: claims read before, identity read after, and the two
+/// halves disagree about which entities exist.
+///
+/// If this control ever goes green-by-agreement (both halves seeing one state),
+/// the guarded test above has stopped proving anything and the scenario needs
+/// rebuilding — which is exactly what a control is for.
+#[test]
+fn the_unguarded_composition_observes_the_fold_it_should_not() {
+    let path = tmp("unguarded");
+
+    let mut writer = WorldStore::open(&path).expect("open writer");
+    claim(&mut writer, "1", "package_17", "dock_b", T0);
+    assert_identity(&mut writer, "1", "dock_b", T0);
+    fold_both(&mut writer);
+    drop(writer);
+
+    let reader = WorldStore::open(&path).expect("open reader");
+
+    // First half, unguarded.
+    let before_claims = reader.current("package_17", T0).expect("claims");
+    assert_eq!(before_claims.len(), 1);
+
+    let mut other = WorldStore::open(&path).expect("open second writer");
+    claim(&mut other, "2", "package_17", "dock_c", T0 + 1);
+    assert_identity(&mut other, "2", "dock_c", T0 + 1);
+    fold_both(&mut other);
+
+    // Second half, unguarded — and it sees a world the first half did not.
+    let view = reader.identity_view().expect("identity");
+    assert!(
+        view.get(&eid("dock_c")).is_some(),
+        "the unguarded composition must observe the concurrent fold — if it does \
+         not, the snapshot test above is not being asked a real question"
+    );
+
+    drop(reader);
+    drop(other);
+    cleanup(&path);
+}
+
+/// **A new snapshot sees the new state.**
+///
+/// The companion to the test above, and the reason it is not merely asserting
+/// that reads are broken: coherence must not be achieved by never seeing
+/// anything. A snapshot taken after the fold sees the fold.
+#[test]
+fn a_snapshot_taken_after_a_fold_sees_it() {
+    let path = tmp("aftershot");
+
+    let mut writer = WorldStore::open(&path).expect("open writer");
+    claim(&mut writer, "1", "package_17", "dock_b", T0);
+    assert_identity(&mut writer, "1", "dock_b", T0);
+    fold_both(&mut writer);
+    assert_identity(&mut writer, "2", "dock_c", T0 + 1);
+    fold_both(&mut writer);
+    drop(writer);
+
+    let reader = WorldStore::open(&path).expect("open reader");
+    let snap = reader.read_snapshot().expect("snapshot");
+    assert!(
+        snap.identity_view()
+            .expect("identity")
+            .get(&eid("dock_c"))
+            .is_some(),
+        "a snapshot taken after the fold must see it"
+    );
+
+    drop(snap);
+    drop(reader);
+    cleanup(&path);
+}
+
+// ---------------------------------------------------------------------------
+// 2. The two generations are not comparable
+// ---------------------------------------------------------------------------
+
+/// **Two fully-folded projections legitimately sit at different generations.**
+///
+/// `fold_range` advances `world_current`'s checkpoint to `MAX(generation) FROM
+/// world_events` — every event CONSIDERED, so a batch that adopts nothing still
+/// moves it. `fold_entity_range` advances only to the generation of the last
+/// adjudication it folded. Append one ordinary claim after an adjudication and
+/// the two checkpoints separate, with both folds complete and nothing wrong.
+///
+/// Pinned because the intuitive way to "prove" snapshot consistency is to
+/// assert the coordinates are equal, and that check would fail here — on a
+/// healthy store. Coherence comes from the snapshot, not from these numbers
+/// agreeing.
+#[test]
+fn the_two_projection_generations_differ_on_a_healthy_store() {
+    let path = tmp("incomparable");
+
+    let mut s = WorldStore::open(&path).expect("open");
+    assert_identity(&mut s, "1", "dock_b", T0);
+    // A non-adjudication event: the entity fold consumes nothing from it.
+    claim(&mut s, "1", "package_17", "dock_b", T0 + 1);
+    fold_both(&mut s);
+
+    let coordinate = s.projection_coordinate().expect("coordinate");
+    let claims_generation = coordinate.world_current().generation();
+    let entity_generation = coordinate.entities().generation();
+
+    assert!(
+        claims_generation > entity_generation,
+        "the claims checkpoint passes every event considered ({claims_generation}), \
+         the entity checkpoint stops at the last adjudication ({entity_generation}) \
+         — an equality check between them would report false drift on a healthy store"
+    );
+
+    // Both folds really are complete: re-folding moves neither.
+    let before = coordinate.clone();
+    fold_both(&mut s);
+    assert_eq!(
+        s.projection_coordinate().expect("coordinate after refold"),
+        before,
+        "a fold with nothing new to consume must not move either checkpoint"
+    );
+
+    drop(s);
+    cleanup(&path);
+}
+
+/// **The coordinate carries a digest, not just a position.**
+///
+/// A generation alone cannot distinguish a fold that advanced from a rebuild
+/// that landed on the same head. The digest is what the fold itself commits
+/// beside the generation, so it is what an observer records.
+#[test]
+fn the_coordinate_reports_a_digest_for_a_folded_projection() {
+    let path = tmp("digest");
+
+    let mut s = WorldStore::open(&path).expect("open");
+    let empty = s.projection_coordinate().expect("coordinate");
+    assert!(
+        empty.world_current().is_unfolded(),
+        "an unfolded projection reports generation 0"
+    );
+    assert_eq!(
+        empty.world_current().state_digest(),
+        "",
+        "an unfolded projection has no state to digest"
+    );
+
+    claim(&mut s, "1", "package_17", "dock_b", T0);
+    fold_both(&mut s);
+
+    let folded = s.projection_coordinate().expect("coordinate");
+    assert!(!folded.world_current().is_unfolded());
+    assert!(
+        !folded.world_current().state_digest().is_empty(),
+        "a folded projection commits a digest beside its generation"
+    );
+    assert_eq!(
+        folded.world_current().state_digest(),
+        s.projection_state_digest().expect("state digest"),
+        "the recorded digest is the projection's actual state, not a stale copy"
+    );
+
+    // Every projection is reported, including ones this store never folded --
+    // so a reader can tell "not read" from "not there".
+    assert_eq!(folded.all().len(), 3);
+    assert!(folded.subject_summary().is_unfolded());
+
+    drop(s);
+    cleanup(&path);
+}

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -1997,7 +1997,8 @@ pressure that produced every stale claim this box already documents.
       `AnswerRef`'s absence.
 - [ ] **3b — Rule / projection versioning.** Declared, behaviour-changing, and
       enforced by corpus + source pin (above). Not decorative metadata.
-- [ ] **3c — Snapshot consistency.** An answer composing several projections
+- [x] **3c — Snapshot consistency.** ✅ **DONE 2026-08-10** — see *"3c closed
+      against its consumer"* below. An answer composing several projections
       (identity, claims, relationships, summaries) must read them at ONE coherent
       point, or report each coordinate explicitly. Projections carry independent
       checkpoints and can sit at different heads, so an envelope naming a single
@@ -2232,10 +2233,10 @@ sequence, each step forced by the consumer rather than by the checklist:
    is categorical, not a magnitude, so the symbolic-seam gate is unaffected).
    **Do not** resolve object identity inside `WorldAnswer`. See *"3a closed
    against its consumer"* below.
-2. **3c** — the composed read now exists: `WorldAnswer.object` → identity
-   resolution → one snapshot coordinate. Prove subject/object resolution cannot
-   mix projection generations: same snapshot, or explicitly degraded/refused.
-   No approximate "close enough".
+2. **3c** — ✅ **DONE 2026-08-10.** The composed read now exists:
+   `WorldAnswer.object` → identity resolution → one snapshot coordinate. Closed
+   on the STRONG arm (one snapshot) rather than the degraded one, and the
+   subject is deliberately excluded — see below for both reasons.
 3. **3d** — the ratchet, so 3a cannot be undone six PRs later. Direct projection
    reads by domain consumers fail mechanically, with **the exact pre-fix
    `mission_context` pattern as the negative fixture** rather than a synthetic
@@ -2536,3 +2537,98 @@ not by duration.
 
 It is not a ruling. Tier 0 is where rulings live, and four of them are still
 open.
+
+
+### 3c closed against its consumer — 2026-08-10
+
+The audit predicted 3c would arrive with the first *correct* implementation of
+`mission_context`'s query, and it did: once `object` is first-class and names an
+entity, comparing it as a raw string is the wrong operation.
+
+**Closed on the strong arm.** The box allows *"one coherent point, OR report each
+coordinate explicitly"*. The second arm was available cheaply and is strictly
+weaker — it turns a concurrent fold into a refused answer where the first turns
+it into a correct one. Every projection is a table in ONE SQLite database and
+every fold commits atomically, so a single read transaction sees the same set of
+commits for all of them. `WorldStore::read_snapshot` is that transaction;
+coherence is by construction, not drift detection after the fact.
+
+| Change | Where |
+|---|---|
+| `ReadSnapshot` — one read transaction over every projection | `kirra-world-store::snapshot` |
+| `SnapshotCoordinate` / `ProjectionCoordinate` — generation + state digest | `kirra-world-store::snapshot` |
+| `ReadSnapshot::identity_is_current` — is identity behind the LOG? | `kirra-world-store::snapshot` |
+| `ObjectIdentity` + `WorldAnswer::object_identity` | `kirra-world-service::read_view` |
+| `ComposedLookup` — the answer and its coordinate, inseparable | `kirra-world-service::read_view` |
+| `WorldSilence::ObjectUnresolved(ObjectResolution)` | `kirra-proposal-context` |
+
+**Two traps found in the machinery, both load-bearing, neither guessed.**
+
+1. **The generations are not comparable across projections.** `world_current`
+   and `subject_summary` advance their checkpoint past every event *considered*;
+   the entity fold advances only to the last *adjudication* it folded. Append one
+   ordinary claim and the checkpoints separate, with both folds complete and
+   nothing wrong. The intuitive way to "prove" snapshot consistency — assert the
+   coordinates are equal — would therefore report constant false drift on a
+   healthy store, and the fix someone reaches for under deadline is to delete the
+   check. `the_two_projection_generations_differ_on_a_healthy_store` pins it as a
+   fact so that tightening gets a red test naming the reason.
+2. **`identity_view` mislabelled its own snapshot.** It read the rows and then
+   the generation in two unrelated statements, so a fold landing between them
+   stamped the view with a generation newer than the rows it held. It now takes
+   both from one snapshot.
+
+**The staleness check is against the LOG, not the projection — and the first
+draft had it wrong in both directions.** Gating on *"has the entity projection
+been folded"* refuses every object-bearing claim on a store that simply has no
+adjudications (most stores, and an availability failure bought for no safety),
+**and admits the genuinely dangerous case** — a projection folded once with
+merges recorded since is not unfolded, so it would have resolved against
+known-stale data and called it success. The Tier 2.5 closure differential caught
+the first half by going red; the second half was found while fixing it.
+`identity_is_current` asks whether identity has consumed every adjudication the
+log holds, which is the question that separates the two.
+
+**The SUBJECT is deliberately not resolved, and this is a limitation rather than
+an oversight.** `world_current` is keyed by the subject string *as written*, so
+rewriting a queried alias to its canonical id would look up a key nothing was
+ever stored under and return **fewer** claims than asking plainly. Reading the
+whole equivalence class and merging it is the operation that would be correct,
+and it is a query design of its own. Resolving the subject "for symmetry" would
+have been a regression wearing the box's name.
+
+**What this is NOT.** `SnapshotCoordinate` is not an `AnswerRef`. A snapshot is
+coherent for as long as it is held and cannot be re-entered once dropped;
+re-executing against a *recorded* coordinate still needs a generation-pinned read
+of `world_current`, which still does not exist and still has its own open box
+above. `KIRRA-WM-ANSWERREF-NAMING-001` reserves the name for the day that closes,
+and this deliberately does not take it.
+
+**The seam stayed symbolic, and it cost a mirror.** The world's `ObjectIdentity`
+carries `Resolved { hops: usize }`, and its refusal reasons carry
+`TraversalBudgetExceeded { limit: usize }`. Re-exporting it into
+`kirra-proposal-context` would have put primitive numerics on the seam and given
+it somewhere to put a number — the one thing `KIRRA-WM-SYMBOLIC-SEAM-001` exists
+to prevent. `ObjectResolution` mirrors it symbolically on the `FactGrade`
+precedent, with a lock-step test walking the real `RefusalReason` enum so the
+tags stay total and pairwise distinct.
+
+**Non-vacuity.** Four mutations were run and each is caught by exactly one test,
+leaving the others green:
+
+| Mutation | Caught by |
+|---|---|
+| fall back to the raw object when the graph is stale | `a_stale_identity_graph_refuses_…` |
+| ignore resolution, match the stored object | `a_merged_object_resolves_to_the_candidate_it_became` |
+| assume identity is always current | `a_stale_identity_graph_refuses_…` |
+| two refusal reasons share one tag | `every_refusal_reason_has_its_own_tag` |
+
+The stale-graph test is the sharp one: the literal match would **succeed** there,
+so a refusal that only fired when the literal match also failed would be
+indistinguishable from doing nothing.
+
+The store-level guarantee carries a permanent negative control rather than a
+one-off mutation — `the_unguarded_composition_observes_the_fold_it_should_not`
+runs the identical interleaving through the ordinary `&self` readers and asserts
+it DOES observe the concurrent fold. If that control ever goes
+green-by-agreement, the snapshot test has stopped being asked a real question.


### PR DESCRIPTION
The audit predicted 3c would arrive with the first *correct* implementation of `mission_context`'s query, and it did. Once `object` is first-class and names an entity (#1430), comparing it as a raw string is the wrong operation — it silently ignores every merge the world has recorded.

## Closed on the strong arm

The box allows *"one coherent point, **or** report each coordinate explicitly"*. The second arm was available cheaply and is strictly weaker: it turns a concurrent fold into a *refused* answer where the first turns it into a *correct* one.

Every projection is a table in ONE SQLite database and every fold commits atomically, so a single read transaction sees the same set of commits for all of them. `WorldStore::read_snapshot` is that transaction — coherence by construction, not drift detection after the fact.

| Change | Where |
|---|---|
| `ReadSnapshot` — one read transaction over every projection | `kirra-world-store::snapshot` |
| `SnapshotCoordinate` / `ProjectionCoordinate` | `kirra-world-store::snapshot` |
| `ReadSnapshot::identity_is_current` | `kirra-world-store::snapshot` |
| `ObjectIdentity` + `WorldAnswer::object_identity` | `kirra-world-service::read_view` |
| `ComposedLookup` — answer and coordinate, inseparable | `kirra-world-service::read_view` |
| `WorldSilence::ObjectUnresolved(ObjectResolution)` | `kirra-proposal-context` |

## Two traps in the machinery, neither guessed

**1. The generations are not comparable across projections.** `world_current` advances its checkpoint past every event *considered*; the entity fold advances only to the last *adjudication* it folded. Append one ordinary claim and the two separate, with both folds complete and nothing wrong.

So the intuitive way to "prove" snapshot consistency — assert the coordinates are equal — reports **constant false drift on a healthy store**, and the fix someone reaches for under deadline is to delete the check. `the_two_projection_generations_differ_on_a_healthy_store` pins it as a fact, so tightening gets a red test naming the reason.

**2. `identity_view` mislabelled its own snapshot.** It read the rows and then the generation in two unrelated statements, so a fold landing between them stamped the view with a generation *newer than the rows it held*. Both now come from one snapshot.

## The staleness check is against the LOG, and the first draft had it wrong in both directions

Gating on *"has the entity projection been folded"*:

- **refused** every object-bearing claim on a store with no adjudications — most stores, an availability failure bought for no safety;
- and **admitted the dangerous case** — a projection folded once with merges recorded since is not unfolded, so it would have resolved against known-stale data and called it success.

The Tier 2.5 closure differential caught the first half by going red. The second was found while fixing it. `identity_is_current` asks whether identity has consumed every adjudication the log holds, which is the question that separates them.

## Deliberately not done

**The subject is not resolved.** `world_current` is keyed by the subject string *as written*, so rewriting a queried alias to its canonical id would look up a key nothing was ever stored under and return **fewer** claims than asking plainly. Reading the whole equivalence class and merging it is the operation that would be correct, and it is a query design of its own. Resolving the subject "for symmetry" would have been a regression wearing the box's name.

**This is not an `AnswerRef`.** A snapshot is coherent while held and cannot be re-entered once dropped; re-executing against a *recorded* coordinate still needs a generation-pinned read of `world_current`, which still does not exist and still has its own open box. `KIRRA-WM-ANSWERREF-NAMING-001` reserves the name for the day that closes.

## The seam stayed symbolic, and it cost a mirror

The world's `ObjectIdentity` carries `Resolved { hops: usize }`, and its refusal reasons carry `TraversalBudgetExceeded { limit: usize }`. Re-exporting it into `kirra-proposal-context` would have put primitive numerics on the seam and given it somewhere to put a number — the one thing `KIRRA-WM-SYMBOLIC-SEAM-001` exists to prevent. `ObjectResolution` mirrors it symbolically on the `FactGrade` precedent, with a lock-step test walking the real `RefusalReason` enum so the tags stay total and pairwise distinct.

## Non-vacuity

Four mutations, each caught by exactly one test, leaving the others green:

| Mutation | Caught by |
|---|---|
| fall back to the raw object when the graph is stale | `a_stale_identity_graph_refuses_…` |
| ignore resolution, match the stored object | `a_merged_object_resolves_to_the_candidate_it_became` |
| assume identity is always current | `a_stale_identity_graph_refuses_…` |
| two refusal reasons share one tag | `every_refusal_reason_has_its_own_tag` |

The stale-graph case is the sharp one: the literal match would **succeed** there, so a refusal that only fired when the literal match also failed would be indistinguishable from doing nothing.

The store-level guarantee carries a **permanent negative control** rather than a one-off mutation — `the_unguarded_composition_observes_the_fold_it_should_not` runs the identical interleaving through the ordinary `&self` readers and asserts it *does* observe the concurrent fold. If that control ever goes green-by-agreement, the snapshot test has stopped being asked a real question.

## Verification

`cargo test --workspace` · `cargo clippy --workspace --all-targets -D warnings` · `cargo fmt --check` · Fence A/B bidirectional fence · symbolic-seam gate (18/18 self-tests) · world domain-logic gate · orphan-cores · re-export shims · mick actuation fence · quality guardrails · all 8 lockfiles `--locked`-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_