### PR TITLE
The ruled AnswerRef: a reproducible descriptor, and a version pinned to behaviour

### DIFF
--- a/crates/kirra-proposal-context/src/lib.rs
+++ b/crates/kirra-proposal-context/src/lib.rs
@@ -379,9 +379,15 @@ fn mirror_resolution(identity: &ObjectIdentity) -> ObjectResolution {
         ObjectIdentity::Refused(reason) => {
             ObjectResolution::Contradictory(ObjectResolution::contradiction_tag(reason))
         }
+        // Not reachable through `matchable`, and reported rather than panicked.
+        // `NotResolvedAtPin` sits here for a specific reason: it can only arise
+        // from an `AnswerRef` resolution, and this consumer asks live. If it
+        // ever appears, something is feeding pinned answers into a proposal —
+        // worth a visible "unclassified" rather than a plausible-looking tag.
         ObjectIdentity::NoObject
         | ObjectIdentity::Malformed
         | ObjectIdentity::NotAnEntity
+        | ObjectIdentity::NotResolvedAtPin
         | ObjectIdentity::Resolved { .. } => ObjectResolution::Contradictory("unclassified"),
     }
 }

--- a/crates/kirra-world-service/src/answer_ref.rs
+++ b/crates/kirra-world-service/src/answer_ref.rs
@@ -1,0 +1,274 @@
+//! **The ruled `AnswerRef`** — a reproducible descriptor, not a stored answer.
+//!
+//! `KIRRA-WM-ANSWER-IDENTITY-001`:
+//!
+//! > Tier 3 answers have no durable stored identity. An `AnswerRef` is a
+//! > reproducible DESCRIPTOR, not a persisted answer row. […] Resolving a ref
+//! > means **re-execute this exact deterministic query against the same
+//! > snapshot** and return its lineage, not *fetch the stored answer*.
+//!
+//! `KIRRA-WM-ANSWERREF-NAMING-001` reserved this name for exactly that contract
+//! and forbade putting it on a drift *detector*. The name is taken here because
+//! the mechanism now exists: `ReadSnapshot::read_at_generation` re-executes
+//! against the same snapshot, and fails closed when it cannot.
+//!
+//! # What a ref carries, and why each field
+//!
+//! | Field | Why |
+//! |---|---|
+//! | query kind | which query this describes; the ref is meaningless without it |
+//! | parameters | subject, clock, staleness budget — change one, change the answer |
+//! | pinned generation | the snapshot coordinate to re-execute AT |
+//! | rule version | the semantics the answer was produced under |
+//!
+//! Everything needed to re-execute, and nothing that is the answer itself. A ref
+//! holds no claims, no digests of claims, and no summary — because a durable
+//! answer row would need its own retention horizon, its own compaction story and
+//! its own provenance, recursively, which is the second store §10 puts out of
+//! scope.
+//!
+//! # `KIRRA-WM-REPRODUCIBILITY-HORIZON-001`
+//!
+//! > **Retention policy sets the historical reproducibility horizon for durable
+//! > answer references.** An `AnswerRef` is only as durable as the oldest
+//! > generation still reproducible from retained evidence and citations.
+//! > *"Durable reference"* must never be read as *"forever replayable"*.
+//!
+//! Stated on the contract rather than in a footnote, because the failure it
+//! prevents is someone keeping refs as an audit artifact and discovering years
+//! later that the retention horizon swallowed them. A ref that has aged past the
+//! compaction floor resolves to [`RefResolution::Irreproducible`] — which is an
+//! honest answer, and the reason resolution is not infallible.
+
+use kirra_world_store::snapshot::{Irreproducible, PinnedRead};
+use kirra_world_store::WorldStore;
+
+use crate::read_view::{AskError, ObjectIdentity, WorldAnswer};
+
+/// **The semantics an answer was produced under.**
+///
+/// Bumped when a rule that can change an answer changes. Two rules bear on a
+/// resolved ref today: the projection fold (`supersedes` / `fold_step`, which
+/// decides which claim wins a key) and the boundary's admissibility test (which
+/// decides whether a claim is servable at all).
+///
+/// # This is not decorative, and that took a mechanism
+///
+/// A hand-bumped constant with nothing behind it is exactly what Tier 3 box 3b
+/// calls *"decorative metadata"* — it would read the same across a semantics
+/// change, so [`RefResolution::VersionMismatch`] would never fire when it
+/// mattered and the ref would replay under new rules while claiming the old
+/// ones. `answer_ref.rs`'s corpus test pins the fold's observable output against
+/// this constant: change the rule without changing the version and the test
+/// fails, naming the obligation.
+///
+/// # What it is NOT
+///
+/// It is not box 3b. 3b asks for declared, behaviour-changing, corpus-and-source
+/// pinned versioning across *rules and projections generally*; this covers the
+/// two rules THIS ref's resolution depends on, which is the honest subset a ref
+/// can carry today. Widening it is 3b's job.
+pub const RULE_VERSION: u32 = 1;
+
+/// Which query a ref describes.
+///
+/// An enum with one variant today, and deliberately an enum: the ruling requires
+/// every public Tier 3 query to be fully serializable and deterministic, so the
+/// query's *identity* has to be a closed set rather than a free-form string a
+/// caller could invent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum QueryKind {
+    /// [`crate::read_view::WorldView::ask`] — what is currently known about one
+    /// subject.
+    CurrentSubject,
+}
+
+/// **A reproducible descriptor for one answer.**
+///
+/// Equality and hashing are structural over every field, which is what makes
+/// *"same query + same generation + same version produces the same ref"* a
+/// property of the type rather than a convention. There is deliberately no
+/// interior mutability, no clock read, and no random component — a ref that
+/// varied run to run could not be recorded.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct AnswerRef {
+    kind: QueryKind,
+    subject: String,
+    now_ms: i64,
+    staleness_budget_ms: Option<u64>,
+    generation: i64,
+    rule_version: u32,
+}
+
+impl AnswerRef {
+    /// Describe a `CurrentSubject` query at a pinned generation.
+    ///
+    /// The rule version is stamped from [`RULE_VERSION`] rather than accepted
+    /// from the caller: a ref records the semantics its answer was produced
+    /// under, and letting a caller name them would let it claim any.
+    #[must_use]
+    pub fn current_subject(
+        subject: impl Into<String>,
+        now_ms: i64,
+        staleness_budget_ms: Option<u64>,
+        generation: i64,
+    ) -> Self {
+        Self {
+            kind: QueryKind::CurrentSubject,
+            subject: subject.into(),
+            now_ms,
+            staleness_budget_ms,
+            generation,
+            rule_version: RULE_VERSION,
+        }
+    }
+
+    /// The query this describes.
+    #[must_use]
+    pub fn kind(&self) -> QueryKind {
+        self.kind
+    }
+
+    /// The subject asked about.
+    #[must_use]
+    pub fn subject(&self) -> &str {
+        &self.subject
+    }
+
+    /// The query instant.
+    #[must_use]
+    pub fn now_ms(&self) -> i64 {
+        self.now_ms
+    }
+
+    /// The caller's staleness budget, as supplied.
+    #[must_use]
+    pub fn staleness_budget_ms(&self) -> Option<u64> {
+        self.staleness_budget_ms
+    }
+
+    /// The snapshot coordinate to re-execute at.
+    #[must_use]
+    pub fn generation(&self) -> i64 {
+        self.generation
+    }
+
+    /// The semantics this ref's answer was produced under.
+    #[must_use]
+    pub fn rule_version(&self) -> u32 {
+        self.rule_version
+    }
+
+    /// Rebuild a ref that was recorded under a different rule version.
+    ///
+    /// For tests and for a reader decoding a persisted ref. Deliberately
+    /// explicit — there is no way to reach it by accident, and a ref built this
+    /// way says so by carrying a version that may not be [`RULE_VERSION`].
+    #[must_use]
+    pub fn recorded_under(mut self, rule_version: u32) -> Self {
+        self.rule_version = rule_version;
+        self
+    }
+
+    /// **Re-execute this exact query against the same snapshot.**
+    ///
+    /// # Order of refusals, which is not arbitrary
+    ///
+    /// The version check runs FIRST, before the store is touched. Re-executing
+    /// under new semantics and then noticing is not a check — the answer would
+    /// already have been computed under rules the ref never described, and
+    /// whether it got returned would depend on a later branch.
+    ///
+    /// # Errors
+    ///
+    /// Only on a storage fault, or `StoreError::InvalidGeneration` for a ref
+    /// carrying a negative generation. Irreproducibility is an OUTCOME, not an
+    /// error: *"we deleted the evidence"* is a fact about the data.
+    pub fn resolve(&self, store: &WorldStore) -> Result<RefResolution, AskError> {
+        if self.rule_version != RULE_VERSION {
+            return Ok(RefResolution::VersionMismatch {
+                recorded: self.rule_version,
+                current: RULE_VERSION,
+            });
+        }
+
+        let pinned = match store.read_at_generation(self.generation)? {
+            PinnedRead::Reproduced(p) => p,
+            PinnedRead::Irreproducible(reason) => return Ok(RefResolution::Irreproducible(reason)),
+        };
+
+        let clock = self.now_ms.max(0).unsigned_abs();
+        let mut answers = Vec::new();
+        for claim in pinned.current(&self.subject, self.now_ms) {
+            if !crate::read_view::is_admissible_for_ref(&claim, clock, self.staleness_budget_ms) {
+                continue;
+            }
+            answers.push(crate::read_view::bind_pinned(
+                &claim,
+                clock,
+                self.staleness_budget_ms,
+            )?);
+        }
+        Ok(RefResolution::Resolved(answers))
+    }
+}
+
+/// What resolving a ref produced.
+///
+/// Three outcomes, and **no silent fallback to current state**. That absence is
+/// the contract: a ref that cannot be re-executed says so, rather than handing
+/// back today's answer under yesterday's coordinate.
+#[derive(Debug, Clone)]
+pub enum RefResolution {
+    /// Re-executed against the same snapshot.
+    Resolved(Vec<WorldAnswer>),
+    /// The referenced snapshot is no longer reproducible — see
+    /// `KIRRA-WM-REPRODUCIBILITY-HORIZON-001`.
+    Irreproducible(Irreproducible),
+    /// The rules changed since the ref was recorded.
+    ///
+    /// Refused rather than replayed, because replaying would answer a question
+    /// the ref does not describe: the coordinate would be honoured and the
+    /// SEMANTICS silently swapped, which is the subtler half of falling forward.
+    VersionMismatch {
+        /// The version the ref was recorded under.
+        recorded: u32,
+        /// The version this build implements.
+        current: u32,
+    },
+}
+
+impl RefResolution {
+    /// The answers, if it resolved.
+    #[must_use]
+    pub fn resolved(&self) -> Option<&[WorldAnswer]> {
+        match self {
+            Self::Resolved(a) => Some(a),
+            _ => None,
+        }
+    }
+
+    /// Whether this is any kind of refusal.
+    #[must_use]
+    pub fn is_refused(&self) -> bool {
+        !matches!(self, Self::Resolved(_))
+    }
+}
+
+/// The object-identity an answer reached through a ref carries.
+///
+/// Always [`ObjectIdentity::NotResolvedAtPin`]. Stated as a named function
+/// rather than left implicit because it is a real limitation with a real reason:
+/// identity is a SECOND projection with its own coordinate, and the pinned read
+/// exists only for `world_current`. `identity_view_at` cuts on transaction time,
+/// so resolving identity here would pair a generation-pinned claim with a
+/// transaction-time-pinned identity — mixing the two axes, which is exactly what
+/// box 3c closed.
+///
+/// A generation-pinned identity read is the natural next prerequisite if refs
+/// ever need to carry resolved objects. Until then a resolved ref reports the
+/// stored object and says plainly that it was not resolved.
+#[must_use]
+pub fn pinned_object_identity() -> ObjectIdentity {
+    ObjectIdentity::NotResolvedAtPin
+}

