### PR TITLE
Tier 3 box 3h: historical answers use the graph as it stood then

### DIFF
--- a/ci/check_world_answer_boundary.py
+++ b/ci/check_world_answer_boundary.py
@@ -89,6 +89,12 @@ DOMAIN_READ_METHODS = (
     "candidates",
     "read_snapshot",
     "read_at_generation",
+    # Box 3h. Gated for a sharper reason than its siblings: this one hands back
+    # a `ProjectedClaim` AND an `IdentityView` together, so a consumer calling
+    # it directly gets everything needed to compose an historical answer while
+    # bypassing the boundary that would have resolved the object properly. The
+    # convenience is exactly what makes it worth gating.
+    "read_composed_at_generation",
     "identity_view",
     "identity_view_at",
     "resolve_at",

--- a/crates/kirra-world-service/src/answer_ref.rs
+++ b/crates/kirra-world-service/src/answer_ref.rs
@@ -12,6 +12,11 @@
 //! the mechanism now exists: `ReadSnapshot::read_at_generation` re-executes
 //! against the same snapshot, and fails closed when it cannot.
 //!
+//! Since box 3h it re-executes against `read_composed_at_generation`, which
+//! reconstructs the claims AND the identity graph at that one coordinate — so a
+//! resolved ref resolves its objects through the graph as it stood then, never
+//! through today's.
+//!
 //! # What a ref carries, and why each field
 //!
 //! | Field | Why |
@@ -40,7 +45,7 @@
 //! compaction floor resolves to [`RefResolution::Irreproducible`] — which is an
 //! honest answer, and the reason resolution is not infallible.
 
-use kirra_world_store::snapshot::{Irreproducible, PinnedRead};
+use kirra_world_store::snapshot::{Irreproducible, PinnedComposedRead};
 use kirra_world_store::WorldStore;
 
 use crate::read_view::{AskError, ObjectIdentity, WorldAnswer};
@@ -49,11 +54,12 @@ use crate::semantics::{SemanticVersions, VersionDifference};
 /// **The semantics a `CurrentSubject` answer is produced under, right now.**
 ///
 /// A convenience over [`SemanticVersions::for_query`], which is where the set is
-/// actually derived. Two rules bear on a resolved ref today — the projection
-/// fold (`supersedes` / `fold_step`, which decides which claim wins a key) and
-/// the boundary's admissibility test (which decides whether a claim is servable
-/// at all) — and both come from their crates' live declarations rather than
-/// being restated here.
+/// actually derived. THREE rules bear on a resolved ref since box 3h — the
+/// claim fold (`supersedes` / `fold_step`, which decides which claim wins a
+/// key), the **identity fold** (which builds the graph a resolved object is
+/// looked up in), and the boundary's admissibility test (which decides whether
+/// a claim is servable at all). All three come from their crates' live
+/// declarations rather than being restated here.
 ///
 /// # This replaced a single opaque constant, and the difference is box 3b
 ///
@@ -62,6 +68,11 @@ use crate::semantics::{SemanticVersions, VersionDifference};
 /// — but it could not say *which* rule moved, and it covered two of the four
 /// versioned rules in the system while the identity and subject-summary folds
 /// had no declared version at all. Both gaps are what 3b names.
+///
+/// The set is not decorative in the other direction either: box 3h ADDED
+/// `entity_fold` to it, and did so because a red test said the old membership
+/// claim had stopped being true — not because someone edited a list to match
+/// the code.
 #[must_use]
 pub fn current_semantics() -> SemanticVersions {
     SemanticVersions::for_query(QueryKind::CurrentSubject)
@@ -212,21 +223,29 @@ impl AnswerRef {
             return Ok(RefResolution::VersionMismatch { differences });
         }
 
-        let pinned = match store.read_at_generation(self.generation)? {
-            PinnedRead::Reproduced(p) => p,
-            PinnedRead::Irreproducible(reason) => return Ok(RefResolution::Irreproducible(reason)),
+        // COMPOSED, not two reads. Box 3h: an historical answer resolves
+        // objects against the identity graph as it stood at this coordinate.
+        // Reading the two halves separately would put a live `identity_view`
+        // one autocomplete away, and today's merges would silently rewrite what
+        // a recorded reference means.
+        let composed = match store.read_composed_at_generation(self.generation)? {
+            PinnedComposedRead::Reproduced(c) => c,
+            PinnedComposedRead::Irreproducible(reason) => {
+                return Ok(RefResolution::Irreproducible(reason))
+            }
         };
 
         let clock = self.now_ms.max(0).unsigned_abs();
         let mut answers = Vec::new();
-        for claim in pinned.current(&self.subject, self.now_ms) {
+        for claim in composed.claims().current(&self.subject, self.now_ms) {
             if !crate::read_view::is_admissible_for_ref(&claim, clock, self.staleness_budget_ms) {
                 continue;
             }
-            answers.push(crate::read_view::bind_pinned(
+            answers.push(crate::read_view::bind_composed(
                 &claim,
                 clock,
                 self.staleness_budget_ms,
+                composed.identity(),
             )?);
         }
         Ok(RefResolution::Resolved(answers))

--- a/crates/kirra-world-service/src/read_view.rs
+++ b/crates/kirra-world-service/src/read_view.rs
@@ -723,21 +723,37 @@ pub(crate) fn is_admissible_for_ref(
     WorldView::is_admissible(claim, clock, budget)
 }
 
-/// Build a `WorldAnswer` from a generation-pinned claim.
+/// **Build a `WorldAnswer` from a claim and the identity of the same pin — 3h.**
 ///
-/// Delegates to [`assemble`] exactly as `WorldView::bind` does; the only
-/// difference is the object identity, which a pinned read cannot resolve — see
-/// [`crate::answer_ref::pinned_object_identity`].
-pub(crate) fn bind_pinned(
+/// The identity view must come from the SAME
+/// [`read_composed_at_generation`][rc] call as the claim. That is not enforced
+/// by the type system here; it is enforced upstream, by that call being the only
+/// way to obtain the pair — which is why `AnswerRef::resolve` uses it rather
+/// than fetching the halves itself.
+///
+/// # Why `identity_is_current` is `true` and not a check
+///
+/// The live path consults [`ReadSnapshot::identity_is_current`][ic] because a
+/// live read reads a *projection* that may lag the log. A pinned composition
+/// does not read the projection at all: it folds the adjudications itself, up
+/// to the pinned generation, so the graph is complete at that coordinate by
+/// construction. Passing `true` states a fact about the reconstruction rather
+/// than skipping a check — and passing the live gate here would be actively
+/// wrong, since it answers a question about a different object.
+///
+/// [rc]: kirra_world_store::snapshot::ReadSnapshot::read_composed_at_generation
+/// [ic]: kirra_world_store::snapshot::ReadSnapshot::identity_is_current
+pub(crate) fn bind_composed(
     claim: &ProjectedClaim,
     clock: u64,
     budget: Option<u64>,
+    identity: &IdentityView,
 ) -> Result<WorldAnswer, AskError> {
     assemble(
         claim,
         clock,
         budget,
-        crate::answer_ref::pinned_object_identity(),
+        WorldView::resolve_object(claim.object.as_deref(), identity, true),
     )
 }
 

--- a/crates/kirra-world-service/src/semantics.rs
+++ b/crates/kirra-world-service/src/semantics.rs
@@ -14,19 +14,31 @@
 //! refusal that fires constantly is one people learn to route around.
 //!
 //! So [`SemanticVersions::for_query`] names exactly the rules a query family
-//! depends on. For [`QueryKind::CurrentSubject`] that is two of the four rules
-//! in the system, and the two exclusions are the interesting part:
+//! depends on. For [`QueryKind::CurrentSubject`] that is three of the four rules
+//! in the system, and the membership test is always the same question — *can
+//! this rule change what the answer says?*
 //!
 //! | Rule | In? | Why |
 //! |---|---|---|
-//! | `world_current_fold` | yes | the pinned replay folds with it |
+//! | `world_current_fold` | yes | the pinned replay folds claims with it |
+//! | `entity_fold` | yes **since 3h** | the pinned replay folds the identity graph the answer resolves objects against |
 //! | `answer_admissibility` | yes | it decides which folded claims are served |
-//! | `entity_fold` | **no** | a pinned ref reports `NotResolvedInReplay`; identity cannot reach the answer |
 //! | `subject_summary_fold` | **no** | a different query family entirely |
 //!
-//! `entity_fold`'s exclusion is a live claim about today's code, not a
-//! permanent one. The moment a ref resolves object identity — the follow-up
-//! box 3h needs — it belongs in this set, and `answer_ref`'s tests say so.
+//! # `entity_fold` entered this set because the composition changed
+//!
+//! Box 3b shipped with `entity_fold` **excluded**, and the exclusion was
+//! correct at the time: a resolved ref reported
+//! `ObjectIdentity::NotResolvedInReplay`, so the identity fold could not reach
+//! the answer and including it would have refused references for a rule they
+//! never consulted.
+//!
+//! Box 3h made refs compose identity at the pinned generation. That is a change
+//! in what an answer is *derived from*, so the rule joined the set — and the
+//! test that pinned the exclusion failed, which is how it was supposed to
+//! happen. A dependency set edited by hand to match the code is a dependency set
+//! that will one day not match it; this one moved because a red test said the
+//! old claim was no longer true.
 //!
 //! [`QueryKind::CurrentSubject`]: crate::answer_ref::QueryKind::CurrentSubject
 
@@ -164,6 +176,14 @@ impl SemanticVersions {
                 RuleVersion {
                     rule: RuleId::WorldCurrentFold.as_str().to_string(),
                     version: store_semantics::version_of(RuleId::WorldCurrentFold),
+                },
+                // Box 3h added this. A resolved ref now composes the identity
+                // graph as it stood at the pinned generation, so the fold that
+                // BUILDS that graph can change what an answer says — which is
+                // the whole test for membership in this set.
+                RuleVersion {
+                    rule: RuleId::EntityFold.as_str().to_string(),
+                    version: store_semantics::version_of(RuleId::EntityFold),
                 },
                 RuleVersion {
                     rule: ADMISSIBILITY.to_string(),
@@ -426,19 +446,39 @@ mod tests {
         );
     }
 
-    /// The exclusions are a claim about today's code, so they are asserted
-    /// rather than only written down.
+    /// The membership of this set is a claim about today's code, so it is
+    /// asserted rather than only written down.
+    ///
+    /// # This test previously asserted TWO rules, and box 3h broke it
+    ///
+    /// That is the intended lifecycle, and worth recording because a dependency
+    /// set is exactly the kind of thing that rots quietly. Under 3b a pinned ref
+    /// reported `ObjectIdentity::NotResolvedInReplay`, so `entity_fold` could
+    /// not reach the answer and its exclusion was correct. 3h made refs compose
+    /// the identity graph at the pinned generation — a change in what the answer
+    /// is *derived from* — and this assertion went red, naming the stale claim.
+    ///
+    /// The set was then widened because a test said the old claim was false, not
+    /// because someone edited a list to match the code. A dependency set
+    /// maintained the other way round is one that will eventually describe a
+    /// composition that no longer exists.
     #[test]
-    fn the_current_subject_query_depends_on_exactly_two_rules() {
+    fn the_current_subject_query_depends_on_exactly_three_rules() {
         let v = SemanticVersions::for_query(QueryKind::CurrentSubject);
         let names: Vec<&str> = v.entries().iter().map(|e| e.rule.as_str()).collect();
-        assert_eq!(names, vec![ADMISSIBILITY, "world_current_fold"]);
-        assert!(
-            v.version_of("entity_fold").is_none(),
-            "a pinned ref does not resolve identity, so the entity fold cannot \
-             reach its answer — including it would refuse references for a rule \
-             they never consulted"
+        assert_eq!(
+            names,
+            vec![ADMISSIBILITY, "entity_fold", "world_current_fold"]
         );
-        assert!(v.version_of("subject_summary_fold").is_none());
+        assert!(
+            v.version_of("entity_fold").is_some(),
+            "since 3h a resolved ref looks its objects up in the identity graph \
+             the entity fold builds, so that fold can change what the answer says"
+        );
+        assert!(
+            v.version_of("subject_summary_fold").is_none(),
+            "subject summaries are a different query family; including them would \
+             refuse references for a rule they never consulted"
+        );
     }
 }

--- a/crates/kirra-world-service/tests/answer_ref.rs
+++ b/crates/kirra-world-service/tests/answer_ref.rs
@@ -202,10 +202,22 @@ fn changing_any_parameter_changes_the_ref() {
         ),
         // A ref that named a dependency this build does not have is a different
         // ref, even though every SHARED rule agrees.
+        // Box 3h added `entity_fold` to this query's dependency set, so it is
+        // a real rule now and belongs beside the other two.
+        (
+            "identity-fold-version",
+            AnswerRef::current_subject("package_17", LATER, Some(60_000), 7)
+                .recorded_with("entity_fold", 99),
+        ),
+        // A ref that named a dependency this build does not have is a different
+        // ref, even though every SHARED rule agrees. `subject_summary_fold` is
+        // the honest choice: it is a declared rule of the STORE that this query
+        // family genuinely does not consult, so the case stays real rather than
+        // resting on a name nothing has claimed yet.
         (
             "extra-rule",
             AnswerRef::current_subject("package_17", LATER, Some(60_000), 7)
-                .recorded_with("entity_fold", 1),
+                .recorded_with("subject_summary_fold", 1),
         ),
     ];
 
@@ -368,18 +380,38 @@ fn a_version_mismatch_refuses_rather_than_replaying() {
     // derives its answer from something else.
     match current
         .clone()
-        .recorded_with("entity_fold", 1)
+        .recorded_with("subject_summary_fold", 1)
         .resolve(&store)
         .expect("resolve")
     {
         RefResolution::VersionMismatch { differences } => {
-            assert_eq!(differences[0].rule, "entity_fold");
+            assert_eq!(differences[0].rule, "subject_summary_fold");
             assert_eq!(
                 differences[0].current, None,
-                "this build has no such dependency"
+                "this query family does not consult the subject summary fold"
             );
         }
         other => panic!("an unknown dependency must refuse, got {other:?}"),
+    }
+
+    // Box 3h: the IDENTITY fold is a dependency now, and moving it alone must
+    // refuse. Before 3h this exact ref was the "unknown dependency" case above
+    // — the same call, a different verdict, because the composition changed.
+    match current
+        .clone()
+        .recorded_with("entity_fold", 99)
+        .resolve(&store)
+        .expect("resolve")
+    {
+        RefResolution::VersionMismatch { differences } => {
+            assert_eq!(differences.len(), 1, "only one rule moved: {differences:?}");
+            assert_eq!(differences[0].rule, "entity_fold");
+            assert_eq!(
+                differences[0].current,
+                current_semantics().version_of("entity_fold"),
+            );
+        }
+        other => panic!("a moved identity fold must refuse, got {other:?}"),
     }
 
     // And the refusal is decided BEFORE the store is touched: a mismatched ref
@@ -449,6 +481,11 @@ fn a_refs_recorded_versions_are_pinned_to_what_it_resolves_to() {
     let pinned = SemanticVersions::new([
         RuleVersion {
             rule: "answer_admissibility".into(),
+            version: 1,
+        },
+        // Added by box 3h, when refs began composing identity at the pin.
+        RuleVersion {
+            rule: "entity_fold".into(),
             version: 1,
         },
         RuleVersion {

--- a/crates/kirra-world-service/tests/historical_composition.rs
+++ b/crates/kirra-world-service/tests/historical_composition.rs
@@ -1,0 +1,406 @@
+//! **Box 3h — historical queries use HISTORICAL identity, never today's graph.**
+//!
+//! The box in one sentence:
+//!
+//! > Historical queries use historical identity (2d) and historical evidence —
+//! > never today's entity graph applied to old evidence.
+//!
+//! # Why the pairing is the dangerous part
+//!
+//! Pinning the *evidence* was box 3b's `read_at_generation`, and it worked. The
+//! failure this box is about survives that fix completely: replay the claims at
+//! generation `g`, then resolve the object they name against the identity graph
+//! **as it is now**. Every claim is historically correct, the coordinate in the
+//! answer is honest, and the object is silently wrong — because a merge recorded
+//! last week says the thing that claim pointed at is now called something else.
+//!
+//! Nothing about that reads as a bug at the call site. It is what you get by
+//! writing the obvious code, which is why the fix is a composed read
+//! (`read_composed_at_generation`) rather than a rule about which functions to
+//! call in which order.
+//!
+//! # The fixture, and why the merge lands where it does
+//!
+//! ```text
+//! gen 1   assert dock_alpha            an entity exists
+//! gen 2   claim  package_17 -> dock_alpha
+//!         ---- PIN HERE ----
+//! gen 3   assert dock_beta
+//! gen 4   merge  dock_alpha -> dock_beta      the graph changes AFTER the pin
+//! ```
+//!
+//! A ref pinned at generation 2 must resolve `dock_alpha` to **itself**. The
+//! live read must resolve it to `dock_beta`. Both are correct answers to
+//! different questions, and a composed read that used today's graph would give
+//! the live answer to the historical question while every other field said
+//! otherwise.
+//!
+//! The two arms differ in the OBJECT RESOLUTION, not in the claim: the stored
+//! object string is `dock_alpha` in both. That is deliberate — a test where the
+//! two arms returned different claims would pass on the evidence pin alone and
+//! prove nothing about identity.
+
+use kirra_world::adjudication::{
+    AssertIdentity, IdentityAdjudication, Justification, MergeEntities,
+};
+use kirra_world::observation::{ClockDomain, DomainInstant};
+use kirra_world::reference::{EntityId, EventId, ObservationId};
+use kirra_world_service::answer_ref::{AnswerRef, RefResolution};
+use kirra_world_service::read_view::{ObjectIdentity, WorldLookup, WorldView};
+use kirra_world_store::adjudication_record::AdjudicationRow;
+use kirra_world_store::snapshot::PinnedComposedRead;
+use kirra_world_store::{ClaimStatus, NewEvent, WorldStore, WriterClass};
+
+const T0: i64 = 1_700_000_000_000;
+const LATER: i64 = T0 + 1_000;
+
+fn tmp(name: &str) -> std::path::PathBuf {
+    static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let n = NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "kirra-hist-comp-{name}-{}-{n}.sqlite",
+        std::process::id()
+    ));
+    cleanup(&p);
+    p
+}
+
+fn cleanup(path: &std::path::Path) {
+    for suffix in ["", "-wal", "-shm"] {
+        let mut q = path.as_os_str().to_os_string();
+        q.push(suffix);
+        let _ = std::fs::remove_file(std::path::PathBuf::from(q));
+    }
+}
+
+fn eid(s: &str) -> EntityId {
+    EntityId::new(s).expect("entity id")
+}
+
+fn just() -> Justification {
+    Justification::new([ObservationId::new("obs-j").expect("obs")]).expect("justification")
+}
+
+fn at() -> DomainInstant {
+    DomainInstant {
+        ms: 1,
+        domain: ClockDomain::System,
+    }
+}
+
+fn adjudicate(store: &mut WorldStore, tag: &str, at_ms: i64, a: &IdentityAdjudication) {
+    let event_id = EventId::new(format!("ev-{tag}")).expect("event id");
+    let observation_id = ObservationId::new(format!("obs-{tag}")).expect("obs");
+    store
+        .append_adjudication(
+            &AdjudicationRow {
+                event_id: &event_id,
+                observation_id: &observation_id,
+                txn_time_ms: at_ms,
+                valid_from_ms: at_ms,
+                source: "operator-console",
+                source_version: "1.0.0",
+                writer_class: WriterClass::Operator,
+            },
+            a,
+        )
+        .expect("append adjudication");
+}
+
+fn claim_pointing_at(store: &mut WorldStore, tag: &str, object: &str, at_ms: i64) {
+    store
+        .append(&NewEvent {
+            event_id: &EventId::new(format!("ev-{tag}")).expect("event id"),
+            observation_id: &ObservationId::new(format!("obs-{tag}")).expect("obs"),
+            txn_time_ms: at_ms,
+            valid_from_ms: at_ms,
+            valid_to_ms: None,
+            source: "warehouse-scanner",
+            source_version: "1.0.0",
+            writer_class: WriterClass::Sensor,
+            claim_status: ClaimStatus::Confirmed,
+            provenance: &[],
+            frame_id: None,
+            map_id: None,
+            kind: "mission",
+            subject: "package_17",
+            subject_ref: None,
+            predicate: Some("last_seen_at"),
+            object: Some(object),
+            payload: "{}",
+            payload_schema: 1,
+            retention_class: "raw",
+            trust: None,
+        })
+        .expect("append");
+}
+
+/// The fixture in the module docs. Returns the store and the generation to pin
+/// at — read from the store rather than assumed, so the test does not silently
+/// pin the wrong coordinate if event numbering changes.
+fn store_where_the_graph_moved_after_the_pin(name: &str) -> (WorldStore, std::path::PathBuf, i64) {
+    let path = tmp(name);
+    let mut store = WorldStore::open(&path).expect("open");
+
+    adjudicate(
+        &mut store,
+        "assert-alpha",
+        T0,
+        &IdentityAdjudication::Assert(AssertIdentity::new(eid("dock_alpha"), just(), at())),
+    );
+    claim_pointing_at(&mut store, "claim", "dock_alpha", T0 + 1);
+    store.fold().expect("fold");
+    store.fold_entity_projection().expect("fold entities");
+
+    let pin = store
+        .projection_coordinate()
+        .expect("coordinate")
+        .world_current()
+        .generation();
+
+    // Everything below happens AFTER the pin.
+    adjudicate(
+        &mut store,
+        "assert-beta",
+        T0 + 2,
+        &IdentityAdjudication::Assert(AssertIdentity::new(eid("dock_beta"), just(), at())),
+    );
+    adjudicate(
+        &mut store,
+        "merge",
+        T0 + 3,
+        &IdentityAdjudication::Merge(
+            MergeEntities::new(vec![eid("dock_alpha")], eid("dock_beta"), just(), at())
+                .expect("merge"),
+        ),
+    );
+    store.fold().expect("fold");
+    // The LIVE arm reads the entity PROJECTION, so it must be folded. The
+    // pinned arms deliberately do not need this: they replay adjudications
+    // from the log themselves, which is why a pinned answer cannot be stale.
+    store.fold_entity_projection().expect("fold entities");
+
+    (store, path, pin)
+}
+
+fn sole_identity(res: &RefResolution) -> ObjectIdentity {
+    let answers = res.resolved().expect("the ref must resolve");
+    assert_eq!(answers.len(), 1, "fixture holds one claim for the subject");
+    answers[0].object_identity().clone()
+}
+
+// ---------------------------------------------------------------------------
+// The property
+// ---------------------------------------------------------------------------
+
+/// **The live read follows the merge.** The control arm.
+///
+/// Without this the historical arm below proves nothing: if the graph never
+/// resolved `dock_alpha` to `dock_beta` at all, the historical answer would be
+/// "unmerged" for a reason that has nothing to do with the pin.
+#[test]
+fn the_live_read_resolves_the_object_through_the_merge() {
+    let (store, path, _pin) = store_where_the_graph_moved_after_the_pin("live");
+    let view = WorldView::new(&store, None);
+
+    let composed = view.ask("package_17", LATER).expect("ask");
+    let WorldLookup::Answered(answers) = composed.lookup() else {
+        panic!("the fixture must answer, got {:?}", composed.lookup());
+    };
+    assert_eq!(answers.len(), 1);
+    assert_eq!(
+        *answers[0].object_identity(),
+        ObjectIdentity::Resolved {
+            entity: "dock_beta".to_string(),
+            hops: 1,
+        },
+        "today's graph merges dock_alpha into dock_beta — if this fails the \
+         fixture is not exercising identity at all"
+    );
+
+    drop(store);
+    cleanup(&path);
+}
+
+/// **THE BOX.** A ref pinned before the merge resolves the object to itself.
+///
+/// This is the assertion 3h exists for. A composed read that reached for the
+/// live graph would return `dock_beta` here — the same value the control arm
+/// above returns — and every other field of the answer would still be correct.
+#[test]
+fn a_ref_pinned_before_the_merge_resolves_identity_as_it_stood_then() {
+    let (store, path, pin) = store_where_the_graph_moved_after_the_pin("pinned");
+
+    let resolved = AnswerRef::current_subject("package_17", LATER, None, pin)
+        .resolve(&store)
+        .expect("resolve");
+
+    assert_eq!(
+        sole_identity(&resolved),
+        ObjectIdentity::Resolved {
+            entity: "dock_alpha".to_string(),
+            hops: 0,
+        },
+        "the merge was recorded AFTER the pinned generation, so it must not \
+         reach an answer pinned before it — this is today's entity graph \
+         applied to old evidence, which is precisely what 3h forbids"
+    );
+
+    drop(store);
+    cleanup(&path);
+}
+
+/// The two arms disagree, and that disagreement is the whole result.
+///
+/// Asserted as a pair rather than left implicit across two tests: if a future
+/// change made both arms return the same identity, each test above could still
+/// be edited into passing separately, while the property they exist to
+/// establish had quietly died.
+#[test]
+fn the_historical_and_live_identities_genuinely_differ() {
+    let (store, path, pin) = store_where_the_graph_moved_after_the_pin("differ");
+
+    let historical = sole_identity(
+        &AnswerRef::current_subject("package_17", LATER, None, pin)
+            .resolve(&store)
+            .expect("resolve"),
+    );
+
+    let view = WorldView::new(&store, None);
+    let composed = view.ask("package_17", LATER).expect("ask");
+    let WorldLookup::Answered(live) = composed.lookup() else {
+        panic!("the fixture must answer");
+    };
+
+    assert_ne!(
+        historical,
+        *live[0].object_identity(),
+        "the historical and live reads returned the SAME object identity, so \
+         this suite cannot tell a composed pinned read from a live one"
+    );
+
+    drop(store);
+    cleanup(&path);
+}
+
+/// A ref pinned AFTER the merge does follow it.
+///
+/// The pin is a coordinate, not a preference for old answers: pin later and the
+/// merge is inside the replay, so it applies. Without this the suite would be
+/// satisfied by an implementation that never resolved identity at all.
+#[test]
+fn a_ref_pinned_after_the_merge_does_follow_it() {
+    let (store, path, _pin) = store_where_the_graph_moved_after_the_pin("after");
+
+    let head = store
+        .projection_coordinate()
+        .expect("coordinate")
+        .world_current()
+        .generation();
+
+    let resolved = AnswerRef::current_subject("package_17", LATER, None, head)
+        .resolve(&store)
+        .expect("resolve");
+
+    assert_eq!(
+        sole_identity(&resolved),
+        ObjectIdentity::Resolved {
+            entity: "dock_beta".to_string(),
+            hops: 1,
+        },
+        "an adjudication at or below the pin is part of the replay"
+    );
+
+    drop(store);
+    cleanup(&path);
+}
+
+// ---------------------------------------------------------------------------
+// The composed read's own contract
+// ---------------------------------------------------------------------------
+
+/// Both halves come from ONE coordinate and ONE refusal.
+#[test]
+fn the_composed_read_reconstructs_both_halves_at_the_same_generation() {
+    let (store, path, pin) = store_where_the_graph_moved_after_the_pin("composed");
+
+    let PinnedComposedRead::Reproduced(c) = store
+        .read_composed_at_generation(pin)
+        .expect("composed read")
+    else {
+        panic!("the fixture must reproduce at its own pin");
+    };
+
+    assert_eq!(c.generation(), pin);
+    assert_eq!(
+        c.claims().current("package_17", LATER).len(),
+        1,
+        "the claims half must hold the fixture's claim"
+    );
+    // The identity half holds dock_alpha (asserted before the pin) and NOT
+    // dock_beta (asserted after it).
+    assert!(c.identity().get(&eid("dock_alpha")).is_some());
+    assert!(
+        c.identity().get(&eid("dock_beta")).is_none(),
+        "an entity asserted after the pin must be absent from the pinned graph"
+    );
+
+    drop(store);
+    cleanup(&path);
+}
+
+/// A generation past the head refuses, and refuses for BOTH halves together.
+#[test]
+fn a_future_generation_refuses_the_whole_composition() {
+    let (store, path, _pin) = store_where_the_graph_moved_after_the_pin("future");
+
+    match store.read_composed_at_generation(99_999).expect("composed") {
+        PinnedComposedRead::Irreproducible(_) => {}
+        PinnedComposedRead::Reproduced(_) => {
+            panic!("a generation the store has not reached must not reproduce")
+        }
+    }
+
+    drop(store);
+    cleanup(&path);
+}
+
+/// **The entity checkpoint is NOT the bound**, and this is the regression guard.
+///
+/// `SnapshotCoordinate` records that the two checkpoints are not comparable:
+/// `world_current` advances past every event considered, the entity fold only to
+/// the last adjudication it folded. The fixture ends with ordinary claims after
+/// the last adjudication, so the entity checkpoint sits legitimately behind —
+/// and a composed read that used it as its head would refuse a perfectly
+/// reproducible generation.
+#[test]
+fn a_lagging_entity_checkpoint_does_not_refuse_a_reproducible_generation() {
+    let (mut store, path, _pin) = store_where_the_graph_moved_after_the_pin("lagging");
+
+    // Append claims only. The entity checkpoint cannot advance past the last
+    // adjudication; `world_current`'s does.
+    claim_pointing_at(&mut store, "tail-1", "dock_alpha", T0 + 10);
+    claim_pointing_at(&mut store, "tail-2", "dock_alpha", T0 + 11);
+    store.fold().expect("fold");
+
+    let coord = store.projection_coordinate().expect("coordinate");
+    let head = coord.world_current().generation();
+    assert!(
+        coord.entities().generation() < head,
+        "fixture precondition: the entity checkpoint must lag, or this test \
+         cannot distinguish the two bounds (entities {}, world_current {head})",
+        coord.entities().generation(),
+    );
+
+    match store.read_composed_at_generation(head).expect("composed") {
+        PinnedComposedRead::Reproduced(c) => assert_eq!(c.generation(), head),
+        PinnedComposedRead::Irreproducible(r) => panic!(
+            "a reproducible generation was refused — the composed read is \
+             bounded by the entity checkpoint instead of the log's progress: {r:?}"
+        ),
+    }
+
+    drop(store);
+    cleanup(&path);
+}

--- a/crates/kirra-world-store/src/entity_projection.rs
+++ b/crates/kirra-world-store/src/entity_projection.rs
@@ -839,6 +839,7 @@ pub fn contradiction_from_json(raw: &str) -> Result<Contradiction, EntityRowErro
 /// A snapshot also means a resolution walk sees ONE state of the world
 /// throughout — a per-query reader could observe a fold landing mid-walk and
 /// answer from two different generations at once.
+#[derive(Debug, Clone)]
 pub struct IdentityView {
     rows: BTreeMap<String, ProjectedEntity>,
     generation: i64,

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -2629,6 +2629,26 @@ impl WorldStore {
         self.read_snapshot()?.read_at_generation(generation)
     }
 
+    /// **Reconstruct claims and identity together at one generation — box 3h.**
+    ///
+    /// See [`snapshot::ReadSnapshot::read_composed_at_generation`]. Both halves
+    /// come from ONE snapshot and ONE coordinate, which is what lets an
+    /// historical answer resolve objects against the graph as it stood then
+    /// rather than the graph as it stands now.
+    ///
+    /// # Errors
+    ///
+    /// As [`Self::read_at_generation`], plus
+    /// [`StoreError::CorruptEntityProjectionRow`] if a stored adjudication
+    /// cannot be decoded faithfully.
+    pub fn read_composed_at_generation(
+        &self,
+        generation: i64,
+    ) -> Result<snapshot::PinnedComposedRead, StoreError> {
+        self.read_snapshot()?
+            .read_composed_at_generation(generation)
+    }
+
     /// Where every projection stands right now, read outside any snapshot.
     ///
     /// For reporting and diagnostics. A composed ANSWER should carry the

--- a/crates/kirra-world-store/src/snapshot.rs
+++ b/crates/kirra-world-store/src/snapshot.rs
@@ -287,6 +287,11 @@ impl<'a> ReadSnapshot<'a> {
     /// code. Composing here makes the shared coordinate structural: one
     /// generation, one compaction check, one refusal covering both halves.
     ///
+    /// The reproducibility rules are **delegated** to
+    /// [`Self::read_at_generation`] rather than restated, so that guarantee
+    /// rests on there being one implementation rather than on two copies
+    /// agreeing.
+    ///
     /// # The bound is the LOG's progress, not the entity checkpoint
     ///
     /// The obvious head for the identity half — `entities_projection`'s own
@@ -317,35 +322,29 @@ impl<'a> ReadSnapshot<'a> {
         &self,
         generation: i64,
     ) -> Result<PinnedComposedRead, StoreError> {
-        if generation < 0 {
-            return Err(StoreError::InvalidGeneration {
-                requested: generation,
-            });
-        }
-
-        let head = checkpoint_on(&self.tx, projection::CURRENT_PROJECTION)?.0;
-        if generation > head {
-            return Ok(PinnedComposedRead::Irreproducible(
-                Irreproducible::NotYetReached { head },
-            ));
-        }
-
-        // ONE compaction check for both halves, before either replay. The two
-        // projections fold the same log, so evidence removed at or below
-        // `generation` ends BOTH reconstructions; checking once is what makes a
-        // half-reproducible answer unrepresentable.
-        let spans = compacted_at_or_below(&self.tx, generation)?;
-        if !spans.is_empty() {
-            return Ok(PinnedComposedRead::Irreproducible(
-                Irreproducible::Compacted { spans },
-            ));
-        }
+        // DELEGATED, not re-derived. Every reproducibility rule — the negative
+        // guard, the head bound, the compaction refusal — lives in
+        // `read_at_generation` and is reached from here, so "one refusal covers
+        // both halves" is true because there is only one implementation of it,
+        // not because two copies currently agree.
+        //
+        // The first draft duplicated the three checks. They were identical, and
+        // that is exactly the problem: a later edit to one path would leave the
+        // other silently reproducing a generation its sibling refuses, and the
+        // half that drifted would be the one nothing tested directly. Caught in
+        // review on #1437.
+        //
+        // Identity replays only on the reproduced path, so a refused
+        // composition does no work and cannot half-succeed.
+        let projection = match self.read_at_generation(generation)? {
+            PinnedRead::Reproduced(p) => p,
+            PinnedRead::Irreproducible(reason) => {
+                return Ok(PinnedComposedRead::Irreproducible(reason))
+            }
+        };
 
         Ok(PinnedComposedRead::Reproduced(PinnedComposition {
-            projection: PinnedProjection {
-                generation,
-                rows: replay_to(&self.tx, generation)?,
-            },
+            projection,
             identity: replay_identity_to(&self.tx, generation)?,
         }))
     }

--- a/crates/kirra-world-store/src/snapshot.rs
+++ b/crates/kirra-world-store/src/snapshot.rs
@@ -273,6 +273,83 @@ impl<'a> ReadSnapshot<'a> {
         }))
     }
 
+    /// **Reconstruct claims AND identity at one generation — box 3h.**
+    ///
+    /// 3h's rule is *"historical queries use historical identity and historical
+    /// evidence — never today's entity graph applied to old evidence."* This is
+    /// the primitive that makes that possible rather than merely intended.
+    ///
+    /// # Why this is one call and not two
+    ///
+    /// A caller who fetched the two halves separately would be one refactor away
+    /// from pinning claims at `g` and resolving identity against the live graph
+    /// — which is exactly the failure 3h names, and it would look like ordinary
+    /// code. Composing here makes the shared coordinate structural: one
+    /// generation, one compaction check, one refusal covering both halves.
+    ///
+    /// # The bound is the LOG's progress, not the entity checkpoint
+    ///
+    /// The obvious head for the identity half — `entities_projection`'s own
+    /// checkpoint — is **wrong**, and wrong in the direction that looks careful.
+    /// [`SnapshotCoordinate`] records at length why the two checkpoints are not
+    /// comparable: `world_current` advances past every event *considered*, while
+    /// the entity fold advances only to the last *adjudication* it folded, so
+    /// appending one ordinary claim leaves the entity checkpoint legitimately
+    /// behind with both folds complete. Gating the identity half on it would
+    /// refuse reproducible generations on a perfectly healthy store — the same
+    /// false drift that finding was recorded to prevent.
+    ///
+    /// Both halves replay from the **log**, so both are bounded by how far the
+    /// log has been folded, which is one number.
+    ///
+    /// # Staleness is not a question here
+    ///
+    /// [`Self::identity_is_current`] exists because a LIVE read consults a
+    /// projection that may lag the log. A pinned read does not: it folds the
+    /// adjudications itself, up to `generation`, so the reconstruction is
+    /// complete at that coordinate by construction. The gate is unnecessary
+    /// rather than skipped.
+    ///
+    /// # Errors
+    ///
+    /// As [`Self::read_at_generation`].
+    pub fn read_composed_at_generation(
+        &self,
+        generation: i64,
+    ) -> Result<PinnedComposedRead, StoreError> {
+        if generation < 0 {
+            return Err(StoreError::InvalidGeneration {
+                requested: generation,
+            });
+        }
+
+        let head = checkpoint_on(&self.tx, projection::CURRENT_PROJECTION)?.0;
+        if generation > head {
+            return Ok(PinnedComposedRead::Irreproducible(
+                Irreproducible::NotYetReached { head },
+            ));
+        }
+
+        // ONE compaction check for both halves, before either replay. The two
+        // projections fold the same log, so evidence removed at or below
+        // `generation` ends BOTH reconstructions; checking once is what makes a
+        // half-reproducible answer unrepresentable.
+        let spans = compacted_at_or_below(&self.tx, generation)?;
+        if !spans.is_empty() {
+            return Ok(PinnedComposedRead::Irreproducible(
+                Irreproducible::Compacted { spans },
+            ));
+        }
+
+        Ok(PinnedComposedRead::Reproduced(PinnedComposition {
+            projection: PinnedProjection {
+                generation,
+                rows: replay_to(&self.tx, generation)?,
+            },
+            identity: replay_identity_to(&self.tx, generation)?,
+        }))
+    }
+
     /// **Has the identity graph consumed every adjudication the log holds?**
     ///
     /// The question a composed read must ask before trusting a resolution, and
@@ -403,6 +480,51 @@ impl PinnedProjection {
     pub fn is_empty(&self) -> bool {
         self.rows.is_empty()
     }
+}
+
+/// **Claims and identity, reconstructed at ONE generation — box 3h.**
+///
+/// The two halves are private and reachable only together, so there is no way
+/// to hold a pinned projection beside a live identity view and call the pair an
+/// historical answer. That is the whole point of the type: 3h's failure mode is
+/// not exotic, it is the natural result of resolving an object while a live
+/// `WorldStore` is in scope.
+#[derive(Debug, Clone)]
+pub struct PinnedComposition {
+    projection: PinnedProjection,
+    identity: entity_projection::IdentityView,
+}
+
+impl PinnedComposition {
+    /// The claims half.
+    pub fn claims(&self) -> &PinnedProjection {
+        &self.projection
+    }
+
+    /// **The identity graph as it stood at the pinned generation.**
+    ///
+    /// Adjudications recorded *after* that coordinate are absent, which is the
+    /// property 3h is about: a merge performed today must not silently rewrite
+    /// what an answer from before it meant.
+    pub fn identity(&self) -> &entity_projection::IdentityView {
+        &self.identity
+    }
+
+    /// The coordinate both halves were reconstructed at.
+    pub fn generation(&self) -> i64 {
+        self.projection.generation()
+    }
+}
+
+/// The outcome of a composed generation-pinned read.
+///
+/// One refusal for both halves — see [`ReadSnapshot::read_composed_at_generation`].
+#[derive(Debug, Clone)]
+pub enum PinnedComposedRead {
+    /// Both halves reconstructed at the requested generation.
+    Reproduced(PinnedComposition),
+    /// Neither half can be reconstructed, and why.
+    Irreproducible(Irreproducible),
 }
 
 /// The outcome of a generation-pinned read.
@@ -633,6 +755,65 @@ pub(crate) fn replay_to(
         projection::fold_step(&mut acc, claim_from_row(row)?);
     }
     Ok(acc)
+}
+
+/// Replay the identity graph from the log up to `generation` — box 3h.
+///
+/// The generation-cut twin of [`crate::WorldStore::identity_view_at`], which
+/// cuts on transaction time. Both exist because the two coordinates answer
+/// different questions and must not be mixed: transaction time asks *"what did
+/// we know then"*, generation asks *"what does this exact recorded position
+/// reconstruct to"*. Box 3c's whole subject is that pairing one with the other
+/// produces an answer whose halves come from different cuts.
+///
+/// Folds with the shipped [`entity_projection::fold_adjudication`] rather than a
+/// re-derivation, so a pinned identity and a live one differ in WHERE they stop
+/// and in nothing else — the same relationship [`replay_to`] has with the claims
+/// fold.
+///
+/// The view's own generation is the last adjudication folded, NOT the requested
+/// `generation`: that is what `IdentityView` means by its coordinate, and
+/// stamping the request onto it would claim the graph had consumed events it
+/// never saw.
+pub(crate) fn replay_identity_to(
+    conn: &Connection,
+    generation: i64,
+) -> Result<entity_projection::IdentityView, StoreError> {
+    let mut acc = BTreeMap::new();
+    let mut head: i64 = 0;
+    if !table_exists(conn, "world_events")? {
+        return Ok(entity_projection::IdentityView::new(acc, head));
+    }
+
+    let mut stmt = conn.prepare(
+        "SELECT generation, payload, payload_schema, provenance
+         FROM world_events
+         WHERE claim_status = 'confirmed' AND kind = ?1 AND generation <= ?2
+         ORDER BY generation ASC",
+    )?;
+    let mut rows = stmt.query(params![
+        crate::adjudication_record::ADJUDICATION_KIND,
+        generation
+    ])?;
+    while let Some(r) = rows.next()? {
+        let at: i64 = r.get(0)?;
+        let payload: String = r.get(1)?;
+        let payload_schema: i64 = r.get(2)?;
+        let provenance: String = r.get(3)?;
+        let cited: Vec<String> = serde_json::from_str(&provenance).map_err(|e| {
+            StoreError::CorruptEntityProjectionRow {
+                detail: format!("provenance is not a JSON array: {e}"),
+            }
+        })?;
+        let adjudication =
+            crate::adjudication_record::decode_adjudication(&payload, payload_schema, &cited)
+                .map_err(|e| StoreError::CorruptEntityProjectionRow {
+                    detail: format!("generation {at}: {e}"),
+                })?;
+        entity_projection::fold_adjudication(&mut acc, &adjudication, at);
+        head = at;
+    }
+    Ok(entity_projection::IdentityView::new(acc, head))
 }
 
 pub(crate) fn table_exists(conn: &Connection, name: &str) -> Result<bool, StoreError> {

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -2039,9 +2039,14 @@ pressure that produced every stale claim this box already documents.
       `Full`/`Degraded` **independently of the payload outcome**, not just
       `subject_summary`. Retention may reduce answer precision; Tier 3 makes the
       loss observable.
-- [ ] **3h — Historical composition.** Historical queries use historical identity
-      (2d) and historical evidence — never today's entity graph applied to old
-      evidence.
+- [x] **3h — Historical composition.** ✅ **DONE 2026-08-11** — see *"3h closed:
+      the graph as it stood then"* below. Historical queries use historical
+      identity (2d) and historical evidence — never today's entity graph applied
+      to old evidence. `ReadSnapshot::read_composed_at_generation` reconstructs
+      claims AND identity at ONE coordinate with ONE refusal, and `AnswerRef`
+      resolves objects through it. Scope bound: this closes the box for the
+      **generation-pinned** family (`AnswerRef`); the transaction-time family
+      (`ask_as_of`) still reports `NotResolvedInReplay` and is the follow-up.
 
 **Cross-cutting, applying to every box above:**
 
@@ -3018,6 +3023,11 @@ never consulted, and a refusal that fires constantly is one people route around.
 The exclusion of `entity_fold` is a claim about *today's* code, asserted by test
 — box 3h's identity-resolving ref will put it in the set.
 
+> **It did, the next day.** 3h made refs compose identity at the pin, the
+> two-rule assertion went red, and the set became three. Left standing rather
+> than rewritten because the prediction and its resolution are the evidence that
+> this set is maintained by tests rather than by hand — see *"3h closed"* below.
+
 #### The three checks, and which hole each closes
 
 | Check | Where | Catches |
@@ -3091,3 +3101,101 @@ only to the axes it names, and the source pin is what covers the rest; and the
 boundary rule's corpus is challenged in **both** directions, because
 over-strictness there (refusing a stale claim) is a regression that reads as
 conservatism.
+
+### 3h closed: the graph as it stood then — 2026-08-11
+
+The box: *"historical queries use historical identity (2d) and historical
+evidence — never today's entity graph applied to old evidence."*
+
+#### The failure survives a correct evidence pin, which is why it needed its own box
+
+Box 3b's `read_at_generation` pinned the *evidence* and worked. The failure this
+box names goes straight through it: replay the claims at generation `g`, then
+resolve the object they name against the identity graph **as it is now**. Every
+claim is historically correct, the coordinate on the answer is honest, and the
+object is silently wrong — because a merge recorded last week says the thing
+that claim pointed at is now called something else.
+
+Nothing about that reads as a bug at the call site. It is what you get from
+writing the obvious code with a live `WorldStore` in scope. So the fix is a
+**composed read** rather than a rule about which functions to call in which
+order: `read_composed_at_generation` returns claims and identity together, and
+`PinnedComposition`'s halves are private and reachable only as a pair.
+
+#### One coordinate, one compaction check, one refusal
+
+Both halves replay from the same log at the same cut, so the compaction check
+runs **once** and covers both. A half-reproducible composition is
+unrepresentable rather than merely discouraged.
+
+#### The trap this box had to walk past
+
+The obvious head for the identity half — `entities_projection`'s own checkpoint
+— is **wrong**, and wrong in the direction that looks careful. Box 3c already
+recorded why the two checkpoints are not comparable: `world_current` advances
+past every event *considered*, the entity fold only to the last *adjudication*
+it folded, so appending one ordinary claim leaves the entity checkpoint
+legitimately behind with both folds complete. Bounding the composed read on it
+would refuse perfectly reproducible generations on a healthy store — the exact
+false drift that finding exists to prevent, re-appearing one box later in new
+clothes. `a_lagging_entity_checkpoint_does_not_refuse_a_reproducible_generation`
+pins the correct bound, and its fixture forces the checkpoints apart so the
+assertion is not vacuous.
+
+A related simplification falls out: a pinned composition needs no staleness gate
+at all. `identity_is_current` exists because a LIVE read consults a projection
+that may lag the log; a pinned read folds the adjudications itself, up to the
+coordinate, so the graph is complete there by construction.
+
+#### `entity_fold` entered the version set because a red test said so
+
+This is the part worth keeping. Box 3b shipped with `entity_fold` **excluded**
+from `SemanticVersions::for_query(CurrentSubject)`, and the exclusion was correct
+then: a resolved ref reported `NotResolvedInReplay`, so the identity fold could
+not reach the answer, and including it would have refused references for a rule
+they never consulted. 3b asserted that exclusion in
+`the_current_subject_query_depends_on_exactly_two_rules`.
+
+3h changed what the answer is derived from, and that test **failed** — which is
+the whole point of having written it. The set was widened because an assertion
+said the old claim had stopped being true, not because someone edited a list to
+match the code. A dependency set maintained the other way round is one that will
+eventually describe a composition that no longer exists. The test is now
+`..._exactly_three_rules` and records the flip in its own docs.
+
+Three further tests moved with it, all for the same reason: `entity_fold` had
+been serving as the *"a dependency this build does not have"* case, and that role
+passed to `subject_summary_fold` — a rule the store really declares and this
+query family really does not consult, so the case stays honest.
+
+#### Measured, not asserted
+
+| Mutation | Caught by |
+|---|---|
+| resolve identity against **today's** graph | `a_ref_pinned_before_the_merge_resolves_identity_as_it_stood_then` **and** `the_historical_and_live_identities_genuinely_differ` |
+| drop `entity_fold` from the version set | `the_current_subject_query_depends_on_exactly_three_rules` (unit) **and** `a_refs_recorded_versions_are_pinned_to_what_it_resolves_to` (end-to-end) |
+| bound the composed read on the **entity checkpoint** | `a_lagging_entity_checkpoint_does_not_refuse_a_reproducible_generation` |
+
+The suite carries its own controls, because each arm is worthless without the
+other: `the_live_read_resolves_the_object_through_the_merge` proves the fixture
+exercises identity at all (otherwise the historical arm would be "unmerged" for
+reasons unrelated to the pin), and `a_ref_pinned_after_the_merge_does_follow_it`
+proves the pin is a coordinate rather than a preference for old answers
+(otherwise an implementation that never resolved identity would pass). The two
+arms differ in the OBJECT RESOLUTION and not in the claim — the stored object
+string is `dock_alpha` in both — so the pair cannot be satisfied by the evidence
+pin alone.
+
+#### What remains
+
+`read_composed_at_generation` is gated by the 3d answer-boundary ratchet, for a
+sharper reason than its siblings: it hands back a `ProjectedClaim` and an
+`IdentityView` *together*, so calling it directly gives a consumer everything
+needed to compose an historical answer while bypassing the boundary. The
+convenience is what makes it worth gating.
+
+The honest scope bound: 3h is closed for the **generation-pinned** family.
+`ask_as_of` — the transaction-time family — still reports
+`ObjectIdentity::NotResolvedInReplay`. That is a scope decision rather than an
+impossibility (both `ask_as_of` and `identity_view_at` cut on transaction time,
+so the axes would agree), and it is the natural next slice.


### PR DESCRIPTION
## The box

> Historical queries use historical identity (2d) and historical evidence — **never today's entity graph applied to old evidence.**

## Why this survives a correct evidence pin

Box 3b's `read_at_generation` pinned the *evidence*, and it worked. The failure this box names goes straight through it:

```rust
let pinned = store.read_at_generation(g)?;        // historically correct claims
let identity = store.identity_view()?;            // …and TODAY's graph
```

Every claim is historically correct. The coordinate on the answer is honest. The object is silently wrong, because a merge recorded last week says the thing that claim pointed at is now called something else.

Nothing about that reads as a bug at the call site — it is what you get from writing the obvious code with a live `WorldStore` in scope. So the fix is a **composed read**, not a rule about which functions to call in which order.

## What landed

`ReadSnapshot::read_composed_at_generation` returns claims and identity from **one snapshot at one coordinate**, with **one compaction check** covering both halves. `PinnedComposition`'s halves are private and reachable only as a pair, so a half-reproducible composition is unrepresentable rather than discouraged. `AnswerRef::resolve` uses it, and resolved refs now carry real object identity instead of `NotResolvedInReplay`.

## The trap this had to walk past

The obvious head for the identity half — `entities_projection`'s own checkpoint — is **wrong**, in the direction that looks careful.

Box 3c already recorded why: `world_current` advances past every event *considered*, while the entity fold advances only to the last *adjudication* it folded, so appending one ordinary claim leaves the entity checkpoint legitimately behind with both folds complete. Bounding the composed read on it would refuse perfectly reproducible generations on a healthy store — the same false drift that finding was written to prevent, re-appearing one box later in new clothes. A finding written for one box caught its own recurrence in the next.

`a_lagging_entity_checkpoint_does_not_refuse_a_reproducible_generation` pins the correct bound, and its fixture forces the checkpoints apart so the assertion isn't vacuous.

A simplification falls out: a pinned composition needs **no staleness gate at all**. `identity_is_current` exists because a live read consults a projection that may lag the log; a pinned read folds the adjudications itself, so the graph is complete at that coordinate by construction.

## `entity_fold` entered the version set because a red test said so

This is the part worth keeping, and it's what you asked for.

Box 3b shipped with `entity_fold` **excluded** from `SemanticVersions::for_query(CurrentSubject)` — correct at the time, since a resolved ref reported `NotResolvedInReplay` and including it would have refused references for a rule they never consulted. 3b **asserted** that exclusion.

3h changed what the answer is derived from, and that assertion **failed**:

```
test the_current_subject_query_depends_on_exactly_two_rules ... FAILED
```

The set widened because a test said the old claim had stopped being true — not because someone edited a list to match the code. A dependency set maintained the other way round is one that will eventually describe a composition that no longer exists.

Three further tests moved with it, all for one reason: `entity_fold` had been serving as the *"a dependency this build does not have"* case, and that role passed to `subject_summary_fold` — a rule the store really declares and this query family really does not consult, so the case stays honest rather than resting on a name nothing has claimed.

## Mutation-measured

| Mutation | Caught by |
|---|---|
| resolve identity against **today's** graph | `a_ref_pinned_before_the_merge_resolves_identity_as_it_stood_then` **and** `the_historical_and_live_identities_genuinely_differ` |
| drop `entity_fold` from the version set | `..._depends_on_exactly_three_rules` (unit) **and** `a_refs_recorded_versions_are_pinned_to_what_it_resolves_to` (end-to-end) |
| bound the composed read on the **entity checkpoint** | `a_lagging_entity_checkpoint_does_not_refuse_a_reproducible_generation` |

The suite carries controls in **both** directions, because each arm is worthless without the other:

- `the_live_read_resolves_the_object_through_the_merge` proves the fixture exercises identity at all — otherwise the historical arm would read "unmerged" for reasons unrelated to the pin.
- `a_ref_pinned_after_the_merge_does_follow_it` proves the pin is a *coordinate*, not a preference for old answers — otherwise an implementation that never resolved identity would pass everything.

The two arms differ in the **object resolution** and not in the claim (the stored object string is `dock_alpha` in both), so the pair cannot be satisfied by the evidence pin alone.

## Fixture

```text
gen 1   assert dock_alpha
gen 2   claim  package_17 -> dock_alpha
        ---- PIN HERE ----
gen 3   assert dock_beta
gen 4   merge  dock_alpha -> dock_beta      the graph changes AFTER the pin
```

Pinned at 2 → `Resolved { entity: "dock_alpha", hops: 0 }`. Live → `Resolved { entity: "dock_beta", hops: 1 }`.

## Ratchet

`read_composed_at_generation` is added to the 3d answer-boundary gate, for a sharper reason than its siblings: it hands back a `ProjectedClaim` **and** an `IdentityView` together, so calling it directly gives a consumer everything needed to compose an historical answer while bypassing the boundary. The convenience is what makes it worth gating.

## Scope bound, stated rather than implied

3h is closed for the **generation-pinned** family (`AnswerRef`). `ask_as_of` — the transaction-time family — still reports `ObjectIdentity::NotResolvedInReplay`. That's a scope decision rather than an impossibility (both it and `identity_view_at` cut on transaction time, so the axes would agree), and it's the natural next slice.

## Verification

`cargo fmt --check` clean; clippy clean on both crates; **324 tests green** across `kirra-world-store` + `kirra-world-service`; all six world gates pass (`check_world_semantics`, `check_world_answer_boundary` + its 12 self-tests, the bidirectional fence, the domain-logic gate, `check_orphan_cores`, `check_proposal_context_symbolic`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_