### PR TITLE
Tier 3 box 3f — lineage retrieval as its own query family

### DIFF
--- a/ci/world_semantics_baseline.json
+++ b/ci/world_semantics_baseline.json
@@ -36,6 +36,13 @@
         "corpus_digest": "c6458e88ed93ce2498a8b02f97e04bdfe3f2c666a1146ed34c081f4e56bcc33f",
         "source_pin": "93d1c69a10f75e8df9e39c9d3cee1a89733b76b8fac7f0b0a7203b25370e04ae"
       }
+    ],
+    "lineage_selection": [
+      {
+        "version": 1,
+        "corpus_digest": "750c6e83b752ea7743032696b2a57b40134e97a91492961513a61e5a1fb8bc55",
+        "source_pin": "e25f2863158f146facab6c2a135c0e6b6efb0fdaa50ee139329bf4b340baa964"
+      }
     ]
   }
 }

--- a/crates/kirra-world-service/src/answer_ref.rs
+++ b/crates/kirra-world-service/src/answer_ref.rs
@@ -98,6 +98,14 @@ pub enum QueryKind {
     /// ([`crate::read_view::TemporalLookup::semantics`]), and that set has to
     /// be derived in the one place every set is derived.
     AsOfSubject,
+    /// [`crate::lineage::LineageRef`] — one page of the evidence bearing on a
+    /// subject at a pinned generation.
+    ///
+    /// A ref family of its own, described by [`crate::lineage::LineageRef`]
+    /// rather than by [`AnswerRef`]: its parameters are a page bound rather
+    /// than a clock and a budget. That module records why the two are separate
+    /// types sharing this enum instead of one struct holding the union.
+    SubjectLineage,
 }
 
 /// **A reproducible descriptor for one answer.**

--- a/crates/kirra-world-service/src/lib.rs
+++ b/crates/kirra-world-service/src/lib.rs
@@ -32,6 +32,7 @@
 
 pub mod answer_ref;
 pub mod freshness;
+pub mod lineage;
 pub mod read_view;
 pub mod semantics;
 

--- a/crates/kirra-world-service/src/lineage.rs
+++ b/crates/kirra-world-service/src/lineage.rs
@@ -1,0 +1,477 @@
+//! **Lineage retrieval — Tier 3 box 3f, the boundary half.**
+//!
+//! `KIRRA-WM-EXPLAIN-TIER-001`:
+//!
+//! > **`Explain` stays at Tier 4. Tier 3 builds only the deterministic lineage
+//! > CONTRACT that Tier 4 consumes.**
+//!
+//! with two constraints the ruling attaches to it regardless of where the
+//! rendering ends up living:
+//!
+//! > * **Bounded and paginated, with truncation visible.** […] A lineage
+//! >   response that silently stops is worse than one that says it stopped.
+//! > * **Historically correct.** Lineage for an answer true at *T* traverses the
+//! >   evidence visible at *T*, not today's graph.
+//!
+//! The selection itself — which events, in what order, where the page ends — is
+//! [`kirra_world_store::lineage::select_lineage`], where it is versioned and
+//! corpus-pinned. This module is the *query family*: a reproducible reference,
+//! its dependency set, and the provenance handles that make each entry citable.
+//!
+//! # A reference of its own, rather than a variant of [`AnswerRef`]
+//!
+//! `KIRRA-WM-ANSWER-IDENTITY-001` says a reference serializes *"query kind,
+//! query parameters, `as_known_at`, the requested valid instant, the
+//! projection/rule version set, the snapshot coordinate, **and the pagination
+//! bound**"*. [`AnswerRef`] carries no pagination bound, because the family it
+//! describes has no pages; this one carries no `now_ms` and no staleness budget,
+//! because lineage is evidence and evidence does not go stale — it is either in
+//! the log at that coordinate or it is not.
+//!
+//! One struct holding the union would let a caller build a lineage reference
+//! carrying a staleness budget, which hashes into the reference's identity while
+//! meaning nothing — so two references describing the *same* query would compare
+//! unequal on a field neither query reads. That would falsify the one property
+//! [`AnswerRef`] exists to have. The two types share what is genuinely shared:
+//! [`QueryKind`], [`SemanticVersions`], the refusal ordering, and the
+//! irreproducibility horizon.
+//!
+//! [`AnswerRef`]: crate::answer_ref::AnswerRef
+
+use kirra_world::evidence::{DigestError, EvidenceDigest};
+use kirra_world_store::compaction::Resolution;
+use kirra_world_store::lineage::{LineageEvent, LineagePage, PageBoundary};
+use kirra_world_store::snapshot::{Irreproducible, PinnedLineage};
+use kirra_world_store::{ClaimStatus, WorldStore, WriterClass};
+
+use crate::answer_ref::QueryKind;
+use crate::read_view::AskError;
+use crate::semantics::{SemanticVersions, VersionDifference};
+
+/// **The semantics a lineage answer is produced under, right now.**
+///
+/// Exactly ONE rule, and the three exclusions are the interesting part — each
+/// is a claim about what a lineage answer is derived from, and each is asserted
+/// in `the_lineage_query_depends_on_exactly_one_rule` rather than merely
+/// written down here.
+///
+/// | Rule | In? | Why |
+/// |---|---|---|
+/// | `lineage_selection` | yes | it decides which events, in what order, and where the page ends |
+/// | `world_current_fold` | **no** | lineage returns evidence, not folded claims. Nothing here asks which claim won a key |
+/// | `entity_fold` | **no** | the subject is matched as written; lineage follows no identity edges |
+/// | `answer_admissibility` | **no** | an inadmissible claim is still evidence — refusing to *serve* it is a different question from whether it *happened*, and hiding it would defeat the purpose |
+///
+/// The `answer_admissibility` exclusion is the one worth pausing on, because
+/// including it would look conservative and would be wrong. Lineage exists to
+/// answer *"why does this answer say what it says"*; an event that was rejected,
+/// or that expired, or that an LLM proposed and nobody confirmed, is frequently
+/// the whole explanation. A lineage that showed only servable claims would be
+/// silent in exactly the cases somebody is investigating.
+///
+/// Each exclusion is also a **tripwire**. If lineage ever follows identity
+/// edges, `entity_fold` starts being able to change what a lineage answer says
+/// and must join this set — and the assertion that it is absent will go red
+/// first, which is how `entity_fold` entered `CurrentSubject`'s set in box 3h.
+#[must_use]
+pub fn lineage_semantics() -> SemanticVersions {
+    SemanticVersions::for_query(QueryKind::SubjectLineage)
+}
+
+/// **A reproducible descriptor for one page of one subject's lineage.**
+///
+/// Structural equality and hashing over every field, including the page bound —
+/// so *"the same query at the same coordinate for the same page"* is one
+/// reference, and a different page is a different reference. A reference whose
+/// identity ignored the page would name a whole lineage while resolving to a
+/// slice of it.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct LineageRef {
+    subject: String,
+    generation: i64,
+    page: LineagePage,
+    semantics: SemanticVersions,
+}
+
+impl LineageRef {
+    /// Describe a lineage page at a pinned generation.
+    ///
+    /// The versions are stamped from the live declarations rather than taken
+    /// from the caller, for the reason [`AnswerRef`] states: a reference records
+    /// the semantics its answer was produced under, and a caller that could name
+    /// them could claim any.
+    ///
+    /// [`AnswerRef`]: crate::answer_ref::AnswerRef
+    #[must_use]
+    pub fn subject_lineage(subject: impl Into<String>, generation: i64, page: LineagePage) -> Self {
+        Self {
+            subject: subject.into(),
+            generation,
+            page,
+            semantics: SemanticVersions::for_query(QueryKind::SubjectLineage),
+        }
+    }
+
+    /// The query this describes. Always [`QueryKind::SubjectLineage`].
+    #[must_use]
+    pub fn kind(&self) -> QueryKind {
+        QueryKind::SubjectLineage
+    }
+
+    /// The subject whose evidence this names.
+    #[must_use]
+    pub fn subject(&self) -> &str {
+        &self.subject
+    }
+
+    /// The coordinate the lineage is pinned at.
+    #[must_use]
+    pub fn generation(&self) -> i64 {
+        self.generation
+    }
+
+    /// The page bound this reference names.
+    #[must_use]
+    pub fn page(&self) -> LineagePage {
+        self.page
+    }
+
+    /// The semantics this reference's answer was produced under.
+    #[must_use]
+    pub fn semantics(&self) -> &SemanticVersions {
+        &self.semantics
+    }
+
+    /// Rebuild a reference recorded under a different semantic version set.
+    ///
+    /// For tests and for a reader decoding a persisted reference — the same
+    /// deliberately-explicit escape hatch [`AnswerRef::recorded_under`] provides.
+    ///
+    /// [`AnswerRef::recorded_under`]: crate::answer_ref::AnswerRef::recorded_under
+    #[must_use]
+    pub fn recorded_under(mut self, semantics: SemanticVersions) -> Self {
+        self.semantics = semantics;
+        self
+    }
+
+    /// **The reference for the page that follows this one**, if any follows.
+    ///
+    /// Minted from a *resolution* rather than from a page number, and that is
+    /// the point: the cursor is the last generation actually returned, which
+    /// only the resolution knows. A caller who computed the next page by adding
+    /// the limit to an offset would skip or repeat at every boundary where the
+    /// selection rule and the arithmetic disagreed — and they disagree whenever
+    /// generations are not contiguous, which is always.
+    ///
+    /// Returns `None` when the page is [`PageBoundary::Complete`]: there is no
+    /// next reference, so none can be constructed. A caller cannot accidentally
+    /// paginate past the end.
+    #[must_use]
+    pub fn next_page(&self, resolved: &LineagePageAnswer) -> Option<Self> {
+        let next = resolved.boundary().next_after_generation()?;
+        Some(Self::subject_lineage(
+            self.subject.clone(),
+            self.generation,
+            LineagePage::new(self.page.limit(), Some(next))
+                .expect("a validated limit stays valid when only the cursor moves"),
+        ))
+    }
+
+    /// **Re-execute this exact lineage query against the same coordinate.**
+    ///
+    /// # Order of refusals
+    ///
+    /// The version check runs FIRST, before the store is touched — the ordering
+    /// [`AnswerRef::resolve`] establishes and for the same reason: selecting
+    /// under new rules and noticing afterwards is not a check, because the page
+    /// would already have been built under rules the reference never described.
+    ///
+    /// [`AnswerRef::resolve`]: crate::answer_ref::AnswerRef::resolve
+    ///
+    /// # Errors
+    ///
+    /// On a storage fault, on a negative generation
+    /// (`StoreError::InvalidGeneration`), or when an entry's stored chain digest
+    /// is not a digest — see [`AskError::CorruptProvenance`], which this family
+    /// raises for the same reason the answer family does: an entry that cannot
+    /// be cited is not lineage.
+    pub fn resolve(&self, store: &WorldStore) -> Result<LineageResolution, AskError> {
+        let differences = self
+            .semantics
+            .differences(&SemanticVersions::for_query(QueryKind::SubjectLineage));
+        if !differences.is_empty() {
+            return Ok(LineageResolution::VersionMismatch { differences });
+        }
+
+        let (selection, completeness) =
+            match store.lineage_at_generation(&self.subject, self.generation, self.page)? {
+                PinnedLineage::Reproduced {
+                    selection,
+                    completeness,
+                } => (selection, completeness),
+                PinnedLineage::Irreproducible(reason) => {
+                    return Ok(LineageResolution::Irreproducible(reason))
+                }
+            };
+
+        let mut entries = Vec::with_capacity(selection.events.len());
+        for event in selection.events {
+            entries.push(LineageEntry::bind(event)?);
+        }
+        Ok(LineageResolution::Resolved(LineagePageAnswer {
+            entries,
+            boundary: selection.boundary,
+            completeness,
+            semantics: SemanticVersions::for_query(QueryKind::SubjectLineage),
+        }))
+    }
+}
+
+/// **One citable piece of evidence.**
+///
+/// The store's [`LineageEvent`] with its chain digest turned into a real
+/// [`EvidenceDigest`]. That conversion is the whole difference between the two
+/// types, and it is not cosmetic: rule 1 says every answer carries a provenance
+/// handle, and an entry whose handle will not parse cannot be verified against
+/// the log by whoever reads it.
+#[derive(Debug, Clone)]
+pub struct LineageEntry {
+    event: LineageEvent,
+    provenance: EvidenceDigest,
+}
+
+impl LineageEntry {
+    /// Bind an event, refusing an unreadable handle.
+    fn bind(event: LineageEvent) -> Result<Self, AskError> {
+        let provenance =
+            EvidenceDigest::new(event.chain_digest.clone()).map_err(|cause: DigestError| {
+                AskError::CorruptProvenance {
+                    subject: event.subject.clone(),
+                    predicate: event.predicate.clone(),
+                    cause,
+                }
+            })?;
+        Ok(Self { event, provenance })
+    }
+
+    /// The log position — also this entry's page cursor.
+    #[must_use]
+    pub fn generation(&self) -> i64 {
+        self.event.generation
+    }
+
+    /// The event's identity.
+    #[must_use]
+    pub fn event_id(&self) -> &str {
+        &self.event.event_id
+    }
+
+    /// The observation this event was written from.
+    #[must_use]
+    pub fn observation_id(&self) -> &str {
+        &self.event.observation_id
+    }
+
+    /// When the store learned it.
+    #[must_use]
+    pub fn txn_time_ms(&self) -> i64 {
+        self.event.txn_time_ms
+    }
+
+    /// When the fact it asserts became true.
+    #[must_use]
+    pub fn valid_from_ms(&self) -> i64 {
+        self.event.valid_from_ms
+    }
+
+    /// When that fact stopped being true, if it has.
+    #[must_use]
+    pub fn valid_to_ms(&self) -> Option<i64> {
+        self.event.valid_to_ms
+    }
+
+    /// Who wrote it.
+    #[must_use]
+    pub fn source(&self) -> &str {
+        &self.event.source
+    }
+
+    /// Which version of that writer.
+    #[must_use]
+    pub fn source_version(&self) -> &str {
+        &self.event.source_version
+    }
+
+    /// The writer's class.
+    #[must_use]
+    pub fn writer_class(&self) -> WriterClass {
+        self.event.writer_class
+    }
+
+    /// Whether this was a confirmed fact or an unconfirmed proposal.
+    #[must_use]
+    pub fn claim_status(&self) -> ClaimStatus {
+        self.event.claim_status
+    }
+
+    /// The recorded provenance array, **verbatim and uninterpreted**.
+    ///
+    /// Passed through as stored rather than parsed. `WM_SCOPE.md` §7 records
+    /// `Explain` as depending on *"derivation edges being real structure rather
+    /// than a JSON array of identifiers"*, and this is that array — walking it
+    /// here would be Tier 3 inventing the structure whose absence is the reason
+    /// `Explain` is Tier 4.
+    #[must_use]
+    pub fn provenance_ids_json(&self) -> &str {
+        &self.event.provenance
+    }
+
+    /// The claim kind.
+    #[must_use]
+    pub fn kind(&self) -> &str {
+        &self.event.kind
+    }
+
+    /// The subject asserted about.
+    #[must_use]
+    pub fn subject(&self) -> &str {
+        &self.event.subject
+    }
+
+    /// The predicate, or `None` for a payload-only claim.
+    #[must_use]
+    pub fn predicate(&self) -> Option<&str> {
+        self.event.predicate.as_deref()
+    }
+
+    /// The object, or `None` for a claim carrying no relationship.
+    #[must_use]
+    pub fn object(&self) -> Option<&str> {
+        self.event.object.as_deref()
+    }
+
+    /// The provenance handle: this event's position in the tamper-evident chain.
+    #[must_use]
+    pub fn provenance(&self) -> &EvidenceDigest {
+        &self.provenance
+    }
+}
+
+/// **One page of lineage, with everything needed to judge it.**
+///
+/// Three things ride alongside the entries, and none is optional:
+/// the page boundary (is this all of it), the compaction verdict (was any of it
+/// deleted), and the semantics (under which rule was it selected). An answer
+/// missing any one of them can be misread as complete when it is not.
+#[derive(Debug, Clone)]
+pub struct LineagePageAnswer {
+    entries: Vec<LineageEntry>,
+    boundary: PageBoundary,
+    completeness: Resolution,
+    semantics: SemanticVersions,
+}
+
+impl LineagePageAnswer {
+    /// The evidence, oldest first.
+    #[must_use]
+    pub fn entries(&self) -> &[LineageEntry] {
+        &self.entries
+    }
+
+    /// **Whether this page is the whole lineage, and where to continue.**
+    ///
+    /// The ruling's *"truncation visible"*, as a value that must be looked at to
+    /// learn where the next page starts — so a caller that paginates cannot do
+    /// it without seeing that the last page said `Complete`.
+    #[must_use]
+    pub fn boundary(&self) -> &PageBoundary {
+        &self.boundary
+    }
+
+    /// Whether this page stopped short of the whole lineage.
+    #[must_use]
+    pub fn is_truncated(&self) -> bool {
+        self.boundary.is_truncated()
+    }
+
+    /// **Whether compaction removed evidence at or below this coordinate.**
+    ///
+    /// Box 3g's obligation, which lineage inherits by being an answer family:
+    /// completeness is carried *independently of the payload outcome*. An empty
+    /// page that is `Degraded` says *"the evidence was deleted"*, which is a
+    /// different fact from *"there was none"* — and on a lineage query, which
+    /// exists to reconstruct what happened, it is the more important one.
+    ///
+    /// Truncation and degradation are **separate** and both can be true: a page
+    /// can be cut short by its own limit *and* be missing a compacted span. One
+    /// is a bound the caller chose; the other is evidence that no longer exists.
+    #[must_use]
+    pub fn completeness(&self) -> &Resolution {
+        &self.completeness
+    }
+
+    /// Whether compaction bore on this answer.
+    #[must_use]
+    pub fn is_degraded(&self) -> bool {
+        self.completeness.is_degraded()
+    }
+
+    /// The rules this page was selected under.
+    #[must_use]
+    pub fn semantics(&self) -> &SemanticVersions {
+        &self.semantics
+    }
+}
+
+/// What resolving a lineage reference produced.
+///
+/// The same three outcomes as [`RefResolution`], deliberately: a lineage
+/// reference is subject to the same reproducibility horizon and the same
+/// version discipline, and giving it a different vocabulary would suggest
+/// otherwise.
+///
+/// [`RefResolution`]: crate::answer_ref::RefResolution
+#[derive(Debug, Clone)]
+pub enum LineageResolution {
+    /// Re-executed at the pinned coordinate.
+    Resolved(LineagePageAnswer),
+    /// The coordinate has not been reached — see
+    /// `KIRRA-WM-REPRODUCIBILITY-HORIZON-001`.
+    ///
+    /// Note what is **not** here: a compacted coordinate. Compaction degrades a
+    /// lineage answer rather than refusing it, because the removed spans are
+    /// themselves reportable — see
+    /// [`ReadSnapshot::lineage_at_generation`][l] for why this family splits
+    /// from the pinned projection read on exactly this point.
+    ///
+    /// [l]: kirra_world_store::snapshot::ReadSnapshot::lineage_at_generation
+    Irreproducible(Irreproducible),
+    /// The selection rule changed since the reference was recorded.
+    ///
+    /// Refused rather than replayed. A lineage reference is the case where
+    /// replaying would be most quietly wrong: the cursor in a recorded page-2
+    /// reference was minted by the *old* ordering, so re-running it under a new
+    /// one returns a set that is neither the old page 2 nor the new one, and
+    /// looks entirely ordinary.
+    VersionMismatch {
+        /// Every rule whose version differs, recorded versus current.
+        differences: Vec<VersionDifference>,
+    },
+}
+
+impl LineageResolution {
+    /// The page, if it resolved.
+    #[must_use]
+    pub fn resolved(&self) -> Option<&LineagePageAnswer> {
+        match self {
+            Self::Resolved(p) => Some(p),
+            _ => None,
+        }
+    }
+
+    /// Whether this is any kind of refusal.
+    #[must_use]
+    pub fn is_refused(&self) -> bool {
+        !matches!(self, Self::Resolved(_))
+    }
+}

