### PR TITLE
ask_as_of composes identity at its own transaction-time cut

### DIFF
--- a/ci/check_world_answer_boundary.py
+++ b/ci/check_world_answer_boundary.py
@@ -95,6 +95,10 @@ DOMAIN_READ_METHODS = (
     # bypassing the boundary that would have resolved the object properly. The
     # convenience is exactly what makes it worth gating.
     "read_composed_at_generation",
+    # The transaction-time twin, gated for the identical reason: claims AND an
+    # identity view in one return value is everything a consumer needs to build
+    # an historical answer without the boundary.
+    "as_of_composed",
     "identity_view",
     "identity_view_at",
     "resolve_at",

--- a/crates/kirra-world-service/src/answer_ref.rs
+++ b/crates/kirra-world-service/src/answer_ref.rs
@@ -89,6 +89,15 @@ pub enum QueryKind {
     /// [`crate::read_view::WorldView::ask`] — what is currently known about one
     /// subject.
     CurrentSubject,
+    /// [`crate::read_view::WorldView::ask_as_of`] — what was known about one
+    /// subject at a transaction-time cut, for facts valid at an instant.
+    ///
+    /// A query FAMILY, not yet a ref family: `AnswerRef` describes
+    /// [`Self::CurrentSubject`] only. This variant exists because the family
+    /// has a dependency set that its answers carry
+    /// ([`crate::read_view::TemporalLookup::semantics`]), and that set has to
+    /// be derived in the one place every set is derived.
+    AsOfSubject,
 }
 
 /// **A reproducible descriptor for one answer.**

--- a/crates/kirra-world-service/src/read_view.rs
+++ b/crates/kirra-world-service/src/read_view.rs
@@ -595,8 +595,10 @@ impl<'a> WorldView<'a> {
         let composed = self
             .store
             .as_of_composed(subject, valid_at_ms, as_known_at_ms)?;
-        let identity = composed.identity().clone();
-        let (answer, _) = composed.into_parts();
+        // Both halves MOVED out together. An earlier draft cloned the identity
+        // view and then dropped the original — a full copy of the entity graph
+        // on every call, for nothing. Caught in review on #1438.
+        let (answer, identity) = composed.into_parts();
         let completeness = answer.resolution;
 
         let clock = valid_at_ms.max(0).unsigned_abs();

--- a/crates/kirra-world-service/src/read_view.rs
+++ b/crates/kirra-world-service/src/read_view.rs
@@ -100,6 +100,9 @@ use kirra_world_store::entity_projection::IdentityView;
 use kirra_world_store::snapshot::SnapshotCoordinate;
 use kirra_world_store::{ProjectedClaim, StoreError, TrustAxes, TrustGrade, Validity, WorldStore};
 
+use crate::answer_ref::QueryKind;
+use crate::semantics::SemanticVersions;
+
 /// Why an ask could not be answered at all.
 ///
 /// Distinct from [`WorldLookup::Unknown`], and the split is rule 3: *absence of
@@ -586,7 +589,14 @@ impl<'a> WorldView<'a> {
         valid_at_ms: i64,
         as_known_at_ms: i64,
     ) -> Result<TemporalLookup, AskError> {
-        let answer = self.store.as_of(subject, valid_at_ms, as_known_at_ms)?;
+        // COMPOSED at one transaction-time cut. Objects resolve through the
+        // identity graph as it stood at `as_known_at_ms`, so an adjudication
+        // recorded after that instant cannot rewrite this answer.
+        let composed = self
+            .store
+            .as_of_composed(subject, valid_at_ms, as_known_at_ms)?;
+        let identity = composed.identity().clone();
+        let (answer, _) = composed.into_parts();
         let completeness = answer.resolution;
 
         let clock = valid_at_ms.max(0).unsigned_abs();
@@ -599,12 +609,11 @@ impl<'a> WorldView<'a> {
                 claim,
                 clock,
                 self.staleness_budget_ms,
-                // A replayed answer does not resolve identity. Unlike the
-                // generation pin the axes would actually AGREE here — both this
-                // query and `identity_view_at` cut on transaction time — so this
-                // is a scope decision rather than an impossibility, and is
-                // recorded as such in WM_SCOPE.
-                ObjectIdentity::NotResolvedInReplay,
+                // `true` for the same reason a pinned composition passes it:
+                // the historical graph was replayed from the log up to the cut,
+                // so it cannot lag it. `identity_is_current` answers a question
+                // about the LIVE projection and would be the wrong question here.
+                Self::resolve_object(claim.object.as_deref(), &identity, true),
             )?);
         }
 
@@ -623,6 +632,7 @@ impl<'a> WorldView<'a> {
         Ok(TemporalLookup {
             lookup,
             completeness,
+            semantics: SemanticVersions::for_query(QueryKind::AsOfSubject),
         })
     }
 
@@ -814,6 +824,7 @@ fn assemble(
 pub struct TemporalLookup {
     lookup: WorldLookup,
     completeness: Resolution,
+    semantics: SemanticVersions,
 }
 
 impl TemporalLookup {
@@ -833,5 +844,24 @@ impl TemporalLookup {
     #[must_use]
     pub fn is_degraded(&self) -> bool {
         self.completeness.is_degraded()
+    }
+
+    /// **The rules this answer was produced under.**
+    ///
+    /// Box 3a said the envelope owns *"completeness, freshness, provenance and
+    /// versions"*, and then excluded versions with a reason: *"no reducer
+    /// version exists to carry. Minting one here would be the decorative
+    /// metadata 3b forbids; it lands with 3b's enforcement."* 3b built that
+    /// enforcement, so the field is no longer decorative and the exclusion is
+    /// spent.
+    ///
+    /// **Carried, not enforced — and the difference matters.** A recorded
+    /// `AnswerRef` REFUSES on a version mismatch; this states which rules
+    /// produced the answer so a caller comparing two answers can see that they
+    /// were not produced alike. There is no `as_of` ref to refuse yet, and
+    /// pretending otherwise is exactly the overclaim 3b exists to prevent.
+    #[must_use]
+    pub fn semantics(&self) -> &SemanticVersions {
+        &self.semantics
     }
 }

--- a/crates/kirra-world-service/src/semantics.rs
+++ b/crates/kirra-world-service/src/semantics.rs
@@ -172,15 +172,24 @@ impl SemanticVersions {
     #[must_use]
     pub fn for_query(kind: QueryKind) -> Self {
         match kind {
-            QueryKind::CurrentSubject => Self::new([
+            // Both families depend on the SAME three rules, and that is a
+            // finding rather than a coincidence: they differ in which
+            // COORDINATE they cut on, not in which rules produce the answer.
+            // Still derived per-family, because "identical today" is not
+            // "identical by construction" — a temporal-resolution rule would
+            // belong to one and not the other, and a shared arm that had to be
+            // split later is a shared arm nobody remembers to split.
+            QueryKind::CurrentSubject | QueryKind::AsOfSubject => Self::new([
                 RuleVersion {
                     rule: RuleId::WorldCurrentFold.as_str().to_string(),
                     version: store_semantics::version_of(RuleId::WorldCurrentFold),
                 },
-                // Box 3h added this. A resolved ref now composes the identity
-                // graph as it stood at the pinned generation, so the fold that
-                // BUILDS that graph can change what an answer says — which is
-                // the whole test for membership in this set.
+                // Box 3h added this for `CurrentSubject`: a resolved ref
+                // composes the identity graph as it stood at the pinned
+                // generation, so the fold that BUILDS that graph can change
+                // what an answer says — the whole test for membership in this
+                // set. `ask_as_of` joined when its composition landed on the
+                // transaction-time axis.
                 RuleVersion {
                     rule: RuleId::EntityFold.as_str().to_string(),
                     version: store_semantics::version_of(RuleId::EntityFold),

--- a/crates/kirra-world-service/tests/as_of_composition.rs
+++ b/crates/kirra-world-service/tests/as_of_composition.rs
@@ -1,0 +1,500 @@
+//! **`ask_as_of` composes identity at its own cut** — 3h's other temporal axis.
+//!
+//! Box 3h closed *"historical queries use historical identity, never today's
+//! entity graph applied to old evidence"* for the **generation-pinned** family.
+//! `ask_as_of` was left reporting `NotResolvedInReplay`, which was honest but
+//! left the same architectural question answered on one axis and open on the
+//! other.
+//!
+//! This is that question on transaction time. The property is identical, and so
+//! is the way it fails: replay the claims as they were known at `T`, then
+//! resolve the object they name against today's graph. Every field is correct
+//! except the one that quietly is not.
+//!
+//! # The fixture, mirrored from `historical_composition.rs`
+//!
+//! ```text
+//! txn T0     assert dock_alpha
+//! txn T0+1   claim  package_17 -> dock_alpha
+//!            ---- as_known_at = T0+1 ----
+//! txn T0+2   assert dock_beta
+//! txn T0+3   merge  dock_alpha -> dock_beta
+//! ```
+//!
+//! Asked at `as_known_at = T0+1`, the object must resolve to **`dock_alpha`**.
+//! Asked at `as_known_at = T0+10`, it must resolve to **`dock_beta`**. The
+//! claim is the same row in both, and the stored object string is `dock_alpha`
+//! in both — so the pair cannot be satisfied by the bitemporal claim filter
+//! alone, only by the identity cut moving with it.
+//!
+//! # What this deliberately does NOT change
+//!
+//! No new resolver: object resolution goes through the same
+//! `WorldView::resolve_object` / `kirra_world::resolution::resolve` the live and
+//! pinned paths use. No valid-time interpretation of identity — adjudications
+//! are cut on transaction time only, because that is the axis they carry. No
+//! fallback to the current graph when the historical one is empty. And
+//! contradiction and refusal outcomes propagate exactly as they do elsewhere,
+//! which the last two tests pin.
+
+use kirra_world::adjudication::{
+    AssertIdentity, IdentityAdjudication, Justification, MergeEntities, SplitEntity,
+};
+use kirra_world::observation::{ClockDomain, DomainInstant};
+use kirra_world::reference::{EntityId, EventId, ObservationId};
+use kirra_world_service::answer_ref::QueryKind;
+use kirra_world_service::read_view::{ObjectIdentity, WorldLookup, WorldView};
+use kirra_world_service::semantics::SemanticVersions;
+use kirra_world_store::adjudication_record::AdjudicationRow;
+use kirra_world_store::{ClaimStatus, NewEvent, WorldStore, WriterClass};
+
+const T0: i64 = 1_700_000_000_000;
+/// The instant facts are asked to be VALID at. Held constant across every test
+/// so the only axis moving is transaction time.
+const VALID_AT: i64 = T0 + 100;
+
+fn tmp(name: &str) -> std::path::PathBuf {
+    static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let n = NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "kirra-asof-comp-{name}-{}-{n}.sqlite",
+        std::process::id()
+    ));
+    cleanup(&p);
+    p
+}
+
+fn cleanup(path: &std::path::Path) {
+    for suffix in ["", "-wal", "-shm"] {
+        let mut q = path.as_os_str().to_os_string();
+        q.push(suffix);
+        let _ = std::fs::remove_file(std::path::PathBuf::from(q));
+    }
+}
+
+fn eid(s: &str) -> EntityId {
+    EntityId::new(s).expect("entity id")
+}
+
+fn just() -> Justification {
+    Justification::new([ObservationId::new("obs-j").expect("obs")]).expect("justification")
+}
+
+fn at() -> DomainInstant {
+    DomainInstant {
+        ms: 1,
+        domain: ClockDomain::System,
+    }
+}
+
+fn adjudicate(store: &mut WorldStore, tag: &str, txn_time_ms: i64, a: &IdentityAdjudication) {
+    let event_id = EventId::new(format!("ev-{tag}")).expect("event id");
+    let observation_id = ObservationId::new(format!("obs-{tag}")).expect("obs");
+    store
+        .append_adjudication(
+            &AdjudicationRow {
+                event_id: &event_id,
+                observation_id: &observation_id,
+                txn_time_ms,
+                valid_from_ms: txn_time_ms,
+                source: "operator-console",
+                source_version: "1.0.0",
+                writer_class: WriterClass::Operator,
+            },
+            a,
+        )
+        .expect("append adjudication");
+}
+
+/// A claim valid from `T0` — before `VALID_AT` — so valid time never filters it
+/// out and transaction time is the only axis under test.
+fn claim_pointing_at(store: &mut WorldStore, tag: &str, object: &str, txn_time_ms: i64) {
+    store
+        .append(&NewEvent {
+            event_id: &EventId::new(format!("ev-{tag}")).expect("event id"),
+            observation_id: &ObservationId::new(format!("obs-{tag}")).expect("obs"),
+            txn_time_ms,
+            valid_from_ms: T0,
+            valid_to_ms: None,
+            source: "warehouse-scanner",
+            source_version: "1.0.0",
+            writer_class: WriterClass::Sensor,
+            claim_status: ClaimStatus::Confirmed,
+            provenance: &[],
+            frame_id: None,
+            map_id: None,
+            kind: "mission",
+            subject: "package_17",
+            subject_ref: None,
+            predicate: Some("last_seen_at"),
+            object: Some(object),
+            payload: "{}",
+            payload_schema: 1,
+            retention_class: "raw",
+            trust: None,
+        })
+        .expect("append");
+}
+
+/// The fixture in the module docs. `CUT` is the `as_known_at` before the graph
+/// moved; anything later sees the merge.
+const CUT: i64 = T0 + 1;
+const AFTER: i64 = T0 + 10;
+
+fn store_where_the_graph_moved_after_the_cut(name: &str) -> (WorldStore, std::path::PathBuf) {
+    let path = tmp(name);
+    let mut store = WorldStore::open(&path).expect("open");
+
+    adjudicate(
+        &mut store,
+        "assert-alpha",
+        T0,
+        &IdentityAdjudication::Assert(AssertIdentity::new(eid("dock_alpha"), just(), at())),
+    );
+    claim_pointing_at(&mut store, "claim", "dock_alpha", CUT);
+
+    // Everything below is recorded AFTER the cut.
+    adjudicate(
+        &mut store,
+        "assert-beta",
+        T0 + 2,
+        &IdentityAdjudication::Assert(AssertIdentity::new(eid("dock_beta"), just(), at())),
+    );
+    adjudicate(
+        &mut store,
+        "merge",
+        T0 + 3,
+        &IdentityAdjudication::Merge(
+            MergeEntities::new(vec![eid("dock_alpha")], eid("dock_beta"), just(), at())
+                .expect("merge"),
+        ),
+    );
+
+    store.fold().expect("fold");
+    store.fold_entity_projection().expect("fold entities");
+    (store, path)
+}
+
+fn sole_identity(store: &WorldStore, as_known_at_ms: i64) -> ObjectIdentity {
+    let view = WorldView::new(store, None);
+    let temporal = view
+        .ask_as_of("package_17", VALID_AT, as_known_at_ms)
+        .expect("ask_as_of");
+    let WorldLookup::Answered(answers) = temporal.lookup() else {
+        panic!(
+            "the fixture must answer at {as_known_at_ms}, got {:?}",
+            temporal.lookup()
+        );
+    };
+    assert_eq!(answers.len(), 1, "fixture holds one claim for the subject");
+    answers[0].object_identity().clone()
+}
+
+// ---------------------------------------------------------------------------
+// The property
+// ---------------------------------------------------------------------------
+
+/// **THE BOX, on transaction time.** An identity change recorded after
+/// `as_known_at` must not rewrite the earlier answer.
+#[test]
+fn a_merge_recorded_after_the_cut_does_not_rewrite_the_earlier_answer() {
+    let (store, path) = store_where_the_graph_moved_after_the_cut("before");
+
+    assert_eq!(
+        sole_identity(&store, CUT),
+        ObjectIdentity::Resolved {
+            entity: "dock_alpha".to_string(),
+            hops: 0,
+        },
+        "the merge was recorded AFTER as_known_at, so it must not reach this \
+         answer — resolving through today's graph would return dock_beta while \
+         every other field still described the earlier state"
+    );
+
+    drop(store);
+    cleanup(&path);
+}
+
+/// The control arm: asked later, the same query DOES follow the merge.
+///
+/// Without this the assertion above proves nothing — an implementation that
+/// never resolved identity, or one whose graph was empty, would satisfy it.
+#[test]
+fn the_same_query_asked_later_follows_the_merge() {
+    let (store, path) = store_where_the_graph_moved_after_the_cut("after");
+
+    assert_eq!(
+        sole_identity(&store, AFTER),
+        ObjectIdentity::Resolved {
+            entity: "dock_beta".to_string(),
+            hops: 1,
+        },
+        "an adjudication at or before as_known_at is part of the cut"
+    );
+
+    drop(store);
+    cleanup(&path);
+}
+
+/// The two cuts disagree, and that disagreement is the result.
+///
+/// Asserted as a pair so a future change that made both return the same
+/// identity cannot be absorbed by editing the two tests above separately.
+#[test]
+fn the_two_cuts_genuinely_differ() {
+    let (store, path) = store_where_the_graph_moved_after_the_cut("differ");
+
+    assert_ne!(
+        sole_identity(&store, CUT),
+        sole_identity(&store, AFTER),
+        "both cuts returned the same object identity, so this suite cannot tell \
+         a transaction-time identity cut from a live one"
+    );
+
+    drop(store);
+    cleanup(&path);
+}
+
+/// The CLAIM is identical across both cuts — only the resolution moves.
+///
+/// This is what stops the pair above being satisfied by the bitemporal claim
+/// filter. If the two arms returned different claims, the evidence cut alone
+/// would explain the difference and identity would be untested.
+#[test]
+fn the_claim_is_the_same_in_both_arms_only_its_object_resolution_moves() {
+    let (store, path) = store_where_the_graph_moved_after_the_cut("sameclaim");
+    let view = WorldView::new(&store, None);
+
+    let render = |as_known_at: i64| {
+        let t = view
+            .ask_as_of("package_17", VALID_AT, as_known_at)
+            .expect("ask_as_of");
+        let WorldLookup::Answered(a) = t.lookup() else {
+            panic!("must answer");
+        };
+        (
+            a[0].subject().to_string(),
+            a[0].predicate().map(str::to_string),
+            a[0].object().map(str::to_string),
+            a[0].value().to_string(),
+        )
+    };
+
+    assert_eq!(
+        render(CUT),
+        render(AFTER),
+        "the claim itself must be identical across the two cuts — the stored \
+         object string is `dock_alpha` in both, and only the RESOLUTION differs"
+    );
+
+    drop(store);
+    cleanup(&path);
+}
+
+/// **No fallback to the current graph.** A cut before any adjudication exists
+/// must report the object as not-an-entity, not silently borrow today's graph.
+#[test]
+fn a_cut_before_any_adjudication_does_not_borrow_todays_graph() {
+    let path = tmp("nofallback");
+    let mut store = WorldStore::open(&path).expect("open");
+
+    // The claim is recorded FIRST; the entity is asserted afterwards.
+    claim_pointing_at(&mut store, "claim", "dock_alpha", T0);
+    adjudicate(
+        &mut store,
+        "assert-alpha",
+        T0 + 5,
+        &IdentityAdjudication::Assert(AssertIdentity::new(eid("dock_alpha"), just(), at())),
+    );
+    store.fold().expect("fold");
+    store.fold_entity_projection().expect("fold entities");
+
+    assert_eq!(
+        sole_identity(&store, T0),
+        ObjectIdentity::NotAnEntity,
+        "at this cut the graph held nothing; reporting the object as resolved \
+         would mean the answer had reached forward for a graph that did not \
+         exist yet"
+    );
+    // …and the same query later sees it, so the arm above is not vacuous.
+    assert_eq!(
+        sole_identity(&store, T0 + 5),
+        ObjectIdentity::Resolved {
+            entity: "dock_alpha".to_string(),
+            hops: 0,
+        },
+    );
+
+    drop(store);
+    cleanup(&path);
+}
+
+// ---------------------------------------------------------------------------
+// Refusal / ambiguity semantics propagate unchanged
+// ---------------------------------------------------------------------------
+
+/// A SPLIT before the cut yields `Ambiguous`, carrying its successors.
+///
+/// The point is that the historical path reports exactly what the live resolver
+/// reports — no separate handling, no flattening of ambiguity into a pick.
+#[test]
+fn a_split_before_the_cut_reports_ambiguous_with_its_successors() {
+    let path = tmp("split");
+    let mut store = WorldStore::open(&path).expect("open");
+
+    adjudicate(
+        &mut store,
+        "assert-alpha",
+        T0,
+        &IdentityAdjudication::Assert(AssertIdentity::new(eid("dock_alpha"), just(), at())),
+    );
+    claim_pointing_at(&mut store, "claim", "dock_alpha", T0);
+    adjudicate(
+        &mut store,
+        "split",
+        T0 + 2,
+        &IdentityAdjudication::Split(
+            SplitEntity::partition(
+                eid("dock_alpha"),
+                [eid("dock_x"), eid("dock_y")],
+                just(),
+                at(),
+            )
+            .expect("partition"),
+        ),
+    );
+    store.fold().expect("fold");
+    store.fold_entity_projection().expect("fold entities");
+
+    // Before the split: a plain resolution.
+    assert_eq!(
+        sole_identity(&store, T0),
+        ObjectIdentity::Resolved {
+            entity: "dock_alpha".to_string(),
+            hops: 0,
+        },
+    );
+
+    // After it: ambiguity, reported rather than resolved away.
+    match sole_identity(&store, T0 + 2) {
+        ObjectIdentity::Ambiguous { successors } => {
+            let mut s = successors;
+            s.sort();
+            assert_eq!(s, vec!["dock_x".to_string(), "dock_y".to_string()]);
+        }
+        other => panic!("a split must report Ambiguous, got {other:?}"),
+    }
+
+    drop(store);
+    cleanup(&path);
+}
+
+/// An ambiguous identity is not `matchable`, on the historical path as on the
+/// live one.
+///
+/// The consumer-facing half of the property above: `matchable` is what a
+/// proposal consults, and it must fail closed for a historically ambiguous
+/// object exactly as it does for a live one.
+#[test]
+fn a_historically_ambiguous_object_is_not_matchable() {
+    let path = tmp("matchable");
+    let mut store = WorldStore::open(&path).expect("open");
+
+    adjudicate(
+        &mut store,
+        "assert-alpha",
+        T0,
+        &IdentityAdjudication::Assert(AssertIdentity::new(eid("dock_alpha"), just(), at())),
+    );
+    claim_pointing_at(&mut store, "claim", "dock_alpha", T0);
+    adjudicate(
+        &mut store,
+        "split",
+        T0 + 2,
+        &IdentityAdjudication::Split(
+            SplitEntity::partition(
+                eid("dock_alpha"),
+                [eid("dock_x"), eid("dock_y")],
+                just(),
+                at(),
+            )
+            .expect("partition"),
+        ),
+    );
+    store.fold().expect("fold");
+    store.fold_entity_projection().expect("fold entities");
+
+    assert!(
+        sole_identity(&store, T0)
+            .matchable(Some("dock_alpha"))
+            .is_some(),
+        "a cleanly resolved historical object is matchable"
+    );
+    assert!(
+        sole_identity(&store, T0 + 2)
+            .matchable(Some("dock_alpha"))
+            .is_none(),
+        "an ambiguous historical object must fail closed, like a live one"
+    );
+
+    drop(store);
+    cleanup(&path);
+}
+
+// ---------------------------------------------------------------------------
+// The version set
+// ---------------------------------------------------------------------------
+
+/// The `as_of` family declares the same three rules, and says so on its answers.
+#[test]
+fn an_as_of_answer_carries_the_familys_version_set() {
+    let (store, path) = store_where_the_graph_moved_after_the_cut("versions");
+    let view = WorldView::new(&store, None);
+
+    let temporal = view
+        .ask_as_of("package_17", VALID_AT, CUT)
+        .expect("ask_as_of");
+
+    assert_eq!(
+        *temporal.semantics(),
+        SemanticVersions::for_query(QueryKind::AsOfSubject),
+    );
+    assert!(
+        temporal.semantics().version_of("entity_fold").is_some(),
+        "this family resolves objects through the identity graph now, so the \
+         fold that builds it can change what the answer says"
+    );
+    assert!(temporal
+        .semantics()
+        .version_of("world_current_fold")
+        .is_some());
+    assert!(temporal
+        .semantics()
+        .version_of("subject_summary_fold")
+        .is_none());
+
+    drop(store);
+    cleanup(&path);
+}
+
+/// Completeness still rides on the answer — 3g's property is untouched.
+///
+/// Included because this change rewrote `ask_as_of`'s body, and 3g's guarantee
+/// lives in exactly the lines that moved.
+#[test]
+fn completeness_still_rides_on_the_answer() {
+    let (store, path) = store_where_the_graph_moved_after_the_cut("completeness");
+    let view = WorldView::new(&store, None);
+
+    let temporal = view
+        .ask_as_of("package_17", VALID_AT, CUT)
+        .expect("ask_as_of");
+    assert!(
+        !temporal.is_degraded(),
+        "nothing was compacted in this fixture"
+    );
+
+    drop(store);
+    cleanup(&path);
+}

--- a/crates/kirra-world-service/tests/as_of_composition.rs
+++ b/crates/kirra-world-service/tests/as_of_composition.rs
@@ -498,3 +498,53 @@ fn completeness_still_rides_on_the_answer() {
     drop(store);
     cleanup(&path);
 }
+
+// ---------------------------------------------------------------------------
+// The composed read's own contract
+// ---------------------------------------------------------------------------
+
+/// **Both halves come from the same cut** — the store-level assertion.
+///
+/// The transaction-time mirror of 3h's
+/// `the_composed_read_reconstructs_both_halves_at_the_same_generation`. Every
+/// test above reaches the composition through `ask_as_of`, which is the path
+/// that matters but also the path that could hide a wrong half behind a right
+/// answer: if the claims half were empty the identity half would never be
+/// consulted, and the suite would still be green.
+///
+/// This is also what exercises [`TemporalComposition::answer`] and
+/// [`TemporalComposition::identity`] directly. `ask_as_of` moves both halves out
+/// with `into_parts`, so without this the two accessors would be public surface
+/// no test had ever called.
+///
+/// [`TemporalComposition::answer`]: kirra_world_store::snapshot::TemporalComposition::answer
+/// [`TemporalComposition::identity`]: kirra_world_store::snapshot::TemporalComposition::identity
+#[test]
+fn the_composed_read_holds_both_halves_at_the_same_cut() {
+    let (store, path) = store_where_the_graph_moved_after_the_cut("composed");
+
+    let at_cut = store
+        .as_of_composed("package_17", VALID_AT, CUT)
+        .expect("composed read");
+    assert_eq!(
+        at_cut.answer().claims.len(),
+        1,
+        "the claims half must hold the fixture's claim — an empty one would \
+         leave the identity half unconsulted and every arm above vacuous"
+    );
+    assert!(at_cut.identity().get(&eid("dock_alpha")).is_some());
+    assert!(
+        at_cut.identity().get(&eid("dock_beta")).is_none(),
+        "an entity asserted after the cut must be absent from the graph at it"
+    );
+
+    // Later, the same read sees both — so the absence above is the cut doing
+    // its job rather than the fixture never having recorded dock_beta.
+    let later = store
+        .as_of_composed("package_17", VALID_AT, AFTER)
+        .expect("composed read");
+    assert!(later.identity().get(&eid("dock_beta")).is_some());
+
+    drop(store);
+    cleanup(&path);
+}

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -2649,6 +2649,48 @@ impl WorldStore {
             .read_composed_at_generation(generation)
     }
 
+    /// **Claims and identity at ONE transaction-time cut.**
+    ///
+    /// The `as_of` twin of [`Self::read_composed_at_generation`]. Box 3h
+    /// established, on the generation axis, that an historical answer must
+    /// resolve objects through the graph as it stood *then*; this is the same
+    /// property on the axis `as_of` asks about.
+    ///
+    /// Both halves are read inside one transaction, so a fold landing between
+    /// them cannot pair claims from one commit with an identity graph from
+    /// another — box 3c's rule, applied to a pair of reads that previously ran
+    /// outside any snapshot because only one of them existed.
+    ///
+    /// # Why this lives on the store rather than on `ReadSnapshot`
+    ///
+    /// Its two halves are store-level temporal queries ([`Self::as_of`],
+    /// [`Self::identity_view_at`]) rather than projection replays, so the
+    /// snapshot is opened here and they are called unchanged. That keeps one
+    /// cut per axis: no second copy of the bitemporal filter, and no second
+    /// adjudication replay to drift from the original.
+    ///
+    /// # Errors
+    ///
+    /// As [`Self::as_of`] and [`Self::identity_view_at`].
+    pub fn as_of_composed(
+        &self,
+        subject: &str,
+        valid_at_ms: i64,
+        as_known_at_ms: i64,
+    ) -> Result<snapshot::TemporalComposition, StoreError> {
+        // One snapshot for both halves. `unchecked_transaction` borrows the
+        // connection immutably, so the calls below run inside it and see one
+        // committed state; dropping it rolls back, which is free for reads.
+        let tx = self.conn.unchecked_transaction()?;
+        let answer = self.as_of(subject, valid_at_ms, as_known_at_ms)?;
+        let identity = self.identity_view_at(as_known_at_ms)?;
+        drop(tx);
+        Ok(snapshot::TemporalComposition::new(
+            answer,
+            identity.view().clone(),
+        ))
+    }
+
     /// Where every projection stands right now, read outside any snapshot.
     ///
     /// For reporting and diagnostics. A composed ANSWER should carry the

--- a/crates/kirra-world-store/src/snapshot.rs
+++ b/crates/kirra-world-store/src/snapshot.rs
@@ -526,6 +526,65 @@ pub enum PinnedComposedRead {
     Irreproducible(Irreproducible),
 }
 
+/// **Claims and identity at ONE transaction-time cut** — the `as_of` twin.
+///
+/// The same composition [`PinnedComposition`] provides on the generation axis,
+/// for the axis `as_of` actually asks about: *what did this store know at time
+/// T*. Both halves come from one snapshot, so a fold landing mid-read cannot
+/// pair claims from one commit with an identity graph from another.
+///
+/// # Why this one has no refusal variant, and the pinned one does
+///
+/// The asymmetry is real and worth stating, because two composed reads with
+/// different failure shapes look like an oversight:
+///
+/// * A **generation pin** promises exact reconstruction of a recorded
+///   coordinate. Evidence removed at or below it makes that impossible, so it
+///   [`Irreproducible`]-refuses — anything else would be a reconstruction with
+///   holes wearing the word "pinned".
+/// * An **`as_of`** promises *what was known then, from what remains*.
+///   Compaction does not make that impossible, it makes it **incomplete** — and
+///   incompleteness already has a carrier, [`crate::Resolution`], on the answer.
+///   Refusing here would throw away an answer the caller can legitimately use
+///   while being told exactly what is missing.
+///
+/// So one refuses and one degrades, and both are honest about which they did.
+#[derive(Debug, Clone)]
+pub struct TemporalComposition {
+    answer: crate::compaction::TemporalAnswer,
+    identity: IdentityView,
+}
+
+impl TemporalComposition {
+    /// Build from halves read in one snapshot.
+    ///
+    /// `pub(crate)` so the only way a caller obtains one is
+    /// [`crate::WorldStore::as_of_composed`], which is what opens that snapshot.
+    /// A public constructor would let the two halves be assembled from separate
+    /// reads — the pairing this type exists to prevent.
+    pub(crate) fn new(answer: crate::compaction::TemporalAnswer, identity: IdentityView) -> Self {
+        Self { answer, identity }
+    }
+
+    /// The claims half, carrying its own completeness.
+    pub fn answer(&self) -> &crate::compaction::TemporalAnswer {
+        &self.answer
+    }
+
+    /// **The identity graph as it stood at the same `as_known_at` cut.**
+    ///
+    /// Adjudications recorded after that instant are absent — the transaction-
+    /// time form of the property box 3h established on the generation axis.
+    pub fn identity(&self) -> &IdentityView {
+        &self.identity
+    }
+
+    /// Consume into the two halves, for a caller that must own the answer.
+    pub fn into_parts(self) -> (crate::compaction::TemporalAnswer, IdentityView) {
+        (self.answer, self.identity)
+    }
+}
+
 /// The outcome of a generation-pinned read.
 ///
 /// A two-variant result rather than `Option` or a fallback, because the one

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -3194,8 +3194,95 @@ sharper reason than its siblings: it hands back a `ProjectedClaim` and an
 needed to compose an historical answer while bypassing the boundary. The
 convenience is what makes it worth gating.
 
-The honest scope bound: 3h is closed for the **generation-pinned** family.
-`ask_as_of` — the transaction-time family — still reports
-`ObjectIdentity::NotResolvedInReplay`. That is a scope decision rather than an
-impossibility (both `ask_as_of` and `identity_view_at` cut on transaction time,
-so the axes would agree), and it is the natural next slice.
+The honest scope bound at the time of writing: 3h was closed for the
+**generation-pinned** family only, with `ask_as_of` still reporting
+`ObjectIdentity::NotResolvedInReplay`.
+
+> **Closed 2026-08-11, immediately after** — see *"3h's other axis"* below.
+> The remainder was taken while the machinery was fresh rather than deferred,
+> on the reasoning that it is the same architectural problem on the other
+> temporal axis rather than a separate feature.
+
+### 3h's other axis: `ask_as_of` composes identity — 2026-08-11
+
+3h closed *"historical queries use historical identity, never today's entity
+graph applied to old evidence"* for the generation-pinned family and left
+`ask_as_of` reporting `NotResolvedInReplay`. That was honest, but it answered
+the same architectural question on one axis and left it open on the other.
+
+Taken immediately rather than deferred behind 3e, on the reasoning that this is
+**the same problem on the other temporal axis, not a separate feature** — and
+that the moment to close an inconsistency is while the machinery that closes it
+is fresh. Everything needed already existed: `ask_as_of` and `identity_view_at`
+both cut on transaction time, the composed-read pattern came from 3h, the
+version machinery from 3b, the one-snapshot rule from 3c.
+
+#### What was built, and what deliberately was not
+
+`WorldStore::as_of_composed` reads both halves inside one transaction. It lives
+on the store rather than on `ReadSnapshot` because its halves are store-level
+temporal queries rather than projection replays — so the existing `as_of` and
+`identity_view_at` are called **unchanged**, keeping one cut per axis with no
+second copy of the bitemporal filter and no second adjudication replay to drift
+from the original.
+
+Held to the stated scope: no new resolver (object resolution goes through the
+same `resolve_object` the live and pinned paths use), no valid-time
+interpretation of identity, no fallback to the current graph, and contradiction
+/ ambiguity outcomes propagate unchanged.
+
+#### The asymmetry between the two compositions, stated so it does not read as an oversight
+
+| | Generation-pinned | `as_of` |
+|---|---|---|
+| promises | exact reconstruction of a recorded coordinate | what was known then, from what remains |
+| on lost evidence | **refuses** (`Irreproducible`) | **degrades** (`Resolution`, already on the answer) |
+
+Refusing on the `as_of` path would discard an answer the caller can legitimately
+use while being told exactly what is missing; reconstructing a generation pin
+from a log with holes would be a reconstruction wearing the word "pinned". Both
+are honest about which they did.
+
+#### The version set, and a finding
+
+`QueryKind::AsOfSubject` joined, and `entity_fold` is in its set for the same
+reason it is in `CurrentSubject`'s. The two families turn out to depend on the
+**same three rules** — a finding rather than a coincidence: they differ in which
+COORDINATE they cut on, not in which rules produce the answer. They are still
+derived per-family, because *"identical today"* is not *"identical by
+construction"*: a temporal-resolution rule would belong to one and not the other,
+and a shared arm that has to be split later is one nobody remembers to split.
+
+`TemporalLookup` now carries that set, which spends a 3a exclusion. 3a said the
+envelope owns *"completeness, freshness, provenance and versions"* and then
+excluded versions because *"no reducer version exists to carry. Minting one here
+would be the decorative metadata 3b forbids; it lands with 3b's enforcement."*
+3b built the enforcement, so the field is no longer decorative.
+
+**Carried, not enforced** — and the docs say so. A recorded `AnswerRef` REFUSES
+on a version mismatch; a `TemporalLookup` states which rules produced it. There
+is no `as_of` ref to refuse yet, and implying otherwise would be the overclaim
+3b exists to prevent.
+
+#### Measured
+
+| Mutation | Caught by |
+|---|---|
+| fall back to today's identity graph | **5** tests, including the box's own assertion and the no-fallback arm |
+| cut identity at the claim's **valid** time instead of transaction time | the same 5 |
+| drop `entity_fold` from the family's version set | `an_as_of_answer_carries_the_familys_version_set` |
+
+The suite's controls: an arm asking the same query LATER (so an implementation
+that never resolved identity fails), an arm asserting the CLAIM is byte-identical
+across both cuts (so the pair cannot be satisfied by the bitemporal claim filter
+alone — only the resolution moves), and a re-assertion that 3g's completeness
+still rides on the answer, because this change rewrote the lines that carry it.
+
+`as_of_composed` joins the 3d answer-boundary ratchet for the same reason its
+generation-axis twin did: claims plus an identity view in one return value is
+everything a consumer needs to build an historical answer without the boundary.
+
+#### Where Tier 3 stands on this question
+
+Both temporal axes now use the same identity semantics. Historical composition
+is no longer a property of one query family.


### PR DESCRIPTION
## The inconsistency this closes

Box 3h (#1437) closed *"historical queries use historical identity, never today's entity graph applied to old evidence"* for the **generation-pinned** family, and left `ask_as_of` reporting `NotResolvedInReplay`. That was honest, but it answered the same architectural question on one axis and left it open on the other.

Taken now rather than after 3e because it is **the same problem on the other temporal axis, not a separate feature** — everything needed already existed: `ask_as_of` and `identity_view_at` both cut on transaction time, the composed-read pattern from 3h, the version machinery from 3b, the one-snapshot rule from 3c.

The failure mode is identical to 3h's: replay the claims as they were known at `T`, then resolve the object they name against today's graph. Every field is correct except the one that quietly is not.

## What landed

`WorldStore::as_of_composed` reads both halves inside one transaction.

It lives on the store rather than on `ReadSnapshot` because its halves are store-level temporal queries rather than projection replays — so `as_of` and `identity_view_at` are called **unchanged**. That keeps one cut per axis: no second copy of the bitemporal filter, and no second adjudication replay to drift from the original.

That pairing previously ran **outside any snapshot**, because only one of the two reads existed. It is now inside one, which is box 3c's rule.

## Held to the stated scope

| Constraint | How |
|---|---|
| resolves through `identity_view_at` at the same cut | `as_of_composed` passes `as_known_at_ms` to both halves |
| no new resolver | goes through the same `WorldView::resolve_object` the live and pinned paths use |
| no valid-time interpretation | adjudications are cut on transaction time only — that is the axis they carry |
| no fallback to current identity | pinned by `a_cut_before_any_adjudication_does_not_borrow_todays_graph` |
| contradiction/refusal semantics unchanged | split → `Ambiguous { successors }`, and `matchable()` fails closed |
| `entity_fold` in the family's version set | `QueryKind::AsOfSubject`, asserted |

## The asymmetry between the two compositions

Stated in the docs so it does not read as an oversight — two composed reads with different failure shapes otherwise look like one of them was forgotten:

| | Generation-pinned | `as_of` |
|---|---|---|
| promises | exact reconstruction of a recorded coordinate | what was known then, from what remains |
| on lost evidence | **refuses** (`Irreproducible`) | **degrades** (`Resolution`, already on the answer) |

Refusing on the `as_of` path would discard an answer the caller can legitimately use while being told exactly what is missing. Reconstructing a generation pin from a log with holes would be a reconstruction wearing the word "pinned". Both are honest about which they did.

## A finding, and a 3a exclusion spent

The two families turn out to depend on the **same three rules**. That is a finding rather than a coincidence: they differ in which *coordinate* they cut on, not in which rules produce the answer. They are still derived per-family, because *"identical today"* is not *"identical by construction"* — a temporal-resolution rule would belong to one and not the other, and a shared arm that has to be split later is one nobody remembers to split.

`TemporalLookup` now carries that set. Box 3a said the envelope owns *"completeness, freshness, provenance and versions"* and then excluded versions with a reason:

> **Version** — no reducer version exists to carry. Minting one here would be the decorative metadata 3b forbids; it lands with 3b's enforcement.

3b built that enforcement, so the field is no longer decorative and the exclusion is spent.

**Carried, not enforced** — and the docs say so. A recorded `AnswerRef` *refuses* on a version mismatch; a `TemporalLookup` *states* which rules produced it. There is no `as_of` ref to refuse yet, and implying otherwise would be exactly the overclaim 3b exists to prevent.

## Mutation-measured

| Mutation | Caught by |
|---|---|
| fall back to today's identity graph | **5** tests, including the box's own assertion and the no-fallback arm |
| cut identity at the claim's **valid** time instead of transaction time | the same 5 |
| drop `entity_fold` from the family's version set | `an_as_of_answer_carries_the_familys_version_set` |

Controls, because each arm is worthless alone:

- `the_same_query_asked_later_follows_the_merge` — otherwise an implementation that never resolved identity passes.
- `the_claim_is_the_same_in_both_arms_only_its_object_resolution_moves` — the claim is byte-identical across both cuts (the stored object string is `dock_alpha` in both), so the pair **cannot** be satisfied by the bitemporal claim filter alone. Only the resolution moves.
- `completeness_still_rides_on_the_answer` — this change rewrote the lines that carry 3g's guarantee, so it is re-asserted rather than assumed.

## Fixture

```text
txn T0     assert dock_alpha
txn T0+1   claim  package_17 -> dock_alpha
           ---- as_known_at = T0+1 ----
txn T0+2   assert dock_beta
txn T0+3   merge  dock_alpha -> dock_beta
```

At `T0+1` → `Resolved { entity: "dock_alpha", hops: 0 }`. At `T0+10` → `Resolved { entity: "dock_beta", hops: 1 }`.

## Ratchet

`as_of_composed` joins the 3d answer-boundary gate for the same reason its generation-axis twin did: claims plus an identity view in one return value is everything a consumer needs to build an historical answer without the boundary.

## Verification

`cargo fmt --check` clean; clippy clean on both crates; **333 tests green** across `kirra-world-store` + `kirra-world-service`; the world gates all pass (`check_world_semantics`, `check_world_answer_boundary` + its 12 self-tests, the bidirectional fence, the domain-logic gate, `check_proposal_context_symbolic`).

## Where Tier 3 stands

Both temporal axes now use the same identity semantics. Historical composition is no longer a property of one query family — which is the cleaner base for tightening freshness in 3e.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_