### PR TITLE
Tier 3 box 3d: gate the answer boundary, so 3a cannot be undone by autocomplete

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1624,6 +1624,35 @@ jobs:
         run: |
           python3 ci/test_proposal_context_symbolic.py
           python3 ci/check_proposal_context_symbolic.py
+      - name: Answer-boundary gate (Tier 3 box 3d)
+        # THE RULE: a crate that asks the world DOMAIN questions goes through
+        # kirra_world_service::WorldView, not the projection-read API on
+        # WorldStore.
+        #
+        # The bypass is not hypothetical and the fixture is not synthetic — it
+        # is the code that shipped. `mission_context` read ProjectedClaim's
+        # public fields straight off `store.current(..)` (no validity, no trust
+        # axes, no provenance, no identity resolution) until boxes 3a (#1430)
+        # and 3c (#1431) repaired it. Repairing a bypass without gating it means
+        # repairing it again: `store.current(..)` is one autocomplete away, it
+        # compiles, and it returns plausible data.
+        #
+        # Scope is self-maintaining — every crate DEPENDING on kirra-world-store
+        # is checked, so a NEW consumer is covered from its first commit without
+        # anyone remembering to add it. Undoing 3a by writing a fresh consumer is
+        # the same regression as undoing it in place.
+        #
+        # Operational reads (verify_chain, schema_version, backup/export,
+        # retention, compaction, the WM-2 harness) are carved out BY
+        # CONSTRUCTION: they are not in the domain-read method list, so they are
+        # never matched and there is no exception list to rot.
+        #
+        # Self-test first, and it carries the anti-neutering case: if the
+        # repaired consumer is ever moved onto the permitted list, the gate is
+        # watching nothing and says so.
+        run: |
+          python3 ci/check_world_answer_boundary.py --self-test
+          python3 ci/check_world_answer_boundary.py
       - name: Kirra World domain-logic gate (ADR-0042 Decision 5)
         # THE RULE: no Kirra World domain implementation may merge until
         # ADR-0042's safety-assurance scope ruling is assigned to a named owner

--- a/ci/check_world_answer_boundary.py
+++ b/ci/check_world_answer_boundary.py
@@ -68,6 +68,7 @@ from __future__ import annotations
 import json
 import re
 import sys
+import tomllib
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -93,7 +94,21 @@ DOMAIN_READ_METHODS = (
     "load_entity_projection",
 )
 
-_CALL_RE = re.compile(r"\.\s*(" + "|".join(DOMAIN_READ_METHODS) + r")\s*\(")
+# Both call syntaxes. `.current(..)` is how anyone would write it; but
+# `WorldStore::current(store, ..)` is the same call in UFCS form, and a regex
+# that only knew the first would advertise zero tolerance while leaving a
+# syntactic door open — the exact overclaim this gate exists to prevent
+# elsewhere. `::` also catches the aliased (`WS::current`) and fully-qualified
+# (`<WorldStore as T>::current`) spellings.
+_CALL_RE = re.compile(r"(?:\.|::)\s*(" + "|".join(DOMAIN_READ_METHODS) + r")\s*\(")
+
+# Dependency tables whose presence means the crate's `src/` can reach the store.
+# `dev-dependencies` is deliberately NOT here: a dev-dependency is unavailable to
+# `src/`, which is the only tree this gate scans, so a crate that dev-depends on
+# the store cannot commit the violation. Including it would put crates in the
+# scope report that were never at risk — `kirra-mission-orchestrator` is exactly
+# that case, and its own module docs say so.
+_DEP_TABLES = ("dependencies", "build-dependencies")
 
 
 def _strip_comments_and_strings(text: str) -> str:
@@ -123,13 +138,25 @@ def crate_name(manifest: Path) -> str:
 
 
 def depends_on_world_store(manifest: Path) -> bool:
-    """True iff this manifest names `kirra-world-store` as a dependency.
+    """True iff this manifest names `kirra-world-store` in a dependency table
+    reachable from `src/`.
 