--- a/crates/kirra-world-service/src/semantics.rs
+++ b/crates/kirra-world-service/src/semantics.rs
@@ -199,6 +199,21 @@ impl SemanticVersions {
                     version: version_of(BoundaryRuleId::Admissibility),
                 },
             ]),
+            // Box 3f. ONE rule, and the three absences are load-bearing claims
+            // rather than an oversight — see `crate::lineage::lineage_semantics`
+            // for the argument on each, and
+            // `the_lineage_query_depends_on_exactly_one_rule` for the assertion
+            // that they are still true.
+            //
+            // In particular `answer_admissibility` is OUT: lineage returns
+            // evidence, and an event the boundary would refuse to *serve* is
+            // often precisely the event that explains the answer. Including it
+            // would make a lineage refuse for a rule it never consults, and
+            // would hide the rejected evidence an investigator came for.
+            QueryKind::SubjectLineage => Self::new([RuleVersion {
+                rule: RuleId::LineageSelection.as_str().to_string(),
+                version: store_semantics::version_of(RuleId::LineageSelection),
+            }]),
         }
     }
 
@@ -489,5 +504,59 @@ mod tests {
             "subject summaries are a different query family; including them would \
              refuse references for a rule they never consulted"
         );
+    }
+
+    /// **Box 3f's dependency claim, and its three tripwires.**
+    ///
+    /// The exclusions are asserted, not assumed. Each is a statement about what
+    /// a lineage answer is derived from today, and each will go red the moment
+    /// it stops being true — which is exactly how `entity_fold` entered
+    /// `CurrentSubject`'s set when box 3h changed the composition.
+    #[test]
+    fn the_lineage_query_depends_on_exactly_one_rule() {
+        let v = SemanticVersions::for_query(QueryKind::SubjectLineage);
+        let names: Vec<&str> = v.entries().iter().map(|e| e.rule.as_str()).collect();
+        assert_eq!(names, vec!["lineage_selection"]);
+
+        assert!(
+            v.version_of("world_current_fold").is_none(),
+            "lineage returns EVIDENCE, not folded claims — nothing in it asks \
+             which claim won a key. If lineage ever marks the winning event, \
+             this fold can change what it says and must join the set"
+        );
+        assert!(
+            v.version_of("entity_fold").is_none(),
+            "lineage matches the subject as written and follows no identity \
+             edges. If it ever reads the equivalence class, this fold decides \
+             which events are in the answer and must join the set"
+        );
+        assert!(
+            v.version_of(ADMISSIBILITY).is_none(),
+            "an inadmissible claim is still evidence: whether the boundary would \
+             SERVE it is a different question from whether it happened, and a \
+             lineage hiding rejected events is silent exactly when someone is \
+             investigating one"
+        );
+    }
+
+    /// Two families that share no rules must not be collapsed into one arm.
+    ///
+    /// `CurrentSubject` and `AsOfSubject` legitimately share theirs, and the
+    /// `for_query` comment records that as a finding rather than a coincidence.
+    /// This pins the other direction: lineage's set is genuinely disjoint, so a
+    /// future edit that folded it into the shared arm for tidiness would be
+    /// changing what a lineage answer claims to depend on.
+    #[test]
+    fn the_lineage_family_shares_no_rule_with_the_answer_families() {
+        let lineage = SemanticVersions::for_query(QueryKind::SubjectLineage);
+        let current = SemanticVersions::for_query(QueryKind::CurrentSubject);
+        for entry in lineage.entries() {
+            assert!(
+                current.version_of(&entry.rule).is_none(),
+                "{} is claimed by both families; if that is genuinely true the \
+                 shared-arm comment in `for_query` needs revisiting",
+                entry.rule
+            );
+        }
     }
 }

