### PR TITLE
Tier 3 box 3b: reducer/projection versioning that cannot be decorative

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1653,6 +1653,28 @@ jobs:
         run: |
           python3 ci/check_world_answer_boundary.py --self-test
           python3 ci/check_world_answer_boundary.py
+      - name: Kirra World reducer semantics gate (Tier 3 box 3b)
+        # THE RULE (KIRRA-WM-REDUCER-VERSION-001): a reducer version changes
+        # whenever behaviour changes in a way that can alter a derived answer,
+        # and a recorded AnswerRef refuses replay under a different version
+        # rather than silently adopting the new rule.
+        #
+        # The Rust conformance tests prove each declared corpus digest IS the
+        # reducer's digest. They cannot see the failure that makes a version
+        # decorative: re-pin the digest and they go green with the version
+        # untouched. This gate can, because the baseline records what each
+        # version's digest WAS — so a behaviour change at a fixed version has
+        # nowhere to hide.
+        #
+        # The source pin is the second, independent mechanism: the corpus
+        # discriminates the axes it exercises, and an axis nobody thought of is
+        # not covered, so any EDIT to a pinned reducer span reds regardless.
+        #
+        # Self-test first, and it asserts its own case count — a harness that
+        # discovers zero cases prints the same "OK" as one that ran them all.
+        run: |
+          python3 ci/check_world_semantics.py --self-test
+          python3 ci/check_world_semantics.py
       - name: Kirra World domain-logic gate (ADR-0042 Decision 5)
         # THE RULE: no Kirra World domain implementation may merge until
         # ADR-0042's safety-assurance scope ruling is assigned to a named owner

--- a/ci/check_orphan_cores.py
+++ b/ci/check_orphan_cores.py
@@ -219,7 +219,7 @@ def ambiguous_item_names(mods: list[tuple[str, str, Path]]) -> set[str]:
     return ambiguous
 
 
-def strip_noncode(text: str) -> str:
+def strip_noncode(text: str, keep_strings: bool = False) -> str:
     """Blank out comments and string literals, preserving line structure.
 
     A name inside a comment or a string is **prose, not consumption**, and the
@@ -242,6 +242,24 @@ def strip_noncode(text: str) -> str:
     each can contain the other's opening token. Newlines are preserved so
     line-oriented rules (`use` at line start) still work, and removed spans
     become spaces so nothing on either side is joined into a new token.
+
+    # `keep_strings`
+
+    `keep_strings=True` blanks comments only, emitting string literals verbatim.
+    Scanning is unchanged either way — a literal still has to be *recognised* to
+    know that a `//` inside it does not open a comment — so the flag changes what
+    is emitted, never what is parsed.
+
+    Added for `check_world_semantics.py`, whose reducer source pins must not go
+    blind to a string constant. Several reducers return stored tokens
+    (`lifecycle_token`, `SummaryKind::as_str`) where the literal IS the
+    behaviour, and a pin that blanked them would sit green through an edit that
+    changed what every projection row says. The cost is a false red on
+    error-message churn, which is the cheap direction: re-pinning costs one
+    commit and the corpus digest proves nothing moved, while blindness costs
+    correctness silently.
+
+    Default `False`, so every existing caller is byte-identical.
     """
     out: list[str] = []
     i, n = 0, len(text)
@@ -272,9 +290,13 @@ def strip_noncode(text: str) -> str:
             close = '"' + m.group(1)
             end = text.find(close, i + m.end())
             end = n if end == -1 else end + len(close)
-            out.extend("\n" if ch == "\n" else " " for ch in text[i:end])
+            if keep_strings:
+                out.append(text[i:end])
+            else:
+                out.extend("\n" if ch == "\n" else " " for ch in text[i:end])
             i = end
         elif c == '"':
+            start, mark = i, len(out)
             out.append(" ")
             i += 1
             while i < n:
@@ -298,6 +320,13 @@ def strip_noncode(text: str) -> str:
                     break
                 out.append("\n" if text[i] == "\n" else " ")
                 i += 1
+            if keep_strings:
+                # Replace the blanks just emitted for this literal with the
+                # literal itself. Done after the scan rather than instead of it
+                # so escape handling — including the line-continuation case
+                # above — still decides where the literal ENDS.
+                del out[mark:]
+                out.append(text[start:i])
         else:
             out.append(c)
             i += 1

