### PR TITLE
Tier 3 box 3g: propagate completeness across the answer boundary

### DIFF
--- a/crates/kirra-proposal-context/src/lib.rs
+++ b/crates/kirra-proposal-context/src/lib.rs
@@ -380,10 +380,11 @@ fn mirror_resolution(identity: &ObjectIdentity) -> ObjectResolution {
             ObjectResolution::Contradictory(ObjectResolution::contradiction_tag(reason))
         }
         // Not reachable through `matchable`, and reported rather than panicked.
-        // `NotResolvedAtPin` sits here for a specific reason: it can only arise
-        // from an `AnswerRef` resolution, and this consumer asks live. If it
-        // ever appears, something is feeding pinned answers into a proposal —
-        // worth a visible "unclassified" rather than a plausible-looking tag.
+        // `NotResolvedInReplay` sits here for a specific reason: it can only
+        // arise from a REPLAYED answer — an `AnswerRef` resolution or a
+        // bitemporal `ask_as_of` — and this consumer asks live. If it ever
+        // appears, something is feeding replayed answers into a proposal, which
+        // is worth a visible "unclassified" rather than a plausible-looking tag.
         ObjectIdentity::NoObject
         | ObjectIdentity::Malformed
         | ObjectIdentity::NotAnEntity

--- a/crates/kirra-proposal-context/src/lib.rs
+++ b/crates/kirra-proposal-context/src/lib.rs
@@ -387,7 +387,7 @@ fn mirror_resolution(identity: &ObjectIdentity) -> ObjectResolution {
         ObjectIdentity::NoObject
         | ObjectIdentity::Malformed
         | ObjectIdentity::NotAnEntity
-        | ObjectIdentity::NotResolvedAtPin
+        | ObjectIdentity::NotResolvedInReplay
         | ObjectIdentity::Resolved { .. } => ObjectResolution::Contradictory("unclassified"),
     }
 }