--- a/crates/kirra-world-service/tests/lineage_retrieval.rs
+++ b/crates/kirra-world-service/tests/lineage_retrieval.rs
@@ -1,0 +1,574 @@
+//! **Box 3f — lineage retrieval, against a real store.**
+//!
+//! `KIRRA-WM-EXPLAIN-TIER-001` attaches two constraints to Tier 3's lineage
+//! contract, and this file exists to make both of them properties of the code
+//! rather than of the prose:
+//!
+//! > * **Bounded and paginated, with truncation visible.**
+//! > * **Historically correct.** Lineage for an answer true at *T* traverses the
+//! >   evidence visible at *T*, not today's graph.
+//!
+//! # The load-bearing test, and why it is the same one twice
+//!
+//! `an_event_appended_after_the_pin_is_not_in_the_lineage` is 3f's version of
+//! the test box 3h and `ask_as_of` each carry on their own axis: record
+//! something *after* the coordinate, and check the earlier answer did not
+//! change. The recurrence is the point — "resolve current state and label it
+//! historical" is the failure this whole tier keeps almost making, and it looks
+//! like ordinary code every time.
+//!
+//! The store-level rule has its own unit tests over synthetic events. These run
+//! the whole path: real store, real append, real fold, real reference.
+//!
+//! # Two axes this file cannot pin, measured rather than assumed
+//!
+//! Both were found by running the mutation, not by reading the code, and both
+//! are structural — the integration path masks them:
+//!
+//! **Ordering.** Deleting the sort from `select_lineage` reds nothing here.
+//! `generation` is `world_events`' primary key, so SQLite hands rows back in
+//! that order anyway and the unsorted rule accidentally agrees with the sorted
+//! one on every store this file can build.
+//!
+//! **The subject filter.** Deleting it from the rule reds nothing here either,
+//! because the SQL pre-filters by subject. So
+//! `another_subjects_evidence_is_not_in_this_lineage` below genuinely tests the
+//! *query*, and does not test the *rule* — which is worth knowing, since the two
+//! are separately editable.
+//!
+//! Both axes are covered where they can be, and both mutations red there:
+//! `lineage::tests::{events_come_back_oldest_first_regardless_of_input_order,
+//! another_subjects_events_are_not_in_this_lineage}` feed the rule directly, and
+//! `the_lineage_corpus_catches_{an_unordered_selection, ignoring_the_subject}`
+//! render the divergence into the pinned digest.
+//!
+//! Stated plainly because the tempting conclusion — *"the integration tests
+//! cover these"* — is false, and a later reader deleting the store-level tests as
+//! redundant would remove the only coverage there is.
+
+use kirra_world_service::answer_ref::QueryKind;
+use kirra_world_service::lineage::{LineageRef, LineageResolution};
+use kirra_world_service::semantics::{RuleVersion, SemanticVersions};
+use kirra_world_store::lineage::LineagePage;
+use kirra_world_store::{ClaimStatus, EventId, NewEvent, ObservationId, WorldStore, WriterClass};
+
+const T0: i64 = 1_700_000_000_000;
+const SUBJECT: &str = "package_17";
+
+fn tmp(name: &str) -> std::path::PathBuf {
+    static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let n = NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "kirra-lineage-{name}-{}-{n}.sqlite",
+        std::process::id()
+    ));
+    cleanup(&p);
+    p
+}
+
+fn cleanup(path: &std::path::Path) {
+    for suffix in ["", "-wal", "-shm"] {
+        let mut q = path.as_os_str().to_os_string();
+        q.push(suffix);
+        let _ = std::fs::remove_file(std::path::PathBuf::from(q));
+    }
+}
+
+/// Append one event about `subject`, returning nothing — the generation is read
+/// back from the fold, so a test never hard-codes a coordinate it did not
+/// observe.
+fn append(store: &mut WorldStore, tag: &str, subject: &str, status: ClaimStatus, offset: i64) {
+    store
+        .append(&NewEvent {
+            event_id: &EventId::new(format!("ev-{tag}")).expect("event id"),
+            observation_id: &ObservationId::new(format!("obs-{tag}")).expect("obs"),
+            txn_time_ms: T0 + offset,
+            valid_from_ms: T0 + offset,
+            valid_to_ms: None,
+            source: "warehouse-scanner",
+            source_version: "1.0.0",
+            writer_class: match status {
+                ClaimStatus::Candidate => WriterClass::LlmCandidate,
+                ClaimStatus::Confirmed => WriterClass::Sensor,
+            },
+            claim_status: status,
+            provenance: &[],
+            frame_id: None,
+            map_id: None,
+            kind: "mission",
+            subject,
+            subject_ref: None,
+            predicate: Some("last_seen_at"),
+            object: Some("dock_b"),
+            payload: "{}",
+            payload_schema: 1,
+            retention_class: "raw",
+            trust: None,
+        })
+        .expect("append");
+}
+
+/// A store with `n` confirmed events about `SUBJECT`, folded.
+fn store_with(n: i64, name: &str) -> (WorldStore, std::path::PathBuf, i64) {
+    let path = tmp(name);
+    let mut store = WorldStore::open(&path).expect("open");
+    for i in 1..=n {
+        append(
+            &mut store,
+            &format!("{i}"),
+            SUBJECT,
+            ClaimStatus::Confirmed,
+            i,
+        );
+    }
+    let generation = store.fold().expect("fold");
+    (store, path, generation)
+}
+
+fn resolve(store: &WorldStore, r: &LineageRef) -> LineageResolution {
+    r.resolve(store).expect("lineage resolves")
+}
+
+fn generations(res: &LineageResolution) -> Vec<i64> {
+    res.resolved()
+        .unwrap_or_else(|| panic!("expected a resolved page, got {res:?}"))
+        .entries()
+        .iter()
+        .map(|e| e.generation())
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Historical correctness — the load-bearing half
+// ---------------------------------------------------------------------------
+
+/// **THE BOX.** Evidence recorded after the pin must not enter the earlier
+/// answer.
+///
+/// The transaction-time and generation axes have each had this test; this is the
+/// lineage family's. A reference resolved before and after a later append must
+/// return the identical page — not a longer one.
+#[test]
+fn an_event_appended_after_the_pin_is_not_in_the_lineage() {
+    let (mut store, path, generation) = store_with(3, "historical");
+    let reference = LineageRef::subject_lineage(SUBJECT, generation, LineagePage::first());
+
+    let before = generations(&resolve(&store, &reference));
+    assert_eq!(before.len(), 3, "the fixture must have three events");
+
+    // The world moves on: more evidence about the same subject, folded.
+    append(&mut store, "late", SUBJECT, ClaimStatus::Confirmed, 500);
+    let later_generation = store.fold().expect("fold");
+    assert!(
+        later_generation > generation,
+        "the append must advance the coordinate, or this proves nothing"
+    );
+
+    let after = generations(&resolve(&store, &reference));
+    assert_eq!(
+        after, before,
+        "a recorded lineage reference changed meaning because new evidence \
+         arrived — the pinned coordinate was ignored and today's log was served \
+         under yesterday's reference"
+    );
+
+    // The positive control: the SAME query at the NEW coordinate does see it.
+    // Without this, a resolver that returned nothing at all would pass above.
+    let now = LineageRef::subject_lineage(SUBJECT, later_generation, LineagePage::first());
+    assert_eq!(
+        generations(&resolve(&store, &now)).len(),
+        4,
+        "the later coordinate must include the later evidence, or the test \
+         above is passing because lineage is broken rather than because it is \
+         pinned"
+    );
+
+    drop(store);
+    cleanup(&path);
+}
+
+/// A coordinate the log has not reached refuses rather than serving what exists.
+#[test]
+fn a_coordinate_beyond_the_log_refuses() {
+    let (store, path, generation) = store_with(2, "unreached");
+    let reference = LineageRef::subject_lineage(SUBJECT, generation + 1_000, LineagePage::first());
+    assert!(
+        matches!(
+            resolve(&store, &reference),
+            LineageResolution::Irreproducible(_)
+        ),
+        "a coordinate that does not exist yet must refuse, not fall back to the \
+         head"
+    );
+    drop(store);
+    cleanup(&path);
+}
+
+// ---------------------------------------------------------------------------
+// Bounded, paginated, truncation visible
+// ---------------------------------------------------------------------------
+
+/// A truncated page says so, and names where to continue.
+#[test]
+fn a_truncated_page_is_visibly_truncated() {
+    let (store, path, generation) = store_with(5, "truncated");
+    let reference = LineageRef::subject_lineage(
+        SUBJECT,
+        generation,
+        LineagePage::new(2, None).expect("valid page"),
+    );
+    let res = resolve(&store, &reference);
+    let page = res.resolved().expect("resolved");
+    assert_eq!(page.entries().len(), 2);
+    assert!(
+        page.is_truncated(),
+        "a page that stopped short must say so — a lineage response that \
+         silently stops is worse than one that says it stopped"
+    );
+    assert!(page.boundary().next_after_generation().is_some());
+    drop(store);
+    cleanup(&path);
+}
+
+/// **Paginating to exhaustion through the REFERENCE visits everything once.**
+///
+/// The cursor is minted from the resolution rather than computed by the caller,
+/// so this also pins that `next_page` is usable without the caller knowing how
+/// generations are numbered — which they are not, contiguously.
+#[test]
+fn paginating_through_references_visits_every_event_exactly_once() {
+    let (store, path, generation) = store_with(7, "paginate");
+    let mut reference = LineageRef::subject_lineage(
+        SUBJECT,
+        generation,
+        LineagePage::new(3, None).expect("valid page"),
+    );
+
+    let mut seen: Vec<i64> = Vec::new();
+    let mut pages = 0;
+    loop {
+        let res = resolve(&store, &reference);
+        let page = res.resolved().expect("resolved");
+        seen.extend(page.entries().iter().map(|e| e.generation()));
+        pages += 1;
+        assert!(pages < 20, "pagination did not terminate");
+        match reference.next_page(page) {
+            Some(next) => reference = next,
+            None => break,
+        }
+    }
+
+    let mut sorted = seen.clone();
+    sorted.sort_unstable();
+    sorted.dedup();
+    assert_eq!(
+        seen, sorted,
+        "pagination repeated or reordered events across page boundaries"
+    );
+    assert_eq!(seen.len(), 7, "pagination lost events");
+
+    drop(store);
+    cleanup(&path);
+}
+
+/// The last page offers no successor, so a caller cannot paginate past the end.
+///
+/// # The bound is EXACTLY the event count, deliberately
+///
+/// A first draft asked for `LineagePage::first()` (limit 256) over two events,
+/// which is a page that could not have been full — so it passed against a rule
+/// that reported `More` on every merely-full page. Measured: the eager-`More`
+/// mutation survived this test and was caught only at the store level.
+///
+/// Sizing the page to exactly the lineage's length puts the off-by-one under
+/// this test as well, which is where a reader looking for it would expect to
+/// find it.
+#[test]
+fn the_final_page_yields_no_next_reference() {
+    let (store, path, generation) = store_with(2, "final");
+    let reference = LineageRef::subject_lineage(
+        SUBJECT,
+        generation,
+        LineagePage::new(2, None).expect("valid page"),
+    );
+    let res = resolve(&store, &reference);
+    let page = res.resolved().expect("resolved");
+    assert_eq!(page.entries().len(), 2, "the page must be exactly full");
+    assert!(
+        !page.is_truncated(),
+        "a page that is exactly full and IS the whole lineage must not report a \
+         successor — a caller paginating to exhaustion would make a wasted round \
+         trip on every lineage whose length divides the page size, and would be \
+         told there is more when there is not"
+    );
+    assert!(
+        reference.next_page(page).is_none(),
+        "a complete page must not mint a successor reference"
+    );
+    drop(store);
+    cleanup(&path);
+}
+
+/// An oversized page is refused, not quietly cut down.
+#[test]
+fn an_oversized_page_bound_is_refused_rather_than_clamped() {
+    assert!(
+        LineagePage::new(kirra_world_store::lineage::MAX_LINEAGE_PAGE + 1, None).is_err(),
+        "a clamp would answer a smaller question and report it as the one asked"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// What lineage includes, and what a reference refuses
+// ---------------------------------------------------------------------------
+
+/// Unconfirmed proposals are in the lineage, though never in an answer.
+///
+/// The distinction 3f rests on: `WorldView::ask` serves facts, lineage explains
+/// them, and *"an LLM proposed this and nobody confirmed it"* is an explanation.
+#[test]
+fn an_unconfirmed_candidate_is_lineage_though_it_is_never_an_answer() {
+    let path = tmp("candidate");
+    let mut store = WorldStore::open(&path).expect("open");
+    append(&mut store, "c1", SUBJECT, ClaimStatus::Confirmed, 1);
+    append(&mut store, "c2", SUBJECT, ClaimStatus::Candidate, 2);
+    let generation = store.fold().expect("fold");
+
+    let reference = LineageRef::subject_lineage(SUBJECT, generation, LineagePage::first());
+    let res = resolve(&store, &reference);
+    let page = res.resolved().expect("resolved");
+    assert_eq!(page.entries().len(), 2);
+    assert!(
+        page.entries()
+            .iter()
+            .any(|e| e.claim_status() == ClaimStatus::Candidate
+                && e.writer_class() == WriterClass::LlmCandidate),
+        "the LLM's proposal must be visible in the record of what was proposed"
+    );
+
+    drop(store);
+    cleanup(&path);
+}
+
+/// Another subject's evidence is not this subject's lineage.
+#[test]
+fn another_subjects_evidence_is_not_in_this_lineage() {
+    let path = tmp("subject");
+    let mut store = WorldStore::open(&path).expect("open");
+    append(&mut store, "mine", SUBJECT, ClaimStatus::Confirmed, 1);
+    append(&mut store, "theirs", "pallet_9", ClaimStatus::Confirmed, 2);
+    let generation = store.fold().expect("fold");
+
+    let reference = LineageRef::subject_lineage(SUBJECT, generation, LineagePage::first());
+    let res = resolve(&store, &reference);
+    let page = res.resolved().expect("resolved");
+    assert_eq!(page.entries().len(), 1);
+    assert_eq!(page.entries()[0].subject(), SUBJECT);
+
+    drop(store);
+    cleanup(&path);
+}
+
+/// Every entry carries a parseable provenance handle — rule 1, at this family.
+#[test]
+fn every_entry_is_citable() {
+    let (store, path, generation) = store_with(3, "citable");
+    let reference = LineageRef::subject_lineage(SUBJECT, generation, LineagePage::first());
+    let res = resolve(&store, &reference);
+    for entry in res.resolved().expect("resolved").entries() {
+        assert_eq!(
+            entry.provenance().as_str().len(),
+            64,
+            "an entry that cannot be cited is not lineage"
+        );
+        assert!(!entry.event_id().is_empty());
+        assert!(!entry.observation_id().is_empty());
+    }
+    drop(store);
+    cleanup(&path);
+}
+
+// ---------------------------------------------------------------------------
+// The version discipline
+// ---------------------------------------------------------------------------
+
+/// **A reference recorded under a different selection rule REFUSES.**
+///
+/// The one that makes the version set more than an annotation. A recorded page-2
+/// cursor was minted by the old ordering, so replaying it under a new one
+/// returns a set that is neither the old page 2 nor the new one — and looks
+/// entirely ordinary.
+#[test]
+fn a_reference_recorded_under_another_selection_version_refuses() {
+    let (store, path, generation) = store_with(3, "version");
+    let reference = LineageRef::subject_lineage(SUBJECT, generation, LineagePage::first())
+        .recorded_under(SemanticVersions::new([RuleVersion {
+            rule: "lineage_selection".to_string(),
+            version: 99,
+        }]));
+
+    match resolve(&store, &reference) {
+        LineageResolution::VersionMismatch { differences } => {
+            assert_eq!(differences.len(), 1);
+            assert_eq!(differences[0].rule, "lineage_selection");
+            assert_eq!(differences[0].recorded, Some(99));
+        }
+        other => panic!("a moved selection rule must refuse, got {other:?}"),
+    }
+
+    drop(store);
+    cleanup(&path);
+}
+
+/// The version check runs **before** the store is touched.
+///
+/// Asserted through a coordinate that would otherwise refuse for a different
+/// reason: if the store were consulted first, this would come back
+/// `Irreproducible` rather than `VersionMismatch`. Ordering that could only be
+/// read off the source is ordering nothing holds in place.
+#[test]
+fn the_version_check_precedes_the_coordinate_check() {
+    let (store, path, generation) = store_with(1, "order");
+    let reference = LineageRef::subject_lineage(SUBJECT, generation + 1_000, LineagePage::first())
+        .recorded_under(SemanticVersions::new([RuleVersion {
+            rule: "lineage_selection".to_string(),
+            version: 99,
+        }]));
+
+    assert!(
+        matches!(
+            resolve(&store, &reference),
+            LineageResolution::VersionMismatch { .. }
+        ),
+        "the coordinate was consulted before the versions — a page would have \
+         been built under rules the reference never described"
+    );
+
+    drop(store);
+    cleanup(&path);
+}
+
+/// A reference declares the family it belongs to, and stamps live versions.
+#[test]
+fn a_fresh_reference_carries_this_builds_semantics() {
+    let reference = LineageRef::subject_lineage(SUBJECT, 1, LineagePage::first());
+    assert_eq!(reference.kind(), QueryKind::SubjectLineage);
+    assert_eq!(
+        reference.semantics(),
+        &SemanticVersions::for_query(QueryKind::SubjectLineage)
+    );
+}
+
+/// Two references for the same query are equal; a different PAGE is a different
+/// reference.
+///
+/// The pagination bound is part of a reference's identity — `KIRRA-WM-ANSWER-
+/// IDENTITY-001` lists it among what a reference serializes — so two pages of
+/// one lineage must not compare equal.
+#[test]
+fn the_page_bound_is_part_of_a_references_identity() {
+    let a = LineageRef::subject_lineage(SUBJECT, 7, LineagePage::new(10, None).expect("valid"));
+    let b = LineageRef::subject_lineage(SUBJECT, 7, LineagePage::new(10, None).expect("valid"));
+    let second_page =
+        LineageRef::subject_lineage(SUBJECT, 7, LineagePage::new(10, Some(3)).expect("valid"));
+    let smaller =
+        LineageRef::subject_lineage(SUBJECT, 7, LineagePage::new(5, None).expect("valid"));
+
+    assert_eq!(a, b, "the same query must produce the same reference");
+    assert_ne!(a, second_page, "a different page is a different reference");
+    assert_ne!(a, smaller, "a different bound is a different reference");
+}
+
+// ---------------------------------------------------------------------------
+// Completeness (box 3g's obligation, inherited)
+// ---------------------------------------------------------------------------
+
+/// An uncompacted store reports `Full`, and truncation is NOT degradation.
+///
+/// The two are independent and it is easy to conflate them: a page cut short by
+/// the caller's own limit is complete evidence, bounded. A page missing a
+/// compacted span is evidence that no longer exists. Reporting the first as
+/// `Degraded` would cry wolf on every paginated read.
+#[test]
+fn a_truncated_page_of_intact_evidence_is_not_degraded() {
+    let (store, path, generation) = store_with(5, "notdegraded");
+    let reference = LineageRef::subject_lineage(
+        SUBJECT,
+        generation,
+        LineagePage::new(2, None).expect("valid page"),
+    );
+    let res = resolve(&store, &reference);
+    let page = res.resolved().expect("resolved");
+    assert!(page.is_truncated(), "the fixture must truncate");
+    assert!(
+        !page.is_degraded(),
+        "a page bounded by the caller's own limit is complete evidence, and \
+         reporting it as degraded would make the signal worthless"
+    );
+    drop(store);
+    cleanup(&path);
+}
+
+/// **Compaction DEGRADES a lineage page rather than refusing it.**
+///
+/// The split this family makes from the pinned projection read, and the
+/// positive control for the `Degraded` arm — without it, `is_degraded()` could
+/// be permanently `false` and every other test here would still pass.
+///
+/// A folded projection over a log with holes is silently *wrong*, so
+/// `read_at_generation` refuses one. Lineage is the evidence itself, so a page
+/// missing a compacted span is *incomplete* — and the citations name exactly
+/// which generations went and under which digest. Refusing would throw away a
+/// usable answer and tell an investigator nothing.
+#[test]
+fn a_compacted_span_degrades_the_page_instead_of_refusing_it() {
+    let (mut store, path, _) = store_with(3, "compacted");
+    // Generation 2 is superseded by 3, so it is compactable; the live head is
+    // structurally protected.
+    let outcome = store
+        .compact_range(2, 2, T0 + 9_000)
+        .expect("a superseded generation is compactable");
+    assert_eq!(outcome.removed, 1, "the fixture must remove evidence");
+    let generation = store.fold().expect("fold");
+
+    let reference = LineageRef::subject_lineage(SUBJECT, generation, LineagePage::first());
+    let res = resolve(&store, &reference);
+    let page = res
+        .resolved()
+        .unwrap_or_else(|| panic!("compaction must DEGRADE, not refuse: {res:?}"));
+
+    assert!(
+        page.is_degraded(),
+        "evidence was deleted at or below this coordinate and the page did not \
+         say so — a lineage that under-reports its own gaps is the one thing an \
+         incident reconstruction cannot tolerate"
+    );
+    assert!(
+        !page.completeness().spans().is_empty(),
+        "a degraded page must name the spans it lost; `Degraded` with nothing \
+         to trace it to is the fail-open version of admitting the loss"
+    );
+    assert!(
+        !page.is_truncated(),
+        "the fixture's surviving evidence fits one page, so this is degradation \
+         WITHOUT truncation — the two axes must be independently observable"
+    );
+
+    drop(store);
+    cleanup(&path);
+}
+
+/// Every resolved page states the rules it was selected under.
+#[test]
+fn a_resolved_page_carries_its_semantics() {
+    let (store, path, generation) = store_with(1, "semantics");
+    let reference = LineageRef::subject_lineage(SUBJECT, generation, LineagePage::first());
+    let res = resolve(&store, &reference);
+    assert_eq!(
+        res.resolved().expect("resolved").semantics(),
+        &SemanticVersions::for_query(QueryKind::SubjectLineage)
+    );
+    drop(store);
+    cleanup(&path);
+}

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -85,6 +85,7 @@ use rusqlite::{params, Connection, OptionalExtension};
 pub mod adjudication_record;
 pub mod compaction;
 pub mod entity_projection;
+pub mod lineage;
 pub mod projection;
 pub mod retention_driver;
 pub mod retention_sweeper;
@@ -2647,6 +2648,24 @@ impl WorldStore {
     ) -> Result<snapshot::PinnedComposedRead, StoreError> {
         self.read_snapshot()?
             .read_composed_at_generation(generation)
+    }
+
+    /// **One page of a subject's lineage at a pinned generation** — box 3f.
+    ///
+    /// See [`snapshot::ReadSnapshot::lineage_at_generation`], including why this
+    /// family degrades on compaction where the pinned projection read refuses.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::InvalidGeneration`] for a negative generation.
+    pub fn lineage_at_generation(
+        &self,
+        subject: &str,
+        generation: i64,
+        page: lineage::LineagePage,
+    ) -> Result<snapshot::PinnedLineage, StoreError> {
+        self.read_snapshot()?
+            .lineage_at_generation(subject, generation, page)
     }
 
     /// **Claims and identity at ONE transaction-time cut.**

--- a/crates/kirra-world-store/src/lineage.rs
+++ b/crates/kirra-world-store/src/lineage.rs
@@ -1,0 +1,507 @@
+//! **Lineage selection — Tier 3 box 3f, the store half.**
+//!
+//! `KIRRA-WM-EXPLAIN-TIER-001`:
+//!
+//! > **`Explain` stays at Tier 4. Tier 3 builds only the deterministic lineage
+//! > CONTRACT that Tier 4 consumes.** […] Bounded and paginated, with truncation
+//! > visible. […] Historically correct.
+//!
+//! This module owns the *selection*: given the evidence a store holds, which
+//! events are in one subject's lineage at one coordinate, in what order, and
+//! where a page ends. The boundary half — the reference, the version set, the
+//! provenance handles — is `kirra_world_service::lineage`.
+//!
+//! # What lineage is here, and what it deliberately is not
+//!
+//! It is the **evidence**: the `world_events` rows bearing on a subject, oldest
+//! first, up to a pinned generation. Each row carries what was recorded about
+//! where it came from — source, writer class, observation id, and the
+//! `provenance` array **verbatim**.
+//!
+//! It is **not** a traversal of that array. `WM_SCOPE.md` §7 records `Explain`
+//! as depending on *"derivation edges being real structure rather than a JSON
+//! array of identifiers"*, and today they are precisely that array. Following it
+//! would mean inventing the structure whose absence is the reason `Explain` is
+//! Tier 4 — so this reports the identifiers as recorded and stops there. The
+//! stopping point is the tier boundary, not an oversight.
+//!
+//! # Why the rule is a pure function over rows
+//!
+//! The SQL that fetches candidates could express the whole thing — filter,
+//! order, limit. It deliberately does not. A rule living in a query string is a
+//! rule no corpus can render and no source pin can cover, which is the
+//! decorative-metadata failure box 3b exists to prevent. So SQL fetches by
+//! subject (an exact equality on an indexed column, which cannot disagree with
+//! the same equality applied here) and [`select_lineage`] decides everything
+//! that involves a judgement: the generation bound, the ordering, and where the
+//! page boundary falls.
+
+use crate::{ClaimStatus, WriterClass};
+
+/// The largest page a caller may request.
+///
+/// Rule 2 — *queries are bounded* — with a number rather than a hope. D-9
+/// measured 10.5 s p99 temporal queries at 100 000 entities and ADR-0041 D-12
+/// bars this class of query from any control or safety deadline path; an
+/// unbounded lineage walk is the shape most likely to breach both.
+pub const MAX_LINEAGE_PAGE: usize = 256;
+
+/// One evidence event in a subject's lineage.
+///
+/// The `world_events` row as recorded. Nothing here is derived, folded or
+/// resolved — a lineage entry is a citation of what the log holds, and a field
+/// this type computed would be a claim the log does not make.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LineageEvent {
+    /// The log position — also this event's page cursor.
+    pub generation: i64,
+    /// The event's identity.
+    pub event_id: String,
+    /// The observation this event was written from.
+    pub observation_id: String,
+    /// When the store learned it.
+    pub txn_time_ms: i64,
+    /// When the fact it asserts became true.
+    pub valid_from_ms: i64,
+    /// When that fact stopped being true, if it has.
+    pub valid_to_ms: Option<i64>,
+    /// Who wrote it.
+    pub source: String,
+    /// Which version of that writer.
+    pub source_version: String,
+    /// The writer's class — ADR-0040's `llm_candidate` distinction lives here.
+    pub writer_class: WriterClass,
+    /// Whether this is a confirmed fact or an unconfirmed proposal.
+    pub claim_status: ClaimStatus,
+    /// The recorded provenance array, **verbatim, uninterpreted**.
+    ///
+    /// A JSON array of observation identifiers, passed through exactly as
+    /// stored. Not parsed, because parsing it here would be the first half of
+    /// treating it as the derivation structure it is not yet — see the module
+    /// docs. A consumer that wants the identifiers can decode this string
+    /// knowing it is doing so.
+    pub provenance: String,
+    /// The claim kind.
+    pub kind: String,
+    /// The subject asserted about.
+    pub subject: String,
+    /// The predicate, or `None` for a payload-only claim.
+    pub predicate: Option<String>,
+    /// The object, or `None` for a claim carrying no relationship.
+    pub object: Option<String>,
+    /// This event's position in the tamper-evident chain.
+    ///
+    /// The raw stored string. The boundary turns it into an
+    /// `EvidenceDigest` — and refuses the entry if it is not one — for the same
+    /// reason an answer refuses an unreadable handle: a lineage entry that
+    /// cannot be cited is not lineage.
+    pub chain_digest: String,
+}
+
+/// **Where a page of lineage stopped, and whether anything follows.**
+///
+/// An enum rather than a `truncated: bool` beside an `Option<cursor>`, because
+/// those two fields can disagree and the disagreement is silent. The ruling asks
+/// for truncation to be *visible*; a shape that can express "complete, and here
+/// is where to continue" has already lost that.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PageBoundary {
+    /// Every event in this lineage is in this page.
+    Complete,
+    /// The page filled. More events follow, starting after this generation.
+    More {
+        /// Pass as [`LineagePage::after_generation`] to continue. Exclusive.
+        next_after_generation: i64,
+    },
+}
+
+impl PageBoundary {
+    /// Whether the page stopped short of the whole lineage.
+    #[must_use]
+    pub fn is_truncated(&self) -> bool {
+        matches!(self, Self::More { .. })
+    }
+
+    /// The cursor to continue from, if there is more.
+    #[must_use]
+    pub fn next_after_generation(&self) -> Option<i64> {
+        match self {
+            Self::Complete => None,
+            Self::More {
+                next_after_generation,
+            } => Some(*next_after_generation),
+        }
+    }
+}
+
+/// A rejected page request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PageSpecError {
+    /// A zero-length page. Refused rather than treated as "no bound": it would
+    /// return nothing while reporting more, which is an infinite loop dressed as
+    /// a paginated read.
+    ZeroLimit,
+    /// Over [`MAX_LINEAGE_PAGE`].
+    ///
+    /// **Refused, never clamped.** A silent clamp answers a different question
+    /// from the one asked and reports the result as though it were the one
+    /// asked — the caller believes it holds 1 000 events and holds 256, with the
+    /// boundary saying `Complete` if the lineage happened to be shorter than its
+    /// clamped request. Same discipline as `SelfFilterMask`: validated at
+    /// construction, refused on violation.
+    LimitTooLarge {
+        /// What was asked for.
+        requested: usize,
+        /// The ceiling.
+        maximum: usize,
+    },
+}
+
+impl core::fmt::Display for PageSpecError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::ZeroLimit => write!(f, "a lineage page limit of 0 returns nothing"),
+            Self::LimitTooLarge { requested, maximum } => write!(
+                f,
+                "lineage page limit {requested} exceeds the maximum of {maximum}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for PageSpecError {}
+
+/// **A validated page request.**
+///
+/// Constructed through [`LineagePage::new`] or not at all, so an out-of-range
+/// bound cannot reach the selection rule.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct LineagePage {
+    limit: usize,
+    after_generation: Option<i64>,
+}
+
+impl LineagePage {
+    /// Validate a page request.
+    ///
+    /// # Errors
+    ///
+    /// [`PageSpecError`] for a zero limit or one over [`MAX_LINEAGE_PAGE`].
+    pub fn new(limit: usize, after_generation: Option<i64>) -> Result<Self, PageSpecError> {
+        if limit == 0 {
+            return Err(PageSpecError::ZeroLimit);
+        }
+        if limit > MAX_LINEAGE_PAGE {
+            return Err(PageSpecError::LimitTooLarge {
+                requested: limit,
+                maximum: MAX_LINEAGE_PAGE,
+            });
+        }
+        Ok(Self {
+            limit,
+            after_generation,
+        })
+    }
+
+    /// The first page at the maximum size.
+    #[must_use]
+    pub fn first() -> Self {
+        Self {
+            limit: MAX_LINEAGE_PAGE,
+            after_generation: None,
+        }
+    }
+
+    /// How many events this page may hold.
+    #[must_use]
+    pub fn limit(&self) -> usize {
+        self.limit
+    }
+
+    /// The exclusive lower bound on generation, if continuing.
+    #[must_use]
+    pub fn after_generation(&self) -> Option<i64> {
+        self.after_generation
+    }
+}
+
+/// One page of a subject's lineage, and whether it is the whole of it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SelectedLineage {
+    /// The events, oldest first.
+    pub events: Vec<LineageEvent>,
+    /// Whether anything follows.
+    pub boundary: PageBoundary,
+}
+
+// SEMANTICS-PIN-BEGIN: lineage_selection
+//
+// The versioned rule — see `crate::semantics`. Digested by
+// `ci/check_world_semantics.py`; changing which events are selected, the order
+// they come back in, or where a page ends moves the corpus digest, and then
+// `SEMANTICS`' version must be bumped so recorded lineage references refuse
+// rather than replay under the new rule.
+
+/// **Which events are in a subject's lineage, in what order, and where the page
+/// ends.**
+///
+/// Four decisions, each of which can change what a lineage answer says:
+///
+/// 1. **Subject** — events whose `subject` column equals `subject`, as written.
+///    Identity is deliberately not followed; see the note below.
+/// 2. **Generation bound** — at or below `at_generation`. This is the
+///    historical-correctness rule: an event appended after the pinned coordinate
+///    is not evidence that was visible at it, and including it would be 2d's
+///    trap ("resolve current state and label it historical") one tier up.
+/// 3. **Ordering** — `generation` ascending. Total and stable, since generation
+///    is `world_events`' primary key, which is what makes a cursor meaningful.
+/// 4. **Page boundary** — at most `page.limit()` events, starting strictly after
+///    `page.after_generation()`.
+///
+/// # Candidates are unfiltered by contract
+///
+/// This takes every event the caller has and does its own filtering, so the rule
+/// is complete in one place. The SQL path pre-filters by subject as an index
+/// optimisation; that is safe precisely because it is the *same* exact equality
+/// applied here, and could not select a different set. Anything involving a
+/// judgement — the bound, the order, the boundary — is here and nowhere else.
+///
+/// # Candidate claims are INCLUDED, and that is the point
+///
+/// `world_current` folds only `claim_status = 'confirmed'`. Lineage does not
+/// filter on it. A proposal that was never confirmed is part of why an answer
+/// says what it says, and an investigator asking "what did the LLM propose here"
+/// is asking exactly this question. ADR-0040's guarantee is that a candidate
+/// never becomes a *fact*; it is not that a candidate becomes invisible.
+///
+/// # Identity is NOT followed, stated because it bounds the answer
+///
+/// An adjudication that merged `pkg-17-alias` into `package_17` is recorded
+/// under whichever subject it names, so it is not in `package_17`'s lineage
+/// here. That is the same limitation `WorldView::ask` states for the subject
+/// side, and for the same reason: reading the whole equivalence class is a
+/// different query, not a flag on this one. It is also what keeps `entity_fold`
+/// honestly OUT of this family's semantic version set — the moment lineage
+/// follows identity edges, that fold can change what a lineage answer says and
+/// must join the set.
+#[must_use]
+pub fn select_lineage(
+    candidates: Vec<LineageEvent>,
+    subject: &str,
+    at_generation: i64,
+    page: LineagePage,
+) -> SelectedLineage {
+    let mut selected: Vec<LineageEvent> = candidates
+        .into_iter()
+        .filter(|e| e.subject == subject)
+        .filter(|e| e.generation <= at_generation)
+        .filter(|e| page.after_generation.is_none_or(|a| e.generation > a))
+        .collect();
+    selected.sort_by_key(|e| e.generation);
+
+    // One over the limit is fetched conceptually here: `More` is reported only
+    // when an event actually exists beyond the page, never when the page merely
+    // filled exactly. A page that is exactly full and complete must not claim a
+    // successor, or a caller paginating to exhaustion makes one wasted round
+    // trip on every lineage whose length divides the page size.
+    if selected.len() > page.limit {
+        selected.truncate(page.limit);
+        let last = selected
+            .last()
+            .expect("a limit of 0 is unrepresentable, so the page is non-empty")
+            .generation;
+        return SelectedLineage {
+            events: selected,
+            boundary: PageBoundary::More {
+                next_after_generation: last,
+            },
+        };
+    }
+    SelectedLineage {
+        events: selected,
+        boundary: PageBoundary::Complete,
+    }
+}
+
+// SEMANTICS-PIN-END: lineage_selection
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ev(generation: i64, subject: &str) -> LineageEvent {
+        LineageEvent {
+            generation,
+            event_id: format!("ev-{generation}"),
+            observation_id: format!("obs-{generation}"),
+            txn_time_ms: 1_000 + generation,
+            valid_from_ms: 1_000 + generation,
+            valid_to_ms: None,
+            source: "scanner".to_string(),
+            source_version: "1.0.0".to_string(),
+            writer_class: WriterClass::Sensor,
+            claim_status: ClaimStatus::Confirmed,
+            provenance: "[]".to_string(),
+            kind: "mission".to_string(),
+            subject: subject.to_string(),
+            predicate: Some("last_seen_at".to_string()),
+            object: None,
+            chain_digest: format!("digest-{generation}"),
+        }
+    }
+
+    fn gens(s: &SelectedLineage) -> Vec<i64> {
+        s.events.iter().map(|e| e.generation).collect()
+    }
+
+    #[test]
+    fn a_zero_limit_is_refused_and_an_oversized_one_is_not_clamped() {
+        assert_eq!(LineagePage::new(0, None), Err(PageSpecError::ZeroLimit));
+        assert_eq!(
+            LineagePage::new(MAX_LINEAGE_PAGE + 1, None),
+            Err(PageSpecError::LimitTooLarge {
+                requested: MAX_LINEAGE_PAGE + 1,
+                maximum: MAX_LINEAGE_PAGE,
+            }),
+            "an oversized limit must REFUSE — a clamp answers a smaller question \
+             and reports it as the one that was asked"
+        );
+        assert!(LineagePage::new(MAX_LINEAGE_PAGE, None).is_ok());
+    }
+
+    #[test]
+    fn events_come_back_oldest_first_regardless_of_input_order() {
+        let out = select_lineage(
+            vec![ev(3, "s"), ev(1, "s"), ev(2, "s")],
+            "s",
+            10,
+            LineagePage::first(),
+        );
+        assert_eq!(gens(&out), vec![1, 2, 3]);
+        assert_eq!(out.boundary, PageBoundary::Complete);
+    }
+
+    #[test]
+    fn another_subjects_events_are_not_in_this_lineage() {
+        let out = select_lineage(
+            vec![ev(1, "s"), ev(2, "other"), ev(3, "s")],
+            "s",
+            10,
+            LineagePage::first(),
+        );
+        assert_eq!(gens(&out), vec![1, 3]);
+    }
+
+    /// The historical-correctness rule, at its smallest.
+    #[test]
+    fn an_event_after_the_pinned_generation_is_not_visible_at_it() {
+        let out = select_lineage(
+            vec![ev(1, "s"), ev(2, "s"), ev(9, "s")],
+            "s",
+            2,
+            LineagePage::first(),
+        );
+        assert_eq!(
+            gens(&out),
+            vec![1, 2],
+            "generation 9 was appended after the pinned coordinate and was not \
+             evidence visible at it"
+        );
+    }
+
+    #[test]
+    fn a_full_page_reports_where_to_continue_and_the_next_page_resumes_there() {
+        let all: Vec<LineageEvent> = (1..=5).map(|g| ev(g, "s")).collect();
+        let page = LineagePage::new(2, None).expect("valid");
+        let first = select_lineage(all.clone(), "s", 10, page);
+        assert_eq!(gens(&first), vec![1, 2]);
+        assert_eq!(
+            first.boundary,
+            PageBoundary::More {
+                next_after_generation: 2
+            }
+        );
+
+        let second = select_lineage(
+            all.clone(),
+            "s",
+            10,
+            LineagePage::new(2, first.boundary.next_after_generation()).expect("valid"),
+        );
+        assert_eq!(gens(&second), vec![3, 4]);
+
+        let third = select_lineage(
+            all,
+            "s",
+            10,
+            LineagePage::new(2, second.boundary.next_after_generation()).expect("valid"),
+        );
+        assert_eq!(gens(&third), vec![5]);
+        assert_eq!(
+            third.boundary,
+            PageBoundary::Complete,
+            "the last page must not advertise a successor"
+        );
+    }
+
+    /// An exactly-full page that IS complete must say so.
+    ///
+    /// The off-by-one a limit-only check gets wrong: `len == limit` is
+    /// indistinguishable from "there is more" unless something looked past the
+    /// boundary. Getting this wrong costs a wasted round trip on every lineage
+    /// whose length divides the page size — and reports `More` for a lineage
+    /// that has no more.
+    #[test]
+    fn an_exactly_full_but_complete_page_does_not_advertise_a_successor() {
+        let out = select_lineage(
+            (1..=2).map(|g| ev(g, "s")).collect(),
+            "s",
+            10,
+            LineagePage::new(2, None).expect("valid"),
+        );
+        assert_eq!(gens(&out), vec![1, 2]);
+        assert_eq!(out.boundary, PageBoundary::Complete);
+    }
+
+    /// Paginating to exhaustion visits every event exactly once.
+    ///
+    /// The property that actually matters to a caller, asserted over the whole
+    /// walk rather than inferred from the single-page cases: a cursor that
+    /// skipped or repeated at a boundary would still pass each test above.
+    #[test]
+    fn paginating_to_exhaustion_visits_every_event_exactly_once() {
+        let all: Vec<LineageEvent> = (1..=7).map(|g| ev(g, "s")).collect();
+        let mut seen = Vec::new();
+        let mut cursor = None;
+        loop {
+            let out = select_lineage(
+                all.clone(),
+                "s",
+                10,
+                LineagePage::new(3, cursor).expect("valid"),
+            );
+            seen.extend(gens(&out));
+            match out.boundary.next_after_generation() {
+                Some(next) => cursor = Some(next),
+                None => break,
+            }
+        }
+        assert_eq!(seen, vec![1, 2, 3, 4, 5, 6, 7]);
+    }
+
+    /// A candidate is evidence about why an answer says what it says, even
+    /// though it is never folded into one.
+    #[test]
+    fn unconfirmed_candidates_are_in_the_lineage() {
+        let mut candidate = ev(2, "s");
+        candidate.claim_status = ClaimStatus::Candidate;
+        candidate.writer_class = WriterClass::LlmCandidate;
+        let out = select_lineage(vec![ev(1, "s"), candidate], "s", 10, LineagePage::first());
+        assert_eq!(
+            gens(&out),
+            vec![1, 2],
+            "a proposal that was never confirmed is part of the record of what \
+             was proposed"
+        );
+    }
+}