--- a/ci/check_world_semantics.py
+++ b/ci/check_world_semantics.py
@@ -1,0 +1,536 @@
+#!/usr/bin/env python3
+"""**Reducer semantics gate — Tier 3 box 3b.**
+
+`crates/kirra-world-store/src/semantics.rs` declares a version for every
+projection reducer, and `KIRRA-WM-REDUCER-VERSION-001` says the version changes
+whenever behaviour changes in a way that can alter a derived answer. This gate
+is what stops that being a promise.
+
+The Rust conformance test (`tests/semantics_corpus.rs`) already proves the
+declared `corpus_digest` is the reducer's *actual* digest. That leaves two holes
+this gate closes, and they are different holes:
+
+1.  **A silent edit the corpus is blind to.** The corpus discriminates the axes
+    it exercises; an axis nobody thought of is not covered. So each reducer also
+    carries a `source_pin` over its own source span, and any edit at all moves
+    it. This is the frozen-talisman technique `validate_vehicle_command` uses,
+    scoped to a marker-delimited region so ordinary churn elsewhere in the file
+    does not trip it.
+
+2.  **A behaviour change that updated the declaration but not the version.**
+    This is the hole that makes a version decorative, and the Rust test *cannot*
+    see it: re-pin `corpus_digest` and the conformance test goes green again
+    with the version untouched. So the recorded history in
+    `ci/world_semantics_baseline.json` holds what each version's digest was, and
+    re-declaring a *different* digest for a version already on record is an
+    error whose only clean resolution is a new version.
+
+# The workflow this produces
+
+| You did | Corpus digest | Source pin | Do |
+|---|---|---|---|
+| nothing | same | same | — |
+| refactored a reducer | same | moved | re-pin `source_pin`, update the baseline row |
+| changed behaviour | moved | moved | bump `version`, re-pin both, ADD a baseline row |
+
+The middle row is why the two mechanisms are not redundant: it is the only case
+where a pin moves and the version legitimately does not, and the corpus digest
+holding is precisely the evidence for that.
+
+# The residual, stated rather than implied
+
+An author who edits the Rust declaration *and* rewrites the baseline's historical
+row in the same commit still passes. No gate can force a human to increment an
+integer. What this removes is doing it silently, doing it by accident, and doing
+it without a reviewer seeing a diff in a file whose only purpose is to be that
+record.
+
+Self-tests: `python3 ci/check_world_semantics.py --self-test`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from check_orphan_cores import strip_noncode  # noqa: E402
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Two crates declare versioned rules: the store owns the three projection
+# reducers, the service owns the answer boundary's admissibility rule. They are
+# read by ONE parser and held to ONE baseline deliberately — a boundary rule
+# checked by a second, differently-shaped gate is a boundary rule checked more
+# weakly, and the whole point of `SemanticVersions` is that a reference carries
+# rules from both crates in one set.
+DECLARATIONS = (
+    REPO / "crates/kirra-world-store/src/semantics.rs",
+    REPO / "crates/kirra-world-service/src/semantics.rs",
+)
+BASELINE = REPO / "ci/world_semantics_baseline.json"
+
+BEGIN = "SEMANTICS-PIN-BEGIN:"
+END = "SEMANTICS-PIN-END:"
+
+# One `RuleSpec { … }` literal. Anchored on the field NAMES rather than on
+# position, so reordering fields inside the struct does not silently defeat the
+# parser -- and `parse_declarations` refuses an empty parse, so a formatting
+# change this pattern cannot follow reds instead of checking nothing.
+_SPEC = re.compile(
+    r"\w*RuleSpec\s*\{\s*"
+    r"rule:\s*\w*RuleId::(?P<variant>\w+)\s*,\s*"
+    r"version:\s*(?P<version>\d+)\s*,\s*"
+    r'corpus_digest:\s*"(?P<corpus_digest>[0-9a-f]{64})"\s*,\s*'
+    r'source_pin:\s*"(?P<source_pin>[0-9a-f]{64})"\s*,\s*'
+    r'source_file:\s*"(?P<source_file>[^"]+)"\s*,\s*'
+    r'span:\s*"(?P<span>[^"]+)"\s*,\s*'
+    r"\}",
+    re.S,
+)
+
+# The `RuleId::as_str` arms, so the gate learns each variant's STABLE name from
+# the same place the Rust code does. Deriving it here by convention would let a
+# rename drift the baseline key silently.
+_AS_STR = re.compile(r"Self::(?P<variant>\w+)\s*=>\s*\"(?P<name>[a-z0-9_]+)\"")
+
+# `RuleSpec` and `BoundaryRuleSpec` are STRUCT DEFINITIONS, not rows. Their
+# field declarations look enough like a row's assignments to be worth excluding
+# explicitly rather than relying on the `:` versus `,` shape to differ.
+_STRUCT_DEF = re.compile(r"pub\s+struct\s+\w*RuleSpec\s*\{.*?\n\}", re.S)
+
+
+class GateError(Exception):
+    """A violation worth failing CI over."""
+
+
+def parse_declarations(text: str, where: str = "declaration") -> list[dict]:
+    """Parse one file's rule declarations, keyed by each rule's stable name.
+
+    Refuses an empty parse. A gate that silently finds nothing to check is the
+    most dangerous shape a gate can take: it is indistinguishable from a gate
+    that checked everything and was satisfied.
+    """
+    names = {m.group("variant"): m.group("name") for m in _AS_STR.finditer(text)}
+    if not names:
+        raise GateError(
+            f"{where}: could not parse any `as_str` arm — the gate cannot learn "
+            "the stable rule names, so it would check nothing"
+        )
+
+    rows = []
+    for m in _SPEC.finditer(_STRUCT_DEF.sub("", text)):
+        variant = m.group("variant")
+        if variant not in names:
+            raise GateError(
+                f"{where}: rule `{variant}` is declared but has no `as_str` arm "
+                "— it would have no stable baseline key"
+            )
+        rows.append(
+            {
+                "rule": names[variant],
+                "version": int(m.group("version")),
+                "corpus_digest": m.group("corpus_digest"),
+                "source_pin": m.group("source_pin"),
+                "source_file": m.group("source_file"),
+                "span": m.group("span"),
+            }
+        )
+
+    if not rows:
+        raise GateError(
+            f"{where}: parsed ZERO rule declarations. Either the table was "
+            "emptied — which would leave its rules unversioned — or its "
+            "formatting changed in a way this gate cannot follow. Both are "
+            "failures; neither is a pass."
+        )
+    return rows
+
+
+def parse_all(sources: dict[str, str]) -> list[dict]:
+    """Every declaration across every declaring crate, with names unique."""
+    rows: list[dict] = []
+    for where, text in sources.items():
+        rows.extend(parse_declarations(text, where))
+
+    seen = [r["rule"] for r in rows]
+    dupes = {r for r in seen if seen.count(r) > 1}
+    if dupes:
+        raise GateError(
+            f"duplicate declarations for: {', '.join(sorted(dupes))} — two rules "
+            "sharing a stable name would share one baseline history"
+        )
+    return rows
+
+
+def extract_span(source: str, span: str) -> str:
+    """The text between this span's begin and end markers.
+
+    Both markers must appear exactly once. A duplicated marker would make the
+    pinned region ambiguous, and an ambiguous region can be silently shrunk to
+    exclude the line someone wanted to change.
+    """
+    starts = [i for i, line in enumerate(source.splitlines()) if f"{BEGIN} {span}" in line]
+    ends = [i for i, line in enumerate(source.splitlines()) if f"{END} {span}" in line]
+    if len(starts) != 1 or len(ends) != 1:
+        raise GateError(
+            f"span `{span}`: expected exactly one {BEGIN} and one {END} marker, "
+            f"found {len(starts)} and {len(ends)}"
+        )
+    if ends[0] <= starts[0]:
+        raise GateError(f"span `{span}`: {END} marker precedes {BEGIN}")
+    lines = source.splitlines()[starts[0] + 1 : ends[0]]
+    body = "\n".join(lines)
+    if not body.strip():
+        raise GateError(
+            f"span `{span}`: the pinned region is empty — a pin over nothing is "
+            "satisfied by any reducer"
+        )
+    return body
+
+
+def pin_of(source: str, span: str) -> str:
+    """The declared-form digest of a reducer span.
+
+    Comments are stripped so ordinary comment churn does not trip the gate and
+    train reflexive re-pinning; string literals are KEPT, because in these
+    reducers a literal can be the behaviour. Whitespace is normalised so
+    `cargo fmt` rewrapping a call is not mistaken for an edit.
+    """
+    stripped = strip_noncode(extract_span(source, span), keep_strings=True)
+    normalised = " ".join(stripped.split())
+    return hashlib.sha256(normalised.encode("utf-8")).hexdigest()
+
+
+def check(declarations: list[dict], baseline: dict, read: callable) -> list[str]:
+    """Every rule check. Returns a list of human-readable violations."""
+    problems: list[str] = []
+    history = baseline.get("rules", {})
+
+    for row in declarations:
+        rule, version = row["rule"], row["version"]
+
+        # 1. The source pin must be the span's actual digest.
+        try:
+            actual = pin_of(read(row["source_file"]), row["span"])
+        except GateError as exc:
+            problems.append(f"{rule}: {exc}")
+            continue
+        if actual != row["source_pin"]:
+            problems.append(
+                f"{rule}: source pin does not match `{row['source_file']}` span "
+                f"`{row['span']}`.\n"
+                f"    declared: {row['source_pin']}\n"
+                f"    actual:   {actual}\n"
+                f"    The reducer was edited. If BEHAVIOUR changed the corpus "
+                f"digest moved too and `version` must be bumped; if it did not, "
+                f"this is a refactor — re-pin `source_pin` here and in the "
+                f"baseline, leaving `version` and `corpus_digest` alone."
+            )
+
+        # 2. Recorded history must exist and be consistent.
+        recorded = history.get(rule)
+        if recorded is None:
+            problems.append(
+                f"{rule}: declared in SEMANTICS but absent from "
+                f"{BASELINE.name}. Add its version history, or the version has "
+                f"no record to be accountable to."
+            )
+            continue
+
+        versions = [int(v["version"]) for v in recorded]
+        if sorted(versions) != list(range(1, len(versions) + 1)):
+            problems.append(
+                f"{rule}: recorded versions {sorted(versions)} are not the "
+                f"contiguous sequence 1..{len(versions)}. A gap or a repeat means "
+                f"a version's history was lost or duplicated."
+            )
+            continue
+        if version != max(versions):
+            problems.append(
+                f"{rule}: declares version {version} but the newest recorded "
+                f"version is {max(versions)}. A version bump needs a baseline row."
+            )
+            continue
+
+        current = next(v for v in recorded if int(v["version"]) == version)
+
+        # 3. THE LOAD-BEARING CHECK. Behaviour may not move at a fixed version.
+        if current["corpus_digest"] != row["corpus_digest"]:
+            problems.append(
+                f"{rule}: the corpus digest for version {version} changed.\n"
+                f"    recorded: {current['corpus_digest']}\n"
+                f"    declared: {row['corpus_digest']}\n"
+                f"    A reducer's behaviour moved while its version stayed put. "
+                f"That is exactly what a recorded AnswerRef cannot survive: it "
+                f"would replay under the new rule while naming the old one.\n"
+                f"    Bump `version` to {version + 1}, re-pin both digests, and "
+                f"ADD a row to {BASELINE.name} — do not rewrite this one."
+            )
+
+        # A refactor is allowed to move the pin, but the baseline must say so,
+        # or the record stops describing the code it claims to pin.
+        if current["source_pin"] != row["source_pin"]:
+            problems.append(
+                f"{rule}: version {version}'s source pin differs from the "
+                f"recorded one.\n"
+                f"    recorded: {current['source_pin']}\n"
+                f"    declared: {row['source_pin']}\n"
+                f"    A refactor at a fixed version is legitimate — update the "
+                f"baseline row's `source_pin` in the same commit so the record "
+                f"still describes the code."
+            )
+
+    declared_names = {r["rule"] for r in declarations}
+    for orphan in sorted(set(history) - declared_names):
+        problems.append(
+            f"{orphan}: recorded in {BASELINE.name} but no longer declared in "
+            f"SEMANTICS. A reducer that lost its declaration is unversioned; if "
+            f"it was genuinely removed, remove its history deliberately."
+        )
+
+    return problems
+
+
+def main() -> int:
+    baseline = json.loads(BASELINE.read_text(encoding="utf-8"))
+    sources = {
+        str(p.relative_to(REPO)): p.read_text(encoding="utf-8") for p in DECLARATIONS
+    }
+
+    try:
+        declarations = parse_all(sources)
+    except GateError as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 1
+
+    problems = check(
+        declarations,
+        baseline,
+        lambda rel: (REPO / rel).read_text(encoding="utf-8"),
+    )
+    if problems:
+        print("FAIL: reducer semantics gate\n", file=sys.stderr)
+        for p in problems:
+            print(f"  - {p}\n", file=sys.stderr)
+        return 1
+
+    print(f"OK: {len(declarations)} reducer(s) versioned, pinned and recorded")
+    for row in declarations:
+        print(f"  {row['rule']} v{row['version']}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Self-tests
+# ---------------------------------------------------------------------------
+
+
+def _self_test() -> int:
+    failures = []
+
+    def check_case(name, fn):
+        try:
+            fn()
+        except AssertionError as exc:
+            failures.append(f"{name}: {exc}")
+
+    src = (
+        "// SEMANTICS-PIN-BEGIN: demo\n"
+        "pub fn r(a: i64) -> bool { a > 0 }\n"
+        "// SEMANTICS-PIN-END: demo\n"
+    )
+
+    def t_span_extracts_between_markers():
+        assert extract_span(src, "demo").strip() == "pub fn r(a: i64) -> bool { a > 0 }"
+
+    def t_comment_churn_does_not_move_the_pin():
+        before = pin_of(src, "demo")
+        churned = src.replace("pub fn r", "// a new remark\npub fn r")
+        assert pin_of(churned, "demo") == before, "a comment moved the pin"
+
+    def t_reformatting_does_not_move_the_pin():
+        before = pin_of(src, "demo")
+        wrapped = src.replace("{ a > 0 }", "{\n    a > 0\n}")
+        assert pin_of(wrapped, "demo") == before, "rewrapping moved the pin"
+
+    def t_a_real_edit_moves_the_pin():
+        before = pin_of(src, "demo")
+        edited = src.replace("a > 0", "a >= 0")
+        assert pin_of(edited, "demo") != before, "an operator change did not move the pin"
+
+    def t_a_string_change_moves_the_pin():
+        # The reason `keep_strings=True` is passed: in these reducers a literal
+        # can be the behaviour.
+        s = (
+            "// SEMANTICS-PIN-BEGIN: demo\n"
+            'pub fn t() -> &str { "merged" }\n'
+            "// SEMANTICS-PIN-END: demo\n"
+        )
+        assert pin_of(s, "demo") != pin_of(s.replace("merged", "retired"), "demo")
+
+    def t_missing_marker_is_an_error():
+        try:
+            extract_span("no markers here", "demo")
+        except GateError:
+            return
+        raise AssertionError("a missing marker was not an error")
+
+    def t_duplicate_marker_is_an_error():
+        try:
+            extract_span(src + src, "demo")
+        except GateError:
+            return
+        raise AssertionError("a duplicated marker was not an error")
+
+    def t_empty_span_is_an_error():
+        try:
+            extract_span(
+                "// SEMANTICS-PIN-BEGIN: demo\n\n// SEMANTICS-PIN-END: demo\n", "demo"
+            )
+        except GateError:
+            return
+        raise AssertionError("an empty pinned region was not an error")
+
+    def t_zero_declarations_is_an_error():
+        try:
+            parse_declarations('Self::Foo => "foo",\nconst SEMANTICS: &[RuleSpec] = &[];')
+        except GateError:
+            return
+        raise AssertionError("an empty declaration table passed")
+
+    def t_a_struct_definition_is_not_mistaken_for_a_row():
+        # `pub struct RuleSpec { rule: RuleId, version: u32, ... }` is a TYPE,
+        # not a declaration. Parsing it as one would invent a rule named after
+        # a field type and fail the run for a reason that does not exist.
+        defn = (
+            'Self::Demo => "demo",\n'
+            "pub struct RuleSpec {\n"
+            "    pub rule: RuleId,\n"
+            "    pub version: u32,\n"
+            "}\n"
+            "const S: &[RuleSpec] = &[RuleSpec { rule: RuleId::Demo, version: 1, "
+            'corpus_digest: "%s", source_pin: "%s", source_file: "a.rs", '
+            'span: "demo", }];' % ("a" * 64, "b" * 64)
+        )
+        rows = parse_declarations(defn)
+        assert len(rows) == 1, f"expected one row, parsed {len(rows)}"
+        assert rows[0]["rule"] == "demo"
+
+    def t_two_crates_sharing_a_rule_name_is_an_error():
+        one = (
+            'Self::Demo => "demo",\n'
+            "const S: &[RuleSpec] = &[RuleSpec { rule: RuleId::Demo, version: 1, "
+            'corpus_digest: "%s", source_pin: "%s", source_file: "a.rs", '
+            'span: "demo", }];' % ("a" * 64, "b" * 64)
+        )
+        try:
+            parse_all({"a.rs": one, "b.rs": one})
+        except GateError:
+            return
+        raise AssertionError("two rules sharing a stable name passed")
+
+    def t_unparseable_names_is_an_error():
+        try:
+            parse_declarations("no as_str arms at all")
+        except GateError:
+            return
+        raise AssertionError("a table with no stable names passed")
+
+    # --- the behavioural checks, over synthetic declarations ----------------
+
+    def decl(**over):
+        row = {
+            "rule": "demo",
+            "version": 1,
+            "corpus_digest": "a" * 64,
+            "source_pin": pin_of(src, "demo"),
+            "source_file": "demo.rs",
+            "span": "demo",
+        }
+        row.update(over)
+        return [row]
+
+    def base(**over):
+        row = {
+            "version": 1,
+            "corpus_digest": "a" * 64,
+            "source_pin": pin_of(src, "demo"),
+        }
+        row.update(over)
+        return {"rules": {"demo": [row]}}
+
+    read = lambda _rel: src  # noqa: E731
+
+    def t_a_consistent_declaration_passes():
+        assert check(decl(), base(), read) == []
+
+    def t_behaviour_change_at_a_fixed_version_fails():
+        problems = check(decl(corpus_digest="b" * 64), base(), read)
+        assert problems, "a corpus digest change at a fixed version passed"
+        assert "behaviour moved" in problems[0] or "corpus digest" in problems[0]
+
+    def t_behaviour_change_with_a_bump_and_a_row_passes():
+        b = base()
+        b["rules"]["demo"].append(
+            {"version": 2, "corpus_digest": "b" * 64, "source_pin": pin_of(src, "demo")}
+        )
+        assert check(decl(version=2, corpus_digest="b" * 64), b, read) == []
+
+    def t_a_bump_without_a_baseline_row_fails():
+        assert check(decl(version=2), base(), read), "a bump with no record passed"
+
+    def t_a_stale_source_pin_fails():
+        assert check(decl(source_pin="c" * 64), base(source_pin="c" * 64), read), (
+            "a source pin that does not match the span passed"
+        )
+
+    def t_a_missing_baseline_entry_fails():
+        assert check(decl(), {"rules": {}}, read), "an unrecorded rule passed"
+
+    def t_an_orphaned_baseline_entry_fails():
+        b = base()
+        b["rules"]["gone"] = [
+            {"version": 1, "corpus_digest": "a" * 64, "source_pin": "a" * 64}
+        ]
+        assert check(decl(), b, read), "an orphaned history passed"
+
+    def t_a_version_gap_fails():
+        b = base()
+        b["rules"]["demo"].append(
+            {"version": 3, "corpus_digest": "b" * 64, "source_pin": "a" * 64}
+        )
+        assert check(decl(version=3, corpus_digest="b" * 64), b, read), "a gap passed"
+
+    cases = [(n, f) for n, f in sorted(locals().items()) if n.startswith("t_") and callable(f)]
+    for name, fn in cases:
+        check_case(name, fn)
+
+    # A harness that discovers zero cases prints the same "OK" as one that ran
+    # them all — the identical silent-pass shape `parse_declarations` refuses.
+    # The floor is asserted rather than merely reported for that reason.
+    expected = 20
+    if len(cases) != expected:
+        print(
+            f"SELF-TEST HARNESS: discovered {len(cases)} cases, expected {expected}. "
+            "Update the count deliberately when adding or removing one.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if failures:
+        print("SELF-TEST FAILURES:", file=sys.stderr)
+        for f in failures:
+            print(f"  - {f}", file=sys.stderr)
+        return 1
+    print(f"self-tests OK ({len(cases)} cases)")
+    return 0
+
+
+if __name__ == "__main__":
+    if "--self-test" in sys.argv:
+        sys.exit(_self_test())
+    sys.exit(main())

--- a/ci/test_orphan_cores.py
+++ b/ci/test_orphan_cores.py
@@ -206,6 +206,38 @@ def strip_preserves_line_structure() -> bool:
     return ok
 
 
+def strip_keep_strings_is_opt_in_and_faithful() -> bool:
+    """`keep_strings=True` blanks comments only; the default is unchanged.
+
+    Both halves are asserted because both are load-bearing. The DEFAULT must
+    stay byte-identical or the orphan gate's own reasoning — a name inside a
+    string is prose, not consumption — quietly reverses. The FLAG must emit the
+    literal verbatim, which is why `check_world_semantics.py` can pin a reducer
+    whose behaviour lives in a returned token.
+    """
+    src = 'let s = "kirra_world::same_as_candidate"; // kirra_world::other\n'
+
+    default = G.strip_noncode(src)
+    kept = G.strip_noncode(src, keep_strings=True)
+
+    checks = [
+        ("default still blanks the literal", "same_as_candidate" not in default),
+        ("default still blanks the comment", "other" not in default),
+        ("keep_strings emits the literal", "same_as_candidate" in kept),
+        ("keep_strings still blanks the comment", "other" not in kept),
+        (
+            "line structure preserved either way",
+            len(default.splitlines()) == len(kept.splitlines()) == len(src.splitlines()),
+        ),
+    ]
+    ok = all(passed for _, passed in checks)
+    print(f"  {'PASS' if ok else 'FAIL'}  strip_noncode keep_strings is opt-in and faithful")
+    for label, passed in checks:
+        if not passed:
+            print(f"        {label}")
+    return ok
+
+
 def main() -> int:
     results = []
 
@@ -377,6 +409,8 @@ def main() -> int:
     )
 
     results.append(strip_preserves_line_structure())
+
+    results.append(strip_keep_strings_is_opt_in_and_faithful())
 
     results.append(historical_non_vacuity())
 

--- a/ci/world_semantics_baseline.json
+++ b/ci/world_semantics_baseline.json
@@ -1,0 +1,41 @@
+{
+  "_comment": [
+    "Recorded semantic-version history for every Kirra World reducer -- Tier 3 box 3b.",
+    "Enforced by ci/check_world_semantics.py. This file is APPEND-ONLY in intent:",
+    "a row records what a version's corpus digest WAS, and the gate refuses a",
+    "declaration that gives an already-recorded version a different digest. The",
+    "only clean way to change reducer behaviour is a NEW row with a NEW version.",
+    "The one legitimate edit to an existing row is `source_pin`, when a refactor",
+    "moved the source without moving the corpus digest -- see the gate's docstring."
+  ],
+  "rules": {
+    "world_current_fold": [
+      {
+        "version": 1,
+        "corpus_digest": "c38fc802ea1d7eca0afbf2dc5a11b8f5d55da0f4008dd43f9fcf22dae1d26da7",
+        "source_pin": "8725833999142be53519dc5029ab37afe03c782d57ab5d90f55dc67aed440c82"
+      }
+    ],
+    "entity_fold": [
+      {
+        "version": 1,
+        "corpus_digest": "966bc0bf440e824f5c3ebc916f2f753eee74dad914c015dab16dc58296b0f39e",
+        "source_pin": "b605bc92b7ae460293ab7f48db814fd3576c68977e1cb0c642ed19e66df9324b"
+      }
+    ],
+    "subject_summary_fold": [
+      {
+        "version": 1,
+        "corpus_digest": "b1008c8775e491639258f64560bcfe0abebab288022c5f03c9a7f682d79a34c7",
+        "source_pin": "2faa627ee865dd00229b52960b35d250caadc42acf4b10aef7bb48f97ecebb85"
+      }
+    ],
+    "answer_admissibility": [
+      {
+        "version": 1,
+        "corpus_digest": "c6458e88ed93ce2498a8b02f97e04bdfe3f2c666a1146ed34c081f4e56bcc33f",
+        "source_pin": "93d1c69a10f75e8df9e39c9d3cee1a89733b76b8fac7f0b0a7203b25370e04ae"
+      }
+    ]
+  }
+}

--- a/crates/kirra-world-service/src/answer_ref.rs
+++ b/crates/kirra-world-service/src/answer_ref.rs
@@ -19,7 +19,7 @@
 //! | query kind | which query this describes; the ref is meaningless without it |
 //! | parameters | subject, clock, staleness budget — change one, change the answer |
 //! | pinned generation | the snapshot coordinate to re-execute AT |
-//! | rule version | the semantics the answer was produced under |
+//! | semantic versions | the rules the answer was produced under — a SET, one entry per rule the query family depends on |
 //!
 //! Everything needed to re-execute, and nothing that is the answer itself. A ref
 //! holds no claims, no digests of claims, and no summary — because a durable
@@ -44,31 +44,28 @@ use kirra_world_store::snapshot::{Irreproducible, PinnedRead};
 use kirra_world_store::WorldStore;
 
 use crate::read_view::{AskError, ObjectIdentity, WorldAnswer};
+use crate::semantics::{SemanticVersions, VersionDifference};
 
-/// **The semantics an answer was produced under.**
+/// **The semantics a `CurrentSubject` answer is produced under, right now.**
 ///
-/// Bumped when a rule that can change an answer changes. Two rules bear on a
-/// resolved ref today: the projection fold (`supersedes` / `fold_step`, which
-/// decides which claim wins a key) and the boundary's admissibility test (which
-/// decides whether a claim is servable at all).
+/// A convenience over [`SemanticVersions::for_query`], which is where the set is
+/// actually derived. Two rules bear on a resolved ref today — the projection
+/// fold (`supersedes` / `fold_step`, which decides which claim wins a key) and
+/// the boundary's admissibility test (which decides whether a claim is servable
+/// at all) — and both come from their crates' live declarations rather than
+/// being restated here.
 ///
-/// # This is not decorative, and that took a mechanism
+/// # This replaced a single opaque constant, and the difference is box 3b
 ///
-/// A hand-bumped constant with nothing behind it is exactly what Tier 3 box 3b
-/// calls *"decorative metadata"* — it would read the same across a semantics
-/// change, so [`RefResolution::VersionMismatch`] would never fire when it
-/// mattered and the ref would replay under new rules while claiming the old
-/// ones. `answer_ref.rs`'s corpus test pins the fold's observable output against
-/// this constant: change the rule without changing the version and the test
-/// fails, naming the obligation.
-///
-/// # What it is NOT
-///
-/// It is not box 3b. 3b asks for declared, behaviour-changing, corpus-and-source
-/// pinned versioning across *rules and projections generally*; this covers the
-/// two rules THIS ref's resolution depends on, which is the honest subset a ref
-/// can carry today. Widening it is 3b's job.
-pub const RULE_VERSION: u32 = 1;
+/// The first version of this file carried `RULE_VERSION: u32 = 1`: one number,
+/// hand-bumped, pinned by one corpus. It refused on a mismatch, which was real
+/// — but it could not say *which* rule moved, and it covered two of the four
+/// versioned rules in the system while the identity and subject-summary folds
+/// had no declared version at all. Both gaps are what 3b names.
+#[must_use]
+pub fn current_semantics() -> SemanticVersions {
+    SemanticVersions::for_query(QueryKind::CurrentSubject)
+}
 
 /// Which query a ref describes.
 ///
@@ -97,15 +94,15 @@ pub struct AnswerRef {
     now_ms: i64,
     staleness_budget_ms: Option<u64>,
     generation: i64,
-    rule_version: u32,
+    semantics: SemanticVersions,
 }
 
 impl AnswerRef {
     /// Describe a `CurrentSubject` query at a pinned generation.
     ///
-    /// The rule version is stamped from [`RULE_VERSION`] rather than accepted
-    /// from the caller: a ref records the semantics its answer was produced
-    /// under, and letting a caller name them would let it claim any.
+    /// The semantic versions are stamped from the live declarations rather than
+    /// accepted from the caller: a ref records the semantics its answer was
+    /// produced under, and letting a caller name them would let it claim any.
     #[must_use]
     pub fn current_subject(
         subject: impl Into<String>,
@@ -119,7 +116,7 @@ impl AnswerRef {
             now_ms,
             staleness_budget_ms,
             generation,
-            rule_version: RULE_VERSION,
+            semantics: SemanticVersions::for_query(QueryKind::CurrentSubject),
         }
     }
 
@@ -155,19 +152,42 @@ impl AnswerRef {
 
     /// The semantics this ref's answer was produced under.
     #[must_use]
-    pub fn rule_version(&self) -> u32 {
-        self.rule_version
+    pub fn semantics(&self) -> &SemanticVersions {
+        &self.semantics
     }
 
-    /// Rebuild a ref that was recorded under a different rule version.
+    /// Rebuild a ref that was recorded under a different semantic version set.
     ///
     /// For tests and for a reader decoding a persisted ref. Deliberately
     /// explicit — there is no way to reach it by accident, and a ref built this
-    /// way says so by carrying a version that may not be [`RULE_VERSION`].
+    /// way says so by carrying versions that may not be this build's.
     #[must_use]
-    pub fn recorded_under(mut self, rule_version: u32) -> Self {
-        self.rule_version = rule_version;
+    pub fn recorded_under(mut self, semantics: SemanticVersions) -> Self {
+        self.semantics = semantics;
         self
+    }
+
+    /// Rebuild a ref with ONE rule's recorded version overridden.
+    ///
+    /// The common shape in a test — *"what if only the fold had moved?"* — and
+    /// writing it out longhand each time invites restating the whole set, which
+    /// would make the test pass for a reason it did not intend. An unknown rule
+    /// name is added rather than rejected, so a ref carrying a dependency this
+    /// build no longer has is representable.
+    #[must_use]
+    pub fn recorded_with(self, rule: &str, version: u32) -> Self {
+        let mut entries: Vec<_> = self
+            .semantics
+            .entries()
+            .iter()
+            .filter(|e| e.rule != rule)
+            .cloned()
+            .collect();
+        entries.push(crate::semantics::RuleVersion {
+            rule: rule.to_string(),
+            version,
+        });
+        self.recorded_under(SemanticVersions::new(entries))
     }
 
     /// **Re-execute this exact query against the same snapshot.**
@@ -185,11 +205,11 @@ impl AnswerRef {
     /// carrying a negative generation. Irreproducibility is an OUTCOME, not an
     /// error: *"we deleted the evidence"* is a fact about the data.
     pub fn resolve(&self, store: &WorldStore) -> Result<RefResolution, AskError> {
-        if self.rule_version != RULE_VERSION {
-            return Ok(RefResolution::VersionMismatch {
-                recorded: self.rule_version,
-                current: RULE_VERSION,
-            });
+        let differences = self
+            .semantics
+            .differences(&SemanticVersions::for_query(self.kind));
+        if !differences.is_empty() {
+            return Ok(RefResolution::VersionMismatch { differences });
         }
 
         let pinned = match store.read_at_generation(self.generation)? {
@@ -230,11 +250,14 @@ pub enum RefResolution {
     /// Refused rather than replayed, because replaying would answer a question
     /// the ref does not describe: the coordinate would be honoured and the
     /// SEMANTICS silently swapped, which is the subtler half of falling forward.
+    ///
+    /// Carries every rule that moved, by name. A refusal that said only *"the
+    /// rules changed"* would leave an operator holding a reference they cannot
+    /// act on — the versions exist precisely so the answer to *"changed how?"*
+    /// is in the refusal rather than in a changelog.
     VersionMismatch {
-        /// The version the ref was recorded under.
-        recorded: u32,
-        /// The version this build implements.
-        current: u32,
+        /// Every rule whose version differs, recorded versus current.
+        differences: Vec<VersionDifference>,
     },
 }
 

--- a/crates/kirra-world-service/src/lib.rs
+++ b/crates/kirra-world-service/src/lib.rs
@@ -32,6 +32,7 @@
 
 pub mod answer_ref;
 pub mod read_view;
+pub mod semantics;
 
 // Both edges exercised, so the proposed three-node graph is genuinely built and
 // not merely described in a manifest. The edge is no longer only exercised --

--- a/crates/kirra-world-service/src/read_view.rs
+++ b/crates/kirra-world-service/src/read_view.rs
@@ -626,6 +626,13 @@ impl<'a> WorldView<'a> {
         })
     }
 
+    // SEMANTICS-PIN-BEGIN: answer_admissibility
+    //
+    // The boundary's own versioned rule — see `crate::semantics`. Digested by
+    // `ci/check_world_semantics.py`; changing what it SERVES moves the corpus
+    // digest too, and then `BOUNDARY_SEMANTICS`' version must be bumped so
+    // recorded references refuse rather than replay under the new rule.
+
     /// Expired, or graded `Inadmissible`, is not servable.
     ///
     /// An **unlabelled** claim is admitted: it has no axes to grade, and
@@ -640,6 +647,8 @@ impl<'a> WorldView<'a> {
             Some(TrustGrade::Inadmissible)
         )
     }
+
+    // SEMANTICS-PIN-END: answer_admissibility
 
     /// Bind a live claim into an answer, resolving its object identity.
     ///

--- a/crates/kirra-world-service/src/semantics.rs
+++ b/crates/kirra-world-service/src/semantics.rs
@@ -240,19 +240,29 @@ pub struct VersionDifference {
 
 /// The admissibility rule's corpus input: `(label, claim, clock, budget)`.
 ///
-/// Each row exercises a distinct branch, and the third is the one a careless
-/// corpus omits:
+/// One bullet per row, in order, because a list that does not match the rows is
+/// a list a reader cannot check coverage against — and checking coverage is the
+/// only reason to write it down:
 ///
-/// * an unbounded unlabelled claim — admitted, the base case;
-/// * an **expired** claim — refused;
-/// * a **stale** claim — **admitted**, carrying its staleness. That the
-///   boundary reports staleness rather than swallowing it is a documented
-///   property of this rule, so a corpus that could not tell "stale" from
-///   "expired" would let the two be merged without moving the digest;
-/// * an `Inadmissible`-graded claim — refused on trust rather than on time;
-/// * an unlabelled claim that would grade `Inadmissible` if it had axes —
-///   admitted, because refusing it would invent a trust judgement from the
-///   absence of one.
+/// | Row | Verdict | The branch it holds open |
+/// |---|---|---|
+/// | `unbounded_unlabelled` | served | the base case, and the **unlabelled** one: a claim with no axes has no trust to grade, and refusing it would invent a judgement from the absence of one |
+/// | `expired` | refused | refused on **time** |
+/// | `stale` | **served** | past the budget, not past `valid_to` |
+/// | `rejected_adjudication` | refused | refused on **trust**, not on time |
+/// | `ambiguous_adjudication` | refused | the other half of `trust_grade`'s `Rejected \| Ambiguous` or-pattern — with only one row present, narrowing that pattern to a single variant would not move the digest |
+/// | `confirmed_adjudication` | served | **labelled** and served, which is what distinguishes "served because unlabelled" from "served despite being graded" |
+///
+/// The `stale` row is the one a careless corpus omits, and its absence is the
+/// expensive kind. That the boundary reports staleness rather than swallowing
+/// it is a documented property of this rule, so a corpus that could not tell
+/// "stale" from "expired" would let the two be merged without moving the digest
+/// — see `the_boundary_corpus_catches_refusing_a_stale_claim`.
+///
+/// The pairing of `unbounded_unlabelled` with `confirmed_adjudication` is what
+/// gives `the_boundary_corpus_catches_refusing_an_unlabelled_claim` its teeth:
+/// a rule that served only labelled claims still serves the second row, so the
+/// two rows together locate the change rather than merely detecting one.
 #[must_use]
 pub fn admissibility_corpus() -> Vec<(&'static str, ProjectedClaim, u64, Option<u64>)> {
     use kirra_world_store::{Adjudication, Corroboration, Origin, TrustAxes};

--- a/crates/kirra-world-service/src/semantics.rs
+++ b/crates/kirra-world-service/src/semantics.rs
@@ -1,0 +1,434 @@
+//! **The answer boundary's own versioned rule, and the composition — box 3b.**
+//!
+//! `kirra_world_store::semantics` versions the *reducers*. An answer is not
+//! produced by a reducer alone: the boundary applies its own rule on the way
+//! out, deciding which folded claims are servable at all. That rule can change
+//! what an answer says without any reducer moving, so it is versioned here on
+//! the same terms — declared, corpus-pinned, source-pinned.
+//!
+//! # Why a query carries a SET of versions rather than one number
+//!
+//! A single composite version would have to move whenever *any* rule moved,
+//! including rules the query never consults. That is not merely inelegant; it
+//! makes every recorded reference refuse for reasons unrelated to it, and a
+//! refusal that fires constantly is one people learn to route around.
+//!
+//! So [`SemanticVersions::for_query`] names exactly the rules a query family
+//! depends on. For [`QueryKind::CurrentSubject`] that is two of the four rules
+//! in the system, and the two exclusions are the interesting part:
+//!
+//! | Rule | In? | Why |
+//! |---|---|---|
+//! | `world_current_fold` | yes | the pinned replay folds with it |
+//! | `answer_admissibility` | yes | it decides which folded claims are served |
+//! | `entity_fold` | **no** | a pinned ref reports `NotResolvedInReplay`; identity cannot reach the answer |
+//! | `subject_summary_fold` | **no** | a different query family entirely |
+//!
+//! `entity_fold`'s exclusion is a live claim about today's code, not a
+//! permanent one. The moment a ref resolves object identity — the follow-up
+//! box 3h needs — it belongs in this set, and `answer_ref`'s tests say so.
+//!
+//! [`QueryKind::CurrentSubject`]: crate::answer_ref::QueryKind::CurrentSubject
+
+use kirra_world_store::projection::ProjectedClaim;
+use kirra_world_store::semantics::{self as store_semantics, RuleId};
+
+use crate::answer_ref::QueryKind;
+use crate::read_view::is_admissible_for_ref;
+
+/// A versioned rule owned by the answer boundary.
+///
+/// Declared in the same shape as [`kirra_world_store::semantics::RuleId`] —
+/// enum, stable `as_str`, one row in a `…RuleSpec` table — so
+/// `ci/check_world_semantics.py` reads both crates' declarations with one
+/// parser and holds them to one contract. A boundary rule checked by a
+/// second, differently-shaped gate is a boundary rule checked more weakly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum BoundaryRuleId {
+    /// [`crate::read_view::is_admissible_for_ref`] — which folded claims are
+    /// servable at all.
+    Admissibility,
+}
+
+impl BoundaryRuleId {
+    /// The stable name used in declarations, baselines and recorded references.
+    ///
+    /// `const` so [`ADMISSIBILITY`] can be defined from it rather than beside
+    /// it — two spellings of one rule name is exactly how a baseline key drifts
+    /// from the thing it keys.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Admissibility => "answer_admissibility",
+        }
+    }
+
+    /// Every versioned rule the boundary owns.
+    #[must_use]
+    pub fn all() -> &'static [BoundaryRuleId] {
+        &[BoundaryRuleId::Admissibility]
+    }
+}
+
+/// The boundary's stable rule name, as it appears in a recorded reference.
+pub const ADMISSIBILITY: &str = BoundaryRuleId::Admissibility.as_str();
+
+/// One boundary rule's declaration. Mirrors
+/// [`kirra_world_store::semantics::RuleSpec`] field for field.
+#[derive(Debug, Clone, Copy)]
+pub struct BoundaryRuleSpec {
+    /// Which rule.
+    pub rule: BoundaryRuleId,
+    /// The declared semantic version.
+    pub version: u32,
+    /// SHA-256 of this rule's corpus rendering, at this version.
+    pub corpus_digest: &'static str,
+    /// SHA-256 of the comment-stripped source span named by `span`.
+    pub source_pin: &'static str,
+    /// The file holding the rule.
+    pub source_file: &'static str,
+    /// The marker name delimiting the rule's span in that file.
+    pub span: &'static str,
+}
+
+/// **The declared semantics of every rule the answer boundary owns.**
+pub const BOUNDARY_SEMANTICS: &[BoundaryRuleSpec] = &[BoundaryRuleSpec {
+    rule: BoundaryRuleId::Admissibility,
+    version: 1,
+    corpus_digest: "c6458e88ed93ce2498a8b02f97e04bdfe3f2c666a1146ed34c081f4e56bcc33f",
+    source_pin: "93d1c69a10f75e8df9e39c9d3cee1a89733b76b8fac7f0b0a7203b25370e04ae",
+    source_file: "crates/kirra-world-service/src/read_view.rs",
+    span: "answer_admissibility",
+}];
+
+/// The declared version of one boundary rule.
+///
+/// # Panics
+///
+/// If [`BOUNDARY_SEMANTICS`] has no row for `rule` — an undeclared rule is an
+/// unversioned one, which is the state box 3b exists to make unrepresentable.
+#[must_use]
+pub fn version_of(rule: BoundaryRuleId) -> u32 {
+    BOUNDARY_SEMANTICS
+        .iter()
+        .find(|s| s.rule == rule)
+        .unwrap_or_else(|| panic!("boundary rule {} has no declaration", rule.as_str()))
+        .version
+}
+
+/// One rule's version, as recorded on a reference.
+///
+/// A `String` name rather than a borrowed one so a reference decoded from
+/// storage — carrying a rule this build may no longer declare — is
+/// representable. A version set that could only hold names this build knows
+/// could not describe the reference it is meant to refuse.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct RuleVersion {
+    /// The rule's stable name.
+    pub rule: String,
+    /// The version it was recorded at.
+    pub version: u32,
+}
+
+/// **The semantics one answer was produced under.**
+///
+/// Sorted and deduplicated at construction, so equality and hashing are
+/// properties of the *content* rather than of the order a caller happened to
+/// supply — which is what makes "the same query at the same coordinate produces
+/// the same reference" true of the type rather than of a convention.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SemanticVersions {
+    entries: Vec<RuleVersion>,
+}
+
+impl SemanticVersions {
+    /// Build from an arbitrary set — for tests, and for decoding a stored
+    /// reference recorded by another build.
+    #[must_use]
+    pub fn new(entries: impl IntoIterator<Item = RuleVersion>) -> Self {
+        let mut entries: Vec<_> = entries.into_iter().collect();
+        entries.sort();
+        entries.dedup_by(|a, b| a.rule == b.rule);
+        Self { entries }
+    }
+
+    /// **The versions this build implements for a query family.**
+    ///
+    /// Read from the live declarations rather than restated, so a bumped
+    /// reducer version reaches recorded references without anyone remembering
+    /// to update a second table.
+    #[must_use]
+    pub fn for_query(kind: QueryKind) -> Self {
+        match kind {
+            QueryKind::CurrentSubject => Self::new([
+                RuleVersion {
+                    rule: RuleId::WorldCurrentFold.as_str().to_string(),
+                    version: store_semantics::version_of(RuleId::WorldCurrentFold),
+                },
+                RuleVersion {
+                    rule: ADMISSIBILITY.to_string(),
+                    version: version_of(BoundaryRuleId::Admissibility),
+                },
+            ]),
+        }
+    }
+
+    /// The recorded rules, sorted by name.
+    #[must_use]
+    pub fn entries(&self) -> &[RuleVersion] {
+        &self.entries
+    }
+
+    /// This rule's version, if the set names it.
+    #[must_use]
+    pub fn version_of(&self, rule: &str) -> Option<u32> {
+        self.entries
+            .iter()
+            .find(|e| e.rule == rule)
+            .map(|e| e.version)
+    }
+
+    /// **Every way `self` (as recorded) differs from `current`.**
+    ///
+    /// Returns differences rather than a boolean because a refusal that cannot
+    /// name the rule that moved is a refusal an operator cannot act on. A rule
+    /// present on one side only is a difference too — `None` on the missing
+    /// side — since a query family gaining or losing a dependency changes what
+    /// the answer is derived from just as surely as a version bump does.
+    #[must_use]
+    pub fn differences(&self, current: &Self) -> Vec<VersionDifference> {
+        let mut names: Vec<&str> = self
+            .entries
+            .iter()
+            .chain(current.entries.iter())
+            .map(|e| e.rule.as_str())
+            .collect();
+        names.sort_unstable();
+        names.dedup();
+
+        names
+            .into_iter()
+            .filter_map(|rule| {
+                let recorded = self.version_of(rule);
+                let now = current.version_of(rule);
+                (recorded != now).then(|| VersionDifference {
+                    rule: rule.to_string(),
+                    recorded,
+                    current: now,
+                })
+            })
+            .collect()
+    }
+}
+
+/// One rule whose version moved between a recorded reference and this build.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VersionDifference {
+    /// The rule's stable name.
+    pub rule: String,
+    /// The version the reference was recorded under, or `None` if the reference
+    /// did not depend on this rule.
+    pub recorded: Option<u32>,
+    /// The version this build implements, or `None` if it no longer declares
+    /// the rule.
+    pub current: Option<u32>,
+}
+
+// ---------------------------------------------------------------------------
+// The admissibility corpus
+// ---------------------------------------------------------------------------
+
+/// The admissibility rule's corpus input: `(label, claim, clock, budget)`.
+///
+/// Each row exercises a distinct branch, and the third is the one a careless
+/// corpus omits:
+///
+/// * an unbounded unlabelled claim — admitted, the base case;
+/// * an **expired** claim — refused;
+/// * a **stale** claim — **admitted**, carrying its staleness. That the
+///   boundary reports staleness rather than swallowing it is a documented
+///   property of this rule, so a corpus that could not tell "stale" from
+///   "expired" would let the two be merged without moving the digest;
+/// * an `Inadmissible`-graded claim — refused on trust rather than on time;
+/// * an unlabelled claim that would grade `Inadmissible` if it had axes —
+///   admitted, because refusing it would invent a trust judgement from the
+///   absence of one.
+#[must_use]
+pub fn admissibility_corpus() -> Vec<(&'static str, ProjectedClaim, u64, Option<u64>)> {
+    use kirra_world_store::{Adjudication, Corroboration, Origin, TrustAxes};
+
+    let claim =
+        |valid_from_ms: i64, valid_to_ms: Option<i64>, trust: Option<TrustAxes>| ProjectedClaim {
+            subject: "package_17".to_string(),
+            predicate: Some("last_seen_at".to_string()),
+            object: Some("dock_alpha".to_string()),
+            kind: "mission".to_string(),
+            payload: "{}".to_string(),
+            frame_id: None,
+            map_id: None,
+            source: "sensor".to_string(),
+            valid_from_ms,
+            valid_to_ms,
+            txn_time_ms: valid_from_ms,
+            generation: 1,
+            event_id: "ev-1".to_string(),
+            chain_digest: "chain-1".to_string(),
+            trust,
+        };
+    let axes = |adjudication| {
+        TrustAxes::new(
+            Origin::Observed,
+            Corroboration::Uncorroborated,
+            adjudication,
+        )
+        .expect("corpus axes are storable")
+    };
+
+    vec![
+        (
+            "unbounded_unlabelled",
+            claim(1_000, None, None),
+            2_000,
+            None,
+        ),
+        ("expired", claim(1_000, Some(1_500), None), 2_000, None),
+        // Past the budget but not past `valid_to`: stale, and servable.
+        ("stale", claim(1_000, None, None), 2_000, Some(100)),
+        (
+            "rejected_adjudication",
+            claim(1_000, None, Some(axes(Adjudication::Rejected))),
+            2_000,
+            None,
+        ),
+        (
+            "ambiguous_adjudication",
+            claim(1_000, None, Some(axes(Adjudication::Ambiguous))),
+            2_000,
+            None,
+        ),
+        (
+            "confirmed_adjudication",
+            claim(1_000, None, Some(axes(Adjudication::Confirmed))),
+            2_000,
+            None,
+        ),
+    ]
+}
+
+/// Render the admissibility rule's verdict over its corpus.
+#[must_use]
+pub fn admissibility_rendering() -> String {
+    let mut out = String::new();
+    for (label, claim, clock, budget) in admissibility_corpus() {
+        out.push_str(label);
+        out.push('\u{1f}');
+        out.push_str(if is_admissible_for_ref(&claim, clock, budget) {
+            "served"
+        } else {
+            "refused"
+        });
+        out.push('\u{1e}');
+    }
+    out
+}
+
+/// The digest of [`admissibility_rendering`], in the form
+/// [`BoundaryRuleSpec::corpus_digest`] declares.
+#[must_use]
+pub fn admissibility_corpus_digest() -> String {
+    store_semantics::digest(&admissibility_rendering())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_version_set_is_order_independent() {
+        let a = SemanticVersions::new([
+            RuleVersion {
+                rule: "b".into(),
+                version: 2,
+            },
+            RuleVersion {
+                rule: "a".into(),
+                version: 1,
+            },
+        ]);
+        let b = SemanticVersions::new([
+            RuleVersion {
+                rule: "a".into(),
+                version: 1,
+            },
+            RuleVersion {
+                rule: "b".into(),
+                version: 2,
+            },
+        ]);
+        assert_eq!(a, b);
+        assert!(a.differences(&b).is_empty());
+    }
+
+    #[test]
+    fn a_moved_version_is_reported_by_name() {
+        let recorded = SemanticVersions::new([RuleVersion {
+            rule: "a".into(),
+            version: 1,
+        }]);
+        let current = SemanticVersions::new([RuleVersion {
+            rule: "a".into(),
+            version: 2,
+        }]);
+        assert_eq!(
+            recorded.differences(&current),
+            vec![VersionDifference {
+                rule: "a".into(),
+                recorded: Some(1),
+                current: Some(2),
+            }]
+        );
+    }
+
+    /// A dependency appearing or disappearing changes what an answer is derived
+    /// from, so it must be a difference rather than silently tolerated.
+    #[test]
+    fn an_added_or_removed_rule_is_a_difference() {
+        let none = SemanticVersions::new([]);
+        let one = SemanticVersions::new([RuleVersion {
+            rule: "a".into(),
+            version: 1,
+        }]);
+        assert_eq!(
+            none.differences(&one),
+            vec![VersionDifference {
+                rule: "a".into(),
+                recorded: None,
+                current: Some(1),
+            }]
+        );
+        assert_eq!(
+            one.differences(&none),
+            vec![VersionDifference {
+                rule: "a".into(),
+                recorded: Some(1),
+                current: None,
+            }]
+        );
+    }
+
+    /// The exclusions are a claim about today's code, so they are asserted
+    /// rather than only written down.
+    #[test]
+    fn the_current_subject_query_depends_on_exactly_two_rules() {
+        let v = SemanticVersions::for_query(QueryKind::CurrentSubject);
+        let names: Vec<&str> = v.entries().iter().map(|e| e.rule.as_str()).collect();
+        assert_eq!(names, vec![ADMISSIBILITY, "world_current_fold"]);
+        assert!(
+            v.version_of("entity_fold").is_none(),
+            "a pinned ref does not resolve identity, so the entity fold cannot \
+             reach its answer — including it would refuse references for a rule \
+             they never consulted"
+        );
+        assert!(v.version_of("subject_summary_fold").is_none());
+    }
+}

--- a/crates/kirra-world-service/tests/answer_ref.rs
+++ b/crates/kirra-world-service/tests/answer_ref.rs
@@ -21,7 +21,8 @@
 //! the store-level suite was vacuous without the second, and a ref inherits that
 //! bound wholesale, so it is re-asserted here at the level a caller sees.
 
-use kirra_world_service::answer_ref::{AnswerRef, QueryKind, RefResolution, RULE_VERSION};
+use kirra_world_service::answer_ref::{current_semantics, AnswerRef, QueryKind, RefResolution};
+use kirra_world_service::semantics::{RuleVersion, SemanticVersions};
 use kirra_world_store::snapshot::Irreproducible;
 use kirra_world_store::{ClaimStatus, EventId, NewEvent, ObservationId, WorldStore, WriterClass};
 
@@ -153,7 +154,7 @@ fn the_same_query_at_the_same_coordinate_produces_the_same_ref() {
     assert_eq!(hash(&a), hash(&b), "equal refs must hash equally");
 
     assert_eq!(a.kind(), QueryKind::CurrentSubject);
-    assert_eq!(a.rule_version(), RULE_VERSION);
+    assert_eq!(*a.semantics(), current_semantics());
 }
 
 /// **Changing any query parameter changes the ref.**
@@ -186,10 +187,25 @@ fn changing_any_parameter_changes_the_ref() {
             "generation",
             AnswerRef::current_subject("package_17", LATER, Some(60_000), 8),
         ),
+        // One rule moving is enough. Varying the WHOLE set would also pass
+        // while proving less: a ref must differ when any single dependency it
+        // names is at a different version, not merely when all of them are.
         (
-            "rule-version",
+            "fold-version",
             AnswerRef::current_subject("package_17", LATER, Some(60_000), 7)
-                .recorded_under(RULE_VERSION + 1),
+                .recorded_with("world_current_fold", 99),
+        ),
+        (
+            "boundary-version",
+            AnswerRef::current_subject("package_17", LATER, Some(60_000), 7)
+                .recorded_with("answer_admissibility", 99),
+        ),
+        // A ref that named a dependency this build does not have is a different
+        // ref, even though every SHARED rule agrees.
+        (
+            "extra-rule",
+            AnswerRef::current_subject("package_17", LATER, Some(60_000), 7)
+                .recorded_with("entity_fold", 1),
         ),
     ];
 
@@ -303,19 +319,43 @@ fn a_version_mismatch_refuses_rather_than_replaying() {
          proves only that the coordinate was bad"
     );
 
-    let stale = current.clone().recorded_under(RULE_VERSION - 1);
+    // ONE rule moving is enough, and the refusal must NAME it. A mismatch that
+    // said only "the rules changed" would leave an operator holding a reference
+    // they cannot act on.
+    let stale = current.clone().recorded_with("world_current_fold", 0);
     match stale.resolve(&store).expect("resolve") {
-        RefResolution::VersionMismatch { recorded, current } => {
-            assert_eq!(recorded, RULE_VERSION - 1);
-            assert_eq!(current, RULE_VERSION);
+        RefResolution::VersionMismatch { differences } => {
+            assert_eq!(differences.len(), 1, "only one rule moved: {differences:?}");
+            assert_eq!(differences[0].rule, "world_current_fold");
+            assert_eq!(differences[0].recorded, Some(0));
+            assert_eq!(
+                differences[0].current,
+                current_semantics().version_of("world_current_fold"),
+            );
         }
-        other => panic!("a stale rule version must refuse, got {other:?}"),
+        other => panic!("a stale fold version must refuse, got {other:?}"),
+    }
+
+    // The BOUNDARY rule is a separate dependency, and moving it alone must
+    // refuse too — otherwise the set is decorative for every rule but one.
+    match current
+        .clone()
+        .recorded_with("answer_admissibility", 99)
+        .resolve(&store)
+        .expect("resolve")
+    {
+        RefResolution::VersionMismatch { differences } => {
+            assert_eq!(differences.len(), 1);
+            assert_eq!(differences[0].rule, "answer_admissibility");
+        }
+        other => panic!("a moved boundary rule must refuse, got {other:?}"),
     }
 
     // A version from the FUTURE refuses too — a ref written by a newer build
     // describes semantics this one does not implement.
     match current
-        .recorded_under(RULE_VERSION + 1)
+        .clone()
+        .recorded_with("world_current_fold", u32::MAX)
         .resolve(&store)
         .expect("resolve")
     {
@@ -323,20 +363,54 @@ fn a_version_mismatch_refuses_rather_than_replaying() {
         other => panic!("an unknown future version must refuse, got {other:?}"),
     }
 
+    // A ref naming a dependency this build does not have refuses, even though
+    // every SHARED rule agrees. A query family that gained or lost a dependency
+    // derives its answer from something else.
+    match current
+        .clone()
+        .recorded_with("entity_fold", 1)
+        .resolve(&store)
+        .expect("resolve")
+    {
+        RefResolution::VersionMismatch { differences } => {
+            assert_eq!(differences[0].rule, "entity_fold");
+            assert_eq!(
+                differences[0].current, None,
+                "this build has no such dependency"
+            );
+        }
+        other => panic!("an unknown dependency must refuse, got {other:?}"),
+    }
+
+    // And the refusal is decided BEFORE the store is touched: a mismatched ref
+    // at an irreproducible coordinate reports the version, not the compaction.
+    match AnswerRef::current_subject("package_17", LATER, None, 99_999)
+        .recorded_with("world_current_fold", 0)
+        .resolve(&store)
+        .expect("resolve")
+    {
+        RefResolution::VersionMismatch { .. } => {}
+        other => panic!("the version check must precede the read, got {other:?}"),
+    }
+
     drop(store);
     cleanup(&path);
 }
 
 // ---------------------------------------------------------------------------
-// The corpus pin that keeps RULE_VERSION honest
+// The END-TO-END corpus pin, over a real store
 // ---------------------------------------------------------------------------
 
-/// **`RULE_VERSION` is pinned to the semantics a REF resolves under.**
+/// **A ref's recorded versions are pinned to what a ref actually resolves to.**
 ///
-/// Without this the version is what box 3b calls decorative metadata: a constant
-/// nobody is obliged to bump, so `VersionMismatch` would never fire on a real
-/// semantics change and a ref would replay under new rules while claiming the
-/// old ones.
+/// The per-rule corpora in `kirra-world-store/tests/semantics_corpus.rs` and
+/// `tests/boundary_semantics.rs` pin each rule in ISOLATION, over pure inputs.
+/// This pins the composition over a REAL store, and the difference is not
+/// ceremonial: the isolated corpora fold in-memory values, while a ref resolves
+/// by replaying rows out of SQLite. Everything between — the event decode, the
+/// confirmed-only filter, the generation cut — sits inside this test and outside
+/// those. A change there moves what every ref answers while every per-rule
+/// corpus stays green.
 ///
 /// # It pins the ref's own output, and the first draft pinned the wrong thing
 ///
@@ -359,21 +433,34 @@ fn a_version_mismatch_refuses_rather_than_replaying() {
 ///
 /// So this pins the resolved ANSWER, canonically rendered. That covers the fold
 /// rule (through the replay) and the boundary's admissibility rule (through the
-/// binding) — the two rules `RULE_VERSION` claims to describe — and it fails on
-/// a change to either.
+/// binding) — the two rules a `CurrentSubject` ref names — and it fails on a
+/// change to either.
 ///
 /// Rendered rather than hashed on purpose: a failure should show WHAT changed,
 /// not merely that something did.
 #[test]
-fn the_rule_version_is_pinned_to_the_semantics_a_ref_resolves_under() {
-    // This rendering belongs to RULE_VERSION 1. Bump both together.
-    const PINNED_FOR_VERSION: u32 = 1;
+fn a_refs_recorded_versions_are_pinned_to_what_it_resolves_to() {
+    // This rendering belongs to the version set below. Move them together.
     const PINNED_ANSWER: &str = "package_17|last_seen_at|dock_second|{}|Timeless|Ungraded";
 
+    // Spelled out rather than read from `current_semantics()`, which would make
+    // the assertion tautological — it would agree with whatever the build
+    // declares, including a version somebody bumped without touching a rule.
+    let pinned = SemanticVersions::new([
+        RuleVersion {
+            rule: "answer_admissibility".into(),
+            version: 1,
+        },
+        RuleVersion {
+            rule: "world_current_fold".into(),
+            version: 1,
+        },
+    ]);
     assert_eq!(
-        RULE_VERSION, PINNED_FOR_VERSION,
-        "RULE_VERSION moved without re-pinning the corpus — the two are a pair, \
-         and a version that moves alone tracks nothing"
+        current_semantics(),
+        pinned,
+        "the version set a ref records moved without re-pinning this rendering — \
+         the two are a pair, and a version that moves alone tracks nothing"
     );
 
     let path = tmp("corpus");
@@ -445,9 +532,9 @@ fn the_rule_version_is_pinned_to_the_semantics_a_ref_resolves_under() {
     assert_eq!(
         rendered.join("\n"),
         PINNED_ANSWER,
-        "the semantics a ref resolves under changed. If that was deliberate, \
-         bump RULE_VERSION and re-pin this rendering in the same commit — a \
-         recorded AnswerRef must not silently replay under the new rule."
+        "the semantics a ref resolves under changed. If that was deliberate, bump \
+         the moved rule's version and re-pin this rendering in the same commit — \
+         a recorded AnswerRef must not silently replay under the new rule."
     );
 
     drop(store);

--- a/crates/kirra-world-service/tests/boundary_semantics.rs
+++ b/crates/kirra-world-service/tests/boundary_semantics.rs
@@ -1,0 +1,202 @@
+//! **The answer boundary's declared rule, and the controls behind it — box 3b.**
+//!
+//! The store's `tests/semantics_corpus.rs` does this for the three reducers.
+//! This is the same discipline for the one rule the *boundary* owns: which
+//! folded claims are servable at all.
+//!
+//! The sensitivity controls matter more here than they look. The admissibility
+//! rule has exactly two ways to be wrong, and they are opposites:
+//!
+//! * **too permissive** — serving an expired or `Inadmissible` claim, which is
+//!   the safety-relevant direction; and
+//! * **too strict** — refusing a *stale* claim, which sounds conservative and is
+//!   actually a regression. Staleness is reported, not swallowed: a caller with
+//!   a budget gets the claim back carrying `Validity::Stale` and decides. A rule
+//!   that silently dropped stale claims would turn a reported condition into an
+//!   invisible one, and the answer would go from "here it is, it is old" to
+//!   "nothing is known" — which is a different fact.
+//!
+//! A corpus blind to either direction would let that half of the rule be
+//! rewritten under a fixed version, so both are challenged explicitly.
+
+use kirra_world_service::answer_ref::QueryKind;
+use kirra_world_service::semantics::{
+    admissibility_corpus, admissibility_corpus_digest, admissibility_rendering, BoundaryRuleId,
+    SemanticVersions, BOUNDARY_SEMANTICS,
+};
+use kirra_world_store::projection::ProjectedClaim;
+use kirra_world_store::semantics::digest;
+use kirra_world_store::{TrustGrade, Validity};
+
+/// The declared digest must be the rule's actual digest.
+#[test]
+fn the_declared_boundary_corpus_digest_matches_the_rule() {
+    for spec in BOUNDARY_SEMANTICS {
+        assert_eq!(
+            admissibility_corpus_digest(),
+            spec.corpus_digest,
+            "\n\n{} behaves differently from its declaration (version {}).\n\
+             \n\
+             If DELIBERATE: bump `version` AND re-pin `corpus_digest` in\n\
+             `BOUNDARY_SEMANTICS`, and add the new version's row to\n\
+             `ci/world_semantics_baseline.json`.\n\
+             \n\
+             rendering now:\n{}\n",
+            spec.rule.as_str(),
+            spec.version,
+            admissibility_rendering().replace('\u{1e}', "\n"),
+        );
+    }
+}
+
+#[test]
+fn no_boundary_declaration_carries_a_placeholder() {
+    assert_eq!(BOUNDARY_SEMANTICS.len(), BoundaryRuleId::all().len());
+    for spec in BOUNDARY_SEMANTICS {
+        for (field, value) in [
+            ("corpus_digest", spec.corpus_digest),
+            ("source_pin", spec.source_pin),
+        ] {
+            assert_eq!(
+                value.len(),
+                64,
+                "{}.{field} is not a sha256",
+                spec.rule.as_str()
+            );
+            assert_ne!(
+                value,
+                "0".repeat(64),
+                "{}.{field} is still the placeholder",
+                spec.rule.as_str()
+            );
+        }
+    }
+}
+
+/// A corpus in which every row lands the same way discriminates nothing: a rule
+/// returning a constant would reproduce it exactly.
+#[test]
+fn the_boundary_corpus_exercises_both_verdicts() {
+    let rendered = admissibility_rendering();
+    assert!(rendered.contains("served"), "no row is served");
+    assert!(rendered.contains("refused"), "no row is refused");
+}
+
+// ---------------------------------------------------------------------------
+// Sensitivity controls
+// ---------------------------------------------------------------------------
+
+/// Render the corpus under a caller-supplied admissibility rule.
+fn render_with(rule: impl Fn(&ProjectedClaim, u64, Option<u64>) -> bool) -> String {
+    let mut out = String::new();
+    for (label, claim, clock, budget) in admissibility_corpus() {
+        out.push_str(label);
+        out.push('\u{1f}');
+        out.push_str(if rule(&claim, clock, budget) {
+            "served"
+        } else {
+            "refused"
+        });
+        out.push('\u{1e}');
+    }
+    out
+}
+
+fn assert_variant_is_caught(variant: &str, rendered: &str) {
+    assert_ne!(
+        rendered,
+        admissibility_rendering(),
+        "\n\nthe admissibility corpus does NOT discriminate the `{variant}` \
+         variant — the declared version would stay green through that change.\n"
+    );
+}
+
+/// The faithfulness control: the harness must reproduce the shipped rule when
+/// given the shipped rule, or a difference it reports is its own bug.
+#[test]
+fn the_boundary_variant_harness_reproduces_the_real_rule() {
+    let real = |c: &ProjectedClaim, clock: u64, budget: Option<u64>| {
+        c.validity_at(clock, budget) != Validity::Expired
+            && !matches!(c.grade_at(clock, budget), Some(TrustGrade::Inadmissible))
+    };
+    assert_eq!(render_with(real), admissibility_rendering());
+}
+
+/// Dropping the expiry check serves a claim that has stopped holding.
+#[test]
+fn the_boundary_corpus_catches_serving_an_expired_claim() {
+    assert_variant_is_caught(
+        "expiry_check_dropped",
+        &render_with(|c, clock, budget| {
+            !matches!(c.grade_at(clock, budget), Some(TrustGrade::Inadmissible))
+        }),
+    );
+}
+
+/// Dropping the trust check serves a `Rejected` or `Ambiguous` claim.
+#[test]
+fn the_boundary_corpus_catches_serving_an_inadmissible_claim() {
+    assert_variant_is_caught(
+        "trust_check_dropped",
+        &render_with(|c, clock, budget| c.validity_at(clock, budget) != Validity::Expired),
+    );
+}
+
+/// **The over-strict direction.** Refusing stale claims looks conservative and
+/// silently converts a reported condition into an absent answer.
+#[test]
+fn the_boundary_corpus_catches_refusing_a_stale_claim() {
+    assert_variant_is_caught(
+        "stale_refused",
+        &render_with(|c, clock, budget| {
+            !matches!(
+                c.validity_at(clock, budget),
+                Validity::Expired | Validity::Stale
+            ) && !matches!(c.grade_at(clock, budget), Some(TrustGrade::Inadmissible))
+        }),
+    );
+}
+
+/// Refusing unlabelled claims invents a trust judgement from the absence of one.
+#[test]
+fn the_boundary_corpus_catches_refusing_an_unlabelled_claim() {
+    assert_variant_is_caught(
+        "unlabelled_refused",
+        &render_with(|c, clock, budget| {
+            c.trust.is_some()
+                && c.validity_at(clock, budget) != Validity::Expired
+                && !matches!(c.grade_at(clock, budget), Some(TrustGrade::Inadmissible))
+        }),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The composition
+// ---------------------------------------------------------------------------
+
+/// The version set a query carries must be derived from the live declarations,
+/// not restated. A second copy is a second thing to forget.
+#[test]
+fn a_querys_versions_come_from_the_live_declarations() {
+    let v = SemanticVersions::for_query(QueryKind::CurrentSubject);
+    assert_eq!(
+        v.version_of("answer_admissibility"),
+        Some(BOUNDARY_SEMANTICS[0].version),
+    );
+    assert_eq!(
+        v.version_of("world_current_fold"),
+        Some(kirra_world_store::semantics::version_of(
+            kirra_world_store::semantics::RuleId::WorldCurrentFold
+        )),
+    );
+}
+
+/// Both crates' declarations must digest their corpora the same way, or the two
+/// halves of one baseline file are not comparable.
+#[test]
+fn both_crates_declare_digests_in_the_same_form() {
+    assert_eq!(
+        digest(&admissibility_rendering()),
+        admissibility_corpus_digest()
+    );
+}

--- a/crates/kirra-world-service/tests/boundary_semantics.rs
+++ b/crates/kirra-world-service/tests/boundary_semantics.rs
@@ -26,7 +26,7 @@ use kirra_world_service::semantics::{
 };
 use kirra_world_store::projection::ProjectedClaim;
 use kirra_world_store::semantics::digest;
-use kirra_world_store::{TrustGrade, Validity};
+use kirra_world_store::{Adjudication, TrustGrade, Validity};
 
 /// The declared digest must be the rule's actual digest.
 #[test]
@@ -154,6 +154,45 @@ fn the_boundary_corpus_catches_refusing_a_stale_claim() {
                 Validity::Expired | Validity::Stale
             ) && !matches!(c.grade_at(clock, budget), Some(TrustGrade::Inadmissible))
         }),
+    );
+}
+
+/// **Narrowing `trust_grade`'s `Rejected | Ambiguous` or-pattern to one variant
+/// must move the digest.**
+///
+/// Both arms of that or-pattern are reached by ONE match arm, so a corpus
+/// carrying only a `Rejected` row would sit green while someone dropped
+/// `Ambiguous` from it — and an ambiguous claim would then grade `Adequate` and
+/// be served. `admissibility_corpus`'s doc claims the second row prevents
+/// exactly that; this is the claim rather than the assertion.
+///
+/// The variant flips precisely one row: every other row's verdict is unchanged,
+/// which is what makes the moved digest attributable to this axis alone.
+#[test]
+fn the_boundary_corpus_catches_narrowing_the_inadmissible_pattern() {
+    let narrowed = render_with(|c, clock, budget| {
+        let rejected_only = c
+            .trust
+            .as_ref()
+            .is_some_and(|a| matches!(a.adjudication(), Adjudication::Rejected));
+        c.validity_at(clock, budget) != Validity::Expired && !rejected_only
+    });
+    assert_variant_is_caught("inadmissible_narrowed_to_rejected", &narrowed);
+
+    // Asserted rather than narrated: a variant that moved SEVERAL rows would
+    // also be "caught", and would prove only that the two rules differ somewhere
+    // — not that this corpus can see the `Ambiguous` arm specifically.
+    let real = admissibility_rendering();
+    let moved: Vec<&str> = real
+        .split('\u{1e}')
+        .zip(narrowed.split('\u{1e}'))
+        .filter(|(a, b)| a != b)
+        .map(|(a, _)| a.split('\u{1f}').next().unwrap_or(""))
+        .collect();
+    assert_eq!(
+        moved,
+        vec!["ambiguous_adjudication"],
+        "exactly the ambiguous row must flip, and nothing else"
     );
 }
 

--- a/crates/kirra-world-store/src/entity_projection.rs
+++ b/crates/kirra-world-store/src/entity_projection.rs
@@ -145,6 +145,11 @@ impl ProjectedEntity {
     }
 }
 
+// SEMANTICS-PIN-BEGIN: entity_fold
+//
+// Digested by `ci/check_world_semantics.py` and pinned in
+// `semantics::SEMANTICS` — see `crate::semantics` for the two-check rationale.
+
 /// **The pure fold step.** Apply one adjudication to the accumulator.
 ///
 /// `BTreeMap` rather than `HashMap` for the same reason
@@ -248,6 +253,8 @@ where
     }
     acc
 }
+
+// SEMANTICS-PIN-END: entity_fold
 
 /// The stored token for a lifecycle state.
 #[must_use]

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -89,6 +89,7 @@ pub mod projection;
 pub mod retention_driver;
 pub mod retention_sweeper;
 pub mod schema;
+pub mod semantics;
 pub mod snapshot;
 pub mod subject_projection;
 

--- a/crates/kirra-world-store/src/projection.rs
+++ b/crates/kirra-world-store/src/projection.rs
@@ -240,6 +240,13 @@ impl ProjectedClaim {
     }
 }
 
+// SEMANTICS-PIN-BEGIN: world_current_fold
+//
+// Everything between these markers is digested by `ci/check_world_semantics.py`
+// and pinned in `semantics::SEMANTICS`. Editing it moves the pin; if the edit
+// changed BEHAVIOUR the corpus digest moves too, and then the declared version
+// must be bumped. See `crate::semantics` for why both checks exist.
+
 /// Does `incoming` supersede `held` for the same key?
 ///
 /// Ordered by `(valid_from_ms, generation)`. Valid time leads because the
@@ -284,6 +291,8 @@ pub fn fold_all<I: IntoIterator<Item = ProjectedClaim>>(
     }
     acc
 }
+
+// SEMANTICS-PIN-END: world_current_fold
 
 #[cfg(test)]
 mod tests {

--- a/crates/kirra-world-store/src/semantics.rs
+++ b/crates/kirra-world-store/src/semantics.rs
@@ -1,0 +1,557 @@
+//! **Declared reducer semantics — Tier 3 box 3b.**
+//!
+//! Every projection in this store is produced by a pure reducer. This module
+//! gives each one a **declared version**, and gives that version two independent
+//! things to be accountable to, because neither alone is enough:
+//!
+//! * a **conformance corpus** — a fixed input with a pinned rendered output, so
+//!   a change in *behaviour* is visible as a diff; and
+//! * a **source pin** — a digest over the reducer's own source span, so a silent
+//!   edit reds CI even when the corpus happens not to exercise it.
+//!
+//! The corpus proves meaning; the pin proves nobody edited quietly. A version
+//! checked by neither is what `WM_SCOPE.md` calls **decorative metadata** — a
+//! constant nobody is obliged to move, so a consumer that refuses on a version
+//! mismatch never fires when it matters.
+//!
+//! # `KIRRA-WM-REDUCER-VERSION-001`
+//!
+//! > **A reducer version changes whenever the reducer's behaviour changes in a
+//! > way that can alter a derived answer. A pinned answer reference refuses
+//! > replay under a different semantic version rather than replaying under the
+//! > new one.**
+//!
+//! The second sentence is the half that gives the first one teeth. A version
+//! that nothing consumes is a comment; the consumer is
+//! `kirra_world_service::answer_ref`, whose `resolve` compares the versions a
+//! reference was recorded under against the versions this build implements and
+//! refuses on any difference.
+//!
+//! # What forces the bump — and the honest limit
+//!
+//! Three checks stack, and it is worth being precise about which one does what,
+//! because the interesting failure is a behaviour change that keeps its version:
+//!
+//! | Check | Where | Catches |
+//! |---|---|---|
+//! | corpus digest == declared | `tests/semantics_corpus.rs` | behaviour moved and the declaration did not |
+//! | source pin == span digest | `ci/check_world_semantics.py` | the reducer was edited at all |
+//! | **corpus digest may not move at a fixed version** | `ci/check_world_semantics.py` | behaviour moved *and* the declaration was updated, but the version was not |
+//!
+//! The third is the one that makes a bump unavoidable in practice. The baseline
+//! records what each version's corpus digest *was*; re-declaring a different
+//! digest for a version already on record reds, and the only clean way forward
+//! is a new version with a new row.
+//!
+//! **The residual, stated rather than papered over:** an author who edits the
+//! Rust declaration *and* the recorded baseline row in one commit still passes.
+//! No gate can force a human to increment an integer. What these remove is doing
+//! it silently, doing it by accident, and doing it without a reviewer seeing a
+//! diff that says — in a file whose only purpose is to be that record — that a
+//! historical fact was rewritten.
+//!
+//! # Why the corpora are ordinary code rather than test fixtures
+//!
+//! They are pure functions over in-memory values: no store is opened, no schema
+//! is installed, nothing is written. That matters for one specific reason beyond
+//! tidiness — ADR-0041's **D-20** measurement compares the on-disk size of a
+//! log-only store against one with projections, and `projection.rs` documents at
+//! length that installing a projection table early would silently move that
+//! figure. A corpus that touched a database would be the same mistake wearing a
+//! different hat. These cannot: they have no `WorldStore` in scope.
+//!
+//! Being ordinary code also lets the *consumer* crate's tests reach them, which
+//! `#[cfg(test)]` items cannot do across a crate boundary.
+//!
+//! # ADR-0042 condition (1)
+//!
+//! Nothing here may become a required safety input. These are pure renderings of
+//! fold outputs for comparison purposes; they hold no corridor, no actuator
+//! handle and no release token, and gate test t24 checks this file by contents.
+
+use std::collections::BTreeMap;
+
+use kirra_world::adjudication::{
+    AssertIdentity, ForgetEntity, IdentityAdjudication, Justification, MergeEntities,
+    RetirementReason, SplitEntity,
+};
+use kirra_world::observation::{ClockDomain, DomainInstant};
+use kirra_world::reference::{EntityId, ObservationId};
+
+use crate::entity_projection::{
+    self, contradiction_json, lifecycle_token, origin_of, redirect_json, ProjectedEntity,
+};
+use crate::projection::{self, ProjectedClaim};
+use crate::subject_projection::{self, ProjectedSubject, SubjectKey, SubjectObservation};
+
+/// A versioned reducer.
+///
+/// A closed enum rather than a string, for the same reason
+/// `kirra_world_service::answer_ref::QueryKind` is one: a rule identity a caller
+/// could invent is a rule identity nothing can be pinned against.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum RuleId {
+    /// [`crate::projection::fold_step`] / [`crate::projection::supersedes`] —
+    /// the `world_current` claim fold.
+    WorldCurrentFold,
+    /// [`crate::entity_projection::fold_adjudication`] — the identity fold.
+    EntityFold,
+    /// [`crate::subject_projection::subject_fold_step`] — the subject summary
+    /// fold.
+    SubjectSummaryFold,
+}
+
+impl RuleId {
+    /// The stable name used in declarations, baselines and mismatch reports.
+    ///
+    /// Stable is the operative word: this string appears in
+    /// `ci/world_semantics_baseline.json`, so renaming it orphans that rule's
+    /// recorded history. It is deliberately not derived from the variant name.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::WorldCurrentFold => "world_current_fold",
+            Self::EntityFold => "entity_fold",
+            Self::SubjectSummaryFold => "subject_summary_fold",
+        }
+    }
+
+    /// Every versioned reducer in this store.
+    ///
+    /// Used by the conformance test to walk the whole set, so a rule added to
+    /// [`RuleId`] without a [`RuleSpec`] fails rather than going unversioned.
+    #[must_use]
+    pub fn all() -> &'static [RuleId] {
+        &[
+            RuleId::WorldCurrentFold,
+            RuleId::EntityFold,
+            RuleId::SubjectSummaryFold,
+        ]
+    }
+}
+
+/// One reducer's declaration.
+///
+/// `source_file` and `span` are here so the gate does not have to guess where a
+/// reducer lives: the pin is computed over the region between
+/// `SEMANTICS-PIN-BEGIN: <span>` and `SEMANTICS-PIN-END: <span>` markers in that
+/// file. Marker comments rather than function-name extraction, because a rule
+/// whose boundary is inferred moves whenever someone renames or reorders, and a
+/// pin that moves for cosmetic reasons trains exactly the reflexive re-pinning
+/// that destroys its signal.
+#[derive(Debug, Clone, Copy)]
+pub struct RuleSpec {
+    /// Which reducer.
+    pub rule: RuleId,
+    /// The declared semantic version.
+    pub version: u32,
+    /// SHA-256 of [`corpus_rendering`] for this rule, at this version.
+    pub corpus_digest: &'static str,
+    /// SHA-256 of the comment-stripped source span named by `span`.
+    ///
+    /// Declared here and computed by `ci/check_world_semantics.py`, not by this
+    /// crate. A pin a program computes over itself at runtime proves only that
+    /// the running code agrees with the running code.
+    pub source_pin: &'static str,
+    /// The file holding the reducer.
+    pub source_file: &'static str,
+    /// The marker name delimiting the reducer's span in that file.
+    pub span: &'static str,
+}
+
+/// **The declared semantics of every reducer in this store.**
+///
+/// Formatted one field per line and parsed by `ci/check_world_semantics.py`. The
+/// gate refuses to pass on an empty parse, so a formatting change that defeats
+/// the parser reds rather than silently checking nothing.
+pub const SEMANTICS: &[RuleSpec] = &[
+    RuleSpec {
+        rule: RuleId::WorldCurrentFold,
+        version: 1,
+        corpus_digest: "c38fc802ea1d7eca0afbf2dc5a11b8f5d55da0f4008dd43f9fcf22dae1d26da7",
+        source_pin: "8725833999142be53519dc5029ab37afe03c782d57ab5d90f55dc67aed440c82",
+        source_file: "crates/kirra-world-store/src/projection.rs",
+        span: "world_current_fold",
+    },
+    RuleSpec {
+        rule: RuleId::EntityFold,
+        version: 1,
+        corpus_digest: "966bc0bf440e824f5c3ebc916f2f753eee74dad914c015dab16dc58296b0f39e",
+        source_pin: "b605bc92b7ae460293ab7f48db814fd3576c68977e1cb0c642ed19e66df9324b",
+        source_file: "crates/kirra-world-store/src/entity_projection.rs",
+        span: "entity_fold",
+    },
+    RuleSpec {
+        rule: RuleId::SubjectSummaryFold,
+        version: 1,
+        corpus_digest: "b1008c8775e491639258f64560bcfe0abebab288022c5f03c9a7f682d79a34c7",
+        source_pin: "2faa627ee865dd00229b52960b35d250caadc42acf4b10aef7bb48f97ecebb85",
+        source_file: "crates/kirra-world-store/src/subject_projection.rs",
+        span: "subject_summary_fold",
+    },
+];
+
+/// The declaration for one rule.
+///
+/// # Panics
+///
+/// If [`SEMANTICS`] has no row for `rule`. Deliberately a panic rather than an
+/// `Option`: a rule with no declaration is an unversioned reducer, which is the
+/// state this module exists to make unrepresentable, and handing callers a
+/// `None` to ignore would let it persist.
+#[must_use]
+pub fn spec(rule: RuleId) -> &'static RuleSpec {
+    SEMANTICS
+        .iter()
+        .find(|s| s.rule == rule)
+        .unwrap_or_else(|| panic!("reducer {} has no declared semantics", rule.as_str()))
+}
+
+/// The declared version of one rule.
+#[must_use]
+pub fn version_of(rule: RuleId) -> u32 {
+    spec(rule).version
+}
+
+// ---------------------------------------------------------------------------
+// Corpora
+// ---------------------------------------------------------------------------
+//
+// Each corpus is split into an INPUT and a RENDERING, rather than one function
+// returning a digest. That split is what lets `tests/semantics_corpus.rs` run a
+// deliberately-divergent reducer over the *same* input and assert the rendering
+// moves — which is how the corpus's sensitivity to each behavioural axis is
+// proved rather than assumed. A corpus that only exercises the happy path
+// produces a stable digest under a mutated rule, and pins nothing.
+
+/// The field separator inside one rendered row.
+const FIELD: char = '\u{1f}';
+/// The separator between rendered rows.
+const ROW: char = '\u{1e}';
+
+/// The `world_current` fold's corpus input.
+///
+/// Every claim here earns its place by discriminating a behaviour:
+///
+/// * `dock_first` then `dock_second` — an **accepted** supersession, later valid
+///   time arriving later.
+/// * `dock_tie` — equal valid time, higher generation: the **tiebreak**, which
+///   is what makes the rule total and rebuild-equals-incremental true.
+/// * `dock_backdated` — a **refused** supersession, earlier valid time arriving
+///   later.
+/// * a second predicate and a predicate-less claim on the same subject — the
+///   **key**, so a fold that keyed on subject alone collides visibly.
+///
+/// # The generation ORDER here is load-bearing, and a first draft got it wrong
+///
+/// `dock_backdated` must carry the **highest** generation for its key. An
+/// earlier draft placed it in the middle, and the corpus went blind to the axis
+/// it exists to cover: under a fold ordering on generation the backdated claim
+/// won *temporarily* and was then displaced by `dock_tie` anyway, so both the
+/// real rule and the mutated one ended on the same row. A fold is only
+/// observable through its FINAL state; an intermediate divergence that later
+/// converges is invisible to any corpus.
+///
+/// Recorded here rather than fixed silently because it is the failure mode a
+/// conformance corpus has by default, and it was found by
+/// `the_claim_corpus_catches_generation_leading_valid_time` — the control doing
+/// precisely the job it was added for, on its first run.
+#[must_use]
+pub fn world_current_corpus() -> Vec<ProjectedClaim> {
+    let base = |predicate: Option<&str>, object: &str, valid_from_ms: i64, generation: i64| {
+        ProjectedClaim {
+            subject: "package_17".to_string(),
+            predicate: predicate.map(str::to_string),
+            object: Some(object.to_string()),
+            kind: "mission".to_string(),
+            payload: "{}".to_string(),
+            frame_id: None,
+            map_id: None,
+            source: "sensor".to_string(),
+            valid_from_ms,
+            valid_to_ms: None,
+            txn_time_ms: valid_from_ms,
+            generation,
+            event_id: format!("ev-{generation}"),
+            chain_digest: format!("chain-{generation}"),
+            trust: None,
+        }
+    };
+    vec![
+        base(Some("last_seen_at"), "dock_first", 1_000, 1),
+        base(Some("last_seen_at"), "dock_second", 1_010, 2),
+        base(Some("last_seen_at"), "dock_tie", 1_010, 3),
+        base(Some("last_seen_at"), "dock_backdated", 1_005, 4),
+        base(Some("carried_by"), "robot_a", 1_000, 5),
+        base(None, "unpredicated", 1_000, 6),
+    ]
+}
+
+/// Render a folded `world_current` accumulator.
+///
+/// Rendered rather than hashed at the assertion site so a failure shows **what**
+/// changed. The digest is taken over this text; the text is what a human reads.
+#[must_use]
+pub fn render_world_current(rows: &BTreeMap<(String, String), ProjectedClaim>) -> String {
+    let mut out = String::new();
+    for ((subject, predicate_key), claim) in rows {
+        out.push_str(subject);
+        out.push(FIELD);
+        out.push_str(predicate_key);
+        out.push(FIELD);
+        out.push_str(claim.object.as_deref().unwrap_or(""));
+        out.push(FIELD);
+        out.push_str(&claim.valid_from_ms.to_string());
+        out.push(FIELD);
+        out.push_str(&claim.generation.to_string());
+        out.push(ROW);
+    }
+    out
+}
+
+/// The identity fold's corpus input, as `(generation, adjudication)`.
+///
+/// Covers creation, a merge that redirects, a split, a retirement, and — the
+/// axis a happy-path corpus would miss — a **contradiction**: re-asserting an
+/// id that already exists. Contradiction handling is sticky and refuses to
+/// advance the entity further, so a fold that dropped either half renders
+/// differently.
+#[must_use]
+pub fn entity_corpus() -> Vec<(i64, IdentityAdjudication)> {
+    let eid = |s: &str| EntityId::new(s).expect("corpus entity id");
+    let just = || {
+        Justification::new([ObservationId::new("obs-corpus").expect("corpus obs")])
+            .expect("corpus justification")
+    };
+    let at = || DomainInstant {
+        ms: 1,
+        domain: ClockDomain::System,
+    };
+
+    vec![
+        (
+            1,
+            IdentityAdjudication::Assert(AssertIdentity::new(eid("a"), just(), at())),
+        ),
+        (
+            2,
+            IdentityAdjudication::Assert(AssertIdentity::new(eid("b"), just(), at())),
+        ),
+        (
+            3,
+            IdentityAdjudication::Merge(
+                MergeEntities::new(vec![eid("a")], eid("b"), just(), at()).expect("corpus merge"),
+            ),
+        ),
+        (
+            4,
+            IdentityAdjudication::Split(
+                SplitEntity::partition(eid("b"), [eid("b1"), eid("b2")], just(), at())
+                    .expect("corpus split"),
+            ),
+        ),
+        (
+            5,
+            IdentityAdjudication::Forget(ForgetEntity::new(
+                eid("b1"),
+                RetirementReason::new("decommissioned").expect("corpus reason"),
+                just(),
+                at(),
+            )),
+        ),
+        // The contradiction axis: `a` was already asserted at generation 1.
+        (
+            6,
+            IdentityAdjudication::Assert(AssertIdentity::new(eid("a"), just(), at())),
+        ),
+    ]
+}
+
+/// Render a folded identity accumulator.
+///
+/// The contradiction **payload** is rendered, not merely a flag, for the reason
+/// [`crate::entity_projection::state_digest_of`] gives: two projections that
+/// refuse the same entities while naming different generations would otherwise
+/// compare equal, and the generation is the field an operator uses to find the
+/// disagreeing event.
+#[must_use]
+pub fn render_entities(rows: &BTreeMap<String, ProjectedEntity>) -> String {
+    let mut out = String::new();
+    for (id, e) in rows {
+        out.push_str(id);
+        out.push(FIELD);
+        out.push_str(lifecycle_token(&e.lifecycle));
+        out.push(FIELD);
+        out.push_str(redirect_json(&e.lifecycle).as_deref().unwrap_or(""));
+        out.push(FIELD);
+        out.push_str(origin_of(&e.lifecycle).map_or("", EntityId::as_str));
+        out.push(FIELD);
+        out.push_str(
+            &e.contradiction
+                .as_ref()
+                .map(contradiction_json)
+                .unwrap_or_default(),
+        );
+        out.push(ROW);
+    }
+    out
+}
+
+/// The subject summary fold's corpus input.
+///
+/// The discriminating entries are the **out-of-order** ones. A summary fold that
+/// tied `last_observed_ms` to the head — the bug `subject_fold_step`'s own docs
+/// record — regresses the maximum when a later generation carries an earlier
+/// transaction time, so the corpus supplies exactly that pair. Two kinds and a
+/// `NULL` discriminant cover the key.
+#[must_use]
+pub fn subject_corpus() -> Vec<SubjectObservation> {
+    let obs = |subject: &str,
+               subject_kind: Option<&str>,
+               txn_time_ms: i64,
+               generation: i64|
+     -> SubjectObservation {
+        SubjectObservation {
+            subject: subject.to_string(),
+            subject_kind: subject_kind.map(str::to_string),
+            txn_time_ms,
+            generation,
+            event_id: format!("ev-{generation}"),
+            chain_digest: format!("chain-{generation}"),
+        }
+    };
+    vec![
+        obs("package_17", Some("entity"), 1_000, 1),
+        obs("package_17", Some("entity"), 1_020, 2),
+        // Later generation, EARLIER transaction time: the head must advance
+        // while `last_observed_ms` must not regress.
+        obs("package_17", Some("entity"), 1_010, 3),
+        // Same subject name under a different kind — a distinct summary.
+        obs("package_17", Some("frame"), 1_030, 4),
+        // No discriminant: the sentinel, and a third distinct summary.
+        obs("package_17", None, 1_040, 5),
+    ]
+}
+
+/// Render a folded subject summary accumulator.
+#[must_use]
+pub fn render_subjects(rows: &BTreeMap<SubjectKey, ProjectedSubject>) -> String {
+    let mut out = String::new();
+    for ((kind, subject), s) in rows {
+        out.push_str(kind.as_str());
+        out.push(FIELD);
+        out.push_str(subject);
+        out.push(FIELD);
+        out.push_str(&s.first_observed_ms.to_string());
+        out.push(FIELD);
+        out.push_str(&s.last_observed_ms.to_string());
+        out.push(FIELD);
+        out.push_str(&s.observation_count.to_string());
+        out.push(FIELD);
+        out.push_str(&s.last_generation.to_string());
+        out.push(FIELD);
+        out.push_str(&s.provenance_head);
+        out.push(ROW);
+    }
+    out
+}
+
+/// **Run one rule's corpus through the real reducer and render the result.**
+///
+/// This is the value the declared [`RuleSpec::corpus_digest`] is a digest of. It
+/// calls the shipped reducers directly — not a copy, not a re-derivation — so a
+/// change to the rule moves this string by construction.
+#[must_use]
+pub fn corpus_rendering(rule: RuleId) -> String {
+    match rule {
+        RuleId::WorldCurrentFold => {
+            render_world_current(&projection::fold_all(world_current_corpus()))
+        }
+        RuleId::EntityFold => {
+            let corpus = entity_corpus();
+            render_entities(&entity_projection::fold_all(
+                corpus.iter().map(|(g, a)| (*g, a)),
+            ))
+        }
+        RuleId::SubjectSummaryFold => {
+            let corpus = subject_corpus();
+            render_subjects(
+                &subject_projection::subject_fold_all(corpus.iter())
+                    .expect("the subject corpus must fold, or it is pinning an error"),
+            )
+        }
+    }
+}
+
+/// The digest of [`corpus_rendering`], in the form [`RuleSpec::corpus_digest`]
+/// declares.
+#[must_use]
+pub fn corpus_digest(rule: RuleId) -> String {
+    digest(&corpus_rendering(rule))
+}
+
+/// Digest a corpus rendering in the form a declaration carries.
+///
+/// Public so the **answer boundary** — which owns a versioned rule of its own,
+/// in another crate — declares its digest in the same form rather than choosing
+/// a second hash and making the two tables incomparable.
+#[must_use]
+pub fn digest(rendering: &str) -> String {
+    crate::sha256_hex(rendering.as_bytes())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every rule in the enum has a declaration, and every declaration names a
+    /// rule in the enum. Without this a reducer added later is silently
+    /// unversioned — which is the exact state 3b exists to end.
+    #[test]
+    fn every_rule_is_declared_exactly_once() {
+        for rule in RuleId::all() {
+            let found: Vec<_> = SEMANTICS.iter().filter(|s| s.rule == *rule).collect();
+            assert_eq!(
+                found.len(),
+                1,
+                "{} must have exactly one declaration",
+                rule.as_str()
+            );
+        }
+        assert_eq!(SEMANTICS.len(), RuleId::all().len());
+    }
+
+    /// A corpus that folds to nothing pins nothing, and would keep pinning
+    /// nothing while the reducer was rewritten underneath it.
+    #[test]
+    fn no_corpus_renders_empty() {
+        for rule in RuleId::all() {
+            let rendered = corpus_rendering(*rule);
+            assert!(
+                !rendered.is_empty(),
+                "{} renders an empty corpus — it pins nothing",
+                rule.as_str()
+            );
+        }
+    }
+
+    /// Rendering must be deterministic within a process, or the digest compares
+    /// unequal to itself.
+    #[test]
+    fn rendering_is_stable() {
+        for rule in RuleId::all() {
+            assert_eq!(corpus_rendering(*rule), corpus_rendering(*rule));
+        }
+    }
+
+    /// Two rules rendering identically would let one stand in for the other.
+    #[test]
+    fn the_corpora_are_distinguishable() {
+        let mut seen: Vec<String> = Vec::new();
+        for rule in RuleId::all() {
+            let d = corpus_digest(*rule);
+            assert!(!seen.contains(&d), "{} shares a digest", rule.as_str());
+            seen.push(d);
+        }
+    }
+}

--- a/crates/kirra-world-store/src/subject_projection.rs
+++ b/crates/kirra-world-store/src/subject_projection.rs
@@ -296,6 +296,11 @@ pub struct ProjectedSubject {
 /// `(subject, kind)` would compile everywhere `(kind, subject)` does.
 pub type SubjectKey = (SummaryKind, String);
 
+// SEMANTICS-PIN-BEGIN: subject_summary_fold
+//
+// Digested by `ci/check_world_semantics.py` and pinned in
+// `semantics::SEMANTICS` — see `crate::semantics` for the two-check rationale.
+
 /// Fold one observation into the accumulator. Returns whether it changed.
 ///
 /// # Ordering is not assumed
@@ -382,6 +387,8 @@ pub fn subject_fold_all<'a, I: IntoIterator<Item = &'a SubjectObservation>>(
     }
     Ok(acc)
 }
+
+// SEMANTICS-PIN-END: subject_summary_fold
 
 #[cfg(test)]
 mod tests {

--- a/crates/kirra-world-store/tests/semantics_corpus.rs
+++ b/crates/kirra-world-store/tests/semantics_corpus.rs
@@ -1,0 +1,497 @@
+//! **The conformance corpus, and the controls that prove it is not decorative.**
+//!
+//! Two jobs, and the second is the one worth reading.
+//!
+//! # 1. Conformance
+//!
+//! For every declared reducer, the corpus rendering's digest must equal the
+//! digest declared in [`kirra_world_store::semantics::SEMANTICS`]. Change a
+//! reducer's behaviour and this reds, naming the rule and showing the rendering
+//! that moved.
+//!
+//! # 2. Sensitivity — the part a corpus usually gets wrong
+//!
+//! A conformance corpus is only worth its declaration if it *discriminates*. A
+//! corpus whose inputs all flow down the happy path produces the same rendering
+//! under a mutated rule, so the digest holds, the test stays green, and the
+//! version it pins tracks nothing. That failure is invisible: everything passes.
+//!
+//! So each rule carries a table of **behaviour variants** — deliberately
+//! divergent reimplementations of the reducer, each flipping exactly one rule —
+//! and every variant must render differently from the real fold over the *same*
+//! corpus input. Each variant is a named, historically-real way the fold could
+//! be wrong:
+//!
+//! * `generation_leads_valid_time` — the classic bitemporal bug, where a
+//!   late-arriving event about the past overwrites the present.
+//! * `no_tiebreak` — an incomplete order, which makes the fold input-order
+//!   dependent and `rebuild_from_zero_equals_incremental` false.
+//! * `last_observed_follows_head` — the regression `subject_fold_step`'s own
+//!   docs record having shipped once.
+//!
+//! This is the standing form of *"change fold behaviour without changing the
+//! version and check the gate catches it"*. Run as a one-off mutation that
+//! answer expires the moment someone edits the corpus; run as a table it is
+//! re-answered on every commit, per behavioural axis.
+//!
+//! **What this does NOT prove.** A variant table proves sensitivity to the axes
+//! it names. An axis nobody thought of is not covered, and no test can close
+//! that — which is why the source pin exists alongside, catching edits the
+//! corpus is blind to.
+//!
+//! # The battery this was measured against
+//!
+//! Run against the real `projection::supersedes`, not a fixture, with the
+//! generation-leads-valid-time flip applied to the shipped reducer:
+//!
+//! | Mutation | Rust conformance | `check_world_semantics.py` |
+//! |---|---|---|
+//! | flip the fold rule | **RED** (corpus digest moved) | **RED** (source pin moved) |
+//! | …then re-pin BOTH digests, leave `version` at 1 | green | **RED** (digest moved at a fixed version) |
+//! | …then bump to v2 and add a baseline row | green | green — and the end-to-end ref pin reds until the recorded set is re-pinned |
+//!
+//! The second row is the whole of box 3b. The Rust test cannot see it: re-pin
+//! the digest and it is satisfied, with the version untouched and every
+//! recorded reference now replaying under a rule it does not name. The third
+//! row shows the bump genuinely reaching a reference rather than stopping at a
+//! constant.
+//!
+//! The FIRST run of this file also found a real hole: `world_current_corpus`
+//! had the backdated claim in the middle of the generation sequence, where the
+//! mutated and real folds converge on the same final state. See that function's
+//! docs — the control did its job before the corpus was ever declared correct.
+
+use std::collections::BTreeMap;
+
+use kirra_world::adjudication::IdentityAdjudication;
+use kirra_world::entity::Lifecycle;
+use kirra_world_store::entity_projection::{Contradiction, ProjectedEntity};
+use kirra_world_store::projection::ProjectedClaim;
+use kirra_world_store::semantics::{
+    self, corpus_digest, corpus_rendering, entity_corpus, render_entities, render_subjects,
+    render_world_current, subject_corpus, world_current_corpus, RuleId, SEMANTICS,
+};
+use kirra_world_store::subject_projection::{
+    ProjectedSubject, SubjectKey, SubjectObservation, SummaryKind,
+};
+
+// ---------------------------------------------------------------------------
+// 1. Conformance
+// ---------------------------------------------------------------------------
+
+/// **The declared digest must be the corpus's actual digest.**
+///
+/// The failure message is deliberately a procedure rather than a value: the
+/// choice a developer faces here — re-pin, or bump and re-pin — is exactly the
+/// choice 3b exists to force, and a message that only printed two hashes would
+/// invite the wrong half of it.
+///
+/// Every rule is checked before the test fails, rather than stopping at the
+/// first — a change that moved two reducers should report both, or the second
+/// is discovered only after the first is fixed and re-run.
+#[test]
+fn every_declared_corpus_digest_matches_the_reducer() {
+    let mut drifted = String::new();
+    for spec in SEMANTICS {
+        let actual = corpus_digest(spec.rule);
+        if actual != spec.corpus_digest {
+            drifted.push_str(&format!(
+                "\n  {} (declared version {})\n    declared: {}\n    actual:   {}\n    rendering now:\n      {}\n",
+                spec.rule.as_str(),
+                spec.version,
+                spec.corpus_digest,
+                actual,
+                corpus_rendering(spec.rule).replace('\u{1e}', "\n      "),
+            ));
+        }
+    }
+    assert!(
+        drifted.is_empty(),
+        "\n\nreducer behaviour no longer matches its declaration:\n{drifted}\n\
+         If this was a DELIBERATE semantics change: bump `version` AND re-pin\n\
+         `corpus_digest` in `semantics::SEMANTICS`, and add the new version's row\n\
+         to `ci/world_semantics_baseline.json`. A recorded AnswerRef must refuse\n\
+         to replay under the new rule rather than silently adopt it.\n\
+         \n\
+         If it was NOT deliberate, a reducer changed by accident.\n"
+    );
+}
+
+/// A declaration whose digest was pasted from a different rule would satisfy the
+/// test above only by coincidence, but a placeholder digest would not satisfy it
+/// at all — so this guards the *shape*, which a copy-paste can preserve.
+#[test]
+fn no_declaration_carries_a_placeholder_digest() {
+    for spec in SEMANTICS {
+        for (field, value) in [
+            ("corpus_digest", spec.corpus_digest),
+            ("source_pin", spec.source_pin),
+        ] {
+            assert_eq!(
+                value.len(),
+                64,
+                "{}.{field} is not a sha256",
+                spec.rule.as_str()
+            );
+            assert!(
+                value.chars().all(|c| c.is_ascii_hexdigit()),
+                "{}.{field} is not hex",
+                spec.rule.as_str()
+            );
+            assert_ne!(
+                value,
+                "0".repeat(64),
+                "{}.{field} is still the placeholder",
+                spec.rule.as_str()
+            );
+        }
+        assert!(spec.version >= 1, "versions start at 1");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 2. Sensitivity controls
+// ---------------------------------------------------------------------------
+
+/// Assert a variant fold renders differently from the real one.
+///
+/// Takes the rendering rather than a digest so a failure can show what the
+/// variant produced — a variant that renders identically is a *hole in the
+/// corpus*, and the reader needs to see which rows failed to move.
+fn assert_variant_is_caught(rule: RuleId, variant: &str, rendered: &str) {
+    assert_ne!(
+        rendered,
+        corpus_rendering(rule),
+        "\n\nthe `{}` corpus does NOT discriminate the `{variant}` variant.\n\
+         \n\
+         A reducer with this rule flipped folds the corpus to the same state, so\n\
+         the declared version would stay green through that behaviour change.\n\
+         Extend the corpus input until this axis is exercised.\n",
+        rule.as_str()
+    );
+}
+
+// --- world_current -------------------------------------------------------
+
+/// Fold the claim corpus with a caller-supplied supersession rule.
+fn fold_current_with(
+    supersedes: impl Fn(&ProjectedClaim, &ProjectedClaim) -> bool,
+    key: impl Fn(&ProjectedClaim) -> (String, String),
+) -> BTreeMap<(String, String), ProjectedClaim> {
+    let mut acc: BTreeMap<(String, String), ProjectedClaim> = BTreeMap::new();
+    for claim in world_current_corpus() {
+        let k = key(&claim);
+        match acc.get(&k) {
+            Some(held) if !supersedes(&claim, held) => {}
+            _ => {
+                acc.insert(k, claim);
+            }
+        }
+    }
+    acc
+}
+
+fn real_key(c: &ProjectedClaim) -> (String, String) {
+    (c.subject.clone(), c.predicate.clone().unwrap_or_default())
+}
+
+/// Transaction order leading valid time: a backdated event overwrites the
+/// present. This is the bug `projection::supersedes` names as the whole reason
+/// valid time leads generation.
+#[test]
+fn the_claim_corpus_catches_generation_leading_valid_time() {
+    let folded = fold_current_with(
+        |i, h| (i.generation, i.valid_from_ms) > (h.generation, h.valid_from_ms),
+        real_key,
+    );
+    assert_variant_is_caught(
+        RuleId::WorldCurrentFold,
+        "generation_leads_valid_time",
+        &render_world_current(&folded),
+    );
+}
+
+/// An order with no tiebreak is not total, and a fold under it depends on
+/// arrival order.
+#[test]
+fn the_claim_corpus_catches_a_missing_tiebreak() {
+    let folded = fold_current_with(|i, h| i.valid_from_ms > h.valid_from_ms, real_key);
+    assert_variant_is_caught(
+        RuleId::WorldCurrentFold,
+        "no_tiebreak",
+        &render_world_current(&folded),
+    );
+}
+
+/// Keying on subject alone collapses distinct predicates into one slot.
+#[test]
+fn the_claim_corpus_catches_a_subject_only_key() {
+    let folded = fold_current_with(
+        |i, h| (i.valid_from_ms, i.generation) > (h.valid_from_ms, h.generation),
+        |c| (c.subject.clone(), String::new()),
+    );
+    assert_variant_is_caught(
+        RuleId::WorldCurrentFold,
+        "subject_only_key",
+        &render_world_current(&folded),
+    );
+}
+
+/// Never superseding — a fold that silently stopped adopting anything after the
+/// first claim per key.
+#[test]
+fn the_claim_corpus_catches_a_fold_that_never_supersedes() {
+    let folded = fold_current_with(|_, _| false, real_key);
+    assert_variant_is_caught(
+        RuleId::WorldCurrentFold,
+        "never_supersedes",
+        &render_world_current(&folded),
+    );
+}
+
+// --- entities ------------------------------------------------------------
+
+/// Fold the identity corpus, optionally dropping one of two rules.
+fn fold_entities_with(
+    assert_overwrites: bool,
+    create_from_consequence: bool,
+) -> BTreeMap<String, ProjectedEntity> {
+    let mut acc: BTreeMap<String, ProjectedEntity> = BTreeMap::new();
+    for (generation, adjudication) in entity_corpus() {
+        if let IdentityAdjudication::Assert(a) = &adjudication {
+            let key = a.entity().as_str().to_owned();
+            match acc.get_mut(&key) {
+                None => {
+                    acc.insert(
+                        key,
+                        ProjectedEntity {
+                            entity: a.entity().clone(),
+                            lifecycle: Lifecycle::Provisional,
+                            contradiction: None,
+                        },
+                    );
+                }
+                Some(existing) => {
+                    if assert_overwrites {
+                        // The variant: re-asserting an existing id RESETS it
+                        // instead of recording that two events each claim to
+                        // have brought the same identity into being.
+                        existing.lifecycle = Lifecycle::Provisional;
+                    } else if existing.contradiction.is_none() {
+                        existing.contradiction = Some(Contradiction {
+                            held: existing.lifecycle.state(),
+                            attempted: kirra_world::entity::LifecycleState::Provisional,
+                            generation,
+                        });
+                    }
+                }
+            }
+            continue;
+        }
+
+        for (entity, next) in adjudication.resulting_lifecycles() {
+            let key = entity.as_str().to_owned();
+            match acc.get_mut(&key) {
+                None => {
+                    if create_from_consequence {
+                        acc.insert(
+                            key,
+                            ProjectedEntity {
+                                entity,
+                                lifecycle: next,
+                                contradiction: None,
+                            },
+                        );
+                    }
+                }
+                Some(held) => {
+                    if held.contradiction.is_some() {
+                        continue;
+                    }
+                    match held.lifecycle.advance_to(next.clone()) {
+                        Ok(moved) => held.lifecycle = moved,
+                        Err(_) => {
+                            held.contradiction = Some(Contradiction {
+                                held: held.lifecycle.state(),
+                                attempted: next.state(),
+                                generation,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+    }
+    acc
+}
+
+/// The control that the variant harness itself is faithful.
+///
+/// Without this, a variant that diverged for an unrelated reason — a
+/// transcription slip in the reimplementation — would still "pass" by rendering
+/// differently, and the table would prove nothing about the axis it names. Both
+/// flags at their real settings must reproduce the shipped fold exactly.
+#[test]
+fn the_entity_variant_harness_reproduces_the_real_fold() {
+    assert_eq!(
+        render_entities(&fold_entities_with(false, true)),
+        corpus_rendering(RuleId::EntityFold),
+        "the variant harness diverges from the real reducer with every rule at \
+         its real setting — so any difference it reports is its own bug, not the \
+         variant's"
+    );
+}
+
+/// Re-asserting an existing id must be recorded as a contradiction, not
+/// silently accepted as a reset.
+#[test]
+fn the_entity_corpus_catches_an_assert_that_overwrites() {
+    assert_variant_is_caught(
+        RuleId::EntityFold,
+        "assert_overwrites",
+        &render_entities(&fold_entities_with(true, true)),
+    );
+}
+
+/// An entity first met in a consequence — a split's outputs — must be created
+/// there, or the identity graph loses entities the log named.
+#[test]
+fn the_entity_corpus_catches_refusing_to_create_from_a_consequence() {
+    assert_variant_is_caught(
+        RuleId::EntityFold,
+        "no_create_from_consequence",
+        &render_entities(&fold_entities_with(false, false)),
+    );
+}
+
+// --- subject summaries ---------------------------------------------------
+
+/// Fold the subject corpus with selectable time-bound and head rules.
+fn fold_subjects_with(
+    last_observed_follows_head: bool,
+    head_follows_time: bool,
+    kind_in_key: bool,
+) -> BTreeMap<SubjectKey, ProjectedSubject> {
+    let mut acc: BTreeMap<SubjectKey, ProjectedSubject> = BTreeMap::new();
+    for incoming in subject_corpus() {
+        let kind = SummaryKind::from_event_column(incoming.subject_kind.as_deref())
+            .expect("corpus kinds are valid");
+        let key = if kind_in_key {
+            (kind, incoming.subject.clone())
+        } else {
+            (SummaryKind::Unlabelled, incoming.subject.clone())
+        };
+        match acc.get_mut(&key) {
+            None => {
+                acc.insert(key, new_summary(kind, &incoming));
+            }
+            Some(held) => {
+                held.observation_count += 1;
+                held.first_observed_ms = held.first_observed_ms.min(incoming.txn_time_ms);
+                if !last_observed_follows_head {
+                    held.last_observed_ms = held.last_observed_ms.max(incoming.txn_time_ms);
+                }
+
+                let advances = if head_follows_time {
+                    incoming.txn_time_ms > held.last_observed_ms
+                } else {
+                    incoming.generation > held.last_generation
+                };
+                if advances {
+                    held.last_generation = incoming.generation;
+                    held.provenance_head = incoming.chain_digest.clone();
+                    held.last_event_id = incoming.event_id.clone();
+                    if last_observed_follows_head {
+                        held.last_observed_ms = incoming.txn_time_ms;
+                    }
+                }
+            }
+        }
+    }
+    acc
+}
+
+fn new_summary(kind: SummaryKind, o: &SubjectObservation) -> ProjectedSubject {
+    ProjectedSubject {
+        subject_kind: kind,
+        subject: o.subject.clone(),
+        first_observed_ms: o.txn_time_ms,
+        last_observed_ms: o.txn_time_ms,
+        provenance_head: o.chain_digest.clone(),
+        observation_count: 1,
+        last_generation: o.generation,
+        last_event_id: o.event_id.clone(),
+    }
+}
+
+/// The same faithfulness control as the entity harness.
+#[test]
+fn the_subject_variant_harness_reproduces_the_real_fold() {
+    assert_eq!(
+        render_subjects(&fold_subjects_with(false, false, true)),
+        corpus_rendering(RuleId::SubjectSummaryFold),
+        "the variant harness diverges from the real reducer at its real settings"
+    );
+}
+
+/// Tying the time bound to the head regresses the maximum when a later
+/// generation carries an earlier transaction time — the regression
+/// `subject_fold_step` records having shipped once.
+#[test]
+fn the_subject_corpus_catches_last_observed_following_the_head() {
+    assert_variant_is_caught(
+        RuleId::SubjectSummaryFold,
+        "last_observed_follows_head",
+        &render_subjects(&fold_subjects_with(true, false, true)),
+    );
+}
+
+/// A head chosen by a tie-breakable transaction time is not reproducible.
+#[test]
+fn the_subject_corpus_catches_a_head_chosen_by_time() {
+    assert_variant_is_caught(
+        RuleId::SubjectSummaryFold,
+        "head_follows_time",
+        &render_subjects(&fold_subjects_with(false, true, true)),
+    );
+}
+
+/// Dropping the kind from the key merges summaries the vocabulary keeps apart.
+#[test]
+fn the_subject_corpus_catches_a_key_without_the_kind() {
+    assert_variant_is_caught(
+        RuleId::SubjectSummaryFold,
+        "kind_not_in_key",
+        &render_subjects(&fold_subjects_with(false, false, false)),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Coverage of the control table itself
+// ---------------------------------------------------------------------------
+
+/// Every declared rule must carry at least one sensitivity control.
+///
+/// A rule whose corpus is never challenged is a corpus nobody has shown to
+/// discriminate anything — which is the state this file exists to end, so the
+/// obligation is machine-checked rather than left to whoever adds the next
+/// reducer.
+#[test]
+fn every_rule_has_at_least_one_sensitivity_control() {
+    // Kept as an explicit list rather than derived, so ADDING a rule to
+    // `RuleId::all()` reds here until its controls are written.
+    let controlled = [
+        RuleId::WorldCurrentFold,
+        RuleId::EntityFold,
+        RuleId::SubjectSummaryFold,
+    ];
+    for rule in RuleId::all() {
+        assert!(
+            controlled.contains(rule),
+            "{} has no sensitivity control — its corpus discriminates nothing \
+             that has been demonstrated",
+            rule.as_str()
+        );
+    }
+    assert_eq!(controlled.len(), semantics::SEMANTICS.len());
+}

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -1873,6 +1873,13 @@ changes. Two mechanisms, because neither alone is enough:
 The corpus proves meaning; the pin proves nobody edited quietly. A version
 checked by neither is decorative metadata.
 
+**Built 2026-08-11**, and one thing this section did not anticipate: neither
+mechanism forces the BUMP. Both are satisfied by re-pinning, so a behaviour
+change that updates its own declaration keeps its version and stays green. That
+needed a third check — a recorded history the declaration is accountable to, so
+a version's corpus digest cannot be redefined after the fact. See *"3b closed"*
+below.
+
 ### `KIRRA-WM-EXPLAIN-TIER-001` — RULED 2026-08-09
 
 > **`Explain` stays at Tier 4. Tier 3 builds only the deterministic lineage
@@ -1996,8 +2003,14 @@ pressure that produced every stale claim this box already documents.
       generation, so a recorded coordinate can actually be re-executed against.
       `KIRRA-WM-ANSWER-IDENTITY-001` now has a mechanism behind it; the ruled
       `AnswerRef` itself is the next step and is still open.
-- [ ] **3b — Rule / projection versioning.** Declared, behaviour-changing, and
-      enforced by corpus + source pin (above). Not decorative metadata.
+- [x] **3b — Rule / projection versioning.** ✅ **DONE 2026-08-11** — see *"3b
+      closed — the version stopped being a promise"* below. Declared,
+      behaviour-changing, and enforced by corpus + source pin (above). Not
+      decorative metadata. Four rules declared (three reducers + the answer
+      boundary's admissibility rule), each corpus-pinned and source-pinned;
+      `ci/check_world_semantics.py` refuses a corpus-digest change at a fixed
+      version, which is the check that makes the bump unavoidable and the one a
+      Rust test structurally cannot perform. `KIRRA-WM-REDUCER-VERSION-001`.
 - [x] **3c — Snapshot consistency.** ✅ **DONE 2026-08-10** — see *"3c closed
       against its consumer"* below. An answer composing several projections
       (identity, claims, relationships, summaries) must read them at ONE coherent
@@ -2852,6 +2865,12 @@ mutating `fold_step` left it green while changing what every ref resolves to.
 The pin is now over the resolved ANSWER, which covers the fold rule (through the
 replay) and admissibility (through the binding), and fails on either.
 
+> **Superseded 2026-08-11 by box 3b.** `RULE_VERSION` is gone; a ref carries a
+> `SemanticVersions` SET naming each rule it depends on, and the refusal reports
+> which one moved. The end-to-end pin described above survives — it is the only
+> check covering the SQLite replay path between the per-rule corpora — but it is
+> now one of several. See *"3b closed"* at the end of this document.
+
 **What a resolved ref deliberately does NOT do.** It does not resolve object
 identity: identity is a second projection with its own coordinate, the pinned
 read exists only for `world_current`, and `identity_view_at` cuts on transaction
@@ -2947,3 +2966,128 @@ follow-up. A replayed answer also does not resolve object identity —
 now covers both replay families. Here the axes would actually AGREE (both this
 query and `identity_view_at` cut on transaction time), so that is a scope
 decision rather than an impossibility, unlike the generation pin.
+
+### 3b closed — the version stopped being a promise — 2026-08-11
+
+**`KIRRA-WM-REDUCER-VERSION-001` — RULED 2026-08-11**
+
+> **A reducer version changes whenever the reducer's behaviour changes in a way
+> that can alter a derived answer. A pinned answer reference refuses replay
+> under a different semantic version rather than replaying under the new one.**
+
+The second sentence is what gives the first one teeth. A version nothing
+consumes is a comment.
+
+#### What existed before, and why it was not 3b
+
+The `AnswerRef` shipped on 2026-08-10 carried `RULE_VERSION: u32 = 1` — one
+number, hand-bumped, pinned by one corpus. That was real: it refused on a
+mismatch, and its corpus was anchored to the resolved answer rather than to the
+live projection (a distinction that had already caught one vacuous draft). But
+it fell short of this box in three specific ways, and naming them is the
+difference between closing 3b and declaring it closed:
+
+1. **It covered two of four rules.** The identity fold and the subject-summary
+   fold had no declared version at all. A change to either moved what the store
+   answers with nothing recording that it had.
+2. **It could not say what moved.** `VersionMismatch { recorded, current }` told
+   an operator the rules had changed, not *which* rule — which is the only part
+   they can act on.
+3. **Nothing forced the bump.** The corpus test asserted `RULE_VERSION ==
+   PINNED_FOR_VERSION` against a local constant, so re-pinning the expected
+   answer and leaving both alone was green. That is precisely the decorative
+   metadata this section warns about, in the code that quoted the warning.
+
+#### What is there now
+
+Four rules are declared — three reducers in `kirra_world_store::semantics`
+(`world_current_fold`, `entity_fold`, `subject_summary_fold`) and one at the
+answer boundary in `kirra_world_service::semantics` (`answer_admissibility`).
+Each carries a version, a conformance-corpus digest, and a source pin over a
+marker-delimited span. Both crates declare in the same shape and are read by one
+parser (`ci/check_world_semantics.py`) against one recorded history
+(`ci/world_semantics_baseline.json`), because a boundary rule checked by a
+second, differently-shaped gate is a boundary rule checked more weakly.
+
+A query family carries the **set** of versions it depends on, not a composite
+number. `SemanticVersions::for_query(CurrentSubject)` names two rules and
+deliberately excludes the other two: `entity_fold` cannot reach a pinned ref's
+answer (it reports `NotResolvedInReplay`), and `subject_summary_fold` is a
+different family. Including them would refuse recorded references for rules they
+never consulted, and a refusal that fires constantly is one people route around.
+The exclusion of `entity_fold` is a claim about *today's* code, asserted by test
+— box 3h's identity-resolving ref will put it in the set.
+
+#### The three checks, and which hole each closes
+
+| Check | Where | Catches |
+|---|---|---|
+| corpus digest == declared | `tests/semantics_corpus.rs`, `tests/boundary_semantics.rs` | behaviour moved and the declaration did not |
+| source pin == span digest | `ci/check_world_semantics.py` | the reducer was edited at all — including on an axis the corpus does not exercise |
+| **corpus digest may not move at a fixed version** | `ci/check_world_semantics.py` | behaviour moved, the declaration was updated, and the version was not |
+
+The third is the one that makes the bump unavoidable, and it is the one the Rust
+test structurally cannot perform: re-pin the digest and the test is satisfied.
+The baseline records what each version's digest *was*, so re-declaring a
+different digest for a recorded version has nowhere to hide.
+
+`strip_noncode` grew a `keep_strings` flag for the pin (default off; every
+existing caller byte-identical). Blanking string literals would leave the pin
+blind to `lifecycle_token` and `SummaryKind::as_str`, where the literal **is**
+the behaviour. The cost is a false red on error-message churn — the cheap
+direction, since re-pinning costs one commit and the corpus digest proves
+nothing moved, while blindness costs correctness silently.
+
+#### Measured, not asserted
+
+Run against the shipped `projection::supersedes` with the
+generation-leads-valid-time flip applied:
+
+| Mutation | Rust conformance | Gate |
+|---|---|---|
+| flip the fold rule | **RED** — corpus digest moved | **RED** — source pin moved |
+| …re-pin BOTH digests, leave `version` at 1 | **green** | **RED** — digest moved at a fixed version |
+| …bump to v2, add a baseline row | green | green — and the end-to-end ref pin reds until the recorded version set is re-pinned |
+
+Row two is the whole box. Row three shows the bump genuinely reaching a
+reference rather than stopping at a constant. The gate's own 20 self-tests were
+mutation-checked the same way: stubbing `check` to return no problems reds six
+of them.
+
+#### The corpus is challenged, permanently
+
+The user's requested control — *change fold behaviour without changing the
+version and confirm the gate catches it* — is in the repo as a standing table
+rather than a one-off run, because a one-off answer expires the moment someone
+edits the corpus. Each rule carries deliberately divergent reimplementations,
+one per behavioural axis, and every one must render differently from the real
+fold over the same input: `generation_leads_valid_time`, `no_tiebreak`,
+`subject_only_key`, `never_supersedes`, `assert_overwrites`,
+`no_create_from_consequence`, `last_observed_follows_head`, `head_follows_time`,
+`kind_not_in_key`, plus four at the boundary including the over-strict
+`stale_refused`. Each variant harness also carries a **faithfulness control**
+asserting it reproduces the real reducer at its real settings — otherwise a
+transcription slip in the variant would render differently and "pass" while
+proving nothing about the axis it names.
+
+This earned itself immediately. On its first run
+`the_claim_corpus_catches_generation_leading_valid_time` **failed**:
+`world_current_corpus` had the backdated claim mid-sequence, where the mutated
+and real folds converge on the same final state. A fold is only observable
+through its final state, so an intermediate divergence that later converges is
+invisible to any corpus — the corpus was blind to the axis it existed to cover,
+and would have shipped that way.
+
+#### The residual, stated rather than papered over
+
+An author who edits the Rust declaration **and** rewrites the baseline's
+historical row in one commit still passes. No gate can force a human to
+increment an integer. What these three checks remove is doing it silently, doing
+it by accident, and doing it without a reviewer seeing a diff — in a file whose
+only purpose is to be that record — saying a historical fact was rewritten.
+
+Two further bounds worth keeping visible: the variant table proves sensitivity
+only to the axes it names, and the source pin is what covers the rest; and the
+boundary rule's corpus is challenged in **both** directions, because
+over-strictness there (refusing a stale claim) is a regression that reads as
+conservatism.


### PR DESCRIPTION
## `KIRRA-WM-REDUCER-VERSION-001`

> **A reducer version changes whenever the reducer's behaviour changes in a way that can alter a derived answer. A pinned answer reference refuses replay under a different semantic version rather than replaying under the new one.**

The second sentence is what gives the first one teeth. A version nothing consumes is a comment.

## The finding: two mechanisms were not enough

`WM_SCOPE.md` already prescribed the shape — a conformance corpus (proves behaviour moved) plus a source pin (proves nobody edited quietly). Building it revealed that **neither forces the bump**. Both are satisfied by re-pinning. Change a reducer's behaviour, update your own declaration, leave `version: 1`, and everything is green.

So there is a third mechanism, and it is the load-bearing one: **`ci/world_semantics_baseline.json` records what each version's corpus digest *was*.** Re-declaring a different digest for a version already on record is an error whose only clean resolution is a new version with a new row. That check is one a Rust test structurally cannot perform, because re-pinning is exactly what satisfies a Rust test.

## The progression, measured against the shipped `projection::supersedes`

Not a synthetic fixture — the generation-leads-valid-time flip applied to the real reducer, then each step of the recovery walked in order:

| Step | Rust conformance | `check_world_semantics.py` |
|---|---|---|
| 1. behaviour changes (flip the fold rule) | **RED** — corpus digest moved | **RED** — source pin moved |
| 2. author re-pins corpus + source digests, leaves `version: 1` | **green** | **RED** — "corpus digest for version 1 changed… bump `version` to 2, ADD a row — do not rewrite this one" |
| 3. bump to v2, add a baseline row | green | **green** |
| 4. downstream `AnswerRef` | **RED** until the recorded version set is re-pinned | — |

Step 2 is the whole box. Step 4 is what proves the version **propagates into answer identity** instead of dying inside a reducer module: the end-to-end ref pin refuses to accept the new version set until it is acknowledged.

The gate's own 20 self-tests were mutation-checked the same way — stubbing its core `check` to return no problems reds six of them.

## `SemanticVersions` replaces `RULE_VERSION`

A ref no longer carries one opaque `u32`. It carries the **set** of rules its query family depends on, and a mismatch reports which one moved:

```rust
RefResolution::VersionMismatch { differences: Vec<VersionDifference> }
// VersionDifference { rule, recorded: Option<u32>, current: Option<u32> }
```

`Option` on both sides because a query family gaining or losing a dependency changes what the answer is derived from just as surely as a version bump does.

Four rules are declared where two were: three reducers in `kirra_world_store::semantics` (`world_current_fold`, `entity_fold`, `subject_summary_fold`) and one at the answer boundary in `kirra_world_service::semantics` (`answer_admissibility`). Both crates declare in the same shape and are read by **one** parser against **one** recorded history — a boundary rule checked by a second, differently-shaped gate is a boundary rule checked more weakly.

`CurrentSubject` names two of the four and excludes two, asserted by test rather than by comment:

| Rule | In? | Why |
|---|---|---|
| `world_current_fold` | yes | the pinned replay folds with it |
| `answer_admissibility` | yes | it decides which folded claims are served |
| `entity_fold` | **no** | a pinned ref reports `NotResolvedInReplay`; identity cannot reach the answer |
| `subject_summary_fold` | **no** | a different query family entirely |

Carrying only the relevant set avoids pretending an unrelated reducer can invalidate an answer it never touched. The `entity_fold` exclusion is explicitly a claim about *today's* code — **box 3h will flip it**, and it should flip because an historical answer starts resolving identity, not because someone edited the assertion.

## The corpus is challenged permanently, not once

The control — *change fold behaviour without changing the version, confirm the gate catches it* — is in the repo as a standing table rather than a one-off run, because a one-off answer expires the moment someone edits the corpus.

Thirteen behaviour variants across the four rules, each flipping exactly one axis, each required to render differently from the real fold over the same input: `generation_leads_valid_time`, `no_tiebreak`, `subject_only_key`, `never_supersedes`, `assert_overwrites`, `no_create_from_consequence`, `last_observed_follows_head`, `head_follows_time`, `kind_not_in_key`, plus four at the boundary including the over-strict `stale_refused`. Each variant harness also carries a **faithfulness control** asserting it reproduces the real reducer at its real settings — otherwise a transcription slip in the variant would render differently and "pass" while proving nothing about the axis it names.

**It earned itself on its first run.** `the_claim_corpus_catches_generation_leading_valid_time` failed: `world_current_corpus` had the backdated claim mid-sequence, where the mutated and real folds converge on the same final state. A fold is only observable through its final state, so an intermediate divergence that later converges is invisible to any corpus. The corpus was blind to the axis it existed to cover and would have shipped that way.

## Limitations, kept explicit

Both are stated in the module docs, the gate's docstring, and `WM_SCOPE.md` — not only here.

1. **The variant corpus proves sensitivity only to the axes it names.** An axis nobody thought of is not covered. That is what the source pin exists for: it catches any edit at all, regardless of whether the corpus exercises it.
2. **A determined author can still rewrite history.** Editing the Rust declaration *and* the baseline's historical row in one commit passes. No gate can force a human to increment an integer. **This is a review-visible ratchet, not cryptographic enforcement of human intent** — what it removes is doing it silently, by accident, or without a reviewer seeing a diff in a file whose only purpose is to be that record.

## Supporting change

`strip_noncode` grows an opt-in `keep_strings` flag (**default off; every existing caller byte-identical**, and the orphan-core gate's 14 tests confirm it). In these reducers a string literal can *be* the behaviour — `lifecycle_token`, `SummaryKind::as_str` — so a pin that blanked them would sit green through an edit that changed what every projection row says. The cost is a false red on error-message churn, which is the cheap direction: re-pinning costs one commit and the corpus digest proves nothing moved, while blindness costs correctness silently.

## Files

| | |
|---|---|
| `crates/kirra-world-store/src/semantics.rs` | new — `RuleId`, `SEMANTICS`, the three corpora |
| `crates/kirra-world-store/tests/semantics_corpus.rs` | new — conformance + 9 sensitivity controls |
| `crates/kirra-world-service/src/semantics.rs` | new — `BoundaryRuleId`, `SemanticVersions`, admissibility corpus |
| `crates/kirra-world-service/tests/boundary_semantics.rs` | new — conformance + 4 controls + composition |
| `ci/check_world_semantics.py` + baseline | new — the gate and the recorded history |
| `crates/kirra-world-service/src/answer_ref.rs` | `RULE_VERSION` → `SemanticVersions` |
| `ci/check_orphan_cores.py` | `keep_strings` flag |
| `docs/design/WM_SCOPE.md` | 3b ticked; closure section; the "two mechanisms were not enough" finding recorded against the section that prescribed them |

## Verification

`cargo fmt --check` clean; clippy clean on both crates; all `kirra-world-store` + `kirra-world-service` tests green; the sibling world gates (`check_world_answer_boundary`, `check_kirra_world_bidirectional_fence`, `check_world_domain_logic_gate`, `check_orphan_cores`, `check_proposal_context_symbolic`) all still pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_