### PR TITLE
Tier 3 box 3e: freshness is ruled, and Timeless must be granted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1675,6 +1675,26 @@ jobs:
         run: |
           python3 ci/check_world_semantics.py --self-test
           python3 ci/check_world_semantics.py
+      - name: Kirra World freshness-coverage gate (Tier 3 box 3e)
+        # THE RULE (KIRRA-WM-FRESHNESS-POLICY-001): freshness semantics are
+        # centrally ruled by claim kind. Timeless must be explicitly granted,
+        # bounded facts require an explicit age limit, and unclassified
+        # semantics REFUSE.
+        #
+        # The refusal is enforced at runtime and is fail-closed, so nothing
+        # unsafe happens when a class is missing. This gate exists for the other
+        # failure, which is silent: the table starts correct and quietly becomes
+        # incomplete as new claim kinds land, and the refusal is discovered by
+        # whoever is holding the pager.
+        #
+        # So every (kind, predicate) the repository WRITES must be either ruled
+        # or listed as knowingly unruled. The baseline is not an escape hatch --
+        # an entry there is a decision that the class refuses, deliberately.
+        #
+        # Self-test first, and it asserts its own case count.
+        run: |
+          python3 ci/check_freshness_coverage.py --self-test
+          python3 ci/check_freshness_coverage.py
       - name: Kirra World domain-logic gate (ADR-0042 Decision 5)
         # THE RULE: no Kirra World domain implementation may merge until
         # ADR-0042's safety-assurance scope ruling is assigned to a named owner

--- a/ci/check_freshness_coverage.py
+++ b/ci/check_freshness_coverage.py
@@ -42,6 +42,9 @@ _KIND = re.compile(r'\bkind:\s*"([^"]*)"')
 _KIND_VAR = re.compile(r"\bkind\s*,")
 _PRED_SOME = re.compile(r'\bpredicate:\s*Some\("([^"]*)"\)')
 _PRED_NONE = re.compile(r"\bpredicate:\s*None\b")