--- a/crates/kirra-world-store/src/semantics.rs
+++ b/crates/kirra-world-store/src/semantics.rs
@@ -99,6 +99,16 @@ pub enum RuleId {
     /// [`crate::subject_projection::subject_fold_step`] — the subject summary
     /// fold.
     SubjectSummaryFold,
+    /// [`crate::lineage::select_lineage`] — the lineage selection rule.
+    ///
+    /// Not a *reducer*, and included anyway. The membership test this module
+    /// applies is *"can changing this alter a derived answer"*, not *"is this a
+    /// fold"* — and lineage selection can alter one four ways at once: the
+    /// events chosen, the generation bound, the order, and where a page ends.
+    /// A recorded lineage reference whose page-2 cursor was minted under a
+    /// different ordering describes a different set of evidence while looking
+    /// identical.
+    LineageSelection,
 }
 
 impl RuleId {
@@ -113,6 +123,7 @@ impl RuleId {
             Self::WorldCurrentFold => "world_current_fold",
             Self::EntityFold => "entity_fold",
             Self::SubjectSummaryFold => "subject_summary_fold",
+            Self::LineageSelection => "lineage_selection",
         }
     }
 
@@ -126,6 +137,7 @@ impl RuleId {
             RuleId::WorldCurrentFold,
             RuleId::EntityFold,
             RuleId::SubjectSummaryFold,
+            RuleId::LineageSelection,
         ]
     }
 }