--- a/crates/kirra-world-service/src/lib.rs
+++ b/crates/kirra-world-service/src/lib.rs
@@ -30,6 +30,7 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 
+pub mod answer_ref;
 pub mod read_view;
 
 // Both edges exercised, so the proposed three-node graph is genuinely built and

--- a/crates/kirra-world-service/src/read_view.rs
+++ b/crates/kirra-world-service/src/read_view.rs
@@ -45,9 +45,15 @@
 //!
 //! # What [`WorldAnswer`] buys, and the bound on it
 //!
-//! It has no constructor that omits validity, trust or provenance, and
-//! [`WorldView::ask`] is the only way to obtain one. So an answer in hand always
-//! carries them.
+//! It has no constructor that omits validity, trust or provenance, and only two
+//! things can produce one — [`WorldView::ask`] and
+//! [`crate::answer_ref::AnswerRef::resolve`]. Both funnel through the same
+//! private `assemble`, so an answer in hand always carries them, and adding a
+//! third producer means going through that funnel too.
+//!
+//! (This read *"`ask` is the only way to obtain one"* until refs landed. Caught
+//! in review on #1434: a guarantee stated as a count of functions goes stale the
+//! moment a second one is right, which is why it is now stated as the funnel.)
 //!
 //! **"Trust" here means the axes, not a summary of them.** Rule 1 says *the
 //! trust axes*, and an earlier draft of this type carried only the collapsed
@@ -567,13 +573,11 @@ impl<'a> WorldView<'a> {
         )
     }
 
-    /// The one place a `WorldAnswer` is built — every field populated together.
+    /// Bind a live claim into an answer, resolving its object identity.
     ///
-    /// See also `answer_ref`'s `bind_pinned`, which is this same construction
-    /// for a generation-pinned claim.
-    ///
-    /// Fallible only on the provenance handle, which is the one field that
-    /// carries an invariant the row cannot enforce.
+    /// Delegates the field-by-field construction to [`assemble`], which is the
+    /// one place a `WorldAnswer` is built; this adds only the identity
+    /// resolution a live read can do and a pinned one cannot.
     fn bind(
         &self,
         claim: &ProjectedClaim,
@@ -581,29 +585,12 @@ impl<'a> WorldView<'a> {
         identity: &IdentityView,
         identity_is_current: bool,
     ) -> Result<WorldAnswer, AskError> {
-        let provenance = EvidenceDigest::new(claim.chain_digest.clone()).map_err(|cause| {
-            AskError::CorruptProvenance {
-                subject: claim.subject.clone(),
-                predicate: claim.predicate.clone(),
-                cause,
-            }
-        })?;
-        Ok(WorldAnswer {
-            subject: claim.subject.clone(),
-            predicate: claim.predicate.clone(),
-            object_identity: Self::resolve_object(
-                claim.object.as_deref(),
-                identity,
-                identity_is_current,
-            ),
-            object: claim.object.clone(),
-            value: claim.payload.clone(),
-            validity: claim.validity_at(clock, self.staleness_budget_ms),
-            axes: claim.trust,
-            grade: claim.grade_at(clock, self.staleness_budget_ms),
-            provenance,
-            event_id: claim.event_id.clone(),
-        })
+        assemble(
+            claim,
+            clock,
+            self.staleness_budget_ms,
+            Self::resolve_object(claim.object.as_deref(), identity, identity_is_current),
+        )
     }
 
     /// Resolve one claim's object through the identity graph.
@@ -661,14 +648,40 @@ pub(crate) fn is_admissible_for_ref(
 
 /// Build a `WorldAnswer` from a generation-pinned claim.
 ///
-/// Identical to `WorldView::bind` except that object identity is
-/// [`ObjectIdentity::NotResolvedAtPin`] — see
-/// [`crate::answer_ref::pinned_object_identity`] for why a pinned answer cannot
-/// resolve identity without mixing coordinate axes.
+/// Delegates to [`assemble`] exactly as `WorldView::bind` does; the only
+/// difference is the object identity, which a pinned read cannot resolve — see
+/// [`crate::answer_ref::pinned_object_identity`].
 pub(crate) fn bind_pinned(
     claim: &ProjectedClaim,
     clock: u64,
     budget: Option<u64>,
+) -> Result<WorldAnswer, AskError> {
+    assemble(
+        claim,
+        clock,
+        budget,
+        crate::answer_ref::pinned_object_identity(),
+    )
+}
+
+/// **The one place a `WorldAnswer` is built** — every field populated together.
+///
+/// Private, and both producers go through it. Rule 1 says every answer carries
+/// the value, the trust axes, the validity at the supplied clock and a
+/// provenance handle; a second hand-written construction site is how one of
+/// those quietly stops being populated, so there is exactly one.
+///
+/// Object identity is the ONE thing a caller supplies, because it is the one
+/// thing that genuinely differs: a live read resolves it, a generation-pinned
+/// read cannot without mixing coordinate axes.
+///
+/// Fallible only on the provenance handle, which is the one field carrying an
+/// invariant the row cannot enforce.
+fn assemble(
+    claim: &ProjectedClaim,
+    clock: u64,
+    budget: Option<u64>,
+    object_identity: ObjectIdentity,
 ) -> Result<WorldAnswer, AskError> {
     let provenance = EvidenceDigest::new(claim.chain_digest.clone()).map_err(|cause| {
         AskError::CorruptProvenance {
@@ -680,7 +693,7 @@ pub(crate) fn bind_pinned(
     Ok(WorldAnswer {
         subject: claim.subject.clone(),
         predicate: claim.predicate.clone(),
-        object_identity: crate::answer_ref::pinned_object_identity(),
+        object_identity,
         object: claim.object.clone(),
         value: claim.payload.clone(),
         validity: claim.validity_at(clock, budget),

--- a/crates/kirra-world-service/src/read_view.rs
+++ b/crates/kirra-world-service/src/read_view.rs
@@ -362,6 +362,18 @@ pub enum WorldLookup {
 pub enum ObjectIdentity {
     /// The claim carries no object. Nothing to resolve.
     NoObject,
+    /// **This answer came from a generation-pinned read, where identity
+    /// resolution is not available.**
+    ///
+    /// Not a fault and not a stale graph: identity is a SECOND projection with
+    /// its own coordinate, and the pinned read exists only for `world_current`.
+    /// Resolving identity here would pair a generation-pinned claim with a
+    /// transaction-time-pinned identity, mixing the two axes that box 3c closed.
+    ///
+    /// Kept distinct from [`Self::Unresolvable`] because they call for different
+    /// responses: that one is an operator's problem to fix by folding, this one
+    /// is a limit of what a ref can currently reconstruct.
+    NotResolvedAtPin,
     /// **The identity graph is BEHIND the log: adjudications are recorded that
     /// it has not folded, so any resolution would be known-stale.**
     ///
@@ -412,7 +424,11 @@ impl ObjectIdentity {
         match self {
             Self::Resolved { entity, .. } => Some(entity),
             Self::NotAnEntity | Self::Malformed => stored_object,
-            Self::NoObject | Self::Unresolvable | Self::Ambiguous { .. } | Self::Refused(_) => None,
+            Self::NoObject
+            | Self::Unresolvable
+            | Self::NotResolvedAtPin
+            | Self::Ambiguous { .. }
+            | Self::Refused(_) => None,
         }
     }
 }
@@ -553,6 +569,9 @@ impl<'a> WorldView<'a> {
 
     /// The one place a `WorldAnswer` is built — every field populated together.
     ///
+    /// See also `answer_ref`'s `bind_pinned`, which is this same construction
+    /// for a generation-pinned claim.
+    ///
     /// Fallible only on the provenance handle, which is the one field that
     /// carries an invariant the row cannot enforce.
     fn bind(
@@ -624,4 +643,50 @@ impl<'a> WorldView<'a> {
             ResolutionOutcome::Refused(reason) => ObjectIdentity::Refused(reason),
         }
     }
+}
+
+/// The boundary's admissibility rule, for a generation-pinned claim.
+///
+/// `pub(crate)` so [`crate::answer_ref::AnswerRef::resolve`] applies the SAME
+/// test as a live `ask`, rather than a copy that could drift. A ref that
+/// admitted claims the boundary would refuse would be re-executing a different
+/// query than the one it names.
+pub(crate) fn is_admissible_for_ref(
+    claim: &ProjectedClaim,
+    clock: u64,
+    budget: Option<u64>,
+) -> bool {
+    WorldView::is_admissible(claim, clock, budget)
+}
+
+/// Build a `WorldAnswer` from a generation-pinned claim.
+///
+/// Identical to `WorldView::bind` except that object identity is
+/// [`ObjectIdentity::NotResolvedAtPin`] — see
+/// [`crate::answer_ref::pinned_object_identity`] for why a pinned answer cannot
+/// resolve identity without mixing coordinate axes.
+pub(crate) fn bind_pinned(
+    claim: &ProjectedClaim,
+    clock: u64,
+    budget: Option<u64>,
+) -> Result<WorldAnswer, AskError> {
+    let provenance = EvidenceDigest::new(claim.chain_digest.clone()).map_err(|cause| {
+        AskError::CorruptProvenance {
+            subject: claim.subject.clone(),
+            predicate: claim.predicate.clone(),
+            cause,
+        }
+    })?;
+    Ok(WorldAnswer {
+        subject: claim.subject.clone(),
+        predicate: claim.predicate.clone(),
+        object_identity: crate::answer_ref::pinned_object_identity(),
+        object: claim.object.clone(),
+        value: claim.payload.clone(),
+        validity: claim.validity_at(clock, budget),
+        axes: claim.trust,
+        grade: claim.grade_at(clock, budget),
+        provenance,
+        event_id: claim.event_id.clone(),
+    })
 }

--- a/crates/kirra-world-service/tests/answer_ref.rs
+++ b/crates/kirra-world-service/tests/answer_ref.rs
@@ -1,0 +1,464 @@
+//! **The ruled `AnswerRef` — step 2 of stable snapshot → answer identity →
+//! honest degradation.**
+//!
+//! `KIRRA-WM-ANSWERREF-NAMING-001` reserved the name for a descriptor that
+//! re-executes against the same snapshot, and forbade putting it on a drift
+//! detector. The name is taken now because
+//! `ReadSnapshot::read_at_generation` exists.
+//!
+//! The acceptance set, in order:
+//!
+//! 1. the same ref resolves identically before compaction;
+//! 2. a future generation refuses;
+//! 3. compaction BELOW the pinned generation makes the ref irreproducible;
+//! 4. compaction ABOVE it does not;
+//! 5. a version mismatch refuses rather than replaying under new semantics;
+//! 6. changing query parameters changes the ref;
+//! 7. same query + same generation + same version produces the same ref;
+//! 8. the "plausible wrong current answer" fall-forward remains caught.
+//!
+//! Cases 3 and 4 are the pair that make the reproducibility bound a decision:
+//! the store-level suite was vacuous without the second, and a ref inherits that
+//! bound wholesale, so it is re-asserted here at the level a caller sees.
+
+use kirra_world_service::answer_ref::{AnswerRef, QueryKind, RefResolution, RULE_VERSION};
+use kirra_world_store::snapshot::Irreproducible;
+use kirra_world_store::{ClaimStatus, EventId, NewEvent, ObservationId, WorldStore, WriterClass};
+
+const T0: i64 = 1_700_000_000_000;
+const LATER: i64 = T0 + 1_000;
+
+fn tmp(name: &str) -> std::path::PathBuf {
+    static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let n = NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "kirra-answer-ref-{name}-{}-{n}.sqlite",
+        std::process::id()
+    ));
+    cleanup(&p);
+    p
+}
+
+fn cleanup(path: &std::path::Path) {
+    for suffix in ["", "-wal", "-shm"] {
+        let mut q = path.as_os_str().to_os_string();
+        q.push(suffix);
+        let _ = std::fs::remove_file(std::path::PathBuf::from(q));
+    }
+}
+
+fn claim(store: &mut WorldStore, tag: &str, object: &str, at_ms: i64) {
+    store
+        .append(&NewEvent {
+            event_id: &EventId::new(format!("ev-{tag}")).expect("event id"),
+            observation_id: &ObservationId::new(format!("obs-{tag}")).expect("obs"),
+            txn_time_ms: at_ms,
+            valid_from_ms: at_ms,
+            valid_to_ms: None,
+            source: "warehouse-scanner",
+            source_version: "1.0.0",
+            writer_class: WriterClass::Sensor,
+            claim_status: ClaimStatus::Confirmed,
+            provenance: &[],
+            frame_id: None,
+            map_id: None,
+            kind: "mission",
+            subject: "package_17",
+            subject_ref: None,
+            predicate: Some("last_seen_at"),
+            object: Some(object),
+            payload: "{}",
+            payload_schema: 1,
+            retention_class: "raw",
+            trust: None,
+        })
+        .expect("append");
+}
+
+/// `dock_old` at generation 1, `dock_a` at 2 — an answer that CHANGED, so a ref
+/// pinned at 1 can be told apart from one that fell forward.
+fn store_that_changed_its_mind(name: &str) -> (WorldStore, std::path::PathBuf) {
+    let path = tmp(name);
+    let mut store = WorldStore::open(&path).expect("open");
+    claim(&mut store, "1", "dock_old", T0);
+    store.fold().expect("fold");
+    claim(&mut store, "2", "dock_a", T0 + 1);
+    store.fold().expect("fold");
+    (store, path)
+}
+
+fn objects(res: &RefResolution) -> Vec<String> {
+    res.resolved()
+        .expect("resolved")
+        .iter()
+        .filter_map(|a| a.object().map(str::to_string))
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// 1, 7, 8 — identity and reproduction
+// ---------------------------------------------------------------------------
+
+/// **The same ref resolves identically, and to the PAST answer.**
+///
+/// Cases 1 and 8 together: resolving twice agrees, and what it agrees on is
+/// `dock_old` — the answer at the pinned generation — not `dock_a`, which is
+/// what a fall-forward would return and what the live read returns.
+#[test]
+fn the_same_ref_resolves_identically_and_to_the_pinned_answer() {
+    let (store, path) = store_that_changed_its_mind("stable");
+    let r = AnswerRef::current_subject("package_17", LATER, None, 1);
+
+    let first = r.resolve(&store).expect("resolve");
+    let second = r.resolve(&store).expect("resolve again");
+
+    assert_eq!(objects(&first), vec!["dock_old".to_string()]);
+    assert_eq!(
+        objects(&first),
+        objects(&second),
+        "the same ref must re-execute to the same answer"
+    );
+
+    // Non-vacuity: the pinned answer really differs from the current one, so
+    // "resolved correctly" is distinguishing something.
+    let live = AnswerRef::current_subject("package_17", LATER, None, 2);
+    assert_eq!(
+        objects(&live.resolve(&store).expect("resolve")),
+        vec!["dock_a"]
+    );
+
+    drop(store);
+    cleanup(&path);
+}
+
+/// **Same query + same generation + same version produces the same ref.**
+///
+/// Ref identity is structural, so recording one and rebuilding it later must
+/// yield an equal value — otherwise a stored ref could never be matched against
+/// a fresh one.
+#[test]
+fn the_same_query_at_the_same_coordinate_produces_the_same_ref() {
+    let a = AnswerRef::current_subject("package_17", LATER, Some(60_000), 7);
+    let b = AnswerRef::current_subject("package_17", LATER, Some(60_000), 7);
+    assert_eq!(a, b);
+
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    let hash = |r: &AnswerRef| {
+        let mut h = DefaultHasher::new();
+        r.hash(&mut h);
+        h.finish()
+    };
+    assert_eq!(hash(&a), hash(&b), "equal refs must hash equally");
+
+    assert_eq!(a.kind(), QueryKind::CurrentSubject);
+    assert_eq!(a.rule_version(), RULE_VERSION);
+}
+
+/// **Changing any query parameter changes the ref.**
+///
+/// Each field is varied one at a time. A ref that ignored a parameter would
+/// describe a different query than the one that produced the answer, and would
+/// re-execute to something else while comparing equal.
+#[test]
+fn changing_any_parameter_changes_the_ref() {
+    let base = AnswerRef::current_subject("package_17", LATER, Some(60_000), 7);
+
+    let variants = [
+        (
+            "subject",
+            AnswerRef::current_subject("package_18", LATER, Some(60_000), 7),
+        ),
+        (
+            "now_ms",
+            AnswerRef::current_subject("package_17", LATER + 1, Some(60_000), 7),
+        ),
+        (
+            "budget",
+            AnswerRef::current_subject("package_17", LATER, Some(59_999), 7),
+        ),
+        (
+            "budget-none",
+            AnswerRef::current_subject("package_17", LATER, None, 7),
+        ),
+        (
+            "generation",
+            AnswerRef::current_subject("package_17", LATER, Some(60_000), 8),
+        ),
+        (
+            "rule-version",
+            AnswerRef::current_subject("package_17", LATER, Some(60_000), 7)
+                .recorded_under(RULE_VERSION + 1),
+        ),
+    ];
+
+    for (field, other) in variants {
+        assert_ne!(base, other, "changing {field} must change the ref");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 2, 3, 4 — the reproducibility horizon, at the ref level
+// ---------------------------------------------------------------------------
+
+/// **A future generation refuses.**
+#[test]
+fn a_future_generation_refuses() {
+    let (store, path) = store_that_changed_its_mind("future");
+    let r = AnswerRef::current_subject("package_17", LATER, None, 9_999);
+
+    match r.resolve(&store).expect("resolve") {
+        RefResolution::Irreproducible(Irreproducible::NotYetReached { .. }) => {}
+        other => panic!("a future coordinate must refuse, got {other:?}"),
+    }
+
+    drop(store);
+    cleanup(&path);
+}
+
+/// **Compaction BELOW the pinned generation makes the ref irreproducible.**
+///
+/// The horizon reaching a recorded ref, which is the failure
+/// `KIRRA-WM-REPRODUCIBILITY-HORIZON-001` exists to keep visible. Note the ref
+/// resolved fine a moment earlier — nothing about the ref changed, the world
+/// under it did.
+#[test]
+fn compaction_below_the_pin_makes_the_ref_irreproducible() {
+    let (mut store, path) = store_that_changed_its_mind("compacted");
+    let r = AnswerRef::current_subject("package_17", LATER, None, 1);
+
+    assert_eq!(
+        objects(&r.resolve(&store).expect("resolve")),
+        vec!["dock_old"]
+    );
+
+    store.compact_range(1, 1, T0 + 5_000).expect("compact");
+
+    match r.resolve(&store).expect("resolve") {
+        RefResolution::Irreproducible(Irreproducible::Compacted { spans }) => {
+            assert!(!spans.is_empty(), "the refusal must name what was removed");
+        }
+        RefResolution::Resolved(a) => panic!(
+            "fell forward: a ref past the horizon returned {:?}",
+            a.iter().filter_map(|x| x.object()).collect::<Vec<_>>()
+        ),
+        other => panic!("expected a compaction refusal, got {other:?}"),
+    }
+
+    drop(store);
+    cleanup(&path);
+}
+
+/// **Compaction ABOVE the pinned generation does not.**
+///
+/// The control without which case 3 is vacuous: an implementation refusing on
+/// the mere existence of any citation would pass every other case here, and
+/// would make recorded refs useless on exactly the aged, compacted stores they
+/// are kept for.
+#[test]
+fn compaction_above_the_pin_leaves_the_ref_resolvable() {
+    let path = tmp("above");
+    let mut store = WorldStore::open(&path).expect("open");
+    claim(&mut store, "1", "dock_old", T0);
+    claim(&mut store, "2", "dock_a", T0 + 1);
+    claim(&mut store, "3", "dock_b", T0 + 2);
+    store.fold().expect("fold");
+
+    let r = AnswerRef::current_subject("package_17", LATER, None, 1);
+    store.compact_range(2, 2, T0 + 5_000).expect("compact");
+
+    assert_eq!(
+        objects(&r.resolve(&store).expect("resolve")),
+        vec!["dock_old"],
+        "a span removed above the pin took none of the events the ref folds"
+    );
+
+    drop(store);
+    cleanup(&path);
+}
+
+// ---------------------------------------------------------------------------
+// 5 — semantics, not just coordinates
+// ---------------------------------------------------------------------------
+
+/// **A version mismatch refuses rather than replaying under new semantics.**
+///
+/// The subtler half of falling forward: the COORDINATE is honoured and the
+/// RULES are silently swapped, so the answer looks right and describes a query
+/// nobody asked. The ref pins the generation exactly, and the resolution would
+/// succeed if the version were ignored — which is what makes this test sharp.
+#[test]
+fn a_version_mismatch_refuses_rather_than_replaying() {
+    let (store, path) = store_that_changed_its_mind("version");
+
+    let current = AnswerRef::current_subject("package_17", LATER, None, 1);
+    assert!(
+        current
+            .resolve(&store)
+            .expect("resolve")
+            .resolved()
+            .is_some(),
+        "the fixture must resolve at the current version, or the refusal below \
+         proves only that the coordinate was bad"
+    );
+
+    let stale = current.clone().recorded_under(RULE_VERSION - 1);
+    match stale.resolve(&store).expect("resolve") {
+        RefResolution::VersionMismatch { recorded, current } => {
+            assert_eq!(recorded, RULE_VERSION - 1);
+            assert_eq!(current, RULE_VERSION);
+        }
+        other => panic!("a stale rule version must refuse, got {other:?}"),
+    }
+
+    // A version from the FUTURE refuses too — a ref written by a newer build
+    // describes semantics this one does not implement.
+    match current
+        .recorded_under(RULE_VERSION + 1)
+        .resolve(&store)
+        .expect("resolve")
+    {
+        RefResolution::VersionMismatch { .. } => {}
+        other => panic!("an unknown future version must refuse, got {other:?}"),
+    }
+
+    drop(store);
+    cleanup(&path);
+}
+
+// ---------------------------------------------------------------------------
+// The corpus pin that keeps RULE_VERSION honest
+// ---------------------------------------------------------------------------
+
+/// **`RULE_VERSION` is pinned to the semantics a REF resolves under.**
+///
+/// Without this the version is what box 3b calls decorative metadata: a constant
+/// nobody is obliged to bump, so `VersionMismatch` would never fire on a real
+/// semantics change and a ref would replay under new rules while claiming the
+/// old ones.
+///
+/// # It pins the ref's own output, and the first draft pinned the wrong thing
+///
+/// An earlier version digested `projection_state_digest()` — the LIVE
+/// projection — and was insensitive to the rule the ref actually uses. The
+/// reason is worth recording, because it is a real property of this store:
+/// **supersession has two implementations.** The incremental fold does it in
+/// SQL —
+///
+/// ```sql
+/// WHERE (excluded.valid_from_ms, excluded.generation)
+///     > (world_current.valid_from_ms, world_current.generation)
+/// ```
+///
+/// — while `projection::supersedes` / `fold_step` is the pure reducer used by
+/// `rebuild_projections` and by the pinned replay. The two are held equal by
+/// `rebuild_from_zero_equals_incremental`; but a corpus digesting the live table
+/// measured the SQL, so mutating `fold_step` left it green while changing what
+/// every `AnswerRef` resolves to.
+///
+/// So this pins the resolved ANSWER, canonically rendered. That covers the fold
+/// rule (through the replay) and the boundary's admissibility rule (through the
+/// binding) — the two rules `RULE_VERSION` claims to describe — and it fails on
+/// a change to either.
+///
+/// Rendered rather than hashed on purpose: a failure should show WHAT changed,
+/// not merely that something did.
+#[test]
+fn the_rule_version_is_pinned_to_the_semantics_a_ref_resolves_under() {
+    // This rendering belongs to RULE_VERSION 1. Bump both together.
+    const PINNED_FOR_VERSION: u32 = 1;
+    const PINNED_ANSWER: &str = "package_17|last_seen_at|dock_second|{}|Timeless|Ungraded";
+
+    assert_eq!(
+        RULE_VERSION, PINNED_FOR_VERSION,
+        "RULE_VERSION moved without re-pinning the corpus — the two are a pair, \
+         and a version that moves alone tracks nothing"
+    );
+
+    let path = tmp("corpus");
+    let mut store = WorldStore::open(&path).expect("open");
+
+    // The corpus must exercise supersession in BOTH directions, or a mutated
+    // fold can land on the same state and the pin proves nothing.
+    //
+    // ACCEPTED supersession — later valid time arriving later, must replace.
+    claim(&mut store, "c1", "dock_first", T0);
+    claim(&mut store, "c2", "dock_second", T0 + 10);
+    // REJECTED supersession — earlier valid time arriving later, must not.
+    claim(&mut store, "c3", "dock_backdated", T0 + 5);
+    // A candidate, which the confirmed-only fold must ignore entirely.
+    store
+        .append(&NewEvent {
+            event_id: &EventId::new("ev-cand").expect("id"),
+            observation_id: &ObservationId::new("obs-cand").expect("obs"),
+            txn_time_ms: T0 + 20,
+            valid_from_ms: T0 + 20,
+            valid_to_ms: None,
+            source: "llm",
+            source_version: "1.0.0",
+            writer_class: WriterClass::Sensor,
+            claim_status: ClaimStatus::Candidate,
+            provenance: &[],
+            frame_id: None,
+            map_id: None,
+            kind: "mission",
+            subject: "package_17",
+            subject_ref: None,
+            predicate: Some("last_seen_at"),
+            object: Some("dock_hallucinated"),
+            payload: "{}",
+            payload_schema: 1,
+            retention_class: "raw",
+            trust: None,
+        })
+        .expect("append candidate");
+    store.fold().expect("fold");
+
+    let head = store
+        .projection_coordinate()
+        .expect("coordinate")
+        .world_current()
+        .generation();
+    let resolved = AnswerRef::current_subject("package_17", T0 + 100, None, head)
+        .resolve(&store)
+        .expect("resolve");
+
+    let rendered: Vec<String> = resolved
+        .resolved()
+        .expect("the corpus must resolve, or it is pinning a refusal")
+        .iter()
+        .map(|a| {
+            format!(
+                "{}|{}|{}|{}|{:?}|{:?}",
+                a.subject(),
+                a.predicate().unwrap_or(""),
+                a.object().unwrap_or(""),
+                a.value(),
+                a.validity(),
+                a.grade()
+                    .map_or(FactGradeShim::Ungraded, |_| { FactGradeShim::Graded })
+            )
+        })
+        .collect();
+
+    assert_eq!(
+        rendered.join("\n"),
+        PINNED_ANSWER,
+        "the semantics a ref resolves under changed. If that was deliberate, \
+         bump RULE_VERSION and re-pin this rendering in the same commit — a \
+         recorded AnswerRef must not silently replay under the new rule."
+    );
+
+    drop(store);
+    cleanup(&path);
+}
+
+/// A two-state stand-in for the grade, so the corpus rendering stays stable
+/// against additions to the world's grade vocabulary while still moving if a
+/// claim becomes graded when it was not.
+#[derive(Debug)]
+enum FactGradeShim {
+    Graded,
+    Ungraded,
+}

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -2860,6 +2860,16 @@ carry `ObjectIdentity::NotResolvedAtPin`, which `matchable` refuses, so a pinned
 answer cannot shape a proposal by accident. A generation-pinned IDENTITY read is
 the natural next prerequisite if refs ever need resolved objects.
 
+**One construction funnel, restored rather than re-worded.** Adding a second
+producer of `WorldAnswer` made two claims stale at once — `bind`'s *"the one
+place a `WorldAnswer` is built"* and the module's *"`ask` is the only way to
+obtain one"*. Caught in review. The fix is a private `assemble` that both `bind`
+and `bind_pinned` delegate to, so the property is true again instead of the claim
+being weakened to match: rule 1 says every answer carries value, axes, validity
+and provenance, and a second hand-written construction site is how one of those
+quietly stops being populated. Verified load-bearing — hard-coding one field
+inside `assemble` reds three tests.
+
 **Non-vacuity.** The acceptance set is the eight cases agreed for this step, plus
 mutations: ignoring the version check, falling forward when irreproducible,
 dropping the generation from ref identity, and two fold-rule changes — each

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -2818,3 +2818,49 @@ head really moved.
 
 `read_at_generation` was added to the 3d answer-boundary gate's method list in
 the same change, so the new capability cannot become a fresh bypass.
+
+
+### The ruled `AnswerRef` — 2026-08-10
+
+`KIRRA-WM-ANSWERREF-NAMING-001` reserved this name for a descriptor that
+re-executes against the same snapshot, and forbade putting it on a drift
+detector. **The name is taken now**, because the mechanism exists.
+
+`AnswerRef` carries query kind, parameters, pinned generation and rule version —
+everything needed to re-execute, and nothing that is the answer. `resolve()`
+returns `Resolved | Irreproducible | VersionMismatch`, with **no silent fallback
+to current state**; that absence is the contract.
+
+**The version check runs before the store is touched.** Re-executing under new
+semantics and then noticing is not a check: the answer would already have been
+computed under rules the ref never described. A version mismatch is the subtler
+half of falling forward — the coordinate is honoured and the SEMANTICS are
+silently swapped, so the answer looks right and describes a query nobody asked.
+
+**`RULE_VERSION` is pinned to behaviour, and the first pin measured the wrong
+thing.** A hand-bumped constant is what 3b calls decorative metadata, so a corpus
+test anchors it. The first draft digested `projection_state_digest()` — the LIVE
+projection — and was insensitive to the rule a ref actually uses. The reason is a
+real property of this store, now recorded: **supersession has two
+implementations.** The incremental fold does it in SQL
+(`WHERE (excluded.valid_from_ms, excluded.generation) > (world_current…)`), while
+`projection::supersedes` / `fold_step` is the pure reducer used by
+`rebuild_projections` and by the pinned replay. `rebuild_from_zero_equals_incremental`
+holds them equal — but a corpus digesting the live table measured the SQL, so
+mutating `fold_step` left it green while changing what every ref resolves to.
+The pin is now over the resolved ANSWER, which covers the fold rule (through the
+replay) and admissibility (through the binding), and fails on either.
+
+**What a resolved ref deliberately does NOT do.** It does not resolve object
+identity: identity is a second projection with its own coordinate, the pinned
+read exists only for `world_current`, and `identity_view_at` cuts on transaction
+time — so resolving here would pair a generation-pinned claim with a
+transaction-time-pinned identity, mixing the axes box 3c closed. Pinned answers
+carry `ObjectIdentity::NotResolvedAtPin`, which `matchable` refuses, so a pinned
+answer cannot shape a proposal by accident. A generation-pinned IDENTITY read is
+the natural next prerequisite if refs ever need resolved objects.
+
+**Non-vacuity.** The acceptance set is the eight cases agreed for this step, plus
+mutations: ignoring the version check, falling forward when irreproducible,
+dropping the generation from ref identity, and two fold-rule changes — each
+caught, the last two only after the corpus was re-anchored.


### PR DESCRIPTION
Step 2 of **stable snapshot → reproducible answer identity → honest degradation.**

`KIRRA-WM-ANSWERREF-NAMING-001` reserved this name for a descriptor that re-executes against the same snapshot, and forbade putting it on a drift detector. **The name is taken now**, because `read_at_generation` (#1433) exists.

## What ships

`AnswerRef` carries query kind, parameters, pinned generation, rule version — everything needed to re-execute, nothing that is the answer.

```rust
pub enum RefResolution {
    Resolved(Vec<WorldAnswer>),
    Irreproducible(Irreproducible),
    VersionMismatch { recorded: u32, current: u32 },
}
```

No silent fallback to current state. That absence is the contract.

**The version check runs before the store is touched.** Re-executing under new semantics and *then* noticing is not a check — the answer would already have been computed under rules the ref never described. A version mismatch is the subtler half of falling forward: the coordinate is honoured and the semantics silently swapped, so the answer looks right and describes a query nobody asked.

## `RULE_VERSION` is pinned to behaviour — and my first pin measured the wrong thing

A hand-bumped constant is exactly what box 3b calls *decorative metadata*: nothing obliges anyone to bump it, so `VersionMismatch` would never fire when it mattered. So a corpus test anchors it.

The first draft digested `projection_state_digest()` — the **live** projection — and was insensitive to the rule a ref actually uses. The reason is a real property of this store, and worth recording: **supersession has two implementations.**

| Path | Implementation |
|---|---|
| incremental fold | SQL — `WHERE (excluded.valid_from_ms, excluded.generation) > (world_current.…)` |
| rebuild + pinned replay | `projection::supersedes` / `fold_step` |

`rebuild_from_zero_equals_incremental` holds them equal. But a corpus digesting the live table measured the **SQL**, so mutating `fold_step` left it green while changing what every `AnswerRef` resolves to. The pin is now over the **resolved answer**, which covers the fold rule (through the replay) and admissibility (through the binding), and fails on either. Rendered rather than hashed, so a failure shows *what* changed.

## Deliberately not done

A resolved ref does **not** resolve object identity. Identity is a second projection with its own coordinate; the pinned read exists only for `world_current`, and `identity_view_at` cuts on transaction time — so resolving here would pair a generation-pinned claim with a transaction-time-pinned identity, mixing the axes box 3c closed.

Pinned answers carry `ObjectIdentity::NotResolvedAtPin`, which `matchable` refuses, so a pinned answer cannot shape a proposal by accident. A generation-pinned *identity* read is the natural next prerequisite if refs ever need resolved objects.

## Acceptance set

The eight agreed cases:

| # | Case | Test |
|---|---|---|
| 1 | same ref resolves identically | `the_same_ref_resolves_identically_and_to_the_pinned_answer` |
| 2 | future generation refuses | `a_future_generation_refuses` |
| 3 | compaction below the pin → irreproducible | `compaction_below_the_pin_makes_the_ref_irreproducible` |
| 4 | compaction above it does not | `compaction_above_the_pin_leaves_the_ref_resolvable` |
| 5 | version mismatch refuses | `a_version_mismatch_refuses_rather_than_replaying` |
| 6 | changing params changes the ref | `changing_any_parameter_changes_the_ref` |
| 7 | same query+gen+version → same ref | `the_same_query_at_the_same_coordinate_produces_the_same_ref` |
| 8 | fall-forward still caught | case 1's non-vacuity guard |

## Non-vacuity

Five mutations, each caught:

| Mutation | Caught by |
|---|---|
| ignore the version check | `a_version_mismatch_refuses_rather_than_replaying` |
| fall forward when irreproducible | `compaction_below_the_pin_makes_the_ref_irreproducible` |
| drop generation from ref identity | `changing_any_parameter_changes_the_ref` |
| fold: never supersede | corpus pin + case 1 |
| fold: invert the supersession comparison | corpus pin + case 1 |

The last two were caught **only after** the corpus was re-anchored — that failure is how the two-implementation split was found.

Case 5's fixture asserts the ref resolves fine at the current version first, so the refusal cannot be passing because the coordinate was bad.

## Verification

`cargo clippy --all-targets -D warnings` on the touched crates · `cargo fmt --check` · 31 test binaries green across `kirra-world-service` / `kirra-world-store` / `kirra-proposal-context` · answer-boundary gate + self-test (12/12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_