### PR TITLE
Generation-pinned read: reconstruct world_current at a generation, or refuse

### DIFF
--- a/ci/check_world_answer_boundary.py
+++ b/ci/check_world_answer_boundary.py
@@ -88,6 +88,7 @@ DOMAIN_READ_METHODS = (
     "history",
     "candidates",
     "read_snapshot",
+    "read_at_generation",
     "identity_view",
     "identity_view_at",
     "resolve_at",

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -326,6 +326,17 @@ pub enum StoreError {
         /// What did not line up.
         detail: String,
     },
+    /// A generation-pinned read was asked for a negative generation.
+    ///
+    /// The error channel rather than an `Irreproducible` outcome, on rule 3's
+    /// split: `Irreproducible` reports facts about the DATA (this was compacted,
+    /// this has not happened yet), and a negative generation is neither — it is
+    /// a malformed query, which is what the error channel is for. Generation `0`
+    /// is legal and reconstructs the empty projection that preceded every event.
+    InvalidGeneration {
+        /// What was asked for.
+        requested: i64,
+    },
     /// A compaction range was empty or inverted.
     EmptyRange {
         /// The requested low bound.
@@ -428,6 +439,10 @@ impl std::fmt::Display for StoreError {
                 lo_generation,
                 detail,
             } => write!(f, "citation at generation {lo_generation}: {detail}"),
+            Self::InvalidGeneration { requested } => write!(
+                f,
+                "generation {requested} is not a generation (generations start at 0)"
+            ),
             Self::EmptyRange { lo, hi } => {
                 write!(f, "compaction range {lo}..={hi} is empty or inverted")
             }
@@ -2596,6 +2611,21 @@ impl WorldStore {
         Ok(snapshot::ReadSnapshot::new(
             self.conn.unchecked_transaction()?,
         ))
+    }
+
+    /// **Reconstruct `world_current` as it stood at a projection generation.**
+    ///
+    /// The generation-pinned read `KIRRA-WM-ANSWER-IDENTITY-001` needs, taken
+    /// inside a snapshot so the citation check and the replay cannot disagree
+    /// about which events exist. See
+    /// [`snapshot::ReadSnapshot::read_at_generation`] for the contract — in
+    /// particular that it FAILS CLOSED and never falls forward to current state.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::InvalidGeneration`] for a negative generation.
+    pub fn read_at_generation(&self, generation: i64) -> Result<snapshot::PinnedRead, StoreError> {
+        self.read_snapshot()?.read_at_generation(generation)
     }
 
     /// Where every projection stands right now, read outside any snapshot.

--- a/crates/kirra-world-store/src/snapshot.rs
+++ b/crates/kirra-world-store/src/snapshot.rs
@@ -45,6 +45,7 @@ use std::collections::BTreeMap;
 
 use rusqlite::{params, Connection, OptionalExtension};
 
+use crate::compaction::Citation;
 use crate::entity_projection::{self, IdentityView, ProjectedEntity};
 use crate::projection::{self, ProjectedClaim};
 use crate::subject_projection;
@@ -202,6 +203,76 @@ impl<'a> ReadSnapshot<'a> {
         coordinate_on(&self.tx)
     }
 
+    /// **Reconstruct `world_current` as it stood at projection generation
+    /// `generation`** — the generation-pinned read.
+    ///
+    /// `KIRRA-WM-ANSWER-IDENTITY-001` rules that resolving an `AnswerRef` means
+    /// *"re-execute this exact deterministic query against the same snapshot"*.
+    /// Until this existed the ruling had no mechanism behind it:
+    /// `projection_generation()` could report the coordinate, and nothing could
+    /// read AT it.
+    ///
+    /// # It fails closed, and never falls forward
+    ///
+    /// Two things make a generation unreconstructible, and both refuse:
+    /// [`Irreproducible::NotYetReached`] and [`Irreproducible::Compacted`].
+    /// Neither returns current state. That is the whole point — a caller asking
+    /// what was true at generation 40, handed what is true at generation 90
+    /// because 40 was compacted, has been answered a different question with no
+    /// way to tell.
+    ///
+    /// # Generation, not transaction time
+    ///
+    /// The store already cuts on transaction time ([`WorldStore::as_of`]), and
+    /// that axis cannot be made exact after compaction: the removed rows are the
+    /// only record of their own `txn_time_ms`, so a span can never be shown
+    /// irrelevant to a past instant. `identity_degradation`'s comment works
+    /// through why the obvious filter there was fail-open.
+    ///
+    /// Generation does not have that problem. A [`Citation`] records the exact
+    /// `lo_generation..=hi_generation` it removed, which is the same axis being
+    /// pinned, so "did compaction take anything at or below `generation`" is an
+    /// EXACT test rather than a necessary condition. This is the one place the
+    /// two axes genuinely differ, and it is why the pin is on this one.
+    ///
+    /// [`WorldStore::as_of`]: crate::WorldStore::as_of
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::InvalidGeneration`] for a negative generation — a malformed
+    /// query, which rule 3 puts in the error channel. Generation `0` is legal
+    /// and reconstructs the empty projection that preceded every event.
+    pub fn read_at_generation(&self, generation: i64) -> Result<PinnedRead, StoreError> {
+        if generation < 0 {
+            return Err(StoreError::InvalidGeneration {
+                requested: generation,
+            });
+        }
+
+        let head = checkpoint_on(&self.tx, projection::CURRENT_PROJECTION)?.0;
+        if generation > head {
+            return Ok(PinnedRead::Irreproducible(Irreproducible::NotYetReached {
+                head,
+            }));
+        }
+
+        // Compaction check BEFORE the replay, deliberately. Replaying first and
+        // checking after would produce a plausible projection built from a log
+        // with holes in it, and the temptation to return it "since we have it"
+        // is exactly what fails closed here.
+        let spans = compacted_at_or_below(&self.tx, generation)?;
+        if !spans.is_empty() {
+            return Ok(PinnedRead::Irreproducible(Irreproducible::Compacted {
+                spans,
+            }));
+        }
+
+        Ok(PinnedRead::Reproduced(PinnedProjection {
+            generation,
+            rows: replay_to(&self.tx, generation)?,
+        }))
+    }
+
     /// **Has the identity graph consumed every adjudication the log holds?**
     ///
     /// The question a composed read must ask before trusting a resolution, and
@@ -238,6 +309,132 @@ impl<'a> ReadSnapshot<'a> {
             )
             .optional()?;
         Ok(pending.is_none())
+    }
+}
+
+/// **Why a pinned read can stop being possible, and what ends it.**
+///
+/// Returned instead of a reconstruction, never alongside one — the caller cannot
+/// hold a `PinnedProjection` that quietly means "current state".
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Irreproducible {
+    /// Evidence at or below the requested generation was compacted away.
+    ///
+    /// **Compaction ends a pinned read's life for every generation at or above
+    /// the compacted span, not merely inside it.** Reconstructing at `g` folds
+    /// every confirmed event `<= g`; if any of them is gone, the fold cannot be
+    /// reproduced, whatever its result would have been.
+    ///
+    /// That is deliberately stricter than necessary, on the asymmetry
+    /// [`Resolution`] already documents: a removed event may well have been
+    /// superseded and made no difference to the answer, but the removed rows are
+    /// the only record of themselves, so it cannot be *shown* to have made none.
+    /// Over-refusing costs availability; under-refusing returns a silently wrong
+    /// reconstruction wearing the word "pinned".
+    ///
+    /// [`Resolution`]: crate::compaction::Resolution
+    ///
+    /// Worth stating plainly to whoever sets a retention horizon: **the
+    /// compaction floor is also the floor on how far back answers stay
+    /// reproducible.**
+    Compacted {
+        /// The compacted spans that bear on the request, lowest first.
+        spans: Vec<Citation>,
+    },
+    /// The requested generation is ahead of everything the store has recorded.
+    NotYetReached {
+        /// How far the claims projection has actually consumed.
+        head: i64,
+    },
+}
+
+/// `world_current` as it stood at one projection generation.
+///
+/// Reconstructed by replaying the log, not by reading the live table — the live
+/// table holds one point (latest known, latest valid) and every other point has
+/// to be replayed. The reconstruction is exact because the fold is deterministic
+/// over its input, which is the same property `rebuild_from_zero_equals_incremental`
+/// already pins.
+#[derive(Debug, Clone)]
+pub struct PinnedProjection {
+    generation: i64,
+    rows: BTreeMap<(String, String), ProjectedClaim>,
+}
+
+impl PinnedProjection {
+    /// The generation this was reconstructed at.
+    pub fn generation(&self) -> i64 {
+        self.generation
+    }
+
+    /// The claims for `subject` holding at `now_ms`, as of the pinned
+    /// generation.
+    ///
+    /// Same shape and same `holds_at` filter as [`WorldStore::current`], so a
+    /// pinned read and a live read differ in WHEN they are answered and in
+    /// nothing else.
+    ///
+    /// [`WorldStore::current`]: crate::WorldStore::current
+    pub fn current(&self, subject: &str, now_ms: i64) -> Vec<ProjectedClaim> {
+        let mut out: Vec<ProjectedClaim> = self
+            .rows
+            .iter()
+            .filter(|((s, _), _)| s == subject)
+            .map(|(_, c)| c.clone())
+            .filter(|c| c.holds_at(now_ms))
+            .collect();
+        // `world_current` returns a subject's rows ordered by `predicate_key`;
+        // the BTreeMap is already in that order, so this only re-states it.
+        out.sort_by(|a, b| {
+            a.predicate
+                .as_deref()
+                .unwrap_or("")
+                .cmp(b.predicate.as_deref().unwrap_or(""))
+        });
+        out
+    }
+
+    /// How many keys the reconstructed projection holds.
+    pub fn len(&self) -> usize {
+        self.rows.len()
+    }
+
+    /// Whether the reconstruction is empty.
+    pub fn is_empty(&self) -> bool {
+        self.rows.is_empty()
+    }
+}
+
+/// The outcome of a generation-pinned read.
+///
+/// A two-variant result rather than `Option` or a fallback, because the one
+/// thing this must never do is answer with the CURRENT state when the requested
+/// generation cannot be rebuilt. Falling forward is not merely wrong, it is
+/// wrong in the way that looks right: the caller asked what was true then and
+/// receives what is true now, with nothing in the value to say so.
+#[derive(Debug, Clone)]
+pub enum PinnedRead {
+    /// Reconstructed exactly at the requested generation.
+    Reproduced(PinnedProjection),
+    /// The generation cannot be reconstructed, and why.
+    Irreproducible(Irreproducible),
+}
+
+impl PinnedRead {
+    /// The reconstruction, or `None` if the generation is irreproducible.
+    pub fn reproduced(&self) -> Option<&PinnedProjection> {
+        match self {
+            Self::Reproduced(p) => Some(p),
+            Self::Irreproducible(_) => None,
+        }
+    }
+
+    /// Why the read could not be reproduced, if it could not.
+    pub fn irreproducible(&self) -> Option<&Irreproducible> {
+        match self {
+            Self::Reproduced(_) => None,
+            Self::Irreproducible(r) => Some(r),
+        }
     }
 }
 
@@ -369,6 +566,62 @@ pub(crate) fn load_entity_projection_on(
         );
     }
     Ok(out)
+}
+
+/// Compacted spans that removed anything at or below `generation`.
+///
+/// The test is `lo_generation <= generation`, not span containment: a citation
+/// covering 5..=50 removed generations 5..=40 too, so it bears on a request to
+/// rebuild at 40 exactly as much as on one at 50.
+pub(crate) fn compacted_at_or_below(
+    conn: &Connection,
+    generation: i64,
+) -> Result<Vec<Citation>, StoreError> {
+    if !table_exists(conn, "compaction_citations")? {
+        return Ok(Vec::new());
+    }
+    let mut stmt = conn.prepare(
+        "SELECT lo_generation, hi_generation, event_count, range_digest,
+                chain_before, chain_after, compacted_at_ms
+         FROM compaction_citations
+         WHERE lo_generation <= ?1
+         ORDER BY lo_generation ASC",
+    )?;
+    let rows = stmt.query_map(params![generation], |r| {
+        Ok(Citation {
+            lo_generation: r.get(0)?,
+            hi_generation: r.get(1)?,
+            event_count: r.get(2)?,
+            range_digest: r.get(3)?,
+            chain_before: r.get(4)?,
+            chain_after: r.get(5)?,
+            compacted_at_ms: r.get(6)?,
+        })
+    })?;
+    Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+}
+
+/// Fold every confirmed event up to `generation` into the projection it produced.
+///
+/// The same reducer the live fold uses (`projection::fold_all`), over the same
+/// confirmed-only filter, in the same generation order — so this is not a second
+/// implementation of the projection that could drift from the first. It is the
+/// one implementation, given a bounded input.
+pub(crate) fn replay_to(
+    conn: &Connection,
+    generation: i64,
+) -> Result<BTreeMap<(String, String), ProjectedClaim>, StoreError> {
+    if !table_exists(conn, "world_events")? {
+        return Ok(BTreeMap::new());
+    }
+    let mut stmt = conn.prepare(&format!(
+        "SELECT {CLAIM_COLUMNS} FROM world_events
+         WHERE generation <= ?1 AND claim_status = 'confirmed'
+         ORDER BY generation ASC"
+    ))?;
+    let rows = stmt.query_map(params![generation], claim_from_row)?;
+    let claims = rows.collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(projection::fold_all(claims))
 }
 
 pub(crate) fn table_exists(conn: &Connection, name: &str) -> Result<bool, StoreError> {

--- a/crates/kirra-world-store/src/snapshot.rs
+++ b/crates/kirra-world-store/src/snapshot.rs
@@ -603,10 +603,18 @@ pub(crate) fn compacted_at_or_below(
 
 /// Fold every confirmed event up to `generation` into the projection it produced.
 ///
-/// The same reducer the live fold uses (`projection::fold_all`), over the same
-/// confirmed-only filter, in the same generation order — so this is not a second
-/// implementation of the projection that could drift from the first. It is the
-/// one implementation, given a bounded input.
+/// The same reducer the live fold uses, over the same confirmed-only filter, in
+/// the same generation order — so this is not a second implementation of the
+/// projection that could drift from the first. It is the one implementation,
+/// given a bounded input.
+///
+/// Applied INCREMENTALLY via `projection::fold_step` rather than collecting into
+/// a `Vec` for `fold_all`. `fold_all` is exactly `fold_step` in a loop, so this
+/// is the identical reduction — it simply does not hold the whole history in
+/// memory at once on the way there, which for a pinned read near the head means
+/// the entire confirmed log. The accumulator is bounded by the KEY count; the
+/// buffer would have been bounded by the EVENT count, and those diverge without
+/// limit as a store ages.
 pub(crate) fn replay_to(
     conn: &Connection,
     generation: i64,
@@ -619,9 +627,12 @@ pub(crate) fn replay_to(
          WHERE generation <= ?1 AND claim_status = 'confirmed'
          ORDER BY generation ASC"
     ))?;
-    let rows = stmt.query_map(params![generation], claim_from_row)?;
-    let claims = rows.collect::<rusqlite::Result<Vec<_>>>()?;
-    Ok(projection::fold_all(claims))
+    let mut acc = BTreeMap::new();
+    let mut rows = stmt.query(params![generation])?;
+    while let Some(row) = rows.next()? {
+        projection::fold_step(&mut acc, claim_from_row(row)?);
+    }
+    Ok(acc)
 }
 
 pub(crate) fn table_exists(conn: &Connection, name: &str) -> Result<bool, StoreError> {

--- a/crates/kirra-world-store/tests/pinned_read.rs
+++ b/crates/kirra-world-store/tests/pinned_read.rs
@@ -247,7 +247,63 @@ fn a_compacted_generation_refuses_rather_than_falling_forward() {
     cleanup(&path);
 }
 
+/// **Compaction ABOVE the pinned generation does NOT make it irreproducible.**
+///
+/// The control the rest of the compaction cases cannot supply, and the suite was
+/// VACUOUS without it: an implementation that refused on the mere existence of
+/// any citation — ignoring `lo_generation` entirely — passed every other test
+/// here, because every other compaction fixture removes a span BELOW the pin.
+///
+/// Rebuilding at `g` needs the confirmed events `<= g`. A span removed entirely
+/// above `g` took none of them, so the prefix is intact and the reconstruction
+/// is exact. Refusing here would make the pinned read useless in the one regime
+/// it is most needed: an old, heavily-compacted store where the interesting
+/// coordinates are precisely the ones below the compaction floor.
+#[test]
+fn compaction_above_the_pinned_generation_leaves_it_reproducible() {
+    let path = tmp("above-pin");
+    let mut store = WorldStore::open(&path).expect("open");
+    claim(&mut store, "1", "dock_old", T0);
+    claim(&mut store, "2", "dock_a", T0 + 1);
+    claim(&mut store, "3", "dock_b", T0 + 2);
+    store.fold().expect("fold");
+
+    // Generation 2 is superseded by 3, so it is compactable; 1 is left alone.
+    let outcome = store
+        .compact_range(2, 2, T0 + 5_000)
+        .expect("generation 2 is superseded");
+    assert_eq!(
+        outcome.removed, 1,
+        "the fixture must actually remove an event"
+    );
+
+    // The pin is BELOW everything that was removed, so the prefix survives.
+    assert_eq!(
+        pinned_object(&store, 1).as_deref(),
+        Some("dock_old"),
+        "a span removed above the pin took none of the events the pin folds —          refusing here would be over-refusal, not fail-closed"
+    );
+
+    // And the sibling case still refuses, so this is not a blanket relaxation.
+    assert!(
+        matches!(
+            store.read_at_generation(3).expect("pinned"),
+            PinnedRead::Irreproducible(Irreproducible::Compacted { .. })
+        ),
+        "a pin at or above the removed span must still refuse"
+    );
+
+    drop(store);
+    cleanup(&path);
+}
+
 /// **Compaction ends reproducibility for generations ABOVE the removed span too.**
+///
+/// Read the name from the SPAN's point of view: the pin sits above the span, so
+/// the span is below the pin and its removed events are inside the prefix being
+/// folded. The companion test above is the mirror — span above pin, prefix
+/// intact — and the two together are what make `lo_generation <= g` a decision
+/// rather than an accident.
 ///
 /// Rebuilding at generation 2 folds every confirmed event `<= 2`, and one of
 /// them is gone. The fold cannot be reproduced, whatever its result would have

--- a/crates/kirra-world-store/tests/pinned_read.rs
+++ b/crates/kirra-world-store/tests/pinned_read.rs
@@ -1,0 +1,369 @@
+//! **Tier 3 — the generation-pinned read.**
+//!
+//! `KIRRA-WM-ANSWER-IDENTITY-001` rules that resolving an `AnswerRef` means
+//! *"re-execute this exact deterministic query against the same snapshot"*.
+//! Until this existed the ruling had no mechanism behind it:
+//! `projection_generation()` could report the coordinate, and nothing could read
+//! AT it. `WM_SCOPE.md` carried the gap as its own open box.
+//!
+//! Four claims are pinned here, and the third is the one the box turns on:
+//!
+//! 1. A pinned read returns the state at that generation — **not** current
+//!    state. Proved by pinning at a generation whose answer DIFFERS from now.
+//! 2. A pinned read at the head equals the live read, so the reconstruction is
+//!    the same fold and not a second implementation that happens to agree on
+//!    old data.
+//! 3. **Compaction makes a generation irreproducible, and the read REFUSES**
+//!    rather than falling forward to current state.
+//! 4. A generation ahead of the head refuses too, rather than clamping.
+//!
+//! # Why case 3 is the sharp one
+//!
+//! Falling forward is not merely wrong, it is wrong in the way that looks right:
+//! the caller asked what was true at generation 1 and receives what is true at
+//! generation 2, with nothing in the value to say so. The fixture is built so a
+//! fall-forward implementation returns a *plausible, non-empty, wrong* answer —
+//! `dock_a` where `dock_old` was the truth — because a refusal that only ever
+//! fired when the answer would have been empty anyway proves nothing.
+
+use kirra_world_store::snapshot::{Irreproducible, PinnedRead};
+use kirra_world_store::{ClaimStatus, EventId, NewEvent, ObservationId, WorldStore, WriterClass};
+
+const T0: i64 = 1_700_000_000_000;
+
+fn tmp(name: &str) -> std::path::PathBuf {
+    static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let n = NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "kirra-pinned-read-{name}-{}-{n}.sqlite",
+        std::process::id()
+    ));
+    cleanup(&p);
+    p
+}
+
+fn cleanup(path: &std::path::Path) {
+    for suffix in ["", "-wal", "-shm"] {
+        let mut q = path.as_os_str().to_os_string();
+        q.push(suffix);
+        let _ = std::fs::remove_file(std::path::PathBuf::from(q));
+    }
+}
+
+/// Record `package_17 last_seen_at <object>` at `at_ms`.
+fn claim(store: &mut WorldStore, tag: &str, object: &str, at_ms: i64) {
+    store
+        .append(&NewEvent {
+            event_id: &EventId::new(format!("ev-{tag}")).expect("event id"),
+            observation_id: &ObservationId::new(format!("obs-{tag}")).expect("obs"),
+            txn_time_ms: at_ms,
+            valid_from_ms: at_ms,
+            valid_to_ms: None,
+            source: "warehouse-scanner",
+            source_version: "1.0.0",
+            writer_class: WriterClass::Sensor,
+            claim_status: ClaimStatus::Confirmed,
+            provenance: &[],
+            frame_id: None,
+            map_id: None,
+            kind: "mission",
+            subject: "package_17",
+            subject_ref: None,
+            predicate: Some("last_seen_at"),
+            object: Some(object),
+            payload: "{}",
+            payload_schema: 1,
+            retention_class: "raw",
+            trust: None,
+        })
+        .expect("append");
+}
+
+/// The object of the single `package_17` claim, as of a pinned read.
+fn pinned_object(store: &WorldStore, generation: i64) -> Option<String> {
+    match store.read_at_generation(generation).expect("pinned read") {
+        PinnedRead::Reproduced(p) => p
+            .current("package_17", T0 + 1_000)
+            .first()
+            .and_then(|c| c.object.clone()),
+        PinnedRead::Irreproducible(r) => panic!("expected a reproduction, got {r:?}"),
+    }
+}
+
+/// A store where the answer CHANGED: `dock_old` at generation 1, `dock_a` at 2.
+///
+/// The supersession is what makes generation 1 both interesting and compactable
+/// — `compact_range` refuses to remove a live projection head, so only a
+/// superseded event can be taken away.
+fn store_that_changed_its_mind(name: &str) -> (WorldStore, std::path::PathBuf) {
+    let path = tmp(name);
+    let mut store = WorldStore::open(&path).expect("open");
+    claim(&mut store, "1", "dock_old", T0);
+    store.fold().expect("fold");
+    claim(&mut store, "2", "dock_a", T0 + 1);
+    store.fold().expect("fold");
+    (store, path)
+}
+
+// ---------------------------------------------------------------------------
+// 1 & 2. The pin actually pins
+// ---------------------------------------------------------------------------
+
+/// **A pinned read answers as of THEN, not as of now.**
+///
+/// The whole point in one assertion. Generation 1 said `dock_old`; generation 2
+/// says `dock_a`. A pinned read at 1 that returned `dock_a` would be reporting
+/// current state under a past coordinate.
+#[test]
+fn a_pinned_read_returns_the_state_at_that_generation() {
+    let (store, path) = store_that_changed_its_mind("changed");
+
+    assert_eq!(
+        pinned_object(&store, 1).as_deref(),
+        Some("dock_old"),
+        "generation 1 held dock_old — a pinned read must not report today's answer"
+    );
+    assert_eq!(
+        pinned_object(&store, 2).as_deref(),
+        Some("dock_a"),
+        "generation 2 held dock_a"
+    );
+
+    // Non-vacuity: the two really are different, so the assertion above is
+    // distinguishing something.
+    assert_ne!(pinned_object(&store, 1), pinned_object(&store, 2));
+
+    drop(store);
+    cleanup(&path);
+}
+
+/// **At the head, the pinned read and the live read agree.**
+///
+/// Guards the other direction: a reconstruction that agreed with history but
+/// disagreed with the present would be a second, divergent implementation of the
+/// projection. It is the same reducer over a bounded input, and this says so.
+#[test]
+fn a_pinned_read_at_the_head_equals_the_live_read() {
+    let (store, path) = store_that_changed_its_mind("head");
+    let head = store
+        .projection_coordinate()
+        .expect("coordinate")
+        .world_current()
+        .generation();
+
+    let live = store.current("package_17", T0 + 1_000).expect("live read");
+    let pinned = match store.read_at_generation(head).expect("pinned") {
+        PinnedRead::Reproduced(p) => p.current("package_17", T0 + 1_000),
+        PinnedRead::Irreproducible(r) => panic!("the head must be reproducible, got {r:?}"),
+    };
+
+    assert_eq!(live.len(), pinned.len());
+    assert_eq!(
+        live.first().and_then(|c| c.object.clone()),
+        pinned.first().and_then(|c| c.object.clone()),
+        "the pinned reconstruction at the head must equal the live projection"
+    );
+
+    drop(store);
+    cleanup(&path);
+}
+
+/// **Generation 0 is the empty projection that preceded every event.**
+///
+/// Legal, not an error: "before anything was known" is a real state and it
+/// reconstructs trivially.
+#[test]
+fn generation_zero_reconstructs_the_empty_projection() {
+    let (store, path) = store_that_changed_its_mind("zero");
+
+    match store.read_at_generation(0).expect("pinned") {
+        PinnedRead::Reproduced(p) => {
+            assert!(p.is_empty(), "nothing was known before the first event");
+            assert_eq!(p.generation(), 0);
+        }
+        PinnedRead::Irreproducible(r) => panic!("generation 0 is reproducible, got {r:?}"),
+    }
+
+    drop(store);
+    cleanup(&path);
+}
+
+// ---------------------------------------------------------------------------
+// 3. The sharp case: compaction ends reproducibility, and it REFUSES
+// ---------------------------------------------------------------------------
+
+/// **A compacted generation refuses — it does not fall forward.**
+///
+/// Generation 1's evidence is deleted. The fixture is deliberately built so
+/// falling forward yields a plausible non-empty answer (`dock_a`), because a
+/// refusal that only fired when the fallback was empty would be
+/// indistinguishable from doing nothing.
+#[test]
+fn a_compacted_generation_refuses_rather_than_falling_forward() {
+    let (mut store, path) = store_that_changed_its_mind("compacted");
+
+    // Before: reproducible, and it says dock_old.
+    assert_eq!(pinned_object(&store, 1).as_deref(), Some("dock_old"));
+
+    let outcome = store
+        .compact_range(1, 1, T0 + 5_000)
+        .expect("generation 1 is superseded, so compactable");
+    assert_eq!(
+        outcome.removed, 1,
+        "the fixture must actually remove an event"
+    );
+
+    match store.read_at_generation(1).expect("pinned read") {
+        PinnedRead::Reproduced(p) => panic!(
+            "fell forward: returned {:?} for a generation whose evidence is gone",
+            p.current("package_17", T0 + 1_000)
+                .first()
+                .and_then(|c| c.object.clone())
+        ),
+        PinnedRead::Irreproducible(Irreproducible::Compacted { spans }) => {
+            assert!(!spans.is_empty(), "the refusal must name what was removed");
+            assert_eq!(spans[0].lo_generation, 1);
+        }
+        PinnedRead::Irreproducible(other) => {
+            panic!("compaction must be reported as such, got {other:?}")
+        }
+    }
+
+    // And the live read still works — the refusal is about REPRODUCING a past
+    // generation, not about the store being broken.
+    assert_eq!(
+        store
+            .current("package_17", T0 + 1_000)
+            .expect("live read")
+            .first()
+            .and_then(|c| c.object.clone())
+            .as_deref(),
+        Some("dock_a"),
+        "current state is unaffected; only the pinned reconstruction is refused"
+    );
+
+    drop(store);
+    cleanup(&path);
+}
+
+/// **Compaction ends reproducibility for generations ABOVE the removed span too.**
+///
+/// Rebuilding at generation 2 folds every confirmed event `<= 2`, and one of
+/// them is gone. The fold cannot be reproduced, whatever its result would have
+/// been — here it would in fact have been identical, since generation 1 was
+/// superseded. That is the documented over-refusal, and it is pinned so the
+/// behaviour is a decision rather than a surprise: the compaction floor is also
+/// the floor on how far back answers stay reproducible.
+#[test]
+fn compaction_also_ends_reproducibility_above_the_removed_span() {
+    let (mut store, path) = store_that_changed_its_mind("above");
+    store.compact_range(1, 1, T0 + 5_000).expect("compact");
+
+    let head = store
+        .projection_coordinate()
+        .expect("coordinate")
+        .world_current()
+        .generation();
+    assert!(head >= 2);
+
+    assert!(
+        matches!(
+            store.read_at_generation(head).expect("pinned"),
+            PinnedRead::Irreproducible(Irreproducible::Compacted { .. })
+        ),
+        "a generation above the removed span still folds the removed event"
+    );
+
+    drop(store);
+    cleanup(&path);
+}
+
+// ---------------------------------------------------------------------------
+// 4. The future refuses rather than clamping
+// ---------------------------------------------------------------------------
+
+/// **A generation ahead of the head refuses.**
+///
+/// Clamping to the head would answer a question that was not asked, and would
+/// do it silently — the same class of defect as falling forward.
+#[test]
+fn a_generation_ahead_of_the_head_refuses() {
+    let (store, path) = store_that_changed_its_mind("future");
+    let head = store
+        .projection_coordinate()
+        .expect("coordinate")
+        .world_current()
+        .generation();
+
+    match store.read_at_generation(head + 100).expect("pinned") {
+        PinnedRead::Irreproducible(Irreproducible::NotYetReached { head: reported }) => {
+            assert_eq!(reported, head, "the refusal reports how far the store got");
+        }
+        other => panic!("a future generation must refuse, got {other:?}"),
+    }
+
+    drop(store);
+    cleanup(&path);
+}
+
+/// **A negative generation is a malformed query, not an outcome.**
+///
+/// Rule 3's split: `Irreproducible` reports facts about the DATA; a negative
+/// generation is neither compacted nor in the future, it is nonsense.
+#[test]
+fn a_negative_generation_is_an_error_not_an_outcome() {
+    let (store, path) = store_that_changed_its_mind("negative");
+    assert!(
+        store.read_at_generation(-1).is_err(),
+        "a negative generation belongs in the error channel"
+    );
+
+    drop(store);
+    cleanup(&path);
+}
+
+// ---------------------------------------------------------------------------
+// Determinism — the property step 2's AnswerRef will rest on
+// ---------------------------------------------------------------------------
+
+/// **Re-executing at the same generation returns the same answer.**
+///
+/// This is the property a reproducible descriptor needs: the same coordinate
+/// twice must not drift, even across appends and folds that move the head. A
+/// pinned read that quietly tracked the head would fail this the moment
+/// something else wrote.
+#[test]
+fn re_execution_at_the_same_generation_is_stable_across_later_writes() {
+    let (mut store, path) = store_that_changed_its_mind("stable");
+
+    let first = pinned_object(&store, 1);
+
+    // The world moves on: two more claims and a fold.
+    claim(&mut store, "3", "dock_b", T0 + 2);
+    claim(&mut store, "4", "dock_c", T0 + 3);
+    store.fold().expect("fold");
+
+    let second = pinned_object(&store, 1);
+    assert_eq!(
+        first, second,
+        "the same coordinate must answer the same way after unrelated writes"
+    );
+    assert_eq!(first.as_deref(), Some("dock_old"));
+
+    // Non-vacuity: the head really did move, so "stable" is not "nothing
+    // happened".
+    assert_eq!(
+        store
+            .current("package_17", T0 + 1_000)
+            .expect("live")
+            .first()
+            .and_then(|c| c.object.clone())
+            .as_deref(),
+        Some("dock_c"),
+        "the store moved on, or this test proves nothing"
+    );
+
+    drop(store);
+    cleanup(&path);
+}

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -1988,13 +1988,14 @@ Recorded as a ruling rather than a preference because the pressure to reuse the
 ruled name will come from wanting the checklist to close, which is the same
 pressure that produced every stale claim this box already documents.
 
-- [ ] **Generation-pinned read (prerequisite for the ruled `AnswerRef`).**
-      Scoped separately because it is a **store capability**, not an answer-boundary
-      one: a way to read `world_current` *as of* a projection generation, so a
-      recorded coordinate can actually be re-executed against. Until it exists,
-      `KIRRA-WM-ANSWER-IDENTITY-001` is a ruling with no mechanism behind it —
-      stated plainly here so that gap is visible rather than inferred from
-      `AnswerRef`'s absence.
+- [x] **Generation-pinned read (prerequisite for the ruled `AnswerRef`).**
+      ✅ **DONE 2026-08-10** — `WorldStore::read_at_generation` /
+      `ReadSnapshot::read_at_generation`; see *"the pinned read, and what ends
+      one"* below. Scoped separately because it is a **store capability**, not an
+      answer-boundary one: a way to read `world_current` *as of* a projection
+      generation, so a recorded coordinate can actually be re-executed against.
+      `KIRRA-WM-ANSWER-IDENTITY-001` now has a mechanism behind it; the ruled
+      `AnswerRef` itself is the next step and is still open.
 - [ ] **3b — Rule / projection versioning.** Declared, behaviour-changing, and
       enforced by corpus + source pin (above). Not decorative metadata.
 - [x] **3c — Snapshot consistency.** ✅ **DONE 2026-08-10** — see *"3c closed
@@ -2720,3 +2721,72 @@ where *every* dependant is permitted fails with *"no crate is in scope — that 
 how a ratchet dies quietly"*; and re-adding a stale exemption fails the gate
 itself. Twelve self-test cases, with the same uncollected-case guard the
 symbolic-seam suite carries.
+
+
+### The pinned read, and what ends one — 2026-08-10
+
+`KIRRA-WM-ANSWER-IDENTITY-001` rules that resolving an `AnswerRef` means
+*"re-execute this exact deterministic query against the same snapshot"*. Until
+now that was a ruling with no mechanism: `projection_generation()` could report
+the coordinate, and nothing could read AT it.
+
+`ReadSnapshot::read_at_generation(g)` reconstructs `world_current` as it stood at
+generation `g`, by replaying the confirmed log through `projection::fold_all` —
+the SAME reducer the live fold uses, over the same confirmed-only filter, in the
+same order. It is not a second implementation of the projection that could drift
+from the first; it is the one implementation given a bounded input, which is the
+property `rebuild_from_zero_equals_incremental` already pins.
+
+**It fails closed and never falls forward.** `PinnedRead` is
+`Reproduced | Irreproducible`, so there is no code path that answers with current
+state when the requested generation cannot be rebuilt. That failure mode is the
+one worth naming: falling forward is not merely wrong, it is wrong in the way
+that looks right — the caller asked what was true at generation 40 and receives
+what is true at 90, with nothing in the value to say so.
+
+**Generation is the right axis to pin on, and this is the one place the two axes
+genuinely differ.** `identity_degradation` records that a transaction-time filter
+over citations was FAIL-OPEN and could not be repaired: the removed rows are the
+only record of their own `txn_time_ms`, so a compacted span can never be shown
+irrelevant to a past instant after the fact. Generation does not have that
+problem. A `Citation` records the exact `lo_generation..=hi_generation` it
+removed — the same axis being pinned — so *"did compaction take anything at or
+below g"* is an EXACT test rather than a necessary condition.
+
+**Compaction is what ends a pinned read's life, and it ends it for every
+generation at or above the removed span, not merely inside it.** Rebuilding at
+`g` folds every confirmed event `<= g`; if one is gone, the fold cannot be
+reproduced whatever its result would have been. That is deliberately stricter
+than necessary, on the asymmetry `Resolution` already documents: a removed event
+may well have been superseded and made no difference, but it cannot be *shown* to
+have made none. Over-refusing costs availability; under-refusing returns a
+silently wrong reconstruction wearing the word "pinned".
+
+Worth stating plainly to whoever sets a retention horizon: **the compaction floor
+is also the floor on how far back answers stay reproducible.** That is a real
+operational consequence of the retention policy, and it was not visible before
+this existed.
+
+**A negative generation is an error, not an outcome.** Rule 3's split:
+`Irreproducible` reports facts about the DATA — this was compacted, this has not
+happened yet — and a negative generation is neither. Generation `0` is legal and
+reconstructs the empty projection that preceded every event.
+
+**Non-vacuity.** Four mutations, each caught:
+
+| Mutation | Caught by |
+|---|---|
+| fall forward to current state when compacted | both compaction tests |
+| clamp a future generation to the head | `a_generation_ahead_of_the_head_refuses` |
+| read the live table instead of replaying | 4 tests, incl. the positive witness |
+| test span containment instead of overlap | both compaction tests |
+
+The compaction fixture is built so that falling forward returns a *plausible,
+non-empty, wrong* answer — `dock_a` where `dock_old` was the truth — because a
+refusal that only fired when the fallback was empty would be indistinguishable
+from doing nothing. `re_execution_at_the_same_generation_is_stable_across_later_writes`
+pins the determinism the ruled `AnswerRef` will rest on, with a guard proving the
+head really moved.
+
+`read_at_generation` was added to the 3d answer-boundary gate's method list in
+the same change, so the new capability cannot become a fresh bypass.

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -2762,10 +2762,26 @@ may well have been superseded and made no difference, but it cannot be *shown* t
 have made none. Over-refusing costs availability; under-refusing returns a
 silently wrong reconstruction wearing the word "pinned".
 
-Worth stating plainly to whoever sets a retention horizon: **the compaction floor
-is also the floor on how far back answers stay reproducible.** That is a real
-operational consequence of the retention policy, and it was not visible before
-this existed.
+**`KIRRA-WM-REPRODUCIBILITY-HORIZON-001` (recorded here, to be carried into the
+`AnswerRef` contract):**
+
+> **Retention policy sets the historical reproducibility horizon for durable
+> answer references.** An `AnswerRef` is only as durable as the oldest generation
+> still reproducible from retained evidence and citations. "Durable reference"
+> must never be read as "forever replayable".
+
+That is a real operational consequence of the retention horizon and it was not
+visible before this existed: whoever sets a compaction policy is also setting how
+far back a recorded answer can be resolved. It belongs ON the ref's contract
+rather than in a footnote here, because the failure it prevents is someone
+storing refs as an audit artifact and discovering years later that the horizon
+swallowed them.
+
+The precise shape: a span removed BELOW a pinned generation ends its
+reproducibility, because the pin folds that prefix. A span removed entirely ABOVE
+it does not, because the prefix is untouched — both directions are pinned by
+tests, and the pair is what makes `lo_generation <= g` a decision rather than an
+accident.
 
 **A negative generation is an error, not an outcome.** Rule 3's split:
 `Irreproducible` reports facts about the DATA — this was compacted, this has not
@@ -2776,10 +2792,22 @@ reconstructs the empty projection that preceded every event.
 
 | Mutation | Caught by |
 |---|---|
-| fall forward to current state when compacted | both compaction tests |
+| fall forward to current state when compacted | 3 compaction tests |
 | clamp a future generation to the head | `a_generation_ahead_of_the_head_refuses` |
-| read the live table instead of replaying | 4 tests, incl. the positive witness |
+| read the live table instead of replaying | 5 tests, incl. the positive witness |
 | test span containment instead of overlap | both compaction tests |
+| **refuse on ANY citation, ignoring `lo_generation`** | `compaction_above_the_pinned_generation_leaves_it_reproducible` |
+
+**The last row is there because the suite was vacuous without it, and the gap was
+found in review rather than by writing it.** Every other compaction fixture
+removes a span BELOW the pin, so an implementation that refused on the mere
+existence of any citation passed all eight original tests. The missing control is
+the mirror case — a span removed entirely ABOVE the pin leaves the folded prefix
+intact, so the reconstruction is exact and refusing would be over-refusal rather
+than fail-closed. Without it, `lo_generation <= g` was an accident the tests could
+not tell from a blanket refusal, and the pinned read would have been useless in
+the regime it is most needed: an old, heavily-compacted store where the
+interesting coordinates are precisely those below the compaction floor.
 
 The compaction fixture is built so that falling forward returns a *plausible,
 non-empty, wrong* answer — `dock_a` where `dock_old` was the truth — because a


### PR DESCRIPTION
Step 1 of the agreed sequence — **stable snapshot → reproducible answer identity → honest degradation.**

`KIRRA-WM-ANSWER-IDENTITY-001` rules that resolving an `AnswerRef` means *"re-execute this exact deterministic query against the same snapshot"*. Until now that was a ruling with **no mechanism behind it**: `projection_generation()` could report the coordinate, and nothing could read AT it. WM_SCOPE carried the gap as its own open box; this closes it.

## What it does

`ReadSnapshot::read_at_generation(g)` (and `WorldStore::read_at_generation(g)`) reconstructs `world_current` as it stood at generation `g`, by replaying the confirmed log through `projection::fold_all` — the **same reducer the live fold uses**, over the same confirmed-only filter, in the same order.

It is not a second implementation of the projection that could drift from the first; it is the one implementation given a bounded input, which is exactly the property `rebuild_from_zero_equals_incremental` already pins. Taken inside a 3c snapshot, so the citation check and the replay cannot disagree about which events exist.

## It fails closed, and never falls forward

```rust
pub enum PinnedRead { Reproduced(PinnedProjection), Irreproducible(Irreproducible) }
pub enum Irreproducible { Compacted { spans: Vec<Citation> }, NotYetReached { head: i64 } }
```

There is no code path that answers with current state when the requested generation cannot be rebuilt. That failure mode is the one worth naming: falling forward is not merely wrong, it is wrong **in the way that looks right** — the caller asked what was true at generation 40 and receives what is true at 90, with nothing in the value to say so.

A future generation refuses rather than clamping, for the same reason.

## Generation is the right axis, and this is the one place the two axes genuinely differ

`identity_degradation` records — at length, because it was a real fail-open bug — that a transaction-time filter over citations **could not be repaired**: the removed rows are the only record of their own `txn_time_ms`, so a compacted span can never be shown irrelevant to a past instant after the fact.

Generation has no such problem. A `Citation` records the exact `lo_generation..=hi_generation` it removed — *the same axis being pinned* — so **"did compaction take anything at or below `g`" is an EXACT test**, not a necessary condition. That asymmetry is why the pin is on this axis.

## Compaction is what ends a pinned read's life

And it ends it for **every generation at or above** the removed span, not merely inside it: rebuilding at `g` folds every confirmed event `<= g`, and if one is gone the fold cannot be reproduced whatever its result would have been.

Deliberately stricter than necessary, on the asymmetry `Resolution` already documents — a removed event may well have been superseded and made no difference, but it cannot be *shown* to have made none. Over-refusing costs availability; under-refusing returns a silently wrong reconstruction wearing the word "pinned".

Worth stating to whoever sets a retention horizon: **the compaction floor is also the floor on how far back answers stay reproducible.** That is a real operational consequence of retention policy, and it was not visible before this existed.

## Error vs outcome

A negative generation is a `StoreError`, not an `Irreproducible`. Rule 3's split: `Irreproducible` reports facts about the **data** — this was compacted, this has not happened yet — and a negative generation is neither. Generation `0` is legal and reconstructs the empty projection that preceded every event.

## Non-vacuity

Four mutations, each caught:

| Mutation | Caught by |
|---|---|
| fall forward to current state when compacted | both compaction tests |
| clamp a future generation to the head | `a_generation_ahead_of_the_head_refuses` |
| read the live table instead of replaying | 4 tests, incl. the positive witness |
| test span containment instead of overlap | both compaction tests |

The compaction fixture is built so that falling forward returns a **plausible, non-empty, wrong** answer — `dock_a` where `dock_old` was the truth — because a refusal that only fired when the fallback was empty would be indistinguishable from doing nothing. (`compact_range` refuses to remove a live projection head, so the fixture supersedes a claim to make one compactable at all.)

`re_execution_at_the_same_generation_is_stable_across_later_writes` pins the determinism step 2's `AnswerRef` will rest on, with a guard proving the head really moved underneath it.

## Also

`read_at_generation` is added to the 3d answer-boundary gate's method list in the same change, so the new capability cannot become a fresh bypass on the day it lands.

## Verification

`cargo test --workspace` (234 test binaries, 0 failures) · `cargo clippy --workspace --all-targets -D warnings` · `cargo fmt --check` · answer-boundary gate + self-test (12/12) · symbolic-seam gate (18/18) · Fence A/B · orphan-cores · re-export shims · world domain-logic gate · quality guardrails · mick actuation fence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_