+# Any `predicate:` field at all, so a form neither literal pattern matches is
+# REPORTED rather than mistaken for "this event has no predicate".
+_PRED_ANY = re.compile(r"\bpredicate:")
 
 # One row of the RULED table.
 _RULED_ROW = re.compile(
@@ -92,17 +95,34 @@ def written_classes(sources: dict[str, str]) -> set[tuple[str, str | None]]:
     return found
 
 
-def dynamic_event_sites(sources: dict[str, str]) -> list[str]:
-    """Files whose `NewEvent` literals take `kind` from a variable.
+def opaque_event_sites(sources: dict[str, str]) -> list[str]:
+    """Files whose `NewEvent` literals this gate cannot read a class out of.
 
-    Reported rather than ignored. This gate reads literals, so a variable
-    `kind` is a class it cannot see — and a gate that quietly skipped them
+    Reported rather than ignored. This gate reads LITERALS, so a class built
+    from variables is one it cannot see — and a gate that quietly skipped them
     would advertise coverage it does not have.
+
+    # Both halves, and the first draft checked only one
+
+    It looked at `kind` alone, which left `predicate: Some(p)` — a variable
+    predicate beside a literal kind — silently invisible. That is precisely the
+    failure this function's own docstring claims to prevent, so it was the worst
+    possible place for the omission. Caught in review on #1439.
+
+    The test is now "did a literal come out for BOTH halves", which is the
+    question that actually matters: either half being dynamic hides the class.
     """
     out = []
     for name, text in sources.items():
         for m in _EVENT.finditer(text):
-            if not _KIND.search(m.group(1)) and _KIND_VAR.search(m.group(1)):
+            body = m.group(1)
+            kind_opaque = not _KIND.search(body) and _KIND_VAR.search(body)
+            predicate_opaque = (
+                _PRED_ANY.search(body)
+                and not _PRED_SOME.search(body)
+                and not _PRED_NONE.search(body)
+            )
+            if kind_opaque or predicate_opaque:
                 out.append(name)
                 break
     return sorted(out)
@@ -160,17 +180,17 @@ def main() -> int:
             print(f"  - {p}\n", file=sys.stderr)
         return 1
 
-    dynamic = dynamic_event_sites(sources)
+    opaque = opaque_event_sites(sources)
     print(
         f"OK: {len(written)} written class(es); "
         f"{len(ruled)} ruled, {len(baselined)} knowingly unruled"
     )
-    if dynamic:
+    if opaque:
         print(
-            "  note: these files build `NewEvent` with a non-literal `kind`, "
-            "so their classes are not visible to this gate:"
+            "  note: these files build `NewEvent` with a non-literal `kind` or "
+            "`predicate`, so their classes are not visible to this gate:"
         )
-        for d in dynamic:
+        for d in opaque:
             print(f"    {d}")
     return 0
 
@@ -250,13 +270,26 @@ def _self_test() -> int:
         })
         '''
         assert written_classes({"d.rs": src}) == set(), "a variable kind was invented"
-        assert dynamic_event_sites({"d.rs": src}) == ["d.rs"]
+        assert opaque_event_sites({"d.rs": src}) == ["d.rs"]
+
+    def t_a_dynamic_PREDICATE_is_reported_too():
+        # The hole the first draft had: a literal kind beside a VARIABLE
+        # predicate produced no class and was reported as fully covered.
+        src = 'store.append(&NewEvent {\n  kind: "mission",\n  predicate: Some(predicate),\n})'
+        assert written_classes({"d.rs": src}) == set(), "a variable predicate was invented"
+        assert opaque_event_sites({"d.rs": src}) == ["d.rs"], (
+            "a variable predicate beside a literal kind was silently skipped — "
+            "the gate would advertise coverage it does not have"
+        )
+
+    def t_a_fully_literal_event_is_not_reported_as_opaque():
+        assert opaque_event_sites({"a.rs": EVENT_SRC}) == []
 
     cases = [(n, f) for n, f in sorted(locals().items()) if n.startswith("t_") and callable(f)]
     for name, fn in cases:
         case(name, fn)
 
-    expected = 9
+    expected = 11
     if len(cases) != expected:
         print(
             f"SELF-TEST HARNESS: discovered {len(cases)} cases, expected {expected}.",

--- a/ci/check_freshness_coverage.py
+++ b/ci/check_freshness_coverage.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""**Freshness-coverage gate — Tier 3 box 3e.**
+
+`KIRRA-WM-FRESHNESS-POLICY-001` says unclassified semantics refuse. That is
+enforced at runtime and is fail-closed, so nothing unsafe happens when a class
+is missing — the query refuses.
+
+This gate exists for the *other* failure, which is silent: **the table starts
+correct and quietly becomes incomplete.** Somebody adds a recency-sensitive
+predicate, never rules it, and the refusal is discovered by whoever is holding
+the pager. Nothing in the type system connects "a new claim kind was written" to
+"its freshness disposition was decided".
+
+So: every `(kind, predicate)` this repository actually WRITES must be either
+
+* ruled in `crates/kirra-world-service/src/freshness.rs`'s `RULED` table, or
+* listed in `ci/freshness_unruled_baseline.json` as deliberately unruled.
+
+A new pair in neither reds. The baseline is not an escape hatch — it is where a
+class says *"this is knowingly unruled and therefore knowingly refuses"*, which
+is a decision somebody made rather than one nobody noticed.
+
+Self-tests: `python3 ci/check_freshness_coverage.py --self-test`.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+POLICY = REPO / "crates/kirra-world-service/src/freshness.rs"
+BASELINE = REPO / "ci/freshness_unruled_baseline.json"
+
+# A `NewEvent { … }` literal, non-greedy to the closing brace of the literal.
+# Both fields are read from the SAME literal so a `kind` from one event cannot
+# be paired with a `predicate` from another.
+_EVENT = re.compile(r"NewEvent\s*\{(.*?)\n\s*\}", re.S)
+_KIND = re.compile(r'\bkind:\s*"([^"]*)"')
+_KIND_VAR = re.compile(r"\bkind\s*,")
+_PRED_SOME = re.compile(r'\bpredicate:\s*Some\("([^"]*)"\)')
+_PRED_NONE = re.compile(r"\bpredicate:\s*None\b")
+
+# One row of the RULED table.
+_RULED_ROW = re.compile(
+    r'SemanticClass\s*\{\s*kind:\s*"([^"]*)"\s*,\s*'
+    r'predicate:\s*(?:Some\("([^"]*)"\)|None)\s*,?\s*\}',
+    re.S,
+)
+
+
+class GateError(Exception):
+    """A violation worth failing CI over."""
+
+
+def ruled_classes(text: str) -> set[tuple[str, str | None]]:
+    """The `(kind, predicate)` pairs the RULED table holds.
+
+    Refuses an empty parse: a gate that reads zero rulings would report every
+    class as unruled, which is noise rather than a signal — and the fix someone
+    reaches for under deadline is to delete the gate.
+    """
+    rows = {(m.group(1), m.group(2)) for m in _RULED_ROW.finditer(text)}
+    if not rows:
+        raise GateError(
+            f"{POLICY.name}: parsed ZERO ruled classes. Either the table was "
+            "emptied, or its formatting changed in a way this gate cannot "
+            "follow. Both are failures; neither is a pass."
+        )
+    return rows
+
+
+def written_classes(sources: dict[str, str]) -> set[tuple[str, str | None]]:
+    """Every `(kind, predicate)` this repository writes.
+
+    A `kind` supplied by a variable rather than a literal is skipped and
+    reported by the caller, not silently treated as covered — see `main`.
+    """
+    found: set[tuple[str, str | None]] = set()
+    for text in sources.values():
+        for m in _EVENT.finditer(text):
+            body = m.group(1)
+            kind_m = _KIND.search(body)
+            if not kind_m:
+                continue
+            if _PRED_SOME.search(body):
+                found.add((kind_m.group(1), _PRED_SOME.search(body).group(1)))
+            elif _PRED_NONE.search(body):
+                found.add((kind_m.group(1), None))
+    return found
+
+
+def dynamic_event_sites(sources: dict[str, str]) -> list[str]:
+    """Files whose `NewEvent` literals take `kind` from a variable.
+
+    Reported rather than ignored. This gate reads literals, so a variable
+    `kind` is a class it cannot see — and a gate that quietly skipped them
+    would advertise coverage it does not have.
+    """
+    out = []
+    for name, text in sources.items():
+        for m in _EVENT.finditer(text):
+            if not _KIND.search(m.group(1)) and _KIND_VAR.search(m.group(1)):
+                out.append(name)
+                break
+    return sorted(out)
+
+
+def check(
+    ruled: set[tuple[str, str | None]],
+    written: set[tuple[str, str | None]],
+    baselined: set[tuple[str, str | None]],
+) -> list[str]:
+    """Violations, most actionable first."""
+    problems = []
+    for kind, pred in sorted(written - ruled - baselined, key=lambda c: (c[0], c[1] or "")):
+        problems.append(
+            f"({kind}, {pred!r}) is written by this repository but has no "
+            f"freshness disposition.\n"
+            f"    Rule it in `RULED` (Timeless or Bounded, with the reasoning), "
+            f"or add it to {BASELINE.name} as knowingly unruled — in which case "
+            f"queries for it REFUSE, deliberately."
+        )
+    for kind, pred in sorted(baselined & ruled, key=lambda c: (c[0], c[1] or "")):
+        problems.append(
+            f"({kind}, {pred!r}) is BOTH ruled and baselined as unruled. The "
+            f"baseline entry is stale — remove it, or the record disagrees with "
+            f"the table about whether this class was decided."
+        )
+    for kind, pred in sorted(baselined - written, key=lambda c: (c[0], c[1] or "")):
+        problems.append(
+            f"({kind}, {pred!r}) is baselined as unruled but nothing writes it. "
+            f"Remove the entry; a baseline listing classes that do not exist "
+            f"grows until nobody reads it."
+        )
+    return problems
+
+
+def main() -> int:
+    sources = {
+        str(p.relative_to(REPO)): p.read_text(encoding="utf-8")
+        for p in (REPO / "crates").rglob("*.rs")
+    }
+    try:
+        ruled = ruled_classes(POLICY.read_text(encoding="utf-8"))
+    except GateError as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 1
+
+    baseline = json.loads(BASELINE.read_text(encoding="utf-8"))
+    baselined = {(e["kind"], e["predicate"]) for e in baseline["unruled"]}
+    written = written_classes(sources)
+
+    problems = check(ruled, written, baselined)
+    if problems:
+        print("FAIL: freshness-coverage gate\n", file=sys.stderr)
+        for p in problems:
+            print(f"  - {p}\n", file=sys.stderr)
+        return 1
+
+    dynamic = dynamic_event_sites(sources)
+    print(
+        f"OK: {len(written)} written class(es); "
+        f"{len(ruled)} ruled, {len(baselined)} knowingly unruled"
+    )
+    if dynamic:
+        print(
+            "  note: these files build `NewEvent` with a non-literal `kind`, "
+            "so their classes are not visible to this gate:"
+        )
+        for d in dynamic:
+            print(f"    {d}")
+    return 0
+
+
+def _self_test() -> int:
+    failures = []
+
+    def case(name, fn):
+        try:
+            fn()
+        except AssertionError as exc:
+            failures.append(f"{name}: {exc}")
+
+    RULED_SRC = '''
+    pub const RULED: &[(SemanticClass, FreshnessPolicy)] = &[
+        (SemanticClass { kind: "mission", predicate: Some("last_seen_at") },
+         FreshnessPolicy::Bounded { max_age_ms: 1 }),
+        (SemanticClass { kind: "observation", predicate: None },
+         FreshnessPolicy::Timeless),
+    ];
+    '''
+
+    EVENT_SRC = '''
+    store.append(&NewEvent {
+        event_id: &e,
+        kind: "mission",
+        subject: "s",
+        predicate: Some("last_seen_at"),
+        object: None,
+    })
+    '''
+
+    def t_ruled_rows_are_parsed_including_the_none_predicate():
+        got = ruled_classes(RULED_SRC)
+        assert got == {("mission", "last_seen_at"), ("observation", None)}, got
+
+    def t_an_empty_ruled_table_is_an_error():
+        try:
+            ruled_classes("pub const RULED: &[(SemanticClass, FreshnessPolicy)] = &[];")
+        except GateError:
+            return
+        raise AssertionError("an empty table passed")
+
+    def t_written_classes_are_found():
+        assert written_classes({"a.rs": EVENT_SRC}) == {("mission", "last_seen_at")}
+
+    def t_kind_and_predicate_come_from_the_SAME_literal():
+        # Two events; pairing across them would invent ("mission", "colour").
+        src = EVENT_SRC + '''
+        store.append(&NewEvent {
+            kind: "observation",
+            predicate: Some("colour"),
+        })
+        '''
+        got = written_classes({"a.rs": src})
+        assert got == {("mission", "last_seen_at"), ("observation", "colour")}, got
+
+    def t_an_unruled_written_class_fails():
+        problems = check({("mission", "last_seen_at")}, {("mission", "invented")}, set())
+        assert problems and "no freshness disposition" in problems[0]
+
+    def t_a_baselined_class_passes():
+        assert check(set(), {("m", "p")}, {("m", "p")}) == []
+
+    def t_a_class_both_ruled_and_baselined_fails():
+        assert check({("m", "p")}, {("m", "p")}, {("m", "p")})
+
+    def t_a_baseline_entry_nothing_writes_fails():
+        assert check({("m", "p")}, {("m", "p")}, {("x", "y")})
+
+    def t_a_dynamic_kind_is_reported_not_silently_covered():
+        src = '''
+        store.append(&NewEvent {
+            event_id: &e,
+            kind,
+            predicate: Some("p"),
+        })
+        '''
+        assert written_classes({"d.rs": src}) == set(), "a variable kind was invented"
+        assert dynamic_event_sites({"d.rs": src}) == ["d.rs"]
+
+    cases = [(n, f) for n, f in sorted(locals().items()) if n.startswith("t_") and callable(f)]
+    for name, fn in cases:
+        case(name, fn)
+
+    expected = 9
+    if len(cases) != expected:
+        print(
+            f"SELF-TEST HARNESS: discovered {len(cases)} cases, expected {expected}.",
+            file=sys.stderr,
+        )
+        return 1
+    if failures:
+        print("SELF-TEST FAILURES:", file=sys.stderr)
+        for f in failures:
+            print(f"  - {f}", file=sys.stderr)
+        return 1
+    print(f"self-tests OK ({len(cases)} cases)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_self_test() if "--self-test" in sys.argv else main())

--- a/ci/freshness_unruled_baseline.json
+++ b/ci/freshness_unruled_baseline.json
@@ -1,0 +1,34 @@
+{
+  "_comment": [
+    "Tier 3 box 3e. Semantic classes this repository writes that are KNOWINGLY",
+    "unruled: they have no freshness disposition, so `FreshnessSource::Ruled`",
+    "queries for them REFUSE (KIRRA-WM-FRESHNESS-POLICY-001).",
+    "",
+    "This is not an escape hatch. An entry here is a decision that the class has",
+    "not been ruled and therefore does not answer -- which is the safe direction.",
+    "The alternative the gate exists to prevent is a class landing with NO record",
+    "either way, where the refusal is discovered in production.",
+    "",
+    "Every entry below is a TEST FIXTURE class. None is domain semantics anyone",
+    "has ruled on, and inventing dispositions for them would be exactly the",
+    "decorative metadata this tier keeps removing: rows nobody decided, read as",
+    "though somebody had. They move into `RULED` when the domain rules them."
+  ],
+  "unruled": [
+    {
+      "kind": "observation",
+      "predicate": null,
+      "why": "A payload-only observation. `KIRRA-WM-CLAIM-SHAPES-001` makes this a legitimate shape, but what an untyped payload MEANS temporally cannot be ruled in general -- it depends on what the payload carries, which is precisely the thing no key can see."
+    },
+    {
+      "kind": "observation",
+      "predicate": "at",
+      "why": "A fixture predicate used by the store's own projection tests. Plausibly a position -- and if it is, it is recency-sensitive -- but 'plausibly' is not a ruling."
+    },
+    {
+      "kind": "spatial",
+      "predicate": "located_in",
+      "why": "A containment relation from the SD-4 frame fixtures. Whether containment ages depends on whether the container moves, which the class alone does not say."
+    }
+  ]
+}

--- a/crates/kirra-proposal-context/src/lib.rs
+++ b/crates/kirra-proposal-context/src/lib.rs
@@ -58,6 +58,7 @@
 
 use kirra_world::resolution::RefusalReason;
 use kirra_world::trust::{TrustGrade, Validity};
+use kirra_world_service::freshness::{FreshnessPolicy, FreshnessSource};
 use kirra_world_service::read_view::{
     AskError, ObjectIdentity, UnknownReason, WorldLookup, WorldView,
 };
@@ -432,7 +433,18 @@ pub fn mission_context(
     now_ms: i64,
     staleness_budget_ms: Option<u64>,
 ) -> Result<ProposalContext, ContextError> {
-    let view = WorldView::new(store, staleness_budget_ms);
+    // 3e: the caller's `Option` becomes an AFFIRMATIVE classification rather
+    // than an absence. `Some(b)` is `Bounded`, and `None` is `Timeless` — which
+    // is what this signature already meant ("I have considered this and this
+    // fact is genuinely timeless"), now said in a type where the alternative
+    // reading is unrepresentable.
+    let view = WorldView::new(
+        store,
+        FreshnessSource::Caller(match staleness_budget_ms {
+            Some(max_age_ms) => FreshnessPolicy::Bounded { max_age_ms },
+            None => FreshnessPolicy::Timeless,
+        }),
+    );
 
     let answers = match view.ask(subject.as_str(), now_ms)?.into_lookup() {
         WorldLookup::Answered(answers) => answers,

--- a/crates/kirra-world-service/src/freshness.rs
+++ b/crates/kirra-world-service/src/freshness.rs
@@ -1,0 +1,321 @@
+//! **Ruled freshness policy — Tier 3 box 3e.**
+//!
+//! `KIRRA-WM-FRESHNESS-POLICY-001`:
+//!
+//! > **Freshness semantics are centrally ruled by claim kind. `Timeless` must be
+//! > explicitly granted. Bounded facts require an explicit age limit.
+//! > Unclassified semantics refuse.**
+//!
+//! And the invariant that follows from it, which is the whole point:
+//!
+//! > **`Timeless` is an affirmative semantic classification, never the absence
+//! > of a freshness policy.**
+//!
+//! # The defect this closes, which was live and documented
+//!
+//! `validity_at` maps `staleness_budget_ms: None` to [`Validity::Timeless`], and
+//! `WorldView` accepted `None` from anyone. `WM_SCOPE.md`'s own FINDING 2
+//! recorded what that meant in practice:
+//!
+//! > *"Where was the package last seen" is about as recency-sensitive as this
+//! > domain gets, so a year-old observation is currently served with the same
+//! > standing as a fresh one, under a label asserting that is fine.*
+//!
+//! `Timeless` is not "we did not check". It is a **positive claim that the
+//! fact's age does not matter**. Serving it by default meant the engine asserted
+//! that claim about every fact in the store, including the ones for which it is
+//! false, and nobody had to decide anything for that to happen.
+//!
+//! # Why a ruled table rather than a caller flag
+//!
+//! Letting the caller declare a query recency-sensitive only moves the trust
+//! decision outward: a careless caller says "insensitive" and manufactures
+//! `Timeless` exactly as the engine did. The API would be satisfied and the
+//! architectural rule defeated. So the disposition is **ruled centrally**, in
+//! one reviewable place, keyed by semantics.
+//!
+//! # Keyed by SEMANTICS, not by storage representation
+//!
+//! [`SemanticClass`] is `(kind, predicate)`. `last_seen_at` and a floor plan can
+//! both be perfectly valid confirmed claims with the same storage shape and
+//! fundamentally different temporal meaning — so the key has to be the thing
+//! that distinguishes them, which is what they MEAN. `kind` is carried as well
+//! as `predicate` because two kinds may legitimately share a predicate name, and
+//! a table that collided them would rule one of them by accident.
+//!
+//! # The state machine, and why there is no `Unknown` freshness
+//!
+//! ```text
+//! policy = Timeless                  -> Validity::Timeless
+//! policy = Bounded, age <= bound     -> Validity::Fresh
+//! policy = Bounded, age  > bound     -> Validity::Stale
+//! no policy                          -> the QUERY refuses
+//! ```
+//!
+//! There is no successful answer for which freshness is unknown. A missing
+//! policy is a **policy-resolution failure**, not a freshness state — so it
+//! travels in the error channel, and a fourth `Validity::Unknown` variant would
+//! be uninhabited. `WM_SCOPE.md` asked this question directly and said to decide
+//! it by finding a reachable case or leaving it out; there is none, so it is
+//! left out. If one is ever found — a claim whose age genuinely cannot be
+//! determined, say from missing time provenance — the variant becomes justified
+//! **then**, established by a reachable test rather than reserved speculatively.
+//!
+//! [`Validity::Timeless`]: kirra_world_store::Validity::Timeless
+
+use crate::read_view::AskError;
+
+/// **What a claim's age MEANS.**
+///
+/// Two variants and no third, because there are only two honest answers to
+/// *"does this fact's age bear on whether it is usable"*. The absence of an
+/// answer is not a third variant — it is a refusal, and it lives in
+/// [`AskError::UnclassifiedFreshness`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FreshnessPolicy {
+    /// Age is semantically irrelevant to this class.
+    ///
+    /// An **affirmative grant**. Reaching this variant means somebody ruled that
+    /// a year-old instance of this fact is as good as a fresh one.
+    Timeless,
+    /// Age matters, and this is the limit past which the fact is `Stale`.
+    Bounded {
+        /// Milliseconds after `valid_from` at which the fact stops being fresh.
+        max_age_ms: u64,
+    },
+}
+
+impl FreshnessPolicy {
+    /// The staleness budget this policy supplies to the read-time computation.
+    ///
+    /// The one place a policy becomes the `Option<u64>` that
+    /// `kirra_world::trust::validity_at` consumes. `None` still means "timeless"
+    /// *there* — what changed is that it can now only arise from an explicit
+    /// [`Self::Timeless`] grant, never from a caller who supplied nothing.
+    #[must_use]
+    pub fn budget(self) -> Option<u64> {
+        match self {
+            Self::Timeless => None,
+            Self::Bounded { max_age_ms } => Some(max_age_ms),
+        }
+    }
+}
+
+/// The semantic identity of a claim, for freshness purposes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SemanticClass {
+    /// The claim kind.
+    pub kind: &'static str,
+    /// The predicate, or `None` for a payload-only claim.
+    pub predicate: Option<&'static str>,
+}
+
+/// **The ruled table.** Every semantic class this build serves, with its
+/// disposition and the reason for it.
+///
+/// # These are rulings, and they are meant to be argued with
+///
+/// Each row is a decision about what a fact MEANS, not a technical fact about
+/// the data, so each carries its reasoning. A row nobody can defend should be
+/// removed — and removing it makes that class refuse, which is the safe
+/// direction.
+///
+/// The table is deliberately **small**. A large speculative table would be the
+/// decorative-metadata failure in another costume: entries nobody ruled, read as
+/// though somebody had. Everything absent refuses, so the table can grow one
+/// argued row at a time without any interim being unsafe.
+pub const RULED: &[(SemanticClass, FreshnessPolicy)] = &[
+    // `WM_SCOPE.md` FINDING 2, verbatim: "'Where was the package last seen' is
+    // about as recency-sensitive as this domain gets, so a year-old observation
+    // is currently served with the same standing as a fresh one, under a label
+    // asserting that is fine." That finding is what this box exists to close, so
+    // this row is the one the box was written for.
+    //
+    // Five minutes: a located package that has not been re-observed in five
+    // minutes is a package whose location is a guess. The number is a ruling,
+    // not a measurement — which is why it is HERE, in one reviewable place,
+    // rather than inside a query.
+    (
+        SemanticClass {
+            kind: "mission",
+            predicate: Some("last_seen_at"),
+        },
+        FreshnessPolicy::Bounded {
+            max_age_ms: 5 * 60 * 1_000,
+        },
+    ),
+    // A position is the canonical recency-sensitive fact: it is a statement
+    // about where something WAS, and everything that makes it useful decays.
+    (
+        SemanticClass {
+            kind: "observation",
+            predicate: Some("position"),
+        },
+        FreshnessPolicy::Bounded {
+            max_age_ms: 30 * 1_000,
+        },
+    ),
+    // An affirmative Timeless grant, and the argument for it: colour is a
+    // property OF the object rather than a relationship between the object and
+    // a moment. A year-old colour observation is not a stale fact, it is the
+    // same fact observed a while ago — so ageing it would refuse valid answers
+    // and buy no safety.
+    (
+        SemanticClass {
+            kind: "observation",
+            predicate: Some("colour"),
+        },
+        FreshnessPolicy::Timeless,
+    ),
+];
+
+/// The ruled disposition for a semantic class, if one exists.
+///
+/// `None` is not a default — it is the input to a refusal. See
+/// [`resolve_policy`].
+#[must_use]
+pub fn ruled_policy(kind: &str, predicate: Option<&str>) -> Option<FreshnessPolicy> {
+    RULED
+        .iter()
+        .find(|(class, _)| class.kind == kind && class.predicate == predicate)
+        .map(|(_, policy)| *policy)
+}
+
+/// **Where a view's freshness dispositions come from.**
+///
+/// There is no variant meaning *"nothing supplied"*, which is the point: the
+/// type makes the old `None` unrepresentable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FreshnessSource {
+    /// The ruled table decides, per claim, by semantic class. Unclassified
+    /// semantics refuse.
+    Ruled,
+    /// **The caller classifies every claim in this view**, taking
+    /// responsibility for the judgement the table would otherwise make.
+    ///
+    /// Retained deliberately rather than removed. `mission_context` already
+    /// forces its caller to decide and documents `None` as *"I have considered
+    /// this and this fact is genuinely timeless"* — an affirmative act, which is
+    /// exactly what this variant carries. It is strictly safer than the global
+    /// default it replaces, because the classification is now a value someone
+    /// wrote rather than a branch nobody took.
+    ///
+    /// It is also the honest interim while [`RULED`] is small: a consumer whose
+    /// semantics have not been ruled yet can still ask, provided it says what it
+    /// believes and is greppable for having said it.
+    Caller(FreshnessPolicy),
+}
+
+/// **Resolve the policy for one claim, or refuse.**
+///
+/// # Errors
+///
+/// [`AskError::UnclassifiedFreshness`] when the source is [`FreshnessSource::Ruled`]
+/// and the class has no row. Fail-closed: not `Timeless`, not an infinite
+/// budget, and not a hidden default.
+pub fn resolve_policy(
+    source: FreshnessSource,
+    kind: &str,
+    predicate: Option<&str>,
+) -> Result<FreshnessPolicy, AskError> {
+    match source {
+        FreshnessSource::Caller(policy) => Ok(policy),
+        FreshnessSource::Ruled => {
+            ruled_policy(kind, predicate).ok_or_else(|| AskError::UnclassifiedFreshness {
+                kind: kind.to_string(),
+                predicate: predicate.map(str::to_string),
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn timeless_supplies_no_budget_and_bounded_supplies_its_limit() {
+        assert_eq!(FreshnessPolicy::Timeless.budget(), None);
+        assert_eq!(FreshnessPolicy::Bounded { max_age_ms: 7 }.budget(), Some(7));
+    }
+
+    /// The load-bearing direction: an unclassified class REFUSES rather than
+    /// falling back to the permissive reading.
+    #[test]
+    fn an_unclassified_class_refuses_under_the_ruled_source() {
+        let err = resolve_policy(FreshnessSource::Ruled, "mission", Some("invented"))
+            .expect_err("an unruled class must refuse");
+        match err {
+            AskError::UnclassifiedFreshness { kind, predicate } => {
+                assert_eq!(kind, "mission");
+                assert_eq!(predicate.as_deref(), Some("invented"));
+            }
+            other => panic!("wrong refusal: {other:?}"),
+        }
+    }
+
+    /// A payload-only claim is a distinct class, not a wildcard.
+    #[test]
+    fn a_predicate_less_claim_is_its_own_class_and_is_unruled_today() {
+        assert!(ruled_policy("observation", None).is_none());
+        assert!(resolve_policy(FreshnessSource::Ruled, "observation", None).is_err());
+    }
+
+    /// Two kinds sharing a predicate name must not collide — the reason `kind`
+    /// is in the key at all.
+    #[test]
+    fn the_key_is_kind_and_predicate_together() {
+        assert!(ruled_policy("observation", Some("colour")).is_some());
+        assert!(
+            ruled_policy("mission", Some("colour")).is_none(),
+            "a ruling for one kind must not silently rule another"
+        );
+    }
+
+    /// The caller source never consults the table — that is what makes it an
+    /// override rather than a fallback.
+    #[test]
+    fn the_caller_source_answers_for_classes_the_table_does_not_hold() {
+        assert_eq!(
+            resolve_policy(
+                FreshnessSource::Caller(FreshnessPolicy::Timeless),
+                "anything",
+                Some("unruled"),
+            )
+            .expect("the caller classified it"),
+            FreshnessPolicy::Timeless,
+        );
+    }
+
+    /// Every ruled row must be reachable by its own key, and no class may be
+    /// ruled twice — a duplicate would make the table's meaning depend on order.
+    #[test]
+    fn the_table_is_well_formed() {
+        for (class, expected) in RULED {
+            assert_eq!(
+                ruled_policy(class.kind, class.predicate),
+                Some(*expected),
+                "{class:?} is not reachable by its own key"
+            );
+        }
+        let mut seen: Vec<&SemanticClass> = Vec::new();
+        for (class, _) in RULED {
+            assert!(
+                !seen.contains(&class),
+                "{class:?} is ruled twice; the table's meaning would depend on order"
+            );
+            seen.push(class);
+        }
+    }
+
+    /// A `Bounded` row with a zero limit would make every instance stale the
+    /// instant it became valid — almost certainly a typo rather than a ruling.
+    #[test]
+    fn no_bounded_row_has_a_zero_limit() {
+        for (class, policy) in RULED {
+            if let FreshnessPolicy::Bounded { max_age_ms } = policy {
+                assert!(*max_age_ms > 0, "{class:?} is bounded at zero");
+            }
+        }
+    }
+}

--- a/crates/kirra-world-service/src/lib.rs
+++ b/crates/kirra-world-service/src/lib.rs
@@ -31,6 +31,7 @@
 #![warn(missing_docs)]
 
 pub mod answer_ref;
+pub mod freshness;
 pub mod read_view;
 pub mod semantics;
 

--- a/crates/kirra-world-service/src/read_view.rs
+++ b/crates/kirra-world-service/src/read_view.rs
@@ -573,15 +573,27 @@ impl<'a> WorldView<'a> {
         let clock = now_ms.max(0).unsigned_abs();
         let mut answers: Vec<WorldAnswer> = Vec::new();
         for c in claims.iter() {
+            // ONE resolution per claim, used by both the admissibility test and
+            // the binding. Resolving twice was not merely wasteful: it made the
+            // fail-closed rule depend on two lookups agreeing, when the whole
+            // point of `policy_for` is that there is one place to refuse.
+            //
             // `?`, NOT a swallowed refusal. A first draft filtered with
             // `.unwrap_or(false)`, which dropped an unclassified claim silently
             // and turned a policy fault into a narrower answer — the exact
             // failure `one_unruled_claim_refuses_the_whole_query_rather_than_narrowing_it`
             // exists to catch, and it caught it.
-            if !self.admissible(c, clock)? {
+            let budget = self.policy_for(c)?.budget();
+            if !Self::is_admissible(c, clock, budget) {
                 continue;
             }
-            answers.push(self.bind(c, clock, &identity, identity_is_current)?);
+            answers.push(Self::bind(
+                c,
+                clock,
+                budget,
+                &identity,
+                identity_is_current,
+            )?);
         }
 
         let lookup = if answers.is_empty() {
@@ -634,13 +646,16 @@ impl<'a> WorldView<'a> {
         let clock = valid_at_ms.max(0).unsigned_abs();
         let mut answers = Vec::new();
         for claim in &answer.claims {
-            if !self.admissible(claim, clock)? {
+            // Resolved once and shared by the admissibility test and the
+            // assembly below — see the note in `ask`.
+            let budget = self.policy_for(claim)?.budget();
+            if !Self::is_admissible(claim, clock, budget) {
                 continue;
             }
             answers.push(assemble(
                 claim,
                 clock,
-                self.policy_for(claim)?.budget(),
+                budget,
                 // `true` for the same reason a pinned composition passes it:
                 // the historical graph was replayed from the log up to the cut,
                 // so it cannot lag it. `identity_is_current` answers a question
@@ -673,17 +688,15 @@ impl<'a> WorldView<'a> {
     /// The single place a claim's semantics become a freshness policy, so the
     /// fail-closed rule cannot be routed around by a second lookup that forgot
     /// to refuse.
+    ///
+    /// Every caller resolves it **once per claim** and passes the resulting
+    /// budget onward. An earlier draft called this twice — once behind an
+    /// `admissible` wrapper and again when binding — which meant the refusal
+    /// that makes 3e fail closed was evaluated twice for one claim, and would
+    /// have kept working had one of the two sites stopped refusing. Caught in
+    /// review on #1439.
     fn policy_for(&self, claim: &ProjectedClaim) -> Result<FreshnessPolicy, AskError> {
         resolve_policy(self.freshness, &claim.kind, claim.predicate.as_deref())
-    }
-
-    /// Admissibility at this claim's ruled policy.
-    fn admissible(&self, claim: &ProjectedClaim, clock: u64) -> Result<bool, AskError> {
-        Ok(Self::is_admissible(
-            claim,
-            clock,
-            self.policy_for(claim)?.budget(),
-        ))
     }
 
     // SEMANTICS-PIN-BEGIN: answer_admissibility
@@ -715,17 +728,20 @@ impl<'a> WorldView<'a> {
     /// Delegates the field-by-field construction to [`assemble`], which is the
     /// one place a `WorldAnswer` is built; this adds only the identity
     /// resolution a live read can do and a pinned one cannot.
+    ///
+    /// Takes the budget rather than resolving it, so the caller's single
+    /// [`Self::policy_for`] call is the only one — see that method.
     fn bind(
-        &self,
         claim: &ProjectedClaim,
         clock: u64,
+        budget: Option<u64>,
         identity: &IdentityView,
         identity_is_current: bool,
     ) -> Result<WorldAnswer, AskError> {
         assemble(
             claim,
             clock,
-            self.policy_for(claim)?.budget(),
+            budget,
             Self::resolve_object(claim.object.as_deref(), identity, identity_is_current),
         )
     }

--- a/crates/kirra-world-service/src/read_view.rs
+++ b/crates/kirra-world-service/src/read_view.rs
@@ -101,6 +101,7 @@ use kirra_world_store::snapshot::SnapshotCoordinate;
 use kirra_world_store::{ProjectedClaim, StoreError, TrustAxes, TrustGrade, Validity, WorldStore};
 
 use crate::answer_ref::QueryKind;
+use crate::freshness::{resolve_policy, FreshnessPolicy, FreshnessSource};
 use crate::semantics::SemanticVersions;
 
 /// Why an ask could not be answered at all.
@@ -143,6 +144,23 @@ pub enum AskError {
         /// What was wrong with the digest.
         cause: DigestError,
     },
+    /// **No ruled freshness policy for this claim's semantics** — box 3e.
+    ///
+    /// `KIRRA-WM-FRESHNESS-POLICY-001`: unclassified semantics refuse. This is
+    /// a **policy-resolution failure**, not a freshness state — which is why it
+    /// is an error rather than a fourth `Validity` variant, and why it is not
+    /// `Unknown`: something IS known about this subject, and the engine has not
+    /// been told what its age means.
+    ///
+    /// Fail-closed by the `KIRRA_VEHICLE_CLASS` precedent. Serving it as
+    /// `Timeless` would assert that the fact's age does not matter — a positive
+    /// claim nobody made.
+    UnclassifiedFreshness {
+        /// The claim kind that has no ruling.
+        kind: String,
+        /// Its predicate, or `None` for a payload-only claim.
+        predicate: Option<String>,
+    },
 }
 
 impl fmt::Display for AskError {
@@ -163,6 +181,12 @@ impl fmt::Display for AskError {
                      (subject={subject:?}, predicate_key={key:?}): {cause}"
                 )
             }
+            Self::UnclassifiedFreshness { kind, predicate } => write!(
+                f,
+                "no ruled freshness policy for kind={kind} predicate={} — \
+                 unclassified semantics refuse (KIRRA-WM-FRESHNESS-POLICY-001)",
+                predicate.as_deref().unwrap_or("<none>")
+            ),
         }
     }
 }
@@ -482,23 +506,24 @@ impl ComposedLookup {
 /// and never adjudicates it.
 pub struct WorldView<'a> {
     store: &'a WorldStore,
-    staleness_budget_ms: Option<u64>,
+    freshness: FreshnessSource,
 }
 
 impl<'a> WorldView<'a> {
-    /// Bind a view with the **caller's** staleness policy.
+    /// Bind a view to a **freshness source** — box 3e.
     ///
-    /// The budget is the caller's deliberately: how long a claim stays fresh is
-    /// a policy of the asking consumer, and a floor plan and a person's location
-    /// go stale at wildly different rates. Baking one budget into the row would
-    /// answer for every reader at once. `None` means this caller treats claims
-    /// as not going stale.
+    /// This took an `Option<u64>` until 3e, and `None` meant *"claims do not go
+    /// stale"*. That was the defect: `Validity::Timeless` is a positive claim
+    /// that a fact's age does not matter, and the engine asserted it about every
+    /// fact in the store whenever a caller supplied nothing.
+    ///
+    /// [`FreshnessSource`] has no variant meaning "nothing supplied", so the old
+    /// default is unrepresentable rather than merely discouraged. Either the
+    /// ruled table decides, or the caller states a policy — and an unclassified
+    /// class under [`FreshnessSource::Ruled`] refuses.
     #[must_use]
-    pub fn new(store: &'a WorldStore, staleness_budget_ms: Option<u64>) -> Self {
-        Self {
-            store,
-            staleness_budget_ms,
-        }
+    pub fn new(store: &'a WorldStore, freshness: FreshnessSource) -> Self {
+        Self { store, freshness }
     }
 
     /// Ask what is currently known about one subject.
@@ -547,10 +572,15 @@ impl<'a> WorldView<'a> {
 
         let clock = now_ms.max(0).unsigned_abs();
         let mut answers: Vec<WorldAnswer> = Vec::new();
-        for c in claims
-            .iter()
-            .filter(|c| Self::is_admissible(c, clock, self.staleness_budget_ms))
-        {
+        for c in claims.iter() {
+            // `?`, NOT a swallowed refusal. A first draft filtered with
+            // `.unwrap_or(false)`, which dropped an unclassified claim silently
+            // and turned a policy fault into a narrower answer — the exact
+            // failure `one_unruled_claim_refuses_the_whole_query_rather_than_narrowing_it`
+            // exists to catch, and it caught it.
+            if !self.admissible(c, clock)? {
+                continue;
+            }
             answers.push(self.bind(c, clock, &identity, identity_is_current)?);
         }
 
@@ -604,13 +634,13 @@ impl<'a> WorldView<'a> {
         let clock = valid_at_ms.max(0).unsigned_abs();
         let mut answers = Vec::new();
         for claim in &answer.claims {
-            if !Self::is_admissible(claim, clock, self.staleness_budget_ms) {
+            if !self.admissible(claim, clock)? {
                 continue;
             }
             answers.push(assemble(
                 claim,
                 clock,
-                self.staleness_budget_ms,
+                self.policy_for(claim)?.budget(),
                 // `true` for the same reason a pinned composition passes it:
                 // the historical graph was replayed from the log up to the cut,
                 // so it cannot lag it. `identity_is_current` answers a question
@@ -636,6 +666,24 @@ impl<'a> WorldView<'a> {
             completeness,
             semantics: SemanticVersions::for_query(QueryKind::AsOfSubject),
         })
+    }
+
+    /// **The ruled disposition for one claim, or a refusal.**
+    ///
+    /// The single place a claim's semantics become a freshness policy, so the
+    /// fail-closed rule cannot be routed around by a second lookup that forgot
+    /// to refuse.
+    fn policy_for(&self, claim: &ProjectedClaim) -> Result<FreshnessPolicy, AskError> {
+        resolve_policy(self.freshness, &claim.kind, claim.predicate.as_deref())
+    }
+
+    /// Admissibility at this claim's ruled policy.
+    fn admissible(&self, claim: &ProjectedClaim, clock: u64) -> Result<bool, AskError> {
+        Ok(Self::is_admissible(
+            claim,
+            clock,
+            self.policy_for(claim)?.budget(),
+        ))
     }
 
     // SEMANTICS-PIN-BEGIN: answer_admissibility
@@ -677,7 +725,7 @@ impl<'a> WorldView<'a> {
         assemble(
             claim,
             clock,
-            self.staleness_budget_ms,
+            self.policy_for(claim)?.budget(),
             Self::resolve_object(claim.object.as_deref(), identity, identity_is_current),
         )
     }

--- a/crates/kirra-world-service/tests/as_of_composition.rs
+++ b/crates/kirra-world-service/tests/as_of_composition.rs
@@ -43,6 +43,7 @@ use kirra_world::adjudication::{
 use kirra_world::observation::{ClockDomain, DomainInstant};
 use kirra_world::reference::{EntityId, EventId, ObservationId};
 use kirra_world_service::answer_ref::QueryKind;
+use kirra_world_service::freshness::{FreshnessPolicy, FreshnessSource};
 use kirra_world_service::read_view::{ObjectIdentity, WorldLookup, WorldView};
 use kirra_world_service::semantics::SemanticVersions;
 use kirra_world_store::adjudication_record::AdjudicationRow;
@@ -177,7 +178,7 @@ fn store_where_the_graph_moved_after_the_cut(name: &str) -> (WorldStore, std::pa
 }
 
 fn sole_identity(store: &WorldStore, as_known_at_ms: i64) -> ObjectIdentity {
-    let view = WorldView::new(store, None);
+    let view = WorldView::new(store, FreshnessSource::Caller(FreshnessPolicy::Timeless));
     let temporal = view
         .ask_as_of("package_17", VALID_AT, as_known_at_ms)
         .expect("ask_as_of");
@@ -264,7 +265,7 @@ fn the_two_cuts_genuinely_differ() {
 #[test]
 fn the_claim_is_the_same_in_both_arms_only_its_object_resolution_moves() {
     let (store, path) = store_where_the_graph_moved_after_the_cut("sameclaim");
-    let view = WorldView::new(&store, None);
+    let view = WorldView::new(&store, FreshnessSource::Caller(FreshnessPolicy::Timeless));
 
     let render = |as_known_at: i64| {
         let t = view
@@ -450,7 +451,7 @@ fn a_historically_ambiguous_object_is_not_matchable() {
 #[test]
 fn an_as_of_answer_carries_the_familys_version_set() {
     let (store, path) = store_where_the_graph_moved_after_the_cut("versions");
-    let view = WorldView::new(&store, None);
+    let view = WorldView::new(&store, FreshnessSource::Caller(FreshnessPolicy::Timeless));
 
     let temporal = view
         .ask_as_of("package_17", VALID_AT, CUT)
@@ -485,7 +486,7 @@ fn an_as_of_answer_carries_the_familys_version_set() {
 #[test]
 fn completeness_still_rides_on_the_answer() {
     let (store, path) = store_where_the_graph_moved_after_the_cut("completeness");
-    let view = WorldView::new(&store, None);
+    let view = WorldView::new(&store, FreshnessSource::Caller(FreshnessPolicy::Timeless));
 
     let temporal = view
         .ask_as_of("package_17", VALID_AT, CUT)

--- a/crates/kirra-world-service/tests/degradation_propagation.rs
+++ b/crates/kirra-world-service/tests/degradation_propagation.rs
@@ -66,6 +66,7 @@
 //! `dock_alpha` when `dock_beta` was the truth. Only the completeness axis
 //! reveals that, which is precisely the loss 3g exists to make observable.
 
+use kirra_world_service::freshness::{FreshnessPolicy, FreshnessSource};
 use kirra_world_service::read_view::{WorldLookup, WorldView};
 use kirra_world_store::{ClaimStatus, EventId, NewEvent, ObservationId, WorldStore, WriterClass};
 
@@ -165,7 +166,7 @@ fn objects(lookup: &WorldLookup) -> Vec<String> {
 #[test]
 fn evidence_outside_the_compacted_span_is_full_and_still_answers() {
     let (store, path) = store_with_a_hole("full");
-    let view = WorldView::new(&store, None);
+    let view = WorldView::new(&store, FreshnessSource::Caller(FreshnessPolicy::Timeless));
 
     let out = view
         .ask_as_of("package_17", T0 + 50, T0 + 50)
@@ -200,7 +201,7 @@ fn evidence_outside_the_compacted_span_is_full_and_still_answers() {
 #[test]
 fn evidence_inside_the_compacted_span_is_degraded_and_the_answer_looks_fine() {
     let (store, path) = store_with_a_hole("degraded");
-    let view = WorldView::new(&store, None);
+    let view = WorldView::new(&store, FreshnessSource::Caller(FreshnessPolicy::Timeless));
 
     let out = view
         .ask_as_of("package_17", T0 + 150, T0 + 9_000)
@@ -265,7 +266,7 @@ fn an_empty_answer_still_reports_that_evidence_was_lost() {
     store.fold().expect("fold");
     store.compact_range(1, 1, T0 + 9_000).expect("compact");
 
-    let view = WorldView::new(&store, None);
+    let view = WorldView::new(&store, FreshnessSource::Caller(FreshnessPolicy::Timeless));
     let out = view
         .ask_as_of("package_17", T0 + 150, T0 + 9_000)
         .expect("ask_as_of");
@@ -327,7 +328,7 @@ fn a_subject_the_compacted_window_never_held_is_full() {
     store.fold().expect("fold");
     store.compact_range(1, 1, T0 + 9_000).expect("compact");
 
-    let view = WorldView::new(&store, None);
+    let view = WorldView::new(&store, FreshnessSource::Caller(FreshnessPolicy::Timeless));
     let out = view
         .ask_as_of("pallet_9", T0 + 1_000, T0 + 9_000)
         .expect("ask_as_of");
@@ -352,7 +353,7 @@ fn a_subject_the_compacted_window_never_held_is_full() {
 #[test]
 fn the_boundary_verdict_equals_the_stores_verdict() {
     let (store, path) = store_with_a_hole("propagates");
-    let view = WorldView::new(&store, None);
+    let view = WorldView::new(&store, FreshnessSource::Caller(FreshnessPolicy::Timeless));
 
     for (valid_at, known_at) in [(T0 + 50, T0 + 50), (T0 + 150, T0 + 9_000)] {
         let store_side = store

--- a/crates/kirra-world-service/tests/freshness_policy.rs
+++ b/crates/kirra-world-service/tests/freshness_policy.rs
@@ -1,0 +1,308 @@
+//! **Box 3e — freshness is ruled, and unclassified semantics refuse.**
+//!
+//! `KIRRA-WM-FRESHNESS-POLICY-001`:
+//!
+//! > Freshness semantics are centrally ruled by claim kind. `Timeless` must be
+//! > explicitly granted. Bounded facts require an explicit age limit.
+//! > Unclassified semantics refuse.
+//!
+//! And the invariant that follows:
+//!
+//! > **`Timeless` is an affirmative semantic classification, never the absence
+//! > of a freshness policy.**
+//!
+//! # The defect, which was live and self-documented
+//!
+//! `WM_SCOPE.md`'s FINDING 2 recorded it before this box was built:
+//!
+//! > *"Where was the package last seen" is about as recency-sensitive as this
+//! > domain gets, so a year-old observation is currently served with the same
+//! > standing as a fresh one, under a label asserting that is fine.*
+//!
+//! `WorldView` took an `Option<u64>` and `None` meant `Validity::Timeless` — a
+//! **positive claim that the fact's age does not matter**, asserted by the
+//! engine about every fact in the store whenever nobody supplied a budget.
+//!
+//! # Why the adversarial pair is the same age
+//!
+//! The two arms below use claims with the **same `valid_from`**, read at the
+//! **same clock**. Nothing about the data distinguishes them; only the ruling
+//! does. A pair at different ages would pass on arithmetic and prove nothing
+//! about the table.
+
+use kirra_world_service::freshness::{FreshnessPolicy, FreshnessSource};
+use kirra_world_service::read_view::{AskError, WorldLookup, WorldView};
+use kirra_world_store::{
+    ClaimStatus, EventId, NewEvent, ObservationId, Validity, WorldStore, WriterClass,
+};
+
+const T0: i64 = 1_700_000_000_000;
+/// One hour after the facts became valid. Past every bound in the ruled table,
+/// so a `Bounded` class is unambiguously stale and a `Timeless` one is not.
+const MUCH_LATER: i64 = T0 + 60 * 60 * 1_000;
+
+fn tmp(name: &str) -> std::path::PathBuf {
+    static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let n = NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "kirra-fresh-{name}-{}-{n}.sqlite",
+        std::process::id()
+    ));
+    cleanup(&p);
+    p
+}
+
+fn cleanup(path: &std::path::Path) {
+    for suffix in ["", "-wal", "-shm"] {
+        let mut q = path.as_os_str().to_os_string();
+        q.push(suffix);
+        let _ = std::fs::remove_file(std::path::PathBuf::from(q));
+    }
+}
+
+fn claim(store: &mut WorldStore, tag: &str, kind: &str, predicate: &str) {
+    store
+        .append(&NewEvent {
+            event_id: &EventId::new(format!("ev-{tag}")).expect("event id"),
+            observation_id: &ObservationId::new(format!("obs-{tag}")).expect("obs"),
+            txn_time_ms: T0,
+            valid_from_ms: T0,
+            valid_to_ms: None,
+            source: "warehouse-scanner",
+            source_version: "1.0.0",
+            writer_class: WriterClass::Sensor,
+            claim_status: ClaimStatus::Confirmed,
+            provenance: &[],
+            frame_id: None,
+            map_id: None,
+            kind,
+            subject: "package_17",
+            subject_ref: None,
+            predicate: Some(predicate),
+            object: None,
+            payload: "{}",
+            payload_schema: 1,
+            retention_class: "raw",
+            trust: None,
+        })
+        .expect("append");
+}
+
+/// Two claims about one subject, **the same age**, with different rulings:
+/// `mission/last_seen_at` is `Bounded`, `observation/colour` is `Timeless`.
+fn store_with_both_dispositions(name: &str) -> (WorldStore, std::path::PathBuf) {
+    let path = tmp(name);
+    let mut store = WorldStore::open(&path).expect("open");
+    claim(&mut store, "seen", "mission", "last_seen_at");
+    claim(&mut store, "colour", "observation", "colour");
+    store.fold().expect("fold");
+    (store, path)
+}
+
+fn validity_of(store: &WorldStore, predicate: &str) -> Validity {
+    let view = WorldView::new(store, FreshnessSource::Ruled);
+    let composed = view.ask("package_17", MUCH_LATER).expect("ask");
+    let WorldLookup::Answered(answers) = composed.lookup() else {
+        panic!("the fixture must answer, got {:?}", composed.lookup());
+    };
+    answers
+        .iter()
+        .find(|a| a.predicate() == Some(predicate))
+        .unwrap_or_else(|| panic!("no answer for {predicate}"))
+        .validity()
+}
+
+// ---------------------------------------------------------------------------
+// The adversarial pair
+// ---------------------------------------------------------------------------
+
+/// **An old `last_seen_at` is Stale.** The claim FINDING 2 said was served as
+/// though its age did not matter.
+#[test]
+fn an_old_recency_sensitive_fact_is_stale() {
+    let (store, path) = store_with_both_dispositions("stale");
+    assert_eq!(
+        validity_of(&store, "last_seen_at"),
+        Validity::Stale,
+        "an hour-old `last_seen_at` is past its ruled bound and must say so"
+    );
+    drop(store);
+    cleanup(&path);
+}
+
+/// **An equally old genuinely timeless fact is Timeless.**
+///
+/// Same `valid_from`, same clock, opposite verdict — so the difference is the
+/// ruling and nothing else.
+#[test]
+fn an_equally_old_timeless_fact_is_timeless() {
+    let (store, path) = store_with_both_dispositions("timeless");
+    assert_eq!(
+        validity_of(&store, "colour"),
+        Validity::Timeless,
+        "colour is ruled Timeless; ageing it would refuse valid answers for no \
+         safety gain"
+    );
+    drop(store);
+    cleanup(&path);
+}
+
+/// The pair asserted together, so neither arm can be edited into passing alone.
+#[test]
+fn the_two_dispositions_differ_at_identical_age() {
+    let (store, path) = store_with_both_dispositions("pair");
+    assert_ne!(
+        validity_of(&store, "last_seen_at"),
+        validity_of(&store, "colour"),
+        "two claims of the SAME age got the same verdict — the ruled table is \
+         not distinguishing anything"
+    );
+    drop(store);
+    cleanup(&path);
+}
+
+// ---------------------------------------------------------------------------
+// Unclassified semantics refuse
+// ---------------------------------------------------------------------------
+
+/// **THE BOX.** A claim whose semantics are not ruled REFUSES the query.
+///
+/// Not `Timeless`, not an infinite budget, and not a hidden default.
+#[test]
+fn an_unclassified_claim_refuses_rather_than_defaulting_to_timeless() {
+    let path = tmp("unruled");
+    let mut store = WorldStore::open(&path).expect("open");
+    claim(&mut store, "unruled", "mission", "invented_predicate");
+    store.fold().expect("fold");
+
+    let view = WorldView::new(&store, FreshnessSource::Ruled);
+    match view.ask("package_17", MUCH_LATER) {
+        Err(AskError::UnclassifiedFreshness { kind, predicate }) => {
+            assert_eq!(kind, "mission");
+            assert_eq!(predicate.as_deref(), Some("invented_predicate"));
+        }
+        Ok(answer) => panic!(
+            "an unruled class was SERVED rather than refused: {:?}",
+            answer.lookup()
+        ),
+        Err(other) => panic!("wrong refusal: {other:?}"),
+    }
+
+    drop(store);
+    cleanup(&path);
+}
+
+/// The refusal is not "nothing is known" — it is a policy fault.
+///
+/// Rule 3 says `Unknown` is a success meaning absence of knowledge. A claim
+/// exists here; what is missing is the ruling about what its age means. Landing
+/// in `Unknown` would tell a caller the store held nothing, which is false.
+#[test]
+fn the_refusal_is_an_error_not_an_unknown_answer() {
+    let path = tmp("notunknown");
+    let mut store = WorldStore::open(&path).expect("open");
+    claim(&mut store, "unruled", "mission", "invented_predicate");
+    store.fold().expect("fold");
+
+    let view = WorldView::new(&store, FreshnessSource::Ruled);
+    assert!(
+        view.ask("package_17", MUCH_LATER).is_err(),
+        "a missing policy is a policy-resolution failure, not a freshness state \
+         and not an absence of knowledge"
+    );
+
+    drop(store);
+    cleanup(&path);
+}
+
+/// One unruled claim refuses the WHOLE query, rather than being dropped.
+///
+/// Dropping it would silently narrow the answer: the caller would receive a
+/// well-formed result missing a row it was never told about, which is the
+/// under-reporting failure `SummaryKindError` refuses for the same reason.
+#[test]
+fn one_unruled_claim_refuses_the_whole_query_rather_than_narrowing_it() {
+    let path = tmp("mixed");
+    let mut store = WorldStore::open(&path).expect("open");
+    claim(&mut store, "seen", "mission", "last_seen_at"); // ruled
+    claim(&mut store, "unruled", "mission", "invented_predicate"); // not
+    store.fold().expect("fold");
+
+    let view = WorldView::new(&store, FreshnessSource::Ruled);
+    assert!(
+        view.ask("package_17", MUCH_LATER).is_err(),
+        "a partially-ruled subject must refuse, not serve the ruled half and \
+         quietly omit the rest"
+    );
+
+    drop(store);
+    cleanup(&path);
+}
+
+// ---------------------------------------------------------------------------
+// The caller source stays an explicit act
+// ---------------------------------------------------------------------------
+
+/// The caller path answers where the table refuses — and says so in a value.
+///
+/// This is the interim `mission_context` relies on. It is safer than the global
+/// default it replaced because the classification is now something a caller
+/// wrote, greppable and reviewable, rather than a branch nobody took.
+#[test]
+fn the_caller_source_can_classify_what_the_table_has_not_ruled() {
+    let path = tmp("caller");
+    let mut store = WorldStore::open(&path).expect("open");
+    claim(&mut store, "unruled", "mission", "invented_predicate");
+    store.fold().expect("fold");
+
+    let view = WorldView::new(
+        &store,
+        FreshnessSource::Caller(FreshnessPolicy::Bounded { max_age_ms: 1_000 }),
+    );
+    let composed = view
+        .ask("package_17", MUCH_LATER)
+        .expect("caller classified it");
+    let WorldLookup::Answered(answers) = composed.lookup() else {
+        panic!("must answer");
+    };
+    assert_eq!(answers[0].validity(), Validity::Stale);
+
+    drop(store);
+    cleanup(&path);
+}
+
+/// **`Timeless` can only come from an affirmative grant.**
+///
+/// The invariant, stated as a test over both sources: every path that yields
+/// `Timeless` traces to somebody classifying the fact that way — the ruled
+/// table, or a caller writing `FreshnessPolicy::Timeless`. There is no third
+/// path, because `FreshnessSource` has no variant meaning "nothing supplied".
+#[test]
+fn timeless_is_always_traceable_to_a_grant() {
+    let (store, path) = store_with_both_dispositions("grant");
+
+    // From the ruled table.
+    assert_eq!(validity_of(&store, "colour"), Validity::Timeless);
+
+    // From an explicit caller grant, on a class the table rules BOUNDED — so
+    // the value cannot have leaked from the table.
+    let view = WorldView::new(&store, FreshnessSource::Caller(FreshnessPolicy::Timeless));
+    let composed = view.ask("package_17", MUCH_LATER).expect("ask");
+    let WorldLookup::Answered(answers) = composed.lookup() else {
+        panic!("must answer");
+    };
+    let seen = answers
+        .iter()
+        .find(|a| a.predicate() == Some("last_seen_at"))
+        .expect("last_seen_at");
+    assert_eq!(
+        seen.validity(),
+        Validity::Timeless,
+        "an explicit caller grant overrides the table — and is the ONLY other \
+         way to reach Timeless"
+    );
+
+    drop(store);
+    cleanup(&path);
+}

--- a/crates/kirra-world-service/tests/freshness_policy.rs
+++ b/crates/kirra-world-service/tests/freshness_policy.rs
@@ -100,8 +100,13 @@ fn store_with_both_dispositions(name: &str) -> (WorldStore, std::path::PathBuf) 
     (store, path)
 }
 
+/// A view under the RULED source — the configuration every refusal test needs.
+fn store_view(store: &WorldStore) -> WorldView<'_> {
+    WorldView::new(store, FreshnessSource::Ruled)
+}
+
 fn validity_of(store: &WorldStore, predicate: &str) -> Validity {
-    let view = WorldView::new(store, FreshnessSource::Ruled);
+    let view = store_view(store);
     let composed = view.ask("package_17", MUCH_LATER).expect("ask");
     let WorldLookup::Answered(answers) = composed.lookup() else {
         panic!("the fixture must answer, got {:?}", composed.lookup());
@@ -235,6 +240,79 @@ fn one_unruled_claim_refuses_the_whole_query_rather_than_narrowing_it() {
         "a partially-ruled subject must refuse, not serve the ruled half and \
          quietly omit the rest"
     );
+
+    drop(store);
+    cleanup(&path);
+}
+
+/// **The bitemporal family refuses too**, and nothing was pinning that.
+///
+/// `ask_as_of` carries the same obligation as `ask` — unclassified semantics
+/// refuse — and it was resolving the policy through the same `policy_for`, so
+/// it looked covered. It was not. Restructuring the loop in review (#1439) to
+/// resolve the policy once per claim made the gap visible: a mutation that
+/// swallowed the refusal in `ask_as_of` reddened NOTHING, while the same
+/// mutation in `ask` reddened three tests.
+///
+/// A rule enforced on one query family and merely *believed* on the other is
+/// how the second family quietly stops enforcing it.
+#[test]
+fn the_bitemporal_family_refuses_an_unclassified_claim_as_well() {
+    let path = tmp("asof-unruled");
+    let mut store = WorldStore::open(&path).expect("open");
+    claim(&mut store, "unruled", "mission", "invented_predicate");
+    store.fold().expect("fold");
+
+    match store_view(&store).ask_as_of("package_17", MUCH_LATER, MUCH_LATER) {
+        Err(AskError::UnclassifiedFreshness { kind, predicate }) => {
+            assert_eq!(kind, "mission");
+            assert_eq!(predicate.as_deref(), Some("invented_predicate"));
+        }
+        Ok(answer) => panic!(
+            "an unruled class was SERVED by the historical path: {:?}",
+            answer.lookup()
+        ),
+        Err(other) => panic!("wrong refusal: {other:?}"),
+    }
+
+    drop(store);
+    cleanup(&path);
+}
+
+/// The same non-narrowing rule on the historical axis: a ruled claim beside an
+/// unruled one refuses the whole query rather than serving the ruled half.
+#[test]
+fn the_bitemporal_family_refuses_rather_than_narrowing() {
+    let path = tmp("asof-mixed");
+    let mut store = WorldStore::open(&path).expect("open");
+    claim(&mut store, "seen", "mission", "last_seen_at"); // ruled
+    claim(&mut store, "unruled", "mission", "invented_predicate"); // not
+    store.fold().expect("fold");
+
+    assert!(
+        store_view(&store)
+            .ask_as_of("package_17", MUCH_LATER, MUCH_LATER)
+            .is_err(),
+        "a partially-ruled subject must refuse on the historical axis too, not \
+         serve the ruled half and quietly omit the rest"
+    );
+
+    drop(store);
+    cleanup(&path);
+}
+
+/// The pair above is only meaningful if the fixture ANSWERS when everything is
+/// ruled — otherwise both would pass against a path that refuses unconditionally.
+#[test]
+fn the_bitemporal_family_answers_when_every_claim_is_ruled() {
+    let (store, path) = store_with_both_dispositions("asof-ok");
+    let lookup = store_view(&store)
+        .ask_as_of("package_17", MUCH_LATER, MUCH_LATER)
+        .expect("a fully-ruled subject must answer");
+    let WorldLookup::Answered(answers) = lookup.lookup() else {
+        panic!("the fixture must answer, got {:?}", lookup.lookup());
+    };
+    assert_eq!(answers.len(), 2, "both ruled claims must be served");
 
     drop(store);
     cleanup(&path);

--- a/crates/kirra-world-service/tests/historical_composition.rs
+++ b/crates/kirra-world-service/tests/historical_composition.rs
@@ -46,6 +46,7 @@ use kirra_world::adjudication::{
 use kirra_world::observation::{ClockDomain, DomainInstant};
 use kirra_world::reference::{EntityId, EventId, ObservationId};
 use kirra_world_service::answer_ref::{AnswerRef, RefResolution};
+use kirra_world_service::freshness::{FreshnessPolicy, FreshnessSource};
 use kirra_world_service::read_view::{ObjectIdentity, WorldLookup, WorldView};
 use kirra_world_store::adjudication_record::AdjudicationRow;
 use kirra_world_store::snapshot::PinnedComposedRead;
@@ -202,7 +203,7 @@ fn sole_identity(res: &RefResolution) -> ObjectIdentity {
 #[test]
 fn the_live_read_resolves_the_object_through_the_merge() {
     let (store, path, _pin) = store_where_the_graph_moved_after_the_pin("live");
-    let view = WorldView::new(&store, None);
+    let view = WorldView::new(&store, FreshnessSource::Caller(FreshnessPolicy::Timeless));
 
     let composed = view.ask("package_17", LATER).expect("ask");
     let WorldLookup::Answered(answers) = composed.lookup() else {
@@ -267,7 +268,7 @@ fn the_historical_and_live_identities_genuinely_differ() {
             .expect("resolve"),
     );
 
-    let view = WorldView::new(&store, None);
+    let view = WorldView::new(&store, FreshnessSource::Caller(FreshnessPolicy::Timeless));
     let composed = view.ask("package_17", LATER).expect("ask");
     let WorldLookup::Answered(live) = composed.lookup() else {
         panic!("the fixture must answer");

--- a/crates/kirra-world-service/tests/read_view.rs
+++ b/crates/kirra-world-service/tests/read_view.rs
@@ -6,6 +6,7 @@
 //! compiling once Tier 3 lands.
 
 use kirra_world::evidence::DigestError;
+use kirra_world_service::freshness::{FreshnessPolicy, FreshnessSource};
 use kirra_world_service::read_view::{AskError, UnknownReason, WorldLookup, WorldView};
 use kirra_world_store::{
     Adjudication, ClaimStatus, Corroboration, EventId, NewEvent, ObservationId, Origin, TrustAxes,
@@ -128,7 +129,10 @@ fn an_answer_carries_validity_trust_and_provenance() {
     let a = axes(Corroboration::Corroborated(2), Adjudication::Confirmed);
     seed(&mut s, 1, "cup-1", None, Some(&a), ClaimStatus::Confirmed);
 
-    let view = WorldView::new(&s, Some(60_000));
+    let view = WorldView::new(
+        &s,
+        FreshnessSource::Caller(FreshnessPolicy::Bounded { max_age_ms: 60_000 }),
+    );
     let WorldLookup::Answered(answers) = view.ask("cup-1", T0).expect("ask").into_lookup() else {
         panic!("expected an answer");
     };
@@ -191,7 +195,10 @@ fn an_answer_carries_the_axes_not_only_the_collapsed_grade() {
     let a = axes(Corroboration::Corroborated(2), Adjudication::Confirmed);
     seed(&mut s, 1, "cup-1", None, Some(&a), ClaimStatus::Confirmed);
 
-    let view = WorldView::new(&s, Some(60_000));
+    let view = WorldView::new(
+        &s,
+        FreshnessSource::Caller(FreshnessPolicy::Bounded { max_age_ms: 60_000 }),
+    );
     let WorldLookup::Answered(answers) = view.ask("cup-1", T0).expect("ask").into_lookup() else {
         panic!("expected an answer");
     };
@@ -242,7 +249,10 @@ fn two_claims_can_share_a_grade_for_different_reasons() {
         ClaimStatus::Confirmed,
     );
 
-    let view = WorldView::new(&s, Some(60_000));
+    let view = WorldView::new(
+        &s,
+        FreshnessSource::Caller(FreshnessPolicy::Bounded { max_age_ms: 60_000 }),
+    );
 
     let WorldLookup::Answered(a1) = view.ask("a", T0).expect("ask").into_lookup() else {
         panic!("expected an answer");
@@ -276,7 +286,10 @@ fn an_unlabelled_claim_has_no_grade_rather_than_a_default() {
     let mut s = open("unlabelled");
     seed(&mut s, 1, "cup-1", None, None, ClaimStatus::Confirmed);
 
-    let view = WorldView::new(&s, Some(60_000));
+    let view = WorldView::new(
+        &s,
+        FreshnessSource::Caller(FreshnessPolicy::Bounded { max_age_ms: 60_000 }),
+    );
     let WorldLookup::Answered(answers) = view.ask("cup-1", T0).expect("ask").into_lookup() else {
         panic!("expected an answer");
     };
@@ -300,7 +313,10 @@ fn an_unlabelled_claim_has_no_grade_rather_than_a_default() {
 #[test]
 fn an_unknown_subject_is_a_success_not_an_error() {
     let s = open("unknown");
-    let view = WorldView::new(&s, Some(60_000));
+    let view = WorldView::new(
+        &s,
+        FreshnessSource::Caller(FreshnessPolicy::Bounded { max_age_ms: 60_000 }),
+    );
 
     let out = view.ask("never-heard-of-it", T0);
     assert!(
@@ -336,7 +352,10 @@ fn an_expired_claim_is_not_served() {
         ClaimStatus::Confirmed,
     );
 
-    let view = WorldView::new(&s, Some(60_000));
+    let view = WorldView::new(
+        &s,
+        FreshnessSource::Caller(FreshnessPolicy::Bounded { max_age_ms: 60_000 }),
+    );
     assert!(matches!(
         view.ask("cup-1", T0 + 500).expect("ask").into_lookup(),
         WorldLookup::Answered(_)
@@ -366,7 +385,10 @@ fn an_inadmissible_claim_never_reaches_the_boundary() {
         ClaimStatus::Candidate,
     );
 
-    let view = WorldView::new(&s, Some(60_000));
+    let view = WorldView::new(
+        &s,
+        FreshnessSource::Caller(FreshnessPolicy::Bounded { max_age_ms: 60_000 }),
+    );
     assert!(matches!(
         view.ask("cup-1", T0).expect("ask").into_lookup(),
         WorldLookup::Unknown(UnknownReason::NoClaim)
@@ -397,14 +419,22 @@ fn the_staleness_budget_belongs_to_the_asking_caller() {
 
     let later = T0 + 120_000;
 
-    let impatient = WorldView::new(&s, Some(60_000));
+    let impatient = WorldView::new(
+        &s,
+        FreshnessSource::Caller(FreshnessPolicy::Bounded { max_age_ms: 60_000 }),
+    );
     let WorldLookup::Answered(a1) = impatient.ask("cup-1", later).expect("ask").into_lookup()
     else {
         panic!("expected an answer");
     };
     assert_eq!(a1[0].validity(), Validity::Stale);
 
-    let patient = WorldView::new(&s, Some(600_000));
+    let patient = WorldView::new(
+        &s,
+        FreshnessSource::Caller(FreshnessPolicy::Bounded {
+            max_age_ms: 600_000,
+        }),
+    );
     let WorldLookup::Answered(a2) = patient.ask("cup-1", later).expect("ask").into_lookup() else {
         panic!("expected an answer");
     };
@@ -442,7 +472,10 @@ fn an_unreadable_provenance_handle_is_refused_rather_than_served() {
 
     // Answerable to begin with -- so the refusal below is caused by the
     // corruption and not by the fixture never having worked.
-    let view = WorldView::new(&s, Some(60_000));
+    let view = WorldView::new(
+        &s,
+        FreshnessSource::Caller(FreshnessPolicy::Bounded { max_age_ms: 60_000 }),
+    );
     assert!(matches!(
         view.ask("cup-1", T0).expect("ask").into_lookup(),
         WorldLookup::Answered(_)
@@ -454,7 +487,10 @@ fn an_unreadable_provenance_handle_is_refused_rather_than_served() {
     ))
     .expect("plant the corruption");
 
-    let view = WorldView::new(&s, Some(60_000));
+    let view = WorldView::new(
+        &s,
+        FreshnessSource::Caller(FreshnessPolicy::Bounded { max_age_ms: 60_000 }),
+    );
     match view.ask("cup-1", T0) {
         Err(AskError::CorruptProvenance {
             subject,
@@ -506,7 +542,10 @@ fn the_error_identifies_which_of_a_subject_s_rows_is_damaged() {
 
     // Two rows, both answerable, so the refusal below is caused by the
     // corruption rather than by a fixture that never worked.
-    let view = WorldView::new(&s, Some(60_000));
+    let view = WorldView::new(
+        &s,
+        FreshnessSource::Caller(FreshnessPolicy::Bounded { max_age_ms: 60_000 }),
+    );
     let WorldLookup::Answered(before) = view.ask("cup-1", T0).expect("ask").into_lookup() else {
         panic!("expected answers");
     };
@@ -519,7 +558,10 @@ fn the_error_identifies_which_of_a_subject_s_rows_is_damaged() {
     ))
     .expect("plant the corruption in ONE row");
 
-    let view = WorldView::new(&s, Some(60_000));
+    let view = WorldView::new(
+        &s,
+        FreshnessSource::Caller(FreshnessPolicy::Bounded { max_age_ms: 60_000 }),
+    );
     match view.ask("cup-1", T0) {
         Err(AskError::CorruptProvenance {
             subject, predicate, ..
@@ -571,7 +613,10 @@ fn a_corrupt_handle_is_not_reported_as_absence_of_knowledge() {
     s.raw_execute_for_test("UPDATE world_current SET chain_digest = ''")
         .expect("plant the corruption");
 
-    let view = WorldView::new(&s, Some(60_000));
+    let view = WorldView::new(
+        &s,
+        FreshnessSource::Caller(FreshnessPolicy::Bounded { max_age_ms: 60_000 }),
+    );
     let out = view.ask("cup-1", T0);
     assert!(
         !matches!(&out, Ok(c) if matches!(c.lookup(), WorldLookup::Unknown(_))),

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -2029,8 +2029,12 @@ pressure that produced every stale claim this box already documents.
       Direct domain reads of projection tables below the engine are
       **mechanically gated**, on the `ci/check_reexport_shims.py` zero-tolerance
       ratchet pattern — an invariant with no gate is prose.
-- [ ] **3e — Freshness.** Computed at read time; threshold supplied by caller or
-      ruled policy; no implicit default for recency-sensitive semantics (above).
+- [x] **3e — Freshness.** ✅ **DONE 2026-08-11** — see *"3e closed: Timeless is
+      granted, never assumed"* below. Computed at read time; threshold supplied
+      by caller or ruled policy; no implicit default for recency-sensitive
+      semantics. `KIRRA-WM-FRESHNESS-POLICY-001`. The fourth `Unknown` freshness
+      variant is **decided and omitted** — no reachable case exists; see the
+      state machine in the closure.
 - [ ] **3f — Lineage retrieval contract.** Deterministic, bounded, paginated,
       truncation visible, historically correct. Consumed by Tier 4's `Explain`;
       does not render.
@@ -3286,3 +3290,112 @@ everything a consumer needs to build an historical answer without the boundary.
 
 Both temporal axes now use the same identity semantics. Historical composition
 is no longer a property of one query family.
+
+### 3e closed: `Timeless` is granted, never assumed — 2026-08-11
+
+**`KIRRA-WM-FRESHNESS-POLICY-001` — RULED 2026-08-11**
+
+> **Freshness semantics are centrally ruled by claim kind. `Timeless` must be
+> explicitly granted. Bounded facts require an explicit age limit. Unclassified
+> semantics refuse.**
+
+And the invariant that follows, which is the one to remember:
+
+> **`Timeless` is an affirmative semantic classification, never the absence of a
+> freshness policy.**
+
+#### The defect was live, and this document had already found it
+
+FINDING 2 above recorded it before the box was built: `validity_at` maps
+`staleness_budget_ms: None` to `Validity::Timeless`, and `WorldView` accepted
+`None` from anyone. `Timeless` is not *"we did not check"* — it is a **positive
+claim that the fact's age does not matter**. The engine asserted that claim
+about every fact in the store whenever nobody supplied a budget, including
+`last_seen_at`, for which it is false.
+
+#### Why a ruled table and not a caller flag
+
+The alternative considered was letting the caller declare a query
+recency-sensitive. Rejected, and the reason is decisive: it merely moves the
+trust decision outward. A careless caller says *"insensitive"* and manufactures
+`Timeless` exactly as the engine did — the API satisfied, the architectural rule
+defeated. So the disposition is ruled centrally, keyed by **semantics**
+(`kind` + `predicate`), because `last_seen_at` and a floor plan can be identical
+in storage shape and opposite in temporal meaning.
+
+#### The state machine, and the `Unknown` question settled
+
+```text
+policy = Timeless               -> Timeless
+policy = Bounded, age <= bound  -> Fresh
+policy = Bounded, age  > bound  -> Stale
+no policy                       -> the QUERY refuses
+```
+
+The open sub-question above asked whether a fourth `Unknown` freshness variant is
+reachable, and said to decide it by finding a reachable case or leaving it out —
+*"do not carry it undecided."* **Decided: omitted.** There is no successful
+answer for which freshness is unknown; a missing policy is a
+*policy-resolution failure*, not a freshness state, so it travels in the error
+channel as `AskError::UnclassifiedFreshness`. A fourth variant would be
+uninhabited — the decorative-semantics failure this tier keeps removing.
+
+The one case that would justify it, recorded so it is recognised if it appears:
+a claim whose age genuinely **cannot be determined**, from missing or invalid
+time provenance. If that is ever found, the variant becomes justified *then*,
+established by a reachable test rather than reserved speculatively.
+
+#### What `None` became
+
+`WorldView::new` took `Option<u64>`; it now takes a `FreshnessSource` with **no
+variant meaning "nothing supplied"**, so the old default is unrepresentable
+rather than discouraged. `mission_context`'s caller-supplied `Option` maps to an
+affirmative policy — `Some(b)` to `Bounded`, `None` to `Timeless` — which is
+what its signature already *meant* (*"I have considered this and this fact is
+genuinely timeless"*), now said in a type where the other reading cannot be
+written.
+
+#### The table is small on purpose
+
+Three ruled rows, each carrying its reasoning; everything else refuses. A large
+speculative table would be decorative metadata in another costume — entries
+nobody decided, read as though somebody had. Because absence refuses, the table
+grows one argued row at a time and no interim is unsafe.
+
+The classes this repository writes but has **not** ruled are recorded in
+`ci/freshness_unruled_baseline.json` as knowingly unruled. All three are test
+fixtures; inventing dispositions for them would have been the same overclaim.
+
+#### The silent failure the gate exists for
+
+The refusal is fail-closed, so a missing class is never *unsafe* — it is
+*invisible*. The table starts correct and quietly goes incomplete as new claim
+kinds land. `ci/check_freshness_coverage.py` makes that mechanical: every
+`(kind, predicate)` the repository writes must be ruled or baselined, and one in
+neither reds. It reports — rather than silently skips — `NewEvent` literals whose
+`kind` comes from a variable, since those are classes it cannot see.
+
+#### Measured, and one bug the tests caught mid-build
+
+| Mutation | Caught by |
+|---|---|
+| missing policy falls back to `Timeless` | **5** tests (3 integration + 2 unit) |
+| a benign new ruled row | nothing — the control, confirming the suite is not brittle |
+
+The adversarial pair uses claims of the **same `valid_from`**, read at the
+**same clock**: `last_seen_at` is `Stale`, `colour` is `Timeless`. Nothing in the
+data distinguishes them, so only the ruling can.
+
+The first draft of `ask` filtered with `.unwrap_or(false)`, which **swallowed
+the refusal and silently dropped the unclassified claim** — turning a policy
+fault into a narrower answer. That is the exact failure
+`one_unruled_claim_refuses_the_whole_query_rather_than_narrowing_it` was written
+to catch, and it caught it during the build rather than in review.
+
+#### What remains
+
+`mission_context` still classifies for itself via `FreshnessSource::Caller`. That
+is safer than the global default it replaced — the classification is a value
+somebody wrote, greppable and reviewable — and it should move to the ruled table
+once an applicable entry exists. The `Caller` variant stays as the honest interim
+while `RULED` is small.


### PR DESCRIPTION
## `KIRRA-WM-FRESHNESS-POLICY-001`

> **Freshness semantics are centrally ruled by claim kind. `Timeless` must be explicitly granted. Bounded facts require an explicit age limit. Unclassified semantics refuse.**

And the invariant that follows:

> **`Timeless` is an affirmative semantic classification, never the absence of a freshness policy.**

## The defect was live, and this repo had already found it

`WM_SCOPE.md`'s own FINDING 2 recorded it before the box was built:

> *"Where was the package last seen" is about as recency-sensitive as this domain gets, so a year-old observation is currently served with the same standing as a fresh one, under a label asserting that is fine.*

`validity_at` maps `staleness_budget_ms: None` to `Validity::Timeless`, and `WorldView` accepted `None` from anyone. `Timeless` is not *"we did not check"* — it is a **positive claim that the fact's age does not matter**, and the engine asserted it about every fact in the store whenever nobody supplied a budget.

## Why a ruled table, not a caller flag

The alternative was letting the caller declare a query recency-sensitive. Rejected because it merely **moves the trust decision outward**: a careless caller says "insensitive" and manufactures `Timeless` exactly as the engine did — the API satisfied, the architectural rule defeated.

So the disposition is ruled centrally, keyed by **semantics** (`kind` + `predicate`) rather than storage representation. `last_seen_at` and a floor plan can be identical in shape and opposite in temporal meaning; the key has to be what they mean.

## What `None` became

`WorldView::new` took `Option<u64>`. It now takes a `FreshnessSource` with **no variant meaning "nothing supplied"** — the old default is *unrepresentable*, not merely discouraged.

`mission_context`'s caller-supplied `Option` maps to an affirmative policy: `Some(b)` → `Bounded`, `None` → `Timeless`. That is what its signature already *meant* (*"I have considered this and this fact is genuinely timeless"*), now said in a type where the other reading cannot be written.

## The state machine, and `Unknown` settled

```text
policy = Timeless               -> Timeless
policy = Bounded, age <= bound  -> Fresh
policy = Bounded, age  > bound  -> Stale
no policy                       -> the QUERY refuses
```

The scope doc's open sub-question — is a fourth `Unknown` freshness variant reachable? — said to decide it by finding a reachable case or leaving it out, *"do not carry it undecided."*

**Decided: omitted.** There is no successful answer for which freshness is unknown. A missing policy is a **policy-resolution failure**, not a freshness state, so it travels in the error channel as `AskError::UnclassifiedFreshness`. A fourth variant would be uninhabited.

The one case that would justify it is recorded so it's recognised if it appears: a claim whose age genuinely **cannot be determined**, from missing or invalid time provenance. Then the variant becomes justified — established by a reachable test, not reserved speculatively.

## The table is small on purpose

Three ruled rows, each carrying its reasoning; everything else refuses.

| Class | Disposition | Why |
|---|---|---|
| `mission` / `last_seen_at` | `Bounded { 5 min }` | the class FINDING 2 named |
| `observation` / `position` | `Bounded { 30 s }` | the canonical recency-sensitive fact |
| `observation` / `colour` | `Timeless` | a property *of* the object, not a relationship to a moment |

A large speculative table would be decorative metadata in another costume — entries nobody decided, read as though somebody had. Because absence refuses, the table grows one argued row at a time and no interim is unsafe.

The classes this repository writes but has **not** ruled are in `ci/freshness_unruled_baseline.json` as knowingly unruled. All three are test fixtures; inventing dispositions for them would have been the same overclaim.

## The silent failure the gate exists for

The refusal is fail-closed, so a missing class is never *unsafe* — it is **invisible**. The table starts correct and quietly goes incomplete as new claim kinds land.

`ci/check_freshness_coverage.py` makes that mechanical: every `(kind, predicate)` the repository writes must be ruled or baselined, and one in neither reds. It **reports rather than silently skips** `NewEvent` literals whose `kind` comes from a variable, since those are classes it cannot see — a gate that quietly skipped them would advertise coverage it doesn't have. 9 self-tests, count-asserted.

## Mutation-measured

| Mutation | Caught by |
|---|---|
| missing policy falls back to `Timeless` | **5** tests (3 integration + 2 unit) |
| a benign new ruled row | **nothing** — the control, confirming the suite isn't brittle |

The adversarial pair uses claims with the **same `valid_from`**, read at the **same clock**: `last_seen_at` → `Stale`, `colour` → `Timeless`. Nothing in the data distinguishes them, so only the ruling can. A pair at different ages would pass on arithmetic and prove nothing about the table.

## A bug the tests caught mid-build

The first draft of `ask` filtered with `.unwrap_or(false)`, which **swallowed the refusal and silently dropped the unclassified claim** — turning a policy fault into a quietly narrower answer. That is precisely what `one_unruled_claim_refuses_the_whole_query_rather_than_narrowing_it` was written to catch, and it caught it during the build rather than in review. `ask` now propagates with `?`.

## What remains

`mission_context` still classifies for itself via `FreshnessSource::Caller`. That is strictly safer than the global default it replaced — the classification is a value somebody wrote, greppable and reviewable — and it moves to the ruled table once an applicable entry exists. The `Caller` variant stays as the honest interim while `RULED` is small.

## Verification

`cargo fmt --check` clean; clippy clean; **375 tests green**; the world gates all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_