@@ -188,6 +200,14 @@ pub const SEMANTICS: &[RuleSpec] = &[
         source_pin: "2faa627ee865dd00229b52960b35d250caadc42acf4b10aef7bb48f97ecebb85",
         source_file: "crates/kirra-world-store/src/subject_projection.rs",
         span: "subject_summary_fold",
+    },
+    RuleSpec {
+        rule: RuleId::LineageSelection,
+        version: 1,
+        corpus_digest: "750c6e83b752ea7743032696b2a57b40134e97a91492961513a61e5a1fb8bc55",
+        source_pin: "e25f2863158f146facab6c2a135c0e6b6efb0fdaa50ee139329bf4b340baa964",
+        source_file: "crates/kirra-world-store/src/lineage.rs",
+        span: "lineage_selection",
     },
 ];
 
@@ -456,6 +476,110 @@ pub fn render_subjects(rows: &BTreeMap<SubjectKey, ProjectedSubject>) -> String 
     out
 }
 
+/// The lineage selection rule's corpus input — the **evidence**.
+///
+/// Supplied deliberately **out of generation order**, so a rule that dropped the
+/// sort produces a different rendering rather than accidentally the same one.
+///
+/// | Event | What it holds open |
+/// |---|---|
+/// | gen 5, `package_17` | supplied FIRST, so ordering is discriminated |
+/// | gen 1, `package_17` | the oldest, and the first page's head |
+/// | gen 3, **`other_subject`** | the **subject filter** — a rule ignoring it interleaves this at position 3 |
+/// | gen 2, `package_17`, **candidate** | candidates are lineage; a rule that filtered on `claim_status` like the claim fold does would drop it |
+/// | gen 4, `package_17` | an ordinary interior event |
+/// | gen 9, `package_17` | **above the pin** in the queries that bound at 5 — the historical-correctness axis |
+#[must_use]
+pub fn lineage_corpus() -> Vec<crate::lineage::LineageEvent> {
+    let ev = |generation: i64,
+              subject: &str,
+              claim_status: crate::ClaimStatus,
+              writer_class: crate::WriterClass| {
+        crate::lineage::LineageEvent {
+            generation,
+            event_id: format!("ev-{generation}"),
+            observation_id: format!("obs-{generation}"),
+            txn_time_ms: 1_000 + generation,
+            valid_from_ms: 1_000 + generation,
+            valid_to_ms: None,
+            source: "warehouse-scanner".to_string(),
+            source_version: "1.0.0".to_string(),
+            writer_class,
+            claim_status,
+            provenance: format!("[\"obs-{generation}\"]"),
+            kind: "mission".to_string(),
+            subject: subject.to_string(),
+            predicate: Some("last_seen_at".to_string()),
+            object: Some(format!("dock-{generation}")),
+            chain_digest: format!("chain-{generation}"),
+        }
+    };
+    use crate::{ClaimStatus::*, WriterClass::*};
+    vec![
+        ev(5, "package_17", Confirmed, Sensor),
+        ev(1, "package_17", Confirmed, Sensor),
+        ev(3, "other_subject", Confirmed, Sensor),
+        ev(2, "package_17", Candidate, LlmCandidate),
+        ev(4, "package_17", Confirmed, Sensor),
+        ev(9, "package_17", Confirmed, Sensor),
+    ]
+}
+
+/// The queries the lineage corpus is rendered under.
+///
+/// A selection rule is a function of the query as well as the data, so the
+/// corpus has to be a set of *queries* — one input rendered once would pin the
+/// ordering and leave the bound, the cursor and the page boundary unexercised.
+///
+/// | Label | Holds open |
+/// |---|---|
+/// | `bounded` | the generation bound (gen 9 excluded) and the subject filter (gen 3 excluded), in one query |
+/// | `page_1` / `page_2` / `page_3` | the cursor walk: fills, resumes, and ends — a rule that mis-set the cursor by one moves `page_2` |
+/// | `exactly_full` | a page whose length equals the limit and which IS complete — the off-by-one that reports a successor that does not exist |
+/// | `other_subject` | the subject filter's **positive** control: a rule that dropped every non-matching row rather than filtering by the queried value would empty this |
+#[must_use]
+pub fn lineage_queries() -> Vec<(&'static str, &'static str, i64, crate::lineage::LineagePage)> {
+    let page = |limit: usize, after: Option<i64>| {
+        crate::lineage::LineagePage::new(limit, after)
+            .expect("the corpus queries must be valid, or they pin an error")
+    };
+    vec![
+        ("bounded", "package_17", 5, page(10, None)),
+        ("page_1", "package_17", 9, page(2, None)),
+        ("page_2", "package_17", 9, page(2, Some(2))),
+        ("page_3", "package_17", 9, page(2, Some(5))),
+        ("exactly_full", "package_17", 5, page(4, None)),
+        ("other_subject", "other_subject", 9, page(10, None)),
+    ]
+}
+
+/// Render the lineage selection rule's verdict over its corpus.
+///
+/// Renders the selected **generations** and the boundary, not whole events: the
+/// rule decides *which* events and *in what order*, and it cannot change an
+/// event's own fields. Rendering the fields would make the digest move when an
+/// unrelated column changed, which is the reflexive re-pinning these digests
+/// exist to avoid.
+#[must_use]
+pub fn render_lineage(selection: &crate::lineage::SelectedLineage) -> String {
+    use crate::lineage::PageBoundary;
+    let mut out = String::new();
+    for e in &selection.events {
+        out.push_str(&e.generation.to_string());
+        out.push(FIELD);
+    }
+    out.push_str(
+        match &selection.boundary {
+            PageBoundary::Complete => "complete".to_string(),
+            PageBoundary::More {
+                next_after_generation,
+            } => format!("more:{next_after_generation}"),
+        }
+        .as_str(),
+    );
+    out
+}
+
 /// **Run one rule's corpus through the real reducer and render the result.**
 ///
 /// This is the value the declared [`RuleSpec::corpus_digest`] is a digest of. It
@@ -479,6 +603,21 @@ pub fn corpus_rendering(rule: RuleId) -> String {
                 &subject_projection::subject_fold_all(corpus.iter())
                     .expect("the subject corpus must fold, or it is pinning an error"),
             )
+        }
+        RuleId::LineageSelection => {
+            let mut out = String::new();
+            for (label, subject, at_generation, page) in lineage_queries() {
+                out.push_str(label);
+                out.push(FIELD);
+                out.push_str(&render_lineage(&crate::lineage::select_lineage(
+                    lineage_corpus(),
+                    subject,
+                    at_generation,
+                    page,
+                )));
+                out.push(ROW);
+            }
+            out
         }
     }
 }

--- a/crates/kirra-world-store/src/semantics.rs
+++ b/crates/kirra-world-store/src/semantics.rs
@@ -568,15 +568,15 @@ pub fn render_lineage(selection: &crate::lineage::SelectedLineage) -> String {
         out.push_str(&e.generation.to_string());
         out.push(FIELD);
     }
-    out.push_str(
-        match &selection.boundary {
-            PageBoundary::Complete => "complete".to_string(),
-            PageBoundary::More {
-                next_after_generation,
-            } => format!("more:{next_after_generation}"),
+    match &selection.boundary {
+        PageBoundary::Complete => out.push_str("complete"),
+        PageBoundary::More {
+            next_after_generation,
+        } => {
+            out.push_str("more:");
+            out.push_str(&next_after_generation.to_string());
         }
-        .as_str(),
-    );
+    }
     out
 }
 

--- a/crates/kirra-world-store/src/snapshot.rs
+++ b/crates/kirra-world-store/src/snapshot.rs
@@ -243,17 +243,8 @@ impl<'a> ReadSnapshot<'a> {
     /// query, which rule 3 puts in the error channel. Generation `0` is legal
     /// and reconstructs the empty projection that preceded every event.
     pub fn read_at_generation(&self, generation: i64) -> Result<PinnedRead, StoreError> {
-        if generation < 0 {
-            return Err(StoreError::InvalidGeneration {
-                requested: generation,
-            });
-        }
-
-        let head = checkpoint_on(&self.tx, projection::CURRENT_PROJECTION)?.0;
-        if generation > head {
-            return Ok(PinnedRead::Irreproducible(Irreproducible::NotYetReached {
-                head,
-            }));
+        if let Some(reason) = self.coordinate_reached(generation)? {
+            return Ok(PinnedRead::Irreproducible(reason));
         }
 
         // Compaction check BEFORE the replay, deliberately. Replaying first and
@@ -271,6 +262,97 @@ impl<'a> ReadSnapshot<'a> {
             generation,
             rows: replay_to(&self.tx, generation)?,
         }))
+    }
+
+    /// **Does this coordinate exist yet?** — the half of reproducibility that
+    /// every pinned read answers the same way.
+    ///
+    /// Shared rather than repeated. The compaction half is deliberately NOT
+    /// here, because the two pinned families answer it differently and one
+    /// helper returning both would hide that: a projection replay must REFUSE a
+    /// compacted coordinate (a fold over a log with holes is silently wrong),
+    /// while a lineage read DEGRADES (the removed spans are themselves a fact,
+    /// and `Resolution::Degraded` is the type for it). Merging them would force
+    /// one family to take the other's answer.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::InvalidGeneration`] for a negative generation — a malformed
+    /// query rather than an unreachable one, so it goes in the error channel.
+    fn coordinate_reached(&self, generation: i64) -> Result<Option<Irreproducible>, StoreError> {
+        if generation < 0 {
+            return Err(StoreError::InvalidGeneration {
+                requested: generation,
+            });
+        }
+        let head = checkpoint_on(&self.tx, projection::CURRENT_PROJECTION)?.0;
+        Ok((generation > head).then_some(Irreproducible::NotYetReached { head }))
+    }
+
+    /// **One page of a subject's lineage, as it stood at `generation`** —
+    /// box 3f.
+    ///
+    /// `KIRRA-WM-EXPLAIN-TIER-001` asks Tier 3 for a lineage contract that is
+    /// *bounded and paginated, with truncation visible* and *historically
+    /// correct*. The selection rule — which events, in what order, where the
+    /// page ends — is [`crate::lineage::select_lineage`], versioned and
+    /// corpus-pinned; this supplies it with candidates and the compaction
+    /// verdict.
+    ///
+    /// # Compaction DEGRADES here rather than refusing
+    ///
+    /// [`Self::read_at_generation`] refuses a compacted coordinate, and must:
+    /// a projection folded from a log with holes in it is silently wrong, and
+    /// looks exactly like a correct one. Lineage is not folded — it is the
+    /// evidence itself — so a page missing a compacted span is *incomplete*
+    /// rather than *wrong*, and the citations say exactly which generations were
+    /// removed and under which digest. Refusing would discard a usable answer;
+    /// `Resolution::Degraded` is 3g's type for precisely this.
+    ///
+    /// The split mirrors one this store already makes: `read_composed_at_generation`
+    /// refuses while `as_of_composed` degrades.
+    ///
+    /// **No summaries ride along, and that is not an omission.** A
+    /// [`crate::DegradedSummary`] summarises folded *claims* for a key; it is
+    /// not a stand-in for removed evidence *rows*, so offering one here would
+    /// answer a question lineage did not ask. The spans are what name the loss.
+    ///
+    /// # Errors
+    ///
+    /// As [`Self::coordinate_reached`].
+    pub fn lineage_at_generation(
+        &self,
+        subject: &str,
+        generation: i64,
+        page: crate::lineage::LineagePage,
+    ) -> Result<PinnedLineage, StoreError> {
+        if let Some(reason) = self.coordinate_reached(generation)? {
+            return Ok(PinnedLineage::Irreproducible(reason));
+        }
+
+        let spans = compacted_at_or_below(&self.tx, generation)?;
+        let completeness = if spans.is_empty() {
+            crate::Resolution::Full
+        } else {
+            crate::Resolution::Degraded {
+                spans,
+                summaries: Vec::new(),
+            }
+        };
+
+        Ok(PinnedLineage::Reproduced {
+            // Pre-filtered by subject ONLY — an exact equality on an indexed
+            // column, which is the same test `select_lineage` applies, so the
+            // index cannot select a different set than the rule would. Every
+            // decision that involves a judgement is left to the rule.
+            selection: crate::lineage::select_lineage(
+                lineage_candidates(&self.tx, subject)?,
+                subject,
+                generation,
+                page,
+            ),
+            completeness,
+        })
     }
 
     /// **Reconstruct claims AND identity at one generation — box 3h.**
@@ -513,6 +595,29 @@ impl PinnedComposition {
     pub fn generation(&self) -> i64 {
         self.projection.generation()
     }
+}
+
+/// The outcome of a composed generation-pinned read.
+///
+/// One refusal for both halves — see [`ReadSnapshot::read_composed_at_generation`].
+/// The outcome of a pinned lineage read — box 3f.
+///
+/// Note the asymmetry with [`PinnedComposedRead`], which is deliberate and
+/// documented on [`ReadSnapshot::lineage_at_generation`]: only *"that coordinate
+/// does not exist yet"* refuses here. Compaction rides on the reproduced arm as
+/// a [`crate::Resolution`], because removed evidence is a fact a lineage answer
+/// can report rather than a reason it cannot be given.
+#[derive(Debug, Clone)]
+pub enum PinnedLineage {
+    /// The page, and whether compaction bore on it.
+    Reproduced {
+        /// The selected events and the page boundary.
+        selection: crate::lineage::SelectedLineage,
+        /// Whether compaction removed evidence at or below this coordinate.
+        completeness: crate::Resolution,
+    },
+    /// The coordinate has not been reached.
+    Irreproducible(Irreproducible),
 }
 
 /// The outcome of a composed generation-pinned read.
@@ -872,6 +977,52 @@ pub(crate) fn replay_identity_to(
         head = at;
     }
     Ok(entity_projection::IdentityView::new(acc, head))
+}
+
+/// Every event recorded under `subject`, unordered and unbounded by generation.
+///
+/// The candidates [`crate::lineage::select_lineage`] rules over. Deliberately
+/// does NOT apply the generation bound, the ordering or the page: those are the
+/// rule, and a query that pre-applied them would be a second implementation of a
+/// versioned rule — the drift `read_composed_at_generation` was corrected for on
+/// #1437, in a place where nothing would notice.
+///
+/// The subject equality it *does* apply is the one filter that cannot disagree
+/// with the rule, because it is the identical comparison on the identical value.
+pub(crate) fn lineage_candidates(
+    conn: &Connection,
+    subject: &str,
+) -> Result<Vec<crate::lineage::LineageEvent>, StoreError> {
+    if !table_exists(conn, "world_events")? {
+        return Ok(Vec::new());
+    }
+    let mut stmt = conn.prepare(
+        "SELECT generation, event_id, observation_id, txn_time_ms, valid_from_ms,
+                valid_to_ms, source, source_version, writer_class, claim_status,
+                provenance, kind, subject, predicate, object, chain_digest
+         FROM world_events WHERE subject = ?1",
+    )?;
+    let rows = stmt.query_map(params![subject], |r| {
+        Ok(crate::lineage::LineageEvent {
+            generation: r.get(0)?,
+            event_id: r.get(1)?,
+            observation_id: r.get(2)?,
+            txn_time_ms: r.get(3)?,
+            valid_from_ms: r.get(4)?,
+            valid_to_ms: r.get(5)?,
+            source: r.get(6)?,
+            source_version: r.get(7)?,
+            writer_class: crate::WriterClass::from_stored(&r.get::<_, String>(8)?),
+            claim_status: crate::ClaimStatus::from_stored(&r.get::<_, String>(9)?),
+            provenance: r.get(10)?,
+            kind: r.get(11)?,
+            subject: r.get(12)?,
+            predicate: r.get(13)?,
+            object: r.get(14)?,
+            chain_digest: r.get(15)?,
+        })
+    })?;
+    Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
 }
 
 pub(crate) fn table_exists(conn: &Connection, name: &str) -> Result<bool, StoreError> {

--- a/crates/kirra-world-store/src/snapshot.rs
+++ b/crates/kirra-world-store/src/snapshot.rs
@@ -341,12 +341,11 @@ impl<'a> ReadSnapshot<'a> {
         };
 
         Ok(PinnedLineage::Reproduced {
-            // Pre-filtered by subject ONLY — an exact equality on an indexed
-            // column, which is the same test `select_lineage` applies, so the
-            // index cannot select a different set than the rule would. Every
-            // decision that involves a judgement is left to the rule.
+            // The fetch is narrowed to the most the rule can consume (see
+            // `lineage_candidates`); the rule still decides everything. The two
+            // are held in agreement by an explicit test rather than by reading.
             selection: crate::lineage::select_lineage(
-                lineage_candidates(&self.tx, subject)?,
+                lineage_candidates(&self.tx, subject, generation, page)?,
                 subject,
                 generation,
                 page,
@@ -597,9 +596,6 @@ impl PinnedComposition {
     }
 }
 
-/// The outcome of a composed generation-pinned read.
-///
-/// One refusal for both halves — see [`ReadSnapshot::read_composed_at_generation`].
 /// The outcome of a pinned lineage read — box 3f.
 ///
 /// Note the asymmetry with [`PinnedComposedRead`], which is deliberate and
@@ -979,17 +975,100 @@ pub(crate) fn replay_identity_to(
     Ok(entity_projection::IdentityView::new(acc, head))
 }
 
-/// Every event recorded under `subject`, unordered and unbounded by generation.
+/// The candidate events [`crate::lineage::select_lineage`] rules over, narrowed
+/// to the most the rule can possibly consume for this request.
 ///
-/// The candidates [`crate::lineage::select_lineage`] rules over. Deliberately
-/// does NOT apply the generation bound, the ordering or the page: those are the
-/// rule, and a query that pre-applied them would be a second implementation of a
+/// # The narrowing is a fetch bound, NOT a second implementation of the rule
+///
+/// An earlier draft of this fetched every event recorded under `subject` and let
+/// the rule bound it, reasoning that a query which pre-applied the generation
+/// bound, the ordering and the page would be a second implementation of a
 /// versioned rule — the drift `read_composed_at_generation` was corrected for on
-/// #1437, in a place where nothing would notice.
+/// #1437, *"in a place where nothing would notice."*
 ///
-/// The subject equality it *does* apply is the one filter that cannot disagree
-/// with the rule, because it is the identical comparison on the identical value.
+/// That reasoning was right about the hazard and wrong about the remedy. Leaving
+/// the fetch unbounded made a two-event page over a long-lived subject load that
+/// subject's entire history into memory, so the page bound governed the answer
+/// but nothing governed the work — a resource ceiling that grows with how long
+/// the system has been running, on an auditor-reachable read.
+///
+/// The remedy the #1437 lesson actually points at is not *"never pre-narrow"* —
+/// it is *"never pre-narrow anywhere that nothing would notice."* So the
+/// narrowing is supplied together with the thing that notices:
+/// `narrowing_never_removes_what_the_rule_would_keep` runs the rule over the
+/// narrowed candidates AND over the unnarrowed ones and asserts the two
+/// selections are identical, across the corpus and every page position. Tighten
+/// this query past the rule and that test goes red.
+///
+/// # Why `limit + 1`
+///
+/// The rule distinguishes a page that is exactly full and complete from one with
+/// a successor by looking for an event beyond the page — its own comment says
+/// *"one over the limit is fetched conceptually here."* Fetching exactly
+/// `limit + 1` makes that actual: one probe row, so `More` stays detectable, and
+/// never the whole tail.
+///
+/// The rule still applies every filter, the ordering and the truncation itself.
+/// It is idempotent over this narrowing — re-filtering an already-filtered set
+/// is a no-op — which is what makes the agreement test a tautology when the two
+/// agree and a failure the moment they do not.
 pub(crate) fn lineage_candidates(
+    conn: &Connection,
+    subject: &str,
+    at_generation: i64,
+    page: crate::lineage::LineagePage,
+) -> Result<Vec<crate::lineage::LineageEvent>, StoreError> {
+    if !table_exists(conn, "world_events")? {
+        return Ok(Vec::new());
+    }
+    // `after_generation` is exclusive, matching the rule's `e.generation > a`.
+    // `i64::MIN` admits everything, so an absent cursor needs no second query.
+    let after = page.after_generation().unwrap_or(i64::MIN);
+    // `limit` is validated into `1..=MAX_LINEAGE_PAGE` at construction, so this
+    // cannot overflow and the cast is lossless.
+    let probe = i64::try_from(page.limit())
+        .unwrap_or(i64::MAX)
+        .saturating_add(1);
+    let mut stmt = conn.prepare(
+        "SELECT generation, event_id, observation_id, txn_time_ms, valid_from_ms,
+                valid_to_ms, source, source_version, writer_class, claim_status,
+                provenance, kind, subject, predicate, object, chain_digest
+         FROM world_events
+         WHERE subject = ?1 AND generation <= ?2 AND generation > ?3
+         ORDER BY generation ASC
+         LIMIT ?4",
+    )?;
+    let rows = stmt.query_map(params![subject, at_generation, after, probe], |r| {
+        Ok(crate::lineage::LineageEvent {
+            generation: r.get(0)?,
+            event_id: r.get(1)?,
+            observation_id: r.get(2)?,
+            txn_time_ms: r.get(3)?,
+            valid_from_ms: r.get(4)?,
+            valid_to_ms: r.get(5)?,
+            source: r.get(6)?,
+            source_version: r.get(7)?,
+            writer_class: crate::WriterClass::from_stored(&r.get::<_, String>(8)?),
+            claim_status: crate::ClaimStatus::from_stored(&r.get::<_, String>(9)?),
+            provenance: r.get(10)?,
+            kind: r.get(11)?,
+            subject: r.get(12)?,
+            predicate: r.get(13)?,
+            object: r.get(14)?,
+            chain_digest: r.get(15)?,
+        })
+    })?;
+    Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+}
+
+/// Every event recorded under `subject`, narrowed by nothing but the subject.
+///
+/// The reference set the narrowed [`lineage_candidates`] is held against. Exists
+/// ONLY for `narrowing_never_removes_what_the_rule_would_keep` — the production
+/// path must never call it, or the resource bound it was written to enforce is
+/// gone.
+#[cfg(test)]
+fn lineage_candidates_unnarrowed(
     conn: &Connection,
     subject: &str,
 ) -> Result<Vec<crate::lineage::LineageEvent>, StoreError> {
@@ -1034,4 +1113,159 @@ pub(crate) fn table_exists(conn: &Connection, name: &str) -> Result<bool, StoreE
         )
         .optional()?;
     Ok(n.is_some())
+}
+
+#[cfg(test)]
+mod lineage_fetch_tests {
+    use super::*;
+    use crate::lineage::{select_lineage, LineagePage};
+    use crate::{ClaimStatus, EventId, NewEvent, ObservationId, WorldStore, WriterClass};
+
+    fn tmp(name: &str) -> std::path::PathBuf {
+        let mut p = std::env::temp_dir();
+        p.push(format!(
+            "kirra-world-lineage-fetch-{}-{}.sqlite",
+            name,
+            std::process::id()
+        ));
+        for s in ["", "-wal", "-shm"] {
+            let mut q = p.as_os_str().to_os_string();
+            q.push(s);
+            let _ = std::fs::remove_file(std::path::PathBuf::from(q));
+        }
+        p
+    }
+
+    /// The log's head, read straight from the event table.
+    ///
+    /// Deliberately NOT the `world_current` checkpoint `lineage_at_generation`
+    /// bounds against: this fixture never folds, and lineage reads evidence
+    /// rather than a projection, so the events exist regardless.
+    fn max_generation(conn: &Connection) -> i64 {
+        conn.query_row("SELECT MAX(generation) FROM world_events", [], |r| r.get(0))
+            .expect("a written log has a head")
+    }
+
+    fn append(s: &mut WorldStore, id: &str, subject: &str) {
+        let event_id = EventId::new(id).expect("admissible event id");
+        let observation_id = ObservationId::new(id).expect("admissible observation id");
+        s.append(&NewEvent {
+            event_id: &event_id,
+            observation_id: &observation_id,
+            txn_time_ms: 1_000,
+            valid_from_ms: 1_000,
+            valid_to_ms: None,
+            source: "sensor-a",
+            source_version: "0.1.0",
+            writer_class: WriterClass::Sensor,
+            claim_status: ClaimStatus::Confirmed,
+            provenance: &[],
+            frame_id: None,
+            map_id: None,
+            kind: "observation",
+            subject,
+            subject_ref: None,
+            predicate: Some("at"),
+            object: Some("bench"),
+            payload: r#"{"n":1}"#,
+            payload_schema: 1,
+            retention_class: "raw",
+            trust: None,
+        })
+        .expect("append");
+    }
+
+    /// **The tripwire that lets `lineage_candidates` narrow at all.**
+    ///
+    /// The narrowed fetch and the rule are two expressions of the same bounds,
+    /// and #1437 is the record of what happens when two such expressions drift
+    /// somewhere nothing is watching. This is the watching.
+    ///
+    /// It asserts the property that makes the narrowing sound: the rule's answer
+    /// over the narrowed candidates is IDENTICAL to its answer over every event
+    /// the subject has. Not merely "the page looks right" — identical, including
+    /// the boundary, so a narrowing that ate the `More` probe fails here even
+    /// though every returned event was correct.
+    ///
+    /// Swept across page positions rather than checked once, because the two
+    /// bounds that can disagree are the cursor and the probe, and both are
+    /// invisible on a first page that fits.
+    #[test]
+    fn narrowing_never_removes_what_the_rule_would_keep() {
+        let mut s = WorldStore::open(&tmp("agreement")).unwrap();
+        for i in 1..=9 {
+            append(&mut s, &format!("ev-{i}"), "subject-a");
+            // A second subject interleaved throughout, so a narrowing that lost
+            // the subject filter would also be caught here.
+            append(&mut s, &format!("other-{i}"), "subject-b");
+        }
+
+        let snap = s.read_snapshot().unwrap();
+        let head = max_generation(&snap.tx);
+
+        let mut checked = 0;
+        for limit in [1_usize, 2, 3, 9, 18] {
+            for cursor in [None, Some(0_i64), Some(3), Some(9), Some(head)] {
+                for at in [head, head / 2, 1] {
+                    let page = LineagePage::new(limit, cursor).expect("valid page");
+
+                    let narrowed = select_lineage(
+                        lineage_candidates(&snap.tx, "subject-a", at, page).unwrap(),
+                        "subject-a",
+                        at,
+                        page,
+                    );
+                    let full = select_lineage(
+                        lineage_candidates_unnarrowed(&snap.tx, "subject-a").unwrap(),
+                        "subject-a",
+                        at,
+                        page,
+                    );
+
+                    assert_eq!(
+                        narrowed, full,
+                        "narrowed and unnarrowed disagree at limit {limit}, \
+                         cursor {cursor:?}, generation {at} — the fetch has been \
+                         tightened past the rule"
+                    );
+                    checked += 1;
+                }
+            }
+        }
+        // The sweep is only evidence if it ran; a bound that silently produced
+        // no cases would pass every assertion above.
+        assert_eq!(checked, 75, "the sweep did not cover what it claims to");
+    }
+
+    /// The narrowing's REASON, asserted rather than described: a small page over
+    /// a long history fetches a small number of rows.
+    ///
+    /// Without this, a later refactor could restore the unbounded fetch and only
+    /// the agreement test would run — which the unbounded fetch also passes, it
+    /// being the thing the narrowed one is compared against.
+    #[test]
+    fn a_small_page_over_a_long_history_fetches_a_small_number_of_rows() {
+        let mut s = WorldStore::open(&tmp("bounded")).unwrap();
+        for i in 1..=200 {
+            append(&mut s, &format!("ev-{i}"), "subject-a");
+        }
+
+        let snap = s.read_snapshot().unwrap();
+        let head = max_generation(&snap.tx);
+        let page = LineagePage::new(2, None).expect("valid page");
+
+        let fetched = lineage_candidates(&snap.tx, "subject-a", head, page).unwrap();
+        assert_eq!(
+            fetched.len(),
+            3,
+            "a 2-event page must fetch the page plus ONE probe row, not the history"
+        );
+
+        let all = lineage_candidates_unnarrowed(&snap.tx, "subject-a").unwrap();
+        assert_eq!(
+            all.len(),
+            200,
+            "the history really is long — the bound is not vacuous"
+        );
+    }
 }

--- a/crates/kirra-world-store/tests/semantics_corpus.rs
+++ b/crates/kirra-world-store/tests/semantics_corpus.rs
@@ -66,6 +66,7 @@ use std::collections::BTreeMap;
 use kirra_world::adjudication::IdentityAdjudication;
 use kirra_world::entity::Lifecycle;
 use kirra_world_store::entity_projection::{Contradiction, ProjectedEntity};
+use kirra_world_store::lineage::{LineageEvent, PageBoundary, SelectedLineage};
 use kirra_world_store::projection::ProjectedClaim;
 use kirra_world_store::semantics::{
     self, corpus_digest, corpus_rendering, entity_corpus, render_entities, render_subjects,
@@ -74,6 +75,7 @@ use kirra_world_store::semantics::{
 use kirra_world_store::subject_projection::{
     ProjectedSubject, SubjectKey, SubjectObservation, SummaryKind,
 };
+use kirra_world_store::ClaimStatus;
 
 // ---------------------------------------------------------------------------
 // 1. Conformance
@@ -466,6 +468,192 @@ fn the_subject_corpus_catches_a_key_without_the_kind() {
     );
 }
 
+// --- lineage_selection ---------------------------------------------------
+
+/// Which behavioural axis a lineage variant flips.
+///
+/// One struct of switches rather than four near-identical copies of the rule:
+/// a copy that drifted from the real selection would weaken every control at
+/// once, silently, and the drift would be invisible because the controls only
+/// ever assert *inequality*.
+#[derive(Clone, Copy)]
+struct LineageVariant {
+    /// Skip the sort, keeping input order.
+    unordered: bool,
+    /// Ignore the `generation <= at_generation` bound.
+    unbounded: bool,
+    /// Ignore the subject filter.
+    any_subject: bool,
+    /// Treat the cursor as inclusive rather than exclusive.
+    inclusive_cursor: bool,
+    /// Report `More` whenever the page is exactly full, successor or not.
+    eager_more: bool,
+    /// Drop unconfirmed candidates, as the claim fold does.
+    confirmed_only: bool,
+}
+
+impl LineageVariant {
+    /// Every switch off — the real rule, reimplemented.
+    fn faithful() -> Self {
+        Self {
+            unordered: false,
+            unbounded: false,
+            any_subject: false,
+            inclusive_cursor: false,
+            eager_more: false,
+            confirmed_only: false,
+        }
+    }
+}
+
+/// Select with one axis flipped, and render it under every corpus query.
+fn render_lineage_variant(v: LineageVariant) -> String {
+    let mut out = String::new();
+    for (label, subject, at_generation, page) in semantics::lineage_queries() {
+        let mut selected: Vec<LineageEvent> = semantics::lineage_corpus()
+            .into_iter()
+            .filter(|e| v.any_subject || e.subject == subject)
+            .filter(|e| v.unbounded || e.generation <= at_generation)
+            .filter(|e| {
+                page.after_generation().is_none_or(|a| {
+                    if v.inclusive_cursor {
+                        e.generation >= a
+                    } else {
+                        e.generation > a
+                    }
+                })
+            })
+            .filter(|e| !v.confirmed_only || e.claim_status == ClaimStatus::Confirmed)
+            .collect();
+        if !v.unordered {
+            selected.sort_by_key(|e| e.generation);
+        }
+
+        let boundary =
+            if selected.len() > page.limit() || (v.eager_more && selected.len() == page.limit()) {
+                selected.truncate(page.limit());
+                PageBoundary::More {
+                    next_after_generation: selected.last().map_or(0, |e| e.generation),
+                }
+            } else {
+                PageBoundary::Complete
+            };
+
+        out.push_str(label);
+        out.push('\u{1f}');
+        out.push_str(&semantics::render_lineage(&SelectedLineage {
+            events: selected,
+            boundary,
+        }));
+        out.push('\u{1e}');
+    }
+    out
+}
+
+/// **The faithfulness control.** The variant harness with every switch off must
+/// reproduce the real rendering EXACTLY.
+///
+/// Without this, the five controls below would all pass against a harness that
+/// had drifted from the real rule — they only assert that something differs, and
+/// a harness wrong in some sixth way differs from the real rule for a reason
+/// none of them names. This is what makes their inequality mean *"this axis"*
+/// rather than merely *"something"*.
+#[test]
+fn the_lineage_variant_harness_reproduces_the_real_rule_when_faithful() {
+    assert_eq!(
+        render_lineage_variant(LineageVariant::faithful()),
+        corpus_rendering(RuleId::LineageSelection),
+        "the variant harness has drifted from `select_lineage`; every control \
+         below is measuring the drift rather than the axis it names"
+    );
+}
+
+/// Losing the sort makes the answer depend on the order rows came back in —
+/// and a cursor over an unordered sequence cannot be resumed at all.
+#[test]
+fn the_lineage_corpus_catches_an_unordered_selection() {
+    assert_variant_is_caught(
+        RuleId::LineageSelection,
+        "unordered",
+        &render_lineage_variant(LineageVariant {
+            unordered: true,
+            ..LineageVariant::faithful()
+        }),
+    );
+}
+
+/// **The historical-correctness axis.** Dropping the generation bound serves
+/// evidence appended after the pinned coordinate — 2d's "resolve current state
+/// and label it historical", one tier up.
+#[test]
+fn the_lineage_corpus_catches_ignoring_the_generation_bound() {
+    assert_variant_is_caught(
+        RuleId::LineageSelection,
+        "unbounded",
+        &render_lineage_variant(LineageVariant {
+            unbounded: true,
+            ..LineageVariant::faithful()
+        }),
+    );
+}
+
+/// A lineage that ignores its subject is another subject's evidence.
+#[test]
+fn the_lineage_corpus_catches_ignoring_the_subject() {
+    assert_variant_is_caught(
+        RuleId::LineageSelection,
+        "any_subject",
+        &render_lineage_variant(LineageVariant {
+            any_subject: true,
+            ..LineageVariant::faithful()
+        }),
+    );
+}
+
+/// An inclusive cursor repeats the previous page's last event on every page —
+/// the kind of defect that looks like a duplicate rather than like a bug.
+#[test]
+fn the_lineage_corpus_catches_an_inclusive_cursor() {
+    assert_variant_is_caught(
+        RuleId::LineageSelection,
+        "inclusive_cursor",
+        &render_lineage_variant(LineageVariant {
+            inclusive_cursor: true,
+            ..LineageVariant::faithful()
+        }),
+    );
+}
+
+/// **The off-by-one at the page boundary.** Reporting `More` because the page
+/// filled — rather than because something follows — advertises a successor that
+/// does not exist. The `exactly_full` corpus query is the row that catches it,
+/// and it is in the corpus for this reason alone.
+#[test]
+fn the_lineage_corpus_catches_reporting_more_on_a_merely_full_page() {
+    assert_variant_is_caught(
+        RuleId::LineageSelection,
+        "eager_more",
+        &render_lineage_variant(LineageVariant {
+            eager_more: true,
+            ..LineageVariant::faithful()
+        }),
+    );
+}
+
+/// Filtering to confirmed claims — as `world_current` legitimately does — hides
+/// what an LLM proposed, which is the question an investigator is asking.
+#[test]
+fn the_lineage_corpus_catches_dropping_unconfirmed_candidates() {
+    assert_variant_is_caught(
+        RuleId::LineageSelection,
+        "confirmed_only",
+        &render_lineage_variant(LineageVariant {
+            confirmed_only: true,
+            ..LineageVariant::faithful()
+        }),
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Coverage of the control table itself
 // ---------------------------------------------------------------------------
@@ -484,6 +672,7 @@ fn every_rule_has_at_least_one_sensitivity_control() {
         RuleId::WorldCurrentFold,
         RuleId::EntityFold,
         RuleId::SubjectSummaryFold,
+        RuleId::LineageSelection,
     ];
     for rule in RuleId::all() {
         assert!(

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -2035,9 +2035,13 @@ pressure that produced every stale claim this box already documents.
       semantics. `KIRRA-WM-FRESHNESS-POLICY-001`. The fourth `Unknown` freshness
       variant is **decided and omitted** — no reachable case exists; see the
       state machine in the closure.
-- [ ] **3f — Lineage retrieval contract.** Deterministic, bounded, paginated,
-      truncation visible, historically correct. Consumed by Tier 4's `Explain`;
-      does not render.
+- [x] **3f — Lineage retrieval contract.** ✅ **DONE 2026-08-12** — see *"3f
+      closed: lineage is a query family, not a field"* below. Deterministic,
+      bounded, paginated, truncation visible, historically correct. Its own
+      query family with a `LineageRef` and a one-rule version set
+      (`lineage_selection`, `RuleId`'s first non-reducer); compaction degrades
+      rather than refusing; `provenance` is carried verbatim, since walking it
+      is the Tier 4 structure `KIRRA-WM-EXPLAIN-TIER-001` keeps out.
 - [x] **3g — Degradation propagation.** ✅ **DONE 2026-08-11** — see *"3g:
       the boundary finally carries completeness"* below. Every answer family preserves
       `Full`/`Degraded` **independently of the payload outcome**, not just
@@ -3399,3 +3403,136 @@ is safer than the global default it replaced — the classification is a value
 somebody wrote, greppable and reviewable — and it should move to the ruled table
 once an applicable entry exists. The `Caller` variant stays as the honest interim
 while `RULED` is small.
+
+---
+
+### 3f closed: lineage is a query family, not a field — 2026-08-12
+
+`KIRRA-WM-EXPLAIN-TIER-001` asked Tier 3 for *"only the deterministic lineage
+CONTRACT that Tier 4 consumes"*, with two constraints attached: **bounded and
+paginated, with truncation visible**, and **historically correct**.
+
+The scoping call was between a *walk from an answer* — follow the
+`EvidenceDigest` a `WorldAnswer` already carries — and a **query family of its
+own**, with a reference and a version set. The family was chosen, and the
+difference turned out to be more than symmetry: a walk has no pagination story,
+so *"truncation visible"* would have had nothing to bite on, and no version set,
+so a change to which evidence is returned would have reached recorded references
+silently.
+
+#### The rule is versioned because it can change an answer four ways
+
+`lineage_selection` (`kirra_world_store::lineage::select_lineage`) is
+`RuleId`'s fourth member and its first non-reducer. The membership test this
+tier applies is *"can changing this alter a derived answer"*, not *"is this a
+fold"*, and lineage selection can alter one along four axes at once: which
+events are chosen, the generation bound, the order, and where a page ends.
+
+The sharpest of those is the **cursor**. A recorded page-2 reference carries a
+cursor minted by the *old* ordering; replaying it under a new one returns a set
+that is neither the old page 2 nor the new one, and looks entirely ordinary. So
+a moved version refuses rather than replays, exactly as `KIRRA-WM-REDUCER-
+VERSION-001` requires.
+
+#### The dependency set is ONE rule, and the three absences are the claim
+
+| Rule | In? | Why |
+|---|---|---|
+| `lineage_selection` | yes | it decides which events, in what order, where the page ends |
+| `world_current_fold` | **no** | lineage returns evidence, not folded claims — nothing asks which claim won a key |
+| `entity_fold` | **no** | the subject is matched as written; no identity edges are followed |
+| `answer_admissibility` | **no** | an inadmissible claim is still evidence |
+
+The `answer_admissibility` exclusion looks careless and is the important one.
+Lineage exists to answer *"why does this answer say what it says"*, and an event
+that was rejected, or expired, or that an LLM proposed and nobody confirmed, is
+frequently the whole explanation. A lineage showing only servable claims would be
+silent in exactly the cases somebody is investigating. So `select_lineage`
+deliberately does **not** filter on `claim_status`, where `world_current` does.
+
+Each exclusion is also a **tripwire**, asserted in
+`the_lineage_query_depends_on_exactly_one_rule` rather than written down. The
+moment lineage follows an identity edge, `entity_fold` can change what it says
+and must join the set — and the assertion goes red first. That is how
+`entity_fold` entered `CurrentSubject`'s set in 3h.
+
+#### Compaction DEGRADES a lineage page; it does not refuse it
+
+`read_at_generation` refuses a compacted coordinate, and must: a projection
+folded from a log with holes is silently *wrong* and looks exactly like a
+correct one. Lineage is not folded — it is the evidence itself — so a page
+missing a compacted span is *incomplete* rather than wrong, and the citations
+name exactly which generations went and under which digest. The split mirrors
+one the store already makes (`read_composed_at_generation` refuses,
+`as_of_composed` degrades), and it is why `PinnedLineage::Irreproducible` carries
+only `NotYetReached`.
+
+Truncation and degradation are kept **independent**, both observable: a page cut
+short by the caller's own limit is complete evidence, bounded; a page missing a
+compacted span is evidence that no longer exists. Conflating them would cry wolf
+on every paginated read.
+
+#### The tier boundary is where the JSON array starts
+
+§7 records `Explain` as depending on *"derivation edges being real structure
+rather than a JSON array of identifiers"*. `provenance` **is** that array today,
+so a lineage entry carries it **verbatim and unparsed**. Walking it here would be
+Tier 3 inventing the structure whose absence is the reason `Explain` is Tier 4.
+The stopping point is the ruling, not an oversight.
+
+#### The mutation battery
+
+Ten mutations, run against the shipped code:
+
+| Mutation | Caught by |
+|---|---|
+| drop the generation bound | integration (the load-bearing test) |
+| drop the ordering | store unit + corpus control |
+| inclusive cursor | integration (pagination walk) |
+| `More` on a merely-full page | integration + store unit + corpus |
+| version check after the store read | integration (ordering test) |
+| `answer_admissibility` joins the set | 2 unit tests |
+| filter to confirmed claims | integration (candidate test) |
+| compaction refuses instead of degrading | integration (degradation test) |
+| drop the subject filter | store unit + corpus control |
+| `next_page` mints a successor past the end | integration |
+
+**Two survived the integration tests and were caught only at store level**, both
+found by running the mutation rather than by reading the code:
+
+* **ordering** — `generation` is `world_events`' primary key, so SQLite returns
+  rows in that order anyway and the unsorted rule accidentally agrees on every
+  store the tests can build;
+* **the subject filter** — the SQL pre-filters by subject, so
+  `another_subjects_evidence_is_not_in_this_lineage` tests the *query* and not
+  the *rule*.
+
+Both are recorded in the test file's own header, because the tempting conclusion
+— *"the integration tests cover these"* — is false, and a later reader deleting
+the store-level tests as redundant would remove the only coverage there is.
+
+The `More`-on-a-full-page mutation also survived the **first** draft of
+`the_final_page_yields_no_next_reference`, which asked for a 256-limit page over
+two events — a page that could not have been full. Sizing the bound to exactly
+the lineage length put the off-by-one under the test a reader would look in.
+
+A **faithfulness control** sits under the six corpus variants: the variant
+harness with every switch off must reproduce the real rendering byte for byte.
+Without it the six only assert that *something* differs, and a harness wrong in
+some seventh way would satisfy them all while naming the wrong axis.
+
+#### The honest limits
+
+* **Lineage follows no identity edges.** An adjudication recorded under a
+  merged-away alias is not in the canonical subject's lineage. Same limitation
+  `WorldView::ask` states for the subject side, same reason — reading the whole
+  equivalence class is a different query, not a flag on this one — and it is what
+  keeps `entity_fold` legitimately out of the version set.
+* **`LineageRef` is a separate type from `AnswerRef`.** `KIRRA-WM-ANSWER-
+  IDENTITY-001` lists the pagination bound among what a reference serializes;
+  `AnswerRef` has none because its family has no pages, and this one has no clock
+  or staleness budget because evidence does not go stale. One struct holding the
+  union would let a caller build a lineage reference carrying a staleness budget
+  — meaningless, but hashed into the reference's identity, so two references for
+  the same query would compare unequal. They share `QueryKind`,
+  `SemanticVersions`, the refusal ordering and the reproducibility horizon.

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -3480,6 +3480,58 @@ so a lineage entry carries it **verbatim and unparsed**. Walking it here would b
 Tier 3 inventing the structure whose absence is the reason `Explain` is Tier 4.
 The stopping point is the ruling, not an oversight.
 
+#### Review follow-up: the fetch was bounded by the rule, not by the query
+
+Shipped as reviewed. The first cut of `lineage_candidates` fetched **every**
+event recorded under the subject and let `select_lineage` bound the result,
+reasoning that a query which pre-applied the generation bound, the ordering and
+the page would be a second implementation of a versioned rule — the #1437 drift,
+*"in a place where nothing would notice."*
+
+That reasoning was right about the hazard and wrong about the remedy, and review
+caught it. A two-event page over a long-lived subject loaded that subject's
+entire history into memory: the page bound governed the *answer* while nothing
+governed the *work*, on an auditor-reachable read, with a ceiling that grows with
+how long the system has been running.
+
+It also sat against a standing ruling. `KIRRA-WM-ANSWER-IDENTITY-001` clause 2
+is *"queries are bounded"* — not a preference, but a consequence of D-9's
+measured 10.5 s p99 at 100 000 entities and ADR-0041 D-12's finding that **an
+unbounded query has no bounded cost whatever its scaling verdict.** A new query
+family whose fetch was unbounded by construction was in tension with the ruling
+the box was written under, and the tension was invisible because the answer it
+returned was correctly bounded.
+
+The remedy the #1437 lesson actually points at is not *"never pre-narrow"* — it
+is *"never pre-narrow anywhere that nothing would notice."* So the fetch is now
+narrowed to `subject`, the as-of bound, the cursor and `LIMIT limit + 1`, and the
+narrowing ships **with the thing that notices**:
+`narrowing_never_removes_what_the_rule_would_keep` runs the rule over the
+narrowed candidates and over the unnarrowed ones and asserts the two selections
+are identical — including the boundary — swept across 75 (limit, cursor,
+generation) combinations, since the two bounds that can disagree are the cursor
+and the probe and both are invisible on a first page that fits.
+
+`limit + 1` is what keeps `More` detectable: the rule's own comment already said
+*"one over the limit is fetched conceptually here"*, so the narrowing made actual
+what the rule had assumed.
+
+**Two tests, because one cannot catch both failures.** Four mutations were run:
+
+| Mutation | Agreement test | Bound test |
+|---|---|---|
+| no probe row (`limit` not `limit + 1`) | red | red |
+| as-of bound tightened to `<` | red | green |
+| cursor made inclusive | red | green |
+| **unbounded fetch restored** | **green** | **red** |
+
+The last row is the one worth keeping in view: the agreement test *cannot* catch
+a re-widening, because the unbounded fetch is the reference it compares against —
+re-widening makes the two sides identical, which is exactly what it asserts. That
+is why `a_small_page_over_a_long_history_fetches_a_small_number_of_rows` exists
+as a separate test rather than an extra assertion, and the division of labour is
+now demonstrated rather than argued.
+
 #### The mutation battery
 
 Ten mutations, run against the shipped code:


### PR DESCRIPTION
Closes box **3f**, the last large box in `WM_SCOPE.md`'s Tier 3 set.

`KIRRA-WM-EXPLAIN-TIER-001` asked Tier 3 for *"only the deterministic lineage CONTRACT that Tier 4 consumes"*, with two constraints attached: **bounded and paginated, with truncation visible**, and **historically correct**.

## The scoping call, and why it mattered more than symmetry

The choice was between a *walk from an answer* — follow the `EvidenceDigest` a `WorldAnswer` already carries — and a **query family of its own**. The family was chosen, and the difference is not cosmetic: a walk has no pagination story, so *"truncation visible"* would have had nothing to bite on, and no version set, so a change to which evidence comes back would reach recorded references silently.

## The rule is versioned because it can change an answer four ways

`lineage_selection` is `RuleId`'s fourth member and its **first non-reducer**. The membership test this tier applies is *"can changing this alter a derived answer"*, not *"is this a fold"* — and lineage selection alters one along four axes at once: which events are chosen, the generation bound, the order, and where a page ends.

The sharpest is the **cursor**. A recorded page-2 reference carries a cursor minted by the *old* ordering; replaying it under a new one returns a set that is neither the old page 2 nor the new one, and looks entirely ordinary. A moved version refuses rather than replays.

## The dependency set is ONE rule, and the three absences are the claim

| Rule | In? | Why |
|---|---|---|
| `lineage_selection` | yes | it decides which events, in what order, where the page ends |
| `world_current_fold` | **no** | lineage returns evidence, not folded claims |
| `entity_fold` | **no** | the subject is matched as written; no identity edges followed |
| `answer_admissibility` | **no** | an inadmissible claim is still evidence |

The `answer_admissibility` exclusion looks careless and is the important one. Lineage exists to answer *"why does this answer say what it says"*, and an event that was rejected, or expired, or that an LLM proposed and nobody confirmed, is frequently the whole explanation. So `select_lineage` deliberately does **not** filter on `claim_status`, where `world_current` does.

Each exclusion is a **tripwire**, asserted rather than written down. The moment lineage follows an identity edge, `entity_fold` can change what it says and must join the set — and the assertion goes red first. That is how `entity_fold` entered `CurrentSubject`'s set in 3h.

## Compaction degrades; it does not refuse

`read_at_generation` refuses a compacted coordinate, and must: a projection folded from a log with holes is silently *wrong* and looks exactly like a correct one. Lineage is not folded — it is the evidence itself — so a page missing a compacted span is *incomplete* rather than wrong, and the citations name exactly which generations went and under which digest. The split mirrors one the store already makes (`read_composed_at_generation` refuses, `as_of_composed` degrades).

Truncation and degradation stay **independent and both observable**: a page cut short by the caller's own limit is complete evidence, bounded; a page missing a compacted span is evidence that no longer exists. Conflating them would cry wolf on every paginated read.

## The tier boundary is where the JSON array starts

§7 records `Explain` as depending on *"derivation edges being real structure rather than a JSON array of identifiers"*. `provenance` **is** that array today, so a lineage entry carries it **verbatim and unparsed**. Walking it here would be Tier 3 inventing the structure whose absence is the reason `Explain` is Tier 4.

## The mutation battery — ten mutations against shipped code

| Mutation | Caught by |
|---|---|
| drop the generation bound | integration (load-bearing test) |
| drop the ordering | store unit + corpus control |
| inclusive cursor | integration (pagination walk) |
| `More` on a merely-full page | integration + store unit + corpus |
| version check after the store read | integration (ordering test) |
| `answer_admissibility` joins the set | 2 unit tests |
| filter to confirmed claims | integration (candidate test) |
| compaction refuses instead of degrading | integration (degradation test) |
| drop the subject filter | store unit + corpus control |
| `next_page` mints a successor past the end | integration |

**Two survived the integration tests**, both found by running the mutation rather than reading the code:

- **ordering** — `generation` is `world_events`' primary key, so SQLite returns rows in that order anyway and the unsorted rule accidentally agrees on every store the tests can build;
- **the subject filter** — the SQL pre-filters by subject, so `another_subjects_evidence_is_not_in_this_lineage` tests the *query* and not the *rule*.

Both are covered at store level (unit test + corpus control, both red on the mutation) and both are recorded in the test file's header — the tempting conclusion *"the integration tests cover these"* is false, and a later reader deleting the store-level tests as redundant would remove the only coverage there is.

The `More`-on-a-full-page mutation also survived the **first draft** of `the_final_page_yields_no_next_reference`, which asked for a 256-limit page over two events — a page that could not have been full. Sizing the bound to exactly the lineage length put the off-by-one under the test a reader would look in.

A **faithfulness control** sits under the six corpus variants: the harness with every switch off must reproduce the real rendering byte for byte. Without it the six only assert that *something* differs, and a harness wrong in some seventh way would satisfy them all while naming the wrong axis.

## The honest limits

- **Lineage follows no identity edges.** An adjudication recorded under a merged-away alias is not in the canonical subject's lineage — the same limitation `WorldView::ask` states for the subject side, and what keeps `entity_fold` legitimately out of the version set.
- **`LineageRef` is a separate type from `AnswerRef`.** `KIRRA-WM-ANSWER-IDENTITY-001` lists the pagination bound among what a reference serializes; `AnswerRef` has none because its family has no pages, and this one has no clock or staleness budget because evidence does not go stale. One struct holding the union would let a caller build a lineage reference carrying a staleness budget — meaningless, but hashed into the reference's identity, so two references for the same query would compare unequal. They share `QueryKind`, `SemanticVersions`, the refusal ordering and the reproducibility horizon.

## Verification

- `cargo test -p kirra-world-store -p kirra-world-service` — green
- `ci/check_world_semantics.py` — 5 rules versioned, pinned and recorded (`lineage_selection` v1 added to the baseline)
- `ci/check_freshness_coverage.py`, `ci/check_kirra_world_bidirectional_fence.py`, `ci/check_reexport_shims.py` — green
- `cargo fmt --all --check`, `cargo clippy --all-targets -D warnings` on both crates — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_