--- a/crates/kirra-world-service/src/answer_ref.rs
+++ b/crates/kirra-world-service/src/answer_ref.rs
@@ -257,7 +257,7 @@ impl RefResolution {
 
 /// The object-identity an answer reached through a ref carries.
 ///
-/// Always [`ObjectIdentity::NotResolvedAtPin`]. Stated as a named function
+/// Always [`ObjectIdentity::NotResolvedInReplay`]. Stated as a named function
 /// rather than left implicit because it is a real limitation with a real reason:
 /// identity is a SECOND projection with its own coordinate, and the pinned read
 /// exists only for `world_current`. `identity_view_at` cuts on transaction time,
@@ -270,5 +270,5 @@ impl RefResolution {
 /// stored object and says plainly that it was not resolved.
 #[must_use]
 pub fn pinned_object_identity() -> ObjectIdentity {
-    ObjectIdentity::NotResolvedAtPin
+    ObjectIdentity::NotResolvedInReplay
 }

--- a/crates/kirra-world-service/src/read_view.rs
+++ b/crates/kirra-world-service/src/read_view.rs
@@ -95,6 +95,7 @@
 use kirra_world::evidence::{DigestError, EvidenceDigest};
 use kirra_world::reference::EntityId;
 use kirra_world::resolution::{resolve, RefusalReason, ResolutionOutcome};
+use kirra_world_store::compaction::Resolution;
 use kirra_world_store::entity_projection::IdentityView;
 use kirra_world_store::snapshot::SnapshotCoordinate;
 use kirra_world_store::{ProjectedClaim, StoreError, TrustAxes, TrustGrade, Validity, WorldStore};
@@ -368,8 +369,8 @@ pub enum WorldLookup {
 pub enum ObjectIdentity {
     /// The claim carries no object. Nothing to resolve.
     NoObject,
-    /// **This answer came from a generation-pinned read, where identity
-    /// resolution is not available.**
+    /// **This answer came from a log REPLAY — generation-pinned or bitemporal —
+    /// where identity resolution is not performed.**
     ///
     /// Not a fault and not a stale graph: identity is a SECOND projection with
     /// its own coordinate, and the pinned read exists only for `world_current`.
@@ -379,7 +380,7 @@ pub enum ObjectIdentity {
     /// Kept distinct from [`Self::Unresolvable`] because they call for different
     /// responses: that one is an operator's problem to fix by folding, this one
     /// is a limit of what a ref can currently reconstruct.
-    NotResolvedAtPin,
+    NotResolvedInReplay,
     /// **The identity graph is BEHIND the log: adjudications are recorded that
     /// it has not folded, so any resolution would be known-stale.**
     ///
@@ -432,7 +433,7 @@ impl ObjectIdentity {
             Self::NotAnEntity | Self::Malformed => stored_object,
             Self::NoObject
             | Self::Unresolvable
-            | Self::NotResolvedAtPin
+            | Self::NotResolvedInReplay
             | Self::Ambiguous { .. }
             | Self::Refused(_) => None,
         }
@@ -556,6 +557,73 @@ impl<'a> WorldView<'a> {
             WorldLookup::Answered(answers)
         };
         Ok(ComposedLookup { lookup, coordinate })
+    }
+
+    /// **Ask what was true at `valid_at_ms`, as the store knew it at
+    /// `as_known_at_ms`** — the bitemporal query, carrying its completeness.
+    ///
+    /// The answer boundary's first query family that can genuinely DEGRADE.
+    /// `ask` reads `world_current`, which compaction structurally protects
+    /// (`compact_range` refuses to remove a live projection head), so its
+    /// completeness would be `Full` by construction and prove nothing. This one
+    /// replays the log, which is precisely what compaction removes.
+    ///
+    /// # The completeness is the store's, propagated — not recomputed
+    ///
+    /// `WorldStore::as_of` already decides `Full` vs `Degraded` against the
+    /// retained summaries on both temporal axes. A second judgement here would
+    /// be a second implementation of the rule that governs whether an answer can
+    /// be trusted, and the two would drift. This carries the store's verdict
+    /// across the boundary unchanged; 3g is about propagation, not about a new
+    /// opinion.
+    ///
+    /// # Errors
+    ///
+    /// As [`WorldView::ask`].
+    pub fn ask_as_of(
+        &self,
+        subject: &str,
+        valid_at_ms: i64,
+        as_known_at_ms: i64,
+    ) -> Result<TemporalLookup, AskError> {
+        let answer = self.store.as_of(subject, valid_at_ms, as_known_at_ms)?;
+        let completeness = answer.resolution;
+
+        let clock = valid_at_ms.max(0).unsigned_abs();
+        let mut answers = Vec::new();
+        for claim in &answer.claims {
+            if !Self::is_admissible(claim, clock, self.staleness_budget_ms) {
+                continue;
+            }
+            answers.push(assemble(
+                claim,
+                clock,
+                self.staleness_budget_ms,
+                // A replayed answer does not resolve identity. Unlike the
+                // generation pin the axes would actually AGREE here — both this
+                // query and `identity_view_at` cut on transaction time — so this
+                // is a scope decision rather than an impossibility, and is
+                // recorded as such in WM_SCOPE.
+                ObjectIdentity::NotResolvedInReplay,
+            )?);
+        }
+
+        // Completeness is attached to BOTH outcomes. An `Unknown` that is
+        // `Degraded` says "we deleted the evidence", which is a different fact
+        // from "nothing was known" and the one 3g exists to keep.
+        let lookup = if answers.is_empty() {
+            WorldLookup::Unknown(if answer.claims.is_empty() {
+                UnknownReason::NoClaim
+            } else {
+                UnknownReason::NoneAdmissible
+            })
+        } else {
+            WorldLookup::Answered(answers)
+        };
+        Ok(TemporalLookup {
+            lookup,
+            completeness,
+        })
     }
 
     /// Expired, or graded `Inadmissible`, is not servable.
@@ -702,4 +770,43 @@ fn assemble(
         provenance,
         event_id: claim.event_id.clone(),
     })
+}
+
+/// **A bitemporal answer and its completeness** — Tier 3 box 3g.
+///
+/// The two are carried TOGETHER and neither is optional, because 3g's whole
+/// claim is that completeness survives *independently of the payload outcome*.
+///
+/// # Completeness rides on `Unknown` too, and that is the point
+///
+/// The tempting shape is to attach a resolution only to `Answered` — an empty
+/// answer has nothing to be incomplete about, so why carry it? Because
+/// *"nothing was known"* and *"we deleted it"* are then the same value, which is
+/// the exact silent rewrite §11.3 forbids and the failure an incident
+/// reconstruction most needs to distinguish. An `Unknown` that is `Degraded` is
+/// the most important thing this type can say.
+#[derive(Debug, Clone)]
+pub struct TemporalLookup {
+    lookup: WorldLookup,
+    completeness: Resolution,
+}
+
+impl TemporalLookup {
+    /// What was found.
+    #[must_use]
+    pub fn lookup(&self) -> &WorldLookup {
+        &self.lookup
+    }
+
+    /// Whether the answer is the whole truth, or what remains of it.
+    #[must_use]
+    pub fn completeness(&self) -> &Resolution {
+        &self.completeness
+    }
+
+    /// Whether compaction could have borne on this answer.
+    #[must_use]
+    pub fn is_degraded(&self) -> bool {
+        self.completeness.is_degraded()
+    }
 }

--- a/crates/kirra-world-service/tests/degradation_propagation.rs
+++ b/crates/kirra-world-service/tests/degradation_propagation.rs
@@ -1,0 +1,374 @@
+//! **Tier 3 box 3g — degradation propagation across the answer boundary.**
+//!
+//! > Every answer family preserves `Full`/`Degraded` **independently of the
+//! > payload outcome**. Retention may reduce answer precision; Tier 3 makes the
+//! > loss observable.
+//!
+//! # What was already true, and what this adds
+//!
+//! The STORE already decides `Full` vs `Degraded` correctly, on both temporal
+//! axes, and `kirra-world-store/tests/degraded_answers.rs` pins it — including
+//! an `as_of` pair that cannot pass by always answering `Full`. Rebuilding that
+//! here would be duplication wearing a closed box.
+//!
+//! What did not exist is the **propagation**. `WorldLookup` is
+//! `{Answered, Unknown}` and carries no completeness at all, and `ask` reads
+//! `world_current`, which `compact_range` structurally protects by refusing to
+//! remove a live projection head — so its completeness would be `Full` by
+//! construction and could never fail. `WorldView::ask_as_of` is the first
+//! boundary query that can genuinely degrade, and `TemporalLookup` is the first
+//! boundary type that carries the verdict.
+//!
+//! # The property, as agreed
+//!
+//! > If retained evidence is sufficient for the query, completeness is `Full`.
+//! > If the query depends on evidence removed by compaction, completeness is
+//! > `Degraded`. Tier 3 may over-report degradation, but it must **never**
+//! > report `Full` after relevant evidence has been lost.
+//!
+//! That asymmetry is `Resolution`'s own documented contract, so **3g proves
+//! non-loss of degradation information, not minimal classification.** A test
+//! demanding "Degraded exactly when it mattered" would contradict the contract
+//! and force a precision the retained evidence cannot justify — the removed rows
+//! are the only record of themselves.
+//!
+//! # This suite is deliberately STRICTER than the contract, in one direction
+//!
+//! Measured, not assumed. Three mutations were run:
+//!
+//! | Mutation | Result |
+//! |---|---|
+//! | force `Full` in the degraded arm | 3 tests fail — the load-bearing direction |
+//! | drop completeness on `Unknown` | the independence test fails |
+//! | force `Degraded` everywhere | **the Full arms fail** |
+//!
+//! The third is the one worth stating plainly. `Resolution`'s contract PERMITS
+//! over-reporting — it may say `Degraded` where a full answer would have been
+//! identical — so a move in that direction is legal, and these tests would red
+//! anyway. They pin current BEHAVIOUR, not the contract's outer bound.
+//!
+//! That is the right trade rather than an oversight: without asserting `Full`,
+//! an implementation that answered `Degraded` unconditionally would pass every
+//! remaining case, and the degraded arm would prove nothing. The Full arms are
+//! what stop the pair collapsing.
+//!
+//! So if a future change legitimately makes an arm here `Degraded`, the correct
+//! response is to update the test **with the reasoning written down**, not to
+//! treat it as a regression — and emphatically not to relax the degraded arm to
+//! match. Only one direction is a bug: `Full` after evidence was lost.
+//!
+//! # Both arms return a plausible, non-empty answer
+//!
+//! Deliberately. A pair that distinguished "got an answer" from "got nothing"
+//! would be measuring emptiness, not completeness. In the degraded arm the
+//! answer is not merely non-empty — it is **plausible and wrong**: the query
+//! instant falls inside the compacted window, so the surviving evidence yields
+//! `dock_alpha` when `dock_beta` was the truth. Only the completeness axis
+//! reveals that, which is precisely the loss 3g exists to make observable.
+
+use kirra_world_service::read_view::{WorldLookup, WorldView};
+use kirra_world_store::{ClaimStatus, EventId, NewEvent, ObservationId, WorldStore, WriterClass};
+
+const T0: i64 = 1_700_000_000_000;
+
+fn tmp(name: &str) -> std::path::PathBuf {
+    static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let n = NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let mut p = std::env::temp_dir();
+    p.push(format!("kirra-3g-{name}-{}-{n}.sqlite", std::process::id()));
+    cleanup(&p);
+    p
+}
+
+fn cleanup(path: &std::path::Path) {
+    for suffix in ["", "-wal", "-shm"] {
+        let mut q = path.as_os_str().to_os_string();
+        q.push(suffix);
+        let _ = std::fs::remove_file(std::path::PathBuf::from(q));
+    }
+}
+
+/// `package_17 last_seen_at <object>`, valid and known from `at_ms`.
+fn claim(store: &mut WorldStore, tag: &str, object: &str, at_ms: i64) {
+    store
+        .append(&NewEvent {
+            event_id: &EventId::new(format!("ev-{tag}")).expect("event id"),
+            observation_id: &ObservationId::new(format!("obs-{tag}")).expect("obs"),
+            txn_time_ms: at_ms,
+            valid_from_ms: at_ms,
+            valid_to_ms: None,
+            source: "warehouse-scanner",
+            source_version: "1.0.0",
+            writer_class: WriterClass::Sensor,
+            claim_status: ClaimStatus::Confirmed,
+            provenance: &[],
+            frame_id: None,
+            map_id: None,
+            kind: "mission",
+            subject: "package_17",
+            subject_ref: None,
+            predicate: Some("last_seen_at"),
+            object: Some(object),
+            payload: "{}",
+            payload_schema: 1,
+            retention_class: "raw",
+            trust: None,
+        })
+        .expect("append");
+}
+
+/// Three observations, the middle one compacted away.
+///
+/// ```text
+///   gen 1   T0+0     dock_alpha    survives  (earliest evidence)
+///   gen 2   T0+100   dock_beta     COMPACTED (the removed window)
+///   gen 3   T0+200   dock_gamma    survives  (the projection head)
+/// ```
+///
+/// Generation 2 is compactable precisely because it is superseded — the head is
+/// protected, so only a superseded observation can be taken away, which is also
+/// why the surviving answer stays plausible.
+fn store_with_a_hole(name: &str) -> (WorldStore, std::path::PathBuf) {
+    let path = tmp(name);
+    let mut store = WorldStore::open(&path).expect("open");
+    claim(&mut store, "alpha", "dock_alpha", T0);
+    claim(&mut store, "beta", "dock_beta", T0 + 100);
+    claim(&mut store, "gamma", "dock_gamma", T0 + 200);
+    store.fold().expect("fold");
+
+    let outcome = store
+        .compact_range(2, 2, T0 + 9_000)
+        .expect("generation 2 is superseded, so compactable");
+    assert_eq!(outcome.removed, 1, "the fixture must remove an observation");
+    (store, path)
+}
+
+fn objects(lookup: &WorldLookup) -> Vec<String> {
+    match lookup {
+        WorldLookup::Answered(a) => a
+            .iter()
+            .filter_map(|x| x.object().map(String::from))
+            .collect(),
+        WorldLookup::Unknown(_) => Vec::new(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The pair
+// ---------------------------------------------------------------------------
+
+/// **Evidence entirely outside the compacted span → `Full`, with a real answer.**
+///
+/// At `T0+50` the only observation that can bear on the answer is `dock_alpha`,
+/// which survives. The removed window begins at `T0+100`, later on BOTH axes, so
+/// nothing lost could have changed this answer and reporting `Full` is honest.
+#[test]
+fn evidence_outside_the_compacted_span_is_full_and_still_answers() {
+    let (store, path) = store_with_a_hole("full");
+    let view = WorldView::new(&store, None);
+
+    let out = view
+        .ask_as_of("package_17", T0 + 50, T0 + 50)
+        .expect("ask_as_of");
+
+    assert_eq!(
+        objects(out.lookup()),
+        vec!["dock_alpha".to_string()],
+        "the full arm must carry a real answer, not an empty one"
+    );
+    assert!(
+        !out.is_degraded(),
+        "the removed window begins after this query on both axes; nothing lost \
+         could have borne on it — got {:?}",
+        out.completeness()
+    );
+
+    drop(store);
+    cleanup(&path);
+}
+
+/// **Evidence inside the compacted span → `Degraded`, with a plausible WRONG
+/// answer.**
+///
+/// The sharp half. At `T0+150` the truth was `dock_beta` — and `dock_beta` has
+/// been deleted. The replay finds `dock_alpha`, which is non-empty, well-formed
+/// and entirely believable. Nothing in the payload betrays the loss; only the
+/// completeness axis does.
+///
+/// This is why 3g is not satisfied by a test that distinguishes an answer from
+/// silence: here the wrong answer and the right one are the same shape.
+#[test]
+fn evidence_inside_the_compacted_span_is_degraded_and_the_answer_looks_fine() {
+    let (store, path) = store_with_a_hole("degraded");
+    let view = WorldView::new(&store, None);
+
+    let out = view
+        .ask_as_of("package_17", T0 + 150, T0 + 9_000)
+        .expect("ask_as_of");
+
+    assert_eq!(
+        objects(out.lookup()),
+        vec!["dock_alpha".to_string()],
+        "the surviving evidence yields a plausible answer — that is the point"
+    );
+    assert!(
+        out.is_degraded(),
+        "dock_beta held at T0+150 and was deleted; reporting Full here would be \
+         the silent rewrite the box forbids — got {:?}",
+        out.completeness()
+    );
+    assert!(
+        !out.completeness().spans().is_empty(),
+        "a degraded answer must name the span it is degraded by"
+    );
+
+    // The two arms genuinely differ, so the pair is distinguishing completeness
+    // rather than agreeing by accident.
+    let full = view
+        .ask_as_of("package_17", T0 + 50, T0 + 50)
+        .expect("ask_as_of");
+    assert_ne!(full.is_degraded(), out.is_degraded());
+    assert_eq!(
+        objects(full.lookup()),
+        objects(out.lookup()),
+        "and they differ ONLY in completeness — same payload, opposite verdict, \
+         which is what 'independently of the payload outcome' means"
+    );
+
+    drop(store);
+    cleanup(&path);
+}
+
+// ---------------------------------------------------------------------------
+// Independence from the payload outcome
+// ---------------------------------------------------------------------------
+
+/// **An `Unknown` still carries completeness, and can be `Degraded`.**
+///
+/// The tempting shape is to attach a resolution only to `Answered` — an empty
+/// answer has nothing to be incomplete about. But then *"nothing was known"* and
+/// *"we deleted it"* become the same value, which is exactly the confusion an
+/// incident reconstruction cannot afford.
+///
+/// Here the subject's ONLY observation is compacted away, so the answer is
+/// empty AND lossy. A boundary that dropped completeness on `Unknown` would
+/// report this identically to a subject the store had never heard of.
+#[test]
+fn an_empty_answer_still_reports_that_evidence_was_lost() {
+    let path = tmp("unknown-degraded");
+    let mut store = WorldStore::open(&path).expect("open");
+    // `solo` is superseded by a later observation so it can be compacted, and
+    // the query instant is chosen BEFORE the survivor's valid time, so the
+    // answer is genuinely empty at that instant.
+    claim(&mut store, "solo", "dock_solo", T0 + 100);
+    claim(&mut store, "later", "dock_later", T0 + 200);
+    store.fold().expect("fold");
+    store.compact_range(1, 1, T0 + 9_000).expect("compact");
+
+    let view = WorldView::new(&store, None);
+    let out = view
+        .ask_as_of("package_17", T0 + 150, T0 + 9_000)
+        .expect("ask_as_of");
+
+    assert!(
+        matches!(out.lookup(), WorldLookup::Unknown(_)),
+        "the only observation holding at T0+150 was deleted, so the payload is \
+         empty — got {:?}",
+        objects(out.lookup())
+    );
+    assert!(
+        out.is_degraded(),
+        "an empty answer that is empty BECAUSE evidence was deleted must say so; \
+         otherwise it is indistinguishable from a subject never heard of"
+    );
+
+    drop(store);
+    cleanup(&path);
+}
+
+/// **A subject the compacted window never held is `Full`.**
+///
+/// The other half of independence: completeness is not a property of the STORE
+/// having compacted something, it is a property of THIS query's evidence. A
+/// boundary that degraded every answer once any compaction had run would be
+/// conservative to the point of uselessness — and would pass the degraded arm
+/// above for the wrong reason.
+#[test]
+fn a_subject_the_compacted_window_never_held_is_full() {
+    let path = tmp("other-subject");
+    let mut store = WorldStore::open(&path).expect("open");
+    claim(&mut store, "alpha", "dock_alpha", T0);
+    claim(&mut store, "beta", "dock_beta", T0 + 100);
+    store
+        .append(&NewEvent {
+            event_id: &EventId::new("ev-other").expect("id"),
+            observation_id: &ObservationId::new("obs-other").expect("obs"),
+            txn_time_ms: T0 + 50,
+            valid_from_ms: T0 + 50,
+            valid_to_ms: None,
+            source: "warehouse-scanner",
+            source_version: "1.0.0",
+            writer_class: WriterClass::Sensor,
+            claim_status: ClaimStatus::Confirmed,
+            provenance: &[],
+            frame_id: None,
+            map_id: None,
+            kind: "mission",
+            subject: "pallet_9",
+            subject_ref: None,
+            predicate: Some("last_seen_at"),
+            object: Some("bay_3"),
+            payload: "{}",
+            payload_schema: 1,
+            retention_class: "raw",
+            trust: None,
+        })
+        .expect("append other subject");
+    store.fold().expect("fold");
+    store.compact_range(1, 1, T0 + 9_000).expect("compact");
+
+    let view = WorldView::new(&store, None);
+    let out = view
+        .ask_as_of("pallet_9", T0 + 1_000, T0 + 9_000)
+        .expect("ask_as_of");
+
+    assert_eq!(objects(out.lookup()), vec!["bay_3".to_string()]);
+    assert!(
+        !out.is_degraded(),
+        "the compacted window held nothing about pallet_9 — degrading here would \
+         make every answer degraded forever after the first compaction"
+    );
+
+    drop(store);
+    cleanup(&path);
+}
+
+/// **The boundary propagates the store's verdict rather than forming its own.**
+///
+/// A second judgement at the boundary would be a second implementation of the
+/// rule that decides whether an answer can be trusted, and the two would drift —
+/// the same defect the `AnswerRef` corpus caught when supersession turned out to
+/// have two implementations. This pins them equal on both arms.
+#[test]
+fn the_boundary_verdict_equals_the_stores_verdict() {
+    let (store, path) = store_with_a_hole("propagates");
+    let view = WorldView::new(&store, None);
+
+    for (valid_at, known_at) in [(T0 + 50, T0 + 50), (T0 + 150, T0 + 9_000)] {
+        let store_side = store
+            .as_of("package_17", valid_at, known_at)
+            .expect("store as_of");
+        let boundary = view
+            .ask_as_of("package_17", valid_at, known_at)
+            .expect("ask_as_of");
+        assert_eq!(
+            &store_side.resolution,
+            boundary.completeness(),
+            "the boundary must carry the store's verdict unchanged at \
+             ({valid_at}, {known_at})"
+        );
+    }
+
+    drop(store);
+    cleanup(&path);
+}

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -2857,7 +2857,7 @@ identity: identity is a second projection with its own coordinate, the pinned
 read exists only for `world_current`, and `identity_view_at` cuts on transaction
 time — so resolving here would pair a generation-pinned claim with a
 transaction-time-pinned identity, mixing the axes box 3c closed. Pinned answers
-carry `ObjectIdentity::NotResolvedAtPin`, which `matchable` refuses, so a pinned
+carry `ObjectIdentity::NotResolvedInReplay`, which `matchable` refuses, so a pinned
 answer cannot shape a proposal by accident. A generation-pinned IDENTITY read is
 the natural next prerequisite if refs ever need resolved objects.
 

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -2021,7 +2021,8 @@ pressure that produced every stale claim this box already documents.
 - [ ] **3f — Lineage retrieval contract.** Deterministic, bounded, paginated,
       truncation visible, historically correct. Consumed by Tier 4's `Explain`;
       does not render.
-- [ ] **3g — Degradation propagation.** Every answer family preserves
+- [x] **3g — Degradation propagation.** ✅ **DONE 2026-08-11** — see *"3g:
+      the boundary finally carries completeness"* below. Every answer family preserves
       `Full`/`Degraded` **independently of the payload outcome**, not just
       `subject_summary`. Retention may reduce answer precision; Tier 3 makes the
       loss observable.
@@ -2874,3 +2875,75 @@ inside `assemble` reds three tests.
 mutations: ignoring the version check, falling forward when irreproducible,
 dropping the generation from ref identity, and two fold-rule changes — each
 caught, the last two only after the corpus was re-anchored.
+
+
+### 3g: the boundary finally carries completeness — 2026-08-11
+
+**What was already true, and what was missing.** The STORE decides `Full` vs
+`Degraded` correctly, on both temporal axes, and `degraded_answers.rs` already
+pins an `as_of` pair that cannot pass by always answering `Full`. Building that
+again here would have been duplication wearing a closed box — and closing 3g on
+it would have been the "looks green, proves nothing" outcome the box is most
+prone to.
+
+The missing half was **propagation**. `WorldLookup` is `{Answered, Unknown}` and
+carried no completeness at all. `ask` reads `world_current`, which `compact_range`
+structurally protects by refusing to remove a live projection head — so its
+completeness is `Full` by construction and could never fail, which is exactly why
+`current()` cannot prove this box. `WorldView::ask_as_of` is the first boundary
+query that can genuinely degrade; `TemporalLookup` is the first boundary type
+that carries the verdict.
+
+**The property, as ruled:**
+
+> If retained evidence is sufficient for the query, completeness is `Full`. If
+> the query depends on evidence removed by compaction, completeness is
+> `Degraded`. Tier 3 may over-report degradation, but it must **never** report
+> `Full` after relevant evidence has been lost.
+
+**Both arms answer, and the degraded one answers WRONG.** The fixture keeps a
+surviving observation either side of a compacted middle, so at `T0+150` the truth
+was `dock_beta` — deleted — and the replay returns `dock_alpha`: non-empty,
+well-formed, believable. Same payload as the `Full` arm, opposite verdict. That
+is what *"independently of the payload outcome"* means, and it is why a pair
+distinguishing an answer from silence would measure emptiness rather than
+completeness.
+
+**Completeness rides on `Unknown` too.** The tempting shape attaches a resolution
+only to `Answered`. Then *"nothing was known"* and *"we deleted it"* become the
+same value — the confusion an incident reconstruction can least afford. Pinned by
+its own test, and by a mutation.
+
+**The verdict is propagated, not recomputed.** A second judgement at the boundary
+would be a second implementation of the rule deciding whether an answer can be
+trusted, and the two would drift — precisely what the `AnswerRef` corpus found
+when supersession turned out to have two implementations. A test pins boundary
+and store equal on both arms.
+
+**This suite is deliberately STRICTER than the contract, in one direction, and
+that was measured rather than assumed.**
+
+| Mutation | Result |
+|---|---|
+| force `Full` in the degraded arm | 3 tests fail — the load-bearing direction |
+| drop completeness on `Unknown` | the independence test fails |
+| force `Degraded` everywhere | **the Full arms fail** |
+
+The third matters. `Resolution` PERMITS over-reporting, so a move that way is
+legal and these tests would red anyway: they pin current behaviour, not the
+contract's outer bound. That is the right trade rather than an oversight —
+without asserting `Full`, an implementation answering `Degraded` unconditionally
+would pass everything else and the degraded arm would prove nothing. If a future
+change legitimately makes an arm `Degraded`, update the test *with reasoning*;
+do not relax the degraded arm to match. **Only one direction is a bug: `Full`
+after evidence was lost.**
+
+**Scope, stated because it is narrower than the box's wording.** `ask_as_of` is
+one family. 3g says *every* family; the ones that exist at the boundary are `ask`
+(structurally `Full`, and now knowably so) and this. `history` and
+`subject_summary` remain unpropagated, and a boundary query for them is the
+follow-up. A replayed answer also does not resolve object identity —
+`ObjectIdentity::NotResolvedInReplay`, renamed from `NotResolvedAtPin` since it
+now covers both replay families. Here the axes would actually AGREE (both this
+query and `identity_view_at` cut on transaction time), so that is a scope
+decision rather than an impossibility, unlike the generation pin.


### PR DESCRIPTION
Step 3 of **stable snapshot → reproducible answer identity → honest degradation**, on `as_of` as agreed.

## The scope shifted, and it's worth knowing why

The store-level `as_of` Full/Degraded pair specified for this step **already exists** — `degraded_answers.rs` has `as_of_before_the_window_began_is_full_and_after_it_is_degraded` and its transaction-axis twin, both already arguing "cannot pass by always answering Full." Rebuilding it would have been duplication wearing a closed box, which is the exact failure this box is most prone to.

The missing half is **propagation**, which is what 3g actually asks for: *"every answer **family** preserves Full/Degraded **independently of the payload outcome**."*

`WorldLookup` is `{Answered, Unknown}` and carried **no completeness at all**. And `ask` reads `world_current`, which `compact_range` structurally protects by refusing to remove a live projection head — so its completeness is `Full` by construction and could never fail. That is precisely why `current()` cannot prove this box.

`WorldView::ask_as_of` is the first boundary query that can genuinely degrade. `TemporalLookup` is the first boundary type that carries the verdict.

## The property

> If retained evidence is sufficient for the query, completeness is `Full`. If the query depends on evidence removed by compaction, completeness is `Degraded`. Tier 3 may over-report degradation, but it must **never** report `Full` after relevant evidence has been lost.

## Both arms answer, and the degraded one answers wrong

```
gen 1   T0+0     dock_alpha    survives
gen 2   T0+100   dock_beta     COMPACTED
gen 3   T0+200   dock_gamma    survives (projection head)
```

At `T0+150` the truth was `dock_beta` — deleted. The replay returns `dock_alpha`: non-empty, well-formed, believable. **Same payload as the `Full` arm, opposite verdict.** That is what "independently of the payload outcome" means, and why a pair distinguishing an answer from silence would be measuring emptiness rather than completeness.

## Completeness rides on `Unknown` too

The tempting shape attaches a resolution only to `Answered` — an empty answer has nothing to be incomplete about. But then *"nothing was known"* and *"we deleted it"* become the same value, which is the confusion an incident reconstruction can least afford. Pinned by its own test and its own mutation.

## Propagated, not recomputed

A second judgement at the boundary would be a second implementation of the rule deciding whether an answer can be trusted, and the two would drift — exactly the defect the `AnswerRef` corpus surfaced when supersession turned out to have two implementations. `the_boundary_verdict_equals_the_stores_verdict` pins them equal on both arms.

## This suite is deliberately stricter than the contract, in one direction

Measured, not assumed:

| Mutation | Result |
|---|---|
| force `Full` in the degraded arm | 3 tests fail — **the load-bearing direction** |
| drop completeness on `Unknown` | the independence test fails |
| force `Degraded` everywhere | **the Full arms fail** |

The third is the one to be explicit about. `Resolution` **permits** over-reporting, so a move that way is legal and these tests would red anyway: they pin current *behaviour*, not the contract's outer bound.

That is the right trade rather than an oversight — without asserting `Full`, an implementation answering `Degraded` unconditionally would pass everything else and the degraded arm would prove nothing. The `Full` arms are what stop the pair collapsing.

If a future change legitimately makes an arm `Degraded`, update the test **with the reasoning written down**; do not relax the degraded arm to match. **Only one direction is a bug: `Full` after evidence was lost.**

## Scope, stated because it is narrower than the box's wording

`ask_as_of` is one family. 3g says *every* family; `history` and `subject_summary` remain unpropagated and are the follow-up. A replayed answer also does not resolve object identity — `ObjectIdentity::NotResolvedAtPin` is renamed `NotResolvedInReplay` now that it covers both replay families. Here the axes would actually **agree** (both this query and `identity_view_at` cut on transaction time), so that is a scope decision rather than an impossibility, unlike the generation pin.

## Verification

`cargo clippy --all-targets -D warnings` on the touched crates · `cargo fmt --check` · 32 test binaries green across `kirra-world-service` / `kirra-world-store` / `kirra-proposal-context` · answer-boundary gate + self-test (12/12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_