-    Read from the manifest rather than resolved through cargo metadata: this
-    gate must run standalone in CI without a build, and a direct dependency is
-    exactly the relationship that makes the calls reachable.
+    Parsed, not substring-matched. A raw `"kirra-world-store" in text` search
+    also matches the crate name in a COMMENT, and two manifests in this repo
+    discuss the dependency in prose precisely to explain why they must not have
+    it — `wm2-persistence-harness` was pulled into scope on the strength of a
+    comment saying it stays out. A gate whose scope is decided by prose it does
+    not understand reports a dependency graph that does not exist.
+
+    Read from the manifest rather than via `cargo metadata` so the gate runs
+    standalone in CI without a build.
     """
-    return "kirra-world-store" in manifest.read_text(encoding="utf-8")
+    data = tomllib.loads(manifest.read_text(encoding="utf-8"))
+    tables = [data.get(t, {}) for t in _DEP_TABLES]
+    # `[target.'cfg(..)'.dependencies]` reaches `src/` just as plainly.
+    for target in data.get("target", {}).values():
+        tables.extend(target.get(t, {}) for t in _DEP_TABLES)
+    return any("kirra-world-store" in table for table in tables)
 
 
 def load_baseline() -> dict:
@@ -155,6 +182,20 @@ def in_scope_crates() -> list[tuple[str, Path]]:
         if depends_on_world_store(manifest):
             out.append((crate_name(manifest), manifest.parent))
     return out
+
+
+def stale_exemptions() -> list[str]:
+    """Permitted readers that are not actually in scope.
+
+    An exemption list only stays honest if entries disappear when they stop
+    being needed. This gate shipped with one such entry already —
+    `wm2-persistence-harness`, admitted on a substring match against a comment —
+    carrying a written justification for an exemption it never required. That is
+    how a carve-out list rots: every entry looks reasoned, and nothing checks
+    whether it is still load-bearing.
+    """
+    in_scope = {name for name, _ in in_scope_crates()}
+    return sorted(set(load_baseline()["permitted_readers"]) - in_scope)
 
 
 def collect() -> tuple[list[dict], list[str], list[str]]:
@@ -314,6 +355,73 @@ def t06_operational_reads_are_not_flagged() -> None:
     )
 
 
+def t07a_ufcs_is_caught_as_well_as_method_syntax() -> None:
+    method = scan_source("fn f() { store.current(s, n); }", "m")
+    ufcs = scan_source("fn f() { WorldStore::current(store, s, n); }", "u")
+    aliased = scan_source("fn f() { WS::current(store, s, n); }", "a")
+    qualified = scan_source("fn f() { <WorldStore as T>::current(store, s); }", "q")
+    missing = [
+        n
+        for n, got in [
+            ("method", method),
+            ("ufcs", ufcs),
+            ("aliased", aliased),
+            ("fully-qualified", qualified),
+        ]
+        if not got
+    ]
+    record(
+        not missing,
+        "t07a_ufcs_is_caught_as_well_as_method_syntax",
+        f"same call, undetected spelling(s): {missing}" if missing else "",
+    )
+
+
+def t07b_a_comment_mentioning_the_crate_is_not_a_dependency() -> None:
+    import tempfile
+
+    manifest = (
+        '# The harness must not depend on `kirra-world-store`. Its manifest\n'
+        '# says so, and this comment is the reason why.\n'
+        '[package]\nname = "prose-only"\nversion = "0.1.0"\n'
+        '[dependencies]\nserde = "1"\n'
+    )
+    with tempfile.TemporaryDirectory() as d:
+        path = Path(d) / "Cargo.toml"
+        path.write_text(manifest, encoding="utf-8")
+        record(
+            not depends_on_world_store(path),
+            "t07b_a_comment_mentioning_the_crate_is_not_a_dependency",
+            "a crate is in scope because a comment names the dependency it avoids",
+        )
+
+
+def t07c_a_real_dependency_is_still_detected() -> None:
+    import tempfile
+
+    manifest = (
+        '[package]\nname = "real"\nversion = "0.1.0"\n'
+        '[dependencies]\nkirra-world-store = { path = "../x" }\n'
+    )
+    with tempfile.TemporaryDirectory() as d:
+        path = Path(d) / "Cargo.toml"
+        path.write_text(manifest, encoding="utf-8")
+        record(
+            depends_on_world_store(path),
+            "t07c_a_real_dependency_is_still_detected",
+            "the parse tightened past the point of detecting anything",
+        )
+
+
+def t07d_no_permitted_reader_is_stale() -> None:
+    stale = stale_exemptions()
+    record(
+        not stale,
+        "t07d_no_permitted_reader_is_stale",
+        f"exemptions carried for crates not in scope: {stale}" if stale else "",
+    )
+
+
 def t07_the_live_tree_is_clean() -> None:
     violations, checked, _ = collect()
     record(
@@ -388,10 +496,22 @@ def main() -> int:
         print()
         if violations:
             for v in violations:
-                print(f"  {v['file']}:{v['line']}  .{v['method']}(  {v['source']}")
+                print(f"  {v['file']}:{v['line']}  {v['method']}(..)  {v['source']}")
         else:
             print("  no direct domain reads")
         return 0
+
+    stale = stale_exemptions()
+    if stale:
+        print("Answer-boundary gate FAILED — stale exemption(s) in the baseline.")
+        print()
+        for name in stale:
+            print(f"  {name} is on `permitted_readers` but is not in scope.")
+        print()
+        print("  An exemption for a crate the gate never scans is a written")
+        print("  justification for a decision nobody is making. Remove it, or")
+        print("  record it under `not_listed_because_never_in_scope`.")
+        return 1
 
     ceiling = baseline["max_violations"]
     if len(violations) > ceiling:
@@ -400,7 +520,7 @@ def main() -> int:
         for v in violations:
             print(f"  {v['file']}:{v['line']}")
             print(f"      {v['source']}")
-            print(f"      `.{v['method']}(` reads a projection directly.")
+            print(f"      `{v['method']}(..)` reads a projection directly.")
         print()
         print("  A domain consumer must ask through the answer boundary:")
         print("      let view = WorldView::new(store, staleness_budget_ms);")

--- a/ci/check_world_answer_boundary.py
+++ b/ci/check_world_answer_boundary.py
@@ -1,0 +1,430 @@
+#!/usr/bin/env python3
+"""Tier 3 box 3d — domain consumers read the world through the ANSWER BOUNDARY.
+
+THE RULE
+--------
+    A crate that asks the world DOMAIN questions must go through
+    `kirra_world_service::WorldView`. It may not call the projection-read API on
+    `WorldStore` directly.
+
+WHY A GATE AND NOT A PARAGRAPH
+------------------------------
+This bypass is not hypothetical and the fixture is not synthetic: it is the code
+that shipped. `mission_context` read `ProjectedClaim`'s public fields straight
+off `store.current(..)` — no validity, no trust axes, no provenance handle, and
+no identity resolution — until boxes 3a (#1430) and 3c (#1431) repaired it. The
+audit that found it recorded WHY it was easy to miss: the boundary had no
+consumer, so nothing noticed what it could not express.
+
+Repairing a bypass without gating it means repairing it again. Six PRs from now
+`store.current(..)` is one autocomplete away, it compiles, it returns plausible
+data, and every negative control still passes — the audit measured exactly that
+about the mechanical translation it predicted. The gate converts a silent
+regression into a red build naming the rule.
+
+    An invariant with no gate is prose. -- WM_SCOPE.md, Tier 3
+
+SCOPE: WHO IS CHECKED
+---------------------
+Only crates that DEPEND on `kirra-world-store`. A crate without that dependency
+cannot make these calls, so scanning it could only manufacture false positives
+from unrelated methods that happen to be called `history` or `candidates`.
+
+That scope is self-maintaining, which is the point: a NEW crate that takes the
+dependency is checked from its first commit, without anyone remembering to add
+it here. Undoing 3a by writing a fresh consumer is the same regression as
+undoing it in place.
+
+Permitted readers are named in the baseline with a reason each, so adding one is
+a visible, argued diff rather than an edit to a regex.
+
+SCOPE: WHAT IS CHECKED
+----------------------
+`src/` only — the production read path. A test that reads rows directly is
+testing the store, and several deliberately do: `answer_boundary.rs` plants
+`world_current` rows with raw SQL to reach a state the sanctioned write path
+cannot produce. Forbidding that would block the tests that prove the boundary
+fails closed. The bypass this gate exists to stop lived in `src/`, and `src/`
+cannot call test code, so gating `src/` closes the production path completely.
+
+OPERATIONAL READS ARE CARVED OUT BY CONSTRUCTION
+------------------------------------------------
+WM_SCOPE.md names `verify_chain`, `schema_version`, backup/export, the retention
+driver, the compaction planner and the WM-2 harness as legitimate readers below
+the engine, and says a rule forbidding them "would be false on the day it was
+written". None of them appears in `DOMAIN_READ_METHODS` below: the list is the
+domain-question entry points, not every method that touches a table. The carve-
+out therefore needs no exception list to maintain, because those calls are never
+matched in the first place.
+
+Usage:
+  python3 ci/check_world_answer_boundary.py             # gate (CI)
+  python3 ci/check_world_answer_boundary.py --list      # show scope + findings
+  python3 ci/check_world_answer_boundary.py --self-test # prove non-vacuity
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BASELINE_PATH = REPO_ROOT / "ci" / "world_answer_boundary_baseline.json"
+
+# The DOMAIN-question entry points on the store. Reaching any of these is how a
+# caller obtains a `ProjectedClaim` or an `IdentityView` without the boundary's
+# validity / trust / provenance / identity wrapping.
+#
+# Deliberately NOT here: `verify_chain`, `schema_version`, `fold`, `append`,
+# backup/export, retention and compaction. Those are operational or write-path
+# calls that WM_SCOPE explicitly permits below the engine.
+DOMAIN_READ_METHODS = (
+    "current",
+    "current_all",
+    "as_of",
+    "history",
+    "candidates",
+    "read_snapshot",
+    "identity_view",
+    "identity_view_at",
+    "resolve_at",
+    "load_entity_projection",
+)
+
+_CALL_RE = re.compile(r"\.\s*(" + "|".join(DOMAIN_READ_METHODS) + r")\s*\(")
+
+
+def _strip_comments_and_strings(text: str) -> str:
+    """Blank out block comments, line comments and string literals.
+
+    Without this a doc comment showing the anti-pattern — `read_view.rs` quotes
+    `store.current("robot-01", now)?[0].payload` precisely to explain why the
+    boundary exists — would be reported as the violation it is warning about.
+    """
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
+    out: list[str] = []
+    for raw in text.splitlines():
+        # A line comment, doc comment or inner doc comment.
+        line = re.sub(r"(?<!:)//.*$", "", raw)
+        # String literals (non-greedy, escaped quotes tolerated).
+        line = re.sub(r'"(?:[^"\\]|\\.)*"', '""', line)
+        out.append(line)
+    return "\n".join(out)
+
+
+def crate_name(manifest: Path) -> str:
+    for line in manifest.read_text(encoding="utf-8").splitlines():
+        m = re.match(r'\s*name\s*=\s*"([^"]+)"', line)
+        if m:
+            return m.group(1)
+    return manifest.parent.name
+
+
+def depends_on_world_store(manifest: Path) -> bool:
+    """True iff this manifest names `kirra-world-store` as a dependency.
+
+    Read from the manifest rather than resolved through cargo metadata: this
+    gate must run standalone in CI without a build, and a direct dependency is
+    exactly the relationship that makes the calls reachable.
+    """
+    return "kirra-world-store" in manifest.read_text(encoding="utf-8")
+
+
+def load_baseline() -> dict:
+    return json.loads(BASELINE_PATH.read_text(encoding="utf-8"))
+
+
+def scan_source(text: str, label: str) -> list[tuple[int, str, str]]:
+    """Return (line_no, method, source_line) for each domain read in `text`."""
+    cleaned = _strip_comments_and_strings(text)
+    found: list[tuple[int, str, str]] = []
+    for n, line in enumerate(cleaned.splitlines(), start=1):
+        for m in _CALL_RE.finditer(line):
+            found.append((n, m.group(1), line.strip()))
+    return found
+
+
+def in_scope_crates() -> list[tuple[str, Path]]:
+    """Every crate that depends on `kirra-world-store`, as (name, crate_dir)."""
+    out: list[tuple[str, Path]] = []
+    for manifest in sorted(REPO_ROOT.glob("crates/*/Cargo.toml")) + sorted(
+        REPO_ROOT.glob("tools/*/Cargo.toml")
+    ):
+        if depends_on_world_store(manifest):
+            out.append((crate_name(manifest), manifest.parent))
+    return out
+
+
+def collect() -> tuple[list[dict], list[str], list[str]]:
+    """Returns (violations, checked_crates, permitted_crates_seen)."""
+    baseline = load_baseline()
+    permitted = set(baseline["permitted_readers"])
+
+    violations: list[dict] = []
+    checked: list[str] = []
+    seen_permitted: list[str] = []
+
+    for name, crate_dir in in_scope_crates():
+        if name in permitted:
+            seen_permitted.append(name)
+            continue
+        checked.append(name)
+        src = crate_dir / "src"
+        if not src.is_dir():
+            continue
+        for path in sorted(src.rglob("*.rs")):
+            rel = path.relative_to(REPO_ROOT).as_posix()
+            for line_no, method, line in scan_source(
+                path.read_text(encoding="utf-8"), rel
+            ):
+                violations.append(
+                    {"file": rel, "line": line_no, "method": method, "source": line}
+                )
+    return violations, checked, seen_permitted
+
+
+# ---------------------------------------------------------------------------
+# Self-test: the fixture is the code that actually shipped
+# ---------------------------------------------------------------------------
+
+# `mission_context` as it stood at 0ad203ee, before box 3a. Reproduced verbatim
+# rather than approximated: a gate whose negative fixture is a synthetic
+# `store.current()` proves it can find a string, not that it would have found
+# THIS bug. The same discipline as the symbolic-seam gate's control 3.
+PRE_FIX_MISSION_CONTEXT = '''
+pub fn mission_context(
+    store: &WorldStore,
+    subject: &ContextId,
+    relation: &ContextId,
+    candidates: &[ContextId],
+    now_ms: i64,
+) -> Result<ProposalContext, ContextError> {
+    let claims = store.current(subject.as_str(), now_ms)?;
+
+    let preferred = claims.iter().find_map(|c| {
+        let predicate = c.predicate.as_deref()?;
+        if predicate != relation.as_str() {
+            return None;
+        }
+        let object = c.object.as_deref()?;
+        candidates.iter().find(|cand| cand.as_str() == object)
+    });
+    ...
+}
+'''
+
+# The same function today: the store is still NAMED and still passed along, but
+# every read goes through the boundary. A gate that flagged this would be
+# unusable, because taking a `&WorldStore` is how you reach `WorldView::new`.
+POST_FIX_MISSION_CONTEXT = '''
+pub fn mission_context(
+    store: &WorldStore,
+    subject: &ContextId,
+    relation: &ContextId,
+    candidates: &[ContextId],
+    now_ms: i64,
+    staleness_budget_ms: Option<u64>,
+) -> Result<ProposalContext, ContextError> {
+    let view = WorldView::new(store, staleness_budget_ms);
+
+    let answers = match view.ask(subject.as_str(), now_ms)?.into_lookup() {
+        WorldLookup::Answered(answers) => answers,
+        WorldLookup::Unknown(reason) => {
+            return Ok(ProposalContext::silent(candidates, silence));
+        }
+    };
+    ...
+}
+'''
+
+RESULTS: list[tuple[bool, str, str]] = []
+
+
+def record(ok: bool, name: str, detail: str = "") -> None:
+    RESULTS.append((ok, name, detail))
+
+
+def t01_the_real_pre_fix_bypass_is_caught() -> None:
+    found = scan_source(PRE_FIX_MISSION_CONTEXT, "pre_fix")
+    record(
+        bool(found) and any(m == "current" for _, m, _ in found),
+        "t01_the_real_pre_fix_bypass_is_caught",
+        "" if found else "the shipped bypass would pass this gate",
+    )
+
+
+def t02_the_repaired_function_is_clean() -> None:
+    found = scan_source(POST_FIX_MISSION_CONTEXT, "post_fix")
+    record(
+        not found,
+        "t02_the_repaired_function_is_clean",
+        "" if not found else f"false positive on the boundary-routed form: {found}",
+    )
+
+
+def t03_a_doc_comment_showing_the_antipattern_is_not_a_violation() -> None:
+    src = '//! let payload = &store.current("robot-01", now)?[0].payload;\nfn f() {}'
+    record(
+        not scan_source(src, "doc"),
+        "t03_a_doc_comment_showing_the_antipattern_is_not_a_violation",
+        "the boundary's own docs quote the anti-pattern to explain it",
+    )
+
+
+def t04_a_string_literal_is_not_a_violation() -> None:
+    src = 'fn f() { let sql = "SELECT .current( FROM x"; }'
+    record(
+        not scan_source(src, "str"),
+        "t04_a_string_literal_is_not_a_violation",
+    )
+
+
+def t05_every_domain_read_method_is_detected() -> None:
+    missed = [
+        m for m in DOMAIN_READ_METHODS if not scan_source(f"fn f() {{ s.{m}(a); }}", m)
+    ]
+    record(
+        not missed,
+        "t05_every_domain_read_method_is_detected",
+        f"declared but undetectable: {missed}" if missed else "",
+    )
+
+
+def t06_operational_reads_are_not_flagged() -> None:
+    # The carve-out WM_SCOPE names explicitly. These must never match, and they
+    # are not exceptions -- they are simply not domain reads.
+    operational = [
+        "verify_chain",
+        "schema_version",
+        "fold",
+        "fold_entity_projection",
+        "append",
+        "compact_range",
+        "projected_row_count",
+    ]
+    flagged = [m for m in operational if scan_source(f"fn f() {{ s.{m}(a); }}", m)]
+    record(
+        not flagged,
+        "t06_operational_reads_are_not_flagged",
+        f"a rule forbidding these would be false the day it was written: {flagged}"
+        if flagged
+        else "",
+    )
+
+
+def t07_the_live_tree_is_clean() -> None:
+    violations, checked, _ = collect()
+    record(
+        not violations and bool(checked),
+        "t07_the_live_tree_is_clean",
+        f"violations: {violations}"
+        if violations
+        else ("no crate is in scope — the gate is watching nothing" if not checked else ""),
+    )
+
+
+def t08_the_gate_watches_the_repaired_consumer() -> None:
+    # The point of the whole exercise: `kirra-proposal-context` must be IN the
+    # checked set. If it ever drifts into `permitted_readers`, this gate has
+    # been neutered and the box it locks is open again.
+    _, checked, _ = collect()
+    record(
+        "kirra-proposal-context" in checked,
+        "t08_the_gate_watches_the_repaired_consumer",
+        f"the repaired consumer is not being checked; checked = {checked}",
+    )
+
+
+ALL = [v for k, v in sorted(globals().items()) if k.startswith("t") and k[1:3].isdigit()]
+
+# A case that is not COLLECTED is the most literal form of a test that cannot
+# fail -- the same guard the symbolic-seam self-test carries, for the same
+# reason it needed one.
+_UNCOLLECTED = [
+    k
+    for k, v in globals().items()
+    if k.startswith("t")
+    and callable(v)
+    and getattr(v, "__module__", None) == __name__
+    and v not in ALL
+]
+
+
+def self_test() -> int:
+    if _UNCOLLECTED:
+        print(f"FAIL: these cases are never run: {sorted(_UNCOLLECTED)}")
+        return 1
+    for fn in ALL:
+        try:
+            fn()
+        except Exception as exc:  # a crashing test is a failing test
+            record(False, fn.__name__, f"raised {type(exc).__name__}: {exc}")
+
+    failed = [r for r in RESULTS if not r[0]]
+    for ok, name, detail in RESULTS:
+        print(f"  {'PASS' if ok else 'FAIL'}  {name}")
+        if not ok and detail:
+            print(f"        {detail}")
+    print()
+    print(f"{len(RESULTS) - len(failed)}/{len(RESULTS)} passed")
+    return 1 if failed else 0
+
+
+def main() -> int:
+    if "--self-test" in sys.argv:
+        return self_test()
+
+    baseline = load_baseline()
+    violations, checked, permitted_seen = collect()
+
+    if "--list" in sys.argv:
+        print("Answer-boundary gate scope (crates depending on kirra-world-store):")
+        for name in permitted_seen:
+            print(f"  [PERMITTED] {name} — {baseline['permitted_readers'][name]}")
+        for name in checked:
+            print(f"  [CHECKED]   {name}")
+        print()
+        if violations:
+            for v in violations:
+                print(f"  {v['file']}:{v['line']}  .{v['method']}(  {v['source']}")
+        else:
+            print("  no direct domain reads")
+        return 0
+
+    ceiling = baseline["max_violations"]
+    if len(violations) > ceiling:
+        print("Answer-boundary gate FAILED — direct domain read below the engine.")
+        print()
+        for v in violations:
+            print(f"  {v['file']}:{v['line']}")
+            print(f"      {v['source']}")
+            print(f"      `.{v['method']}(` reads a projection directly.")
+        print()
+        print("  A domain consumer must ask through the answer boundary:")
+        print("      let view = WorldView::new(store, staleness_budget_ms);")
+        print("      let answers = view.ask(subject, now_ms)?;")
+        print()
+        print("  This is the bypass boxes 3a and 3c repaired. Reading the row")
+        print("  directly loses validity, trust axes, provenance and identity")
+        print("  resolution — and compiles, and returns plausible data.")
+        print()
+        print(f"  ({len(violations)} found, ceiling {ceiling}.)")
+        return 1
+
+    if not checked:
+        print("Answer-boundary gate FAILED — no crate is in scope.")
+        print("  Every world-store dependant is on the permitted list, so this")
+        print("  gate is watching nothing. That is how a ratchet dies quietly.")
+        return 1
+
+    print(
+        f"Answer-boundary gate green: {len(checked)} domain crate(s) checked "
+        f"({', '.join(checked)}), 0 direct projection reads."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/world_answer_boundary_baseline.json
+++ b/ci/world_answer_boundary_baseline.json
@@ -4,11 +4,14 @@
   "max_violations": 0,
   "why_zero": "This is not an aspiration being ratcheted down. The one real violation -- mission_context reading ProjectedClaim's public fields off store.current(..) -- was repaired by boxes 3a (#1430) and 3c (#1431), so the tree is already clean. The ceiling starts at 0 and has nowhere to go.",
   "permitted_readers": {
-    "kirra-world-store": "Owns the projection tables. Gating the crate that defines them would be circular.",
     "kirra-world-service": "IS the answer boundary. Its whole job is to read a projection and wrap it in validity, trust axes, provenance and identity resolution -- this is the one crate that must call these methods.",
-    "wm2-persistence-harness": "ADR-0041 measurement instrument. WM_SCOPE names the WM-2 harness as a legitimate reader below the engine: it measures storage behaviour, which is not a domain question.",
-    "wm2-schema-growth": "ADR-0041 D-20 measurement instrument, same carve-out as the persistence harness."
+    "wm2-schema-growth": "ADR-0041 D-20 measurement instrument. WM_SCOPE names the WM-2 harness as a legitimate reader below the engine: it measures storage behaviour, which is not a domain question."
   },
-  "on_adding_a_permitted_reader": "Do not. A new domain consumer going through the boundary needs no entry here, and one that cannot is the regression this gate exists to catch. If an entry is genuinely required, it belongs in review with the reason written above -- which is why this is a JSON file with a prose field rather than a regex in the gate.",
+  "not_listed_because_never_in_scope": {
+    "kirra-world-store": "Owns the projection tables and cannot depend on itself, so it is never scanned. An entry here would have described a decision nobody is making -- it was removed after the gate's own stale-exemption check flagged it.",
+    "wm2-persistence-harness": "Does NOT depend on kirra-world-store; its manifest only discusses the dependency in a comment explaining why it stays out. An earlier substring-matching draft of the gate pulled it into scope on that comment and carried a written justification for an exemption it never needed. Caught in review on #1432.",
+    "kirra-mission-orchestrator": "Depends on kirra-world-store as a DEV-dependency only, which is unreachable from src/ -- the only tree this gate scans. Its own module docs say it does not depend on kirra-world* at all."
+  },
+  "on_adding_a_permitted_reader": "Do not. A new domain consumer going through the boundary needs no entry here, and one that cannot is the regression this gate exists to catch. If an entry is genuinely required, it belongs in review with the reason written above -- which is why this is a JSON file with a prose field rather than a regex in the gate. Note the gate FAILS on an entry that is not in scope, so a carve-out cannot outlive its reason.",
   "violations": []
 }

--- a/ci/world_answer_boundary_baseline.json
+++ b/ci/world_answer_boundary_baseline.json
@@ -1,0 +1,14 @@
+{
+  "rule": "A crate that asks the world DOMAIN questions must go through kirra_world_service::WorldView, not the projection-read API on WorldStore. Tier 3 box 3d; see docs/design/WM_SCOPE.md.",
+  "gate": "ci/check_world_answer_boundary.py",
+  "max_violations": 0,
+  "why_zero": "This is not an aspiration being ratcheted down. The one real violation -- mission_context reading ProjectedClaim's public fields off store.current(..) -- was repaired by boxes 3a (#1430) and 3c (#1431), so the tree is already clean. The ceiling starts at 0 and has nowhere to go.",
+  "permitted_readers": {
+    "kirra-world-store": "Owns the projection tables. Gating the crate that defines them would be circular.",
+    "kirra-world-service": "IS the answer boundary. Its whole job is to read a projection and wrap it in validity, trust axes, provenance and identity resolution -- this is the one crate that must call these methods.",
+    "wm2-persistence-harness": "ADR-0041 measurement instrument. WM_SCOPE names the WM-2 harness as a legitimate reader below the engine: it measures storage behaviour, which is not a domain question.",
+    "wm2-schema-growth": "ADR-0041 D-20 measurement instrument, same carve-out as the persistence harness."
+  },
+  "on_adding_a_permitted_reader": "Do not. A new domain consumer going through the boundary needs no entry here, and one that cannot is the regression this gate exists to catch. If an entry is genuinely required, it belongs in review with the reason written above -- which is why this is a JSON file with a prose field rather than a regex in the gate.",
+  "violations": []
+}

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -2662,14 +2662,38 @@ NAMES `&WorldStore` and passes it to `WorldView::new`, and a gate that flagged
 that would be unusable.
 
 **Scope is self-maintaining, which is the part that matters in six months.**
-Every crate *depending on* `kirra-world-store` is checked; permitted readers are
-named in the baseline with a reason each. So a NEW domain consumer is covered
-from its first commit, without anyone remembering to add it — undoing 3a by
-writing a fresh consumer is the same regression as undoing it in place, and a
-hand-maintained list of watched crates would have missed it. Crates without the
-dependency are not scanned at all, since they cannot make the call and scanning
-them could only manufacture false positives from unrelated `history()` /
-`candidates()` methods.
+Every crate whose `src/` can reach `kirra-world-store` — a normal or build
+dependency, parsed from the manifest — is checked; permitted readers are named in
+the baseline with a reason each. So a NEW domain consumer is covered from its
+first commit, without anyone remembering to add it: undoing 3a by writing a fresh
+consumer is the same regression as undoing it in place, and a hand-maintained
+list of watched crates would have missed it. Crates that cannot make the call are
+not scanned, since doing so could only manufacture false positives from unrelated
+`history()` / `candidates()` methods.
+
+**Three scope corrections came out of review, and they were all the same
+mistake** — deciding scope from text the gate did not understand. The first draft
+substring-matched the manifest, so `wm2-persistence-harness` was pulled in on a
+COMMENT saying it deliberately does not take the dependency, and then carried a
+written justification for an exemption it never needed. `kirra-world-store` was
+listed too, though it cannot depend on itself and is therefore never scanned. And
+`kirra-mission-orchestrator` reaches the store only as a DEV-dependency, which
+`src/` cannot use — its own module docs say it does not depend on `kirra-world*`
+at all. The manifest is now parsed, and the baseline records all three under
+`not_listed_because_never_in_scope` rather than pretending they were decisions.
+
+**The gate now fails on a stale exemption**, which is the general form of that
+mistake. An exemption for a crate the gate never scans is a written
+justification for a decision nobody is making, and that is how a carve-out list
+rots: every entry looks reasoned, and nothing checks whether it is still
+load-bearing. Both stale entries above were found by this check on its first run,
+against the baseline I had just written.
+
+**Both call syntaxes are detected.** `.current(..)` is how anyone would write it,
+but `WorldStore::current(store, ..)` is the same call in UFCS form — also caught,
+along with the aliased and fully-qualified spellings. A gate advertising zero
+tolerance while leaving a syntactic door open is the exact overclaim it exists to
+prevent elsewhere.
 
 **The operational carve-out needs no exception list.** WM_SCOPE names
 `verify_chain`, `schema_version`, backup/export, the retention driver, the
@@ -2689,9 +2713,10 @@ code, so gating `src/` closes the production path completely.
 **Non-vacuity, end to end rather than in a string.** Reintroducing
 `store.current(subject.as_str(), now_ms)?` into the live
 `kirra-proposal-context/src/lib.rs` reds the gate with the file, line and rule;
-removing it greens. And the anti-neutering case is pinned: moving
-`kirra-proposal-context` onto the permitted list fails
-`t08_the_gate_watches_the_repaired_consumer`, and a baseline where *every*
-dependant is permitted fails with *"no crate is in scope — that is how a ratchet
-dies quietly"*. Eight self-test cases, with the same uncollected-case guard the
+removing it greens — in both the method-call and the UFCS spelling. And the
+anti-neutering cases are pinned: moving `kirra-proposal-context` onto the
+permitted list fails `t08_the_gate_watches_the_repaired_consumer`; a baseline
+where *every* dependant is permitted fails with *"no crate is in scope — that is
+how a ratchet dies quietly"*; and re-adding a stale exemption fails the gate
+itself. Twelve self-test cases, with the same uncollected-case guard the
 symbolic-seam suite carries.

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -2005,8 +2005,10 @@ pressure that produced every stale claim this box already documents.
       `as_known_at` over a multi-projection answer is otherwise approximately a
       lie. `IdentityView` already records the single-snapshot argument for one
       walk; this is that argument across projections.
-- [ ] **3d — Typed query engine.** The only supported path for **domain
-      questions**. Operational reads are explicitly carved out — `verify_chain`,
+- [~] **3d — Typed query engine.** The RATCHET half is ✅ **DONE 2026-08-10**
+      (`ci/check_world_answer_boundary.py`); the typed engine itself is still
+      open — see *"3d's ratchet closed ahead of its engine"* below. The only
+      supported path for **domain questions**. Operational reads are explicitly carved out — `verify_chain`,
       `schema_version`, backup/export, the retention driver, the compaction
       planner and the WM-2 measurement harness all legitimately read below it,
       and a rule that forbade them would be false on the day it was written.
@@ -2237,12 +2239,11 @@ sequence, each step forced by the consumer rather than by the checklist:
    `WorldAnswer.object` → identity resolution → one snapshot coordinate. Closed
    on the STRONG arm (one snapshot) rather than the degraded one, and the
    subject is deliberately excluded — see below for both reasons.
-3. **3d** — the ratchet, so 3a cannot be undone six PRs later. Direct projection
-   reads by domain consumers fail mechanically, with **the exact pre-fix
-   `mission_context` pattern as the negative fixture** rather than a synthetic
-   approximation — the same discipline as the symbolic-seam gate's control 3, and
-   it gives the gate a real provenance story: this bypass existed, was repaired,
-   and cannot return.
+3. **3d** — ✅ **RATCHET DONE 2026-08-10.** Direct projection reads by domain
+   consumers fail mechanically, with the exact pre-fix `mission_context` pattern
+   as the negative fixture. The typed query engine it will eventually guard is
+   still to be built; the gate does not wait for it, because the bypass it stops
+   is reachable today.
 
 ### 3a closed against its consumer — 2026-08-10
 
@@ -2632,3 +2633,65 @@ one-off mutation — `the_unguarded_composition_observes_the_fold_it_should_not`
 runs the identical interleaving through the ordinary `&self` readers and asserts
 it DOES observe the concurrent fold. If that control ever goes
 green-by-agreement, the snapshot test has stopped being asked a real question.
+
+
+### 3d's ratchet closed ahead of its engine — 2026-08-10
+
+Box 3d has two halves: a typed query engine, and a mechanical gate making it the
+only path for domain questions. **The gate shipped first, deliberately.** The
+engine is a design still to be done; the bypass it will guard is one autocomplete
+away right now, and 3a's repair is worth exactly as much as the thing stopping it
+from being undone.
+
+`ci/check_world_answer_boundary.py` + `ci/world_answer_boundary_baseline.json`,
+wired into the guardrails job with its self-test.
+
+**The rule.** A crate that asks the world DOMAIN questions goes through
+`kirra_world_service::WorldView`. It may not call the projection-read API on
+`WorldStore` (`current`, `current_all`, `as_of`, `history`, `candidates`,
+`read_snapshot`, `identity_view*`, `resolve_at`, `load_entity_projection`).
+
+**The negative fixture is the code that shipped**, quoted verbatim from
+`0ad203ee` rather than approximated — `store.current(..)` followed by
+`c.predicate.as_deref()` / `c.object.as_deref()`. A gate whose fixture is a
+synthetic `store.current()` proves it can find a string, not that it would have
+found *this* bug. Same discipline as the symbolic-seam gate's control 3, and it
+gives the gate a provenance story: this bypass existed, was repaired, and cannot
+return. The self-test also pins the *positive* case — the repaired function still
+NAMES `&WorldStore` and passes it to `WorldView::new`, and a gate that flagged
+that would be unusable.
+
+**Scope is self-maintaining, which is the part that matters in six months.**
+Every crate *depending on* `kirra-world-store` is checked; permitted readers are
+named in the baseline with a reason each. So a NEW domain consumer is covered
+from its first commit, without anyone remembering to add it — undoing 3a by
+writing a fresh consumer is the same regression as undoing it in place, and a
+hand-maintained list of watched crates would have missed it. Crates without the
+dependency are not scanned at all, since they cannot make the call and scanning
+them could only manufacture false positives from unrelated `history()` /
+`candidates()` methods.
+
+**The operational carve-out needs no exception list.** WM_SCOPE names
+`verify_chain`, `schema_version`, backup/export, the retention driver, the
+compaction planner and the WM-2 harness as legitimate readers below the engine,
+and says a rule forbidding them "would be false on the day it was written". None
+of them is in the domain-read method list, so none is ever matched. The carve-out
+is achieved by scoping the *symbols* rather than exempting *callers*, so there is
+nothing to keep in sync as those subsystems grow.
+
+**`src/` only, and the reason is not laziness.** Several tests read rows directly
+on purpose — `answer_boundary.rs` plants `world_current` rows with raw SQL to
+reach a state the sanctioned write path cannot produce, which is how the
+fail-closed behaviour is proven at all. Gating tests would block the tests that
+prove the boundary works. The bypass lived in `src/`, and `src/` cannot call test
+code, so gating `src/` closes the production path completely.
+
+**Non-vacuity, end to end rather than in a string.** Reintroducing
+`store.current(subject.as_str(), now_ms)?` into the live
+`kirra-proposal-context/src/lib.rs` reds the gate with the file, line and rule;
+removing it greens. And the anti-neutering case is pinned: moving
+`kirra-proposal-context` onto the permitted list fails
+`t08_the_gate_watches_the_repaired_consumer`, and a baseline where *every*
+dependant is permitted fails with *"no crate is in scope — that is how a ratchet
+dies quietly"*. Eight self-test cases, with the same uncollected-case guard the
+symbolic-seam suite carries.


### PR DESCRIPTION
Box 3d has two halves — a typed query engine, and a mechanical gate making it the only path for domain questions. **The gate ships first, deliberately.** The engine is a design still to be done; the bypass it will guard is reachable today, and 3a's repair is worth exactly as much as the thing stopping it from being undone.

No Rust changes. This PR is a CI gate, its baseline, the workflow wiring, and the WM_SCOPE record.

## The rule

A crate that asks the world **domain** questions goes through `kirra_world_service::WorldView`. It may not call the projection-read API on `WorldStore` — `current`, `current_all`, `as_of`, `history`, `candidates`, `read_snapshot`, `identity_view*`, `resolve_at`, `load_entity_projection`.

## The negative fixture is the code that shipped

Quoted verbatim from `0ad203ee` rather than approximated:

```rust
let claims = store.current(subject.as_str(), now_ms)?;
let preferred = claims.iter().find_map(|c| {
    let predicate = c.predicate.as_deref()?;
    ...
    let object = c.object.as_deref()?;
```

A gate whose fixture is a synthetic `store.current()` proves it can find a string, not that it would have found *this* bug. Same discipline as the symbolic-seam gate's control 3, and it gives the gate a provenance story: this bypass existed, was repaired by #1430 and #1431, and cannot return.

The self-test also pins the **positive** case — the repaired function still *names* `&WorldStore` and passes it to `WorldView::new`, and a gate that flagged that would be unusable.

## Scope

Every crate whose `src/` can reach `kirra-world-store` — a normal or build dependency, **parsed from the manifest** — is checked.

```
[PERMITTED] kirra-world-service  — IS the answer boundary
[PERMITTED] wm2-schema-growth    — ADR-0041 D-20 measurement instrument
[CHECKED]   kirra-proposal-context
```

A new domain consumer is therefore covered from its first commit without anyone remembering to add it — **undoing 3a by writing a fresh consumer is the same regression as undoing it in place**, and a hand-maintained watch list would have missed exactly that.

### Three scope corrections came out of review, and they were all the same mistake

Deciding scope from text the gate did not understand. The first draft substring-matched the manifest, so:

- **`wm2-persistence-harness`** was pulled in on a *comment* saying it deliberately does **not** take the dependency — and then carried a written justification for an exemption it never needed.
- **`kirra-world-store`** was listed too, though it cannot depend on itself and so is never scanned.
- **`kirra-mission-orchestrator`** reaches the store only as a **dev-dependency**, unreachable from `src/`. Its own module docs say it does not depend on `kirra-world*` at all, and my `[CHECKED]` list contradicted them.

All three are now recorded under `not_listed_because_never_in_scope` with a reason each, rather than pretending they were decisions.

**The gate now fails on a stale exemption**, which is the general form of that mistake — an exemption for a crate the gate never scans is a written justification for a decision nobody is making, and that is how a carve-out list rots. It found both stale entries on its first run, against a baseline written minutes earlier.

## Both call syntaxes are detected

`.current(..)` is how anyone would write it, but `WorldStore::current(store, ..)` is the same call in UFCS form — also caught, along with the aliased and fully-qualified spellings. A gate advertising zero tolerance while leaving a syntactic door open is the exact overclaim it exists to prevent elsewhere.

## The operational carve-out needs no exception list

WM_SCOPE names `verify_chain`, `schema_version`, backup/export, the retention driver, the compaction planner and the WM-2 harness as legitimate readers below the engine, and says a rule forbidding them *"would be false on the day it was written"*. None is in the domain-read method list, so none is ever matched. The carve-out is achieved by scoping the **symbols** rather than exempting **callers**, so there is nothing to keep in sync as those subsystems grow. `t06` pins it.

## `src/` only, and the reason is not laziness

Several tests read rows directly on purpose — `answer_boundary.rs` plants `world_current` rows with raw SQL to reach a state the sanctioned write path cannot produce, which is how the fail-closed behaviour is proven at all. Gating tests would block the tests that prove the boundary works. The bypass lived in `src/`, and `src/` cannot call test code, so gating `src/` closes the production path completely.

## Non-vacuity, end to end rather than in a string

Planting the bypass into the live `kirra-proposal-context/src/lib.rs` — in **either** call syntax — reds the gate with file, line and rule:

```
Answer-boundary gate FAILED — direct domain read below the engine.

  crates/kirra-proposal-context/src/lib.rs:428
      let _b = WorldStore::current(store, subject.as_str(), now_ms)?;
      `current(..)` reads a projection directly.
  (1 found, ceiling 0.)
```

Removing it greens. The **anti-neutering** cases are pinned too: moving `kirra-proposal-context` onto the permitted list fails `t08_the_gate_watches_the_repaired_consumer`; a baseline where *every* dependant is permitted fails with *"no crate is in scope — that is how a ratchet dies quietly"*; and re-adding a stale exemption fails the gate itself.

Twelve self-test cases, carrying the same uncollected-case guard the symbolic-seam suite carries (a case that is never collected is the most literal form of a test that cannot fail).

## Verification

`ci/check_world_answer_boundary.py --self-test` (12/12) · the gate itself · symbolic-seam gate (18/18) · orphan-cores · re-export shims · Fence A/B bidirectional fence · world domain-logic gate · quality guardrails · mick actuation fence · workflow PR coverage · `cargo clippy --workspace --all-targets -D warnings` · `cargo fmt --check` · `ci.yml` parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW