### PR TITLE
3g follow-up — completeness for history and subject_summary

### DIFF
--- a/ci/freshness_unruled_baseline.json
+++ b/ci/freshness_unruled_baseline.json
@@ -16,6 +16,11 @@
   ],
   "unruled": [
     {
+      "kind": "not_a_ruled_kind",
+      "predicate": "whatever",
+      "why": "The 3g follow-up's negative control. Deliberately names a class no ruling will ever cover, so `an_unruled_claim_refuses_the_whole_history` can prove that 3e's fail-closed refusal reaches the history family -- which is the ONLY reason `answer_admissibility` is in that family's version set. Ruling it would delete the test's premise."
+    },
+    {
       "kind": "observation",
       "predicate": null,
       "why": "A payload-only observation. `KIRRA-WM-CLAIM-SHAPES-001` makes this a legitimate shape, but what an untyped payload MEANS temporally cannot be ruled in general -- it depends on what the payload carries, which is precisely the thing no key can see."

--- a/crates/kirra-world-service/src/answer_ref.rs
+++ b/crates/kirra-world-service/src/answer_ref.rs
@@ -98,6 +98,22 @@ pub enum QueryKind {
     /// ([`crate::read_view::TemporalLookup::semantics`]), and that set has to
     /// be derived in the one place every set is derived.
     AsOfSubject,
+    /// [`crate::read_view::WorldView::history`] — every confirmed claim ever
+    /// recorded about one subject, in generation order.
+    ///
+    /// Distinct from [`Self::AsOfSubject`] despite both replaying the log: that
+    /// one answers *"what held at an instant"* and returns a SET, this one
+    /// answers *"what has ever been claimed"* and returns a SEQUENCE whose
+    /// order is part of the answer.
+    SubjectHistory,
+    /// [`crate::read_view::WorldView::subject_summary`] — the aggregate
+    /// summary for one subject, and how much of its evidence survives.
+    ///
+    /// The one family whose completeness is NOT a
+    /// [`kirra_world_store::Resolution`]. See
+    /// [`crate::read_view::SummaryLookup`] for why coercing it into one would
+    /// have to invent a field.
+    SubjectSummary,
     /// [`crate::lineage::LineageRef`] — one page of the evidence bearing on a
     /// subject at a pinned generation.
     ///

--- a/crates/kirra-world-service/src/read_view.rs
+++ b/crates/kirra-world-service/src/read_view.rs
@@ -98,6 +98,7 @@ use kirra_world::resolution::{resolve, RefusalReason, ResolutionOutcome};
 use kirra_world_store::compaction::Resolution;
 use kirra_world_store::entity_projection::IdentityView;
 use kirra_world_store::snapshot::SnapshotCoordinate;
+use kirra_world_store::subject_projection::SubjectSummaryAnswer;
 use kirra_world_store::{ProjectedClaim, StoreError, TrustAxes, TrustGrade, Validity, WorldStore};
 
 use crate::answer_ref::QueryKind;
@@ -683,6 +684,110 @@ impl<'a> WorldView<'a> {
         })
     }
 
+    /// **Every confirmed claim ever recorded about `subject`, and how much of
+    /// that record survives** — the 3g follow-up.
+    ///
+    /// # This does NOT filter on admissibility, and the version set says it does
+    ///
+    /// Each claim's freshness policy is still RESOLVED, so 3e's fail-closed
+    /// refusal on unclassified semantics reaches this family — an unruled claim
+    /// refuses the whole query here exactly as it does in [`Self::ask`]. But no
+    /// claim is dropped for being stale.
+    ///
+    /// The distinction is the whole design. `ask` answers *"what is true now"*,
+    /// where serving a claim past its freshness budget is the error 3e exists
+    /// to prevent. This answers *"what has ever been claimed"*, where a claim
+    /// that has since gone stale is not a claim to hide — it is the record.
+    /// Filtering here would make history lie about the past in exactly the way
+    /// an admissibility filter on a lineage would hide the evidence an
+    /// investigator came for.
+    ///
+    /// # The completeness is the store's, propagated
+    ///
+    /// [`WorldStore::history`] already decides `Full` vs `Degraded` against the
+    /// retained citations and summaries. This carries that verdict across
+    /// unchanged, exactly as [`Self::ask_as_of`] does. A second judgement here
+    /// would be a second implementation of the rule governing whether an answer
+    /// can be trusted, and the two would drift.
+    ///
+    /// That verdict is deliberately CONSERVATIVE and this does not sharpen it:
+    /// the store's citation check is store-wide, so a retained citation with no
+    /// summaries degrades every subject's history, including subjects the
+    /// compacted span never touched. Over-reporting `Degraded` is the safe
+    /// direction and the acceptance rule this family is held to — *"never
+    /// report `Full` when required evidence may have been removed"* — permits
+    /// it. Narrowing the check to the queried subject would turn a conservative
+    /// signal into an exact-loss detector, and an exact-loss detector that is
+    /// wrong is silent.
+    ///
+    /// # Errors
+    ///
+    /// As [`Self::ask`].
+    pub fn history(&self, subject: &str) -> Result<TemporalLookup, AskError> {
+        let answer = self.store.history(subject)?;
+        let completeness = answer.resolution;
+
+        let mut answers = Vec::new();
+        for claim in &answer.claims {
+            // Resolved and DISCARDED, deliberately. The `?` is the entire
+            // reason this call is here: it propagates 3e's refusal for an
+            // unclassified claim. The budget it yields is then handed to
+            // `assemble` for the recorded grade, and is NOT used to filter.
+            let budget = self.policy_for(claim)?.budget();
+            answers.push(assemble(
+                claim,
+                // The claim's OWN transaction time is the clock, not a caller's
+                // "now". A history entry's grade describes what the claim was
+                // when it was made; grading the whole record against the moment
+                // somebody happened to run the query would make the same
+                // history read differently on every call.
+                claim.txn_time_ms.max(0).unsigned_abs(),
+                budget,
+                // A replay does not resolve identity — the same limit
+                // `ask_as_of` states, for the same reason: identity is a second
+                // projection with its own coordinate.
+                ObjectIdentity::NotResolvedInReplay,
+            )?);
+        }
+
+        // `NoneAdmissible` is unreachable here BY CONSTRUCTION, because nothing
+        // is filtered. An empty history means the log holds no confirmed claim
+        // for this subject — and if evidence was compacted away, the
+        // completeness alongside says so rather than the reason code.
+        let lookup = if answers.is_empty() {
+            WorldLookup::Unknown(UnknownReason::NoClaim)
+        } else {
+            WorldLookup::Answered(answers)
+        };
+        Ok(TemporalLookup {
+            lookup,
+            completeness,
+            semantics: SemanticVersions::for_query(QueryKind::SubjectHistory),
+        })
+    }
+
+    /// **The aggregate summary for `subject`, and how much of the evidence
+    /// behind it survives** — the 3g follow-up.
+    ///
+    /// # Errors
+    ///
+    /// [`AskError::Store`] on any read failure.
+    pub fn subject_summary(&self, subject: &str) -> Result<SummaryLookup, AskError> {
+        // Filtered by subject at the boundary, which is the one narrowing that
+        // cannot disagree with the store: it is an equality on the same string
+        // the store keyed by. Completeness is not touched.
+        let found = self
+            .store
+            .subject_summaries_with_coverage()?
+            .into_iter()
+            .find(|s| s.subject == subject);
+
+        Ok(SummaryLookup {
+            summary: found,
+            semantics: SemanticVersions::for_query(QueryKind::SubjectSummary),
+        })
+    }
+
     /// **The ruled disposition for one claim, or a refusal.**
     ///
     /// The single place a claim's semantics become a freshness policy, so the
@@ -871,6 +976,86 @@ fn assemble(
         provenance,
         event_id: claim.event_id.clone(),
     })
+}
+
+/// **One subject's summary and its evidence coverage** — the 3g follow-up.
+///
+/// # Why this carries `SummaryCoverage` and not `Resolution`
+///
+/// Every other family's completeness is a [`Resolution`], and making this one
+/// match would be tidier. It would also require inventing a field.
+///
+/// The two signals are computed from different things and have different
+/// shapes. `Resolution::Degraded` carries `{spans, summaries}` — a
+/// RANGE-oriented verdict, built from the compaction citations overlapping a
+/// queried interval. [`SummaryCoverage::Degraded`] carries `{summaries}` alone
+/// — a PER-SUBJECT verdict, recorded by the fold about the evidence behind one
+/// row. Coercing the second into the first means passing `spans: vec![]`, which
+/// reads as *"no compacted span bore on this"*. That is false, and false in the
+/// reassuring direction, which is the one direction this architecture must
+/// never round toward.
+///
+/// So the native type crosses the boundary unchanged. One source of truth per
+/// family beats one type across families.
+///
+/// # Numerical reconciliation is NOT evidence coverage
+///
+/// [`SubjectSummaryAnswer::reconciled_observation_count`] and
+/// [`SubjectSummaryAnswer::reconciled_first_observed_ms`] can both reconstruct
+/// their pre-compaction values from citations. It is tempting to read that
+/// success as completeness — the numbers add up, so nothing was lost.
+///
+/// They are not the same claim, and the gap between them is exactly where a
+/// silent loss would live. A citation names a SPAN; it does not name the events
+/// inside it. So `observation_count` and `first_observed_ms` reconstruct, while
+/// `provenance_head` and `last_event_id` cannot — and for a subject whose every
+/// contributing event was compacted, [`SubjectSummaryAnswer::retained`] is
+/// `None` and those fields do not exist at all. An answer reporting `Complete`
+/// because two counts reconciled would be asserting something true of two
+/// numbers about the whole answer contract.
+///
+/// [`Self::is_degraded`] therefore reads `coverage` and ONLY `coverage`. There
+/// is deliberately no constructor taking a reconciliation result.
+#[derive(Debug, Clone)]
+pub struct SummaryLookup {
+    summary: Option<SubjectSummaryAnswer>,
+    semantics: SemanticVersions,
+}
+
+impl SummaryLookup {
+    /// The summary and its coverage, or `None` if the store has never
+    /// summarised this subject.
+    ///
+    /// `None` means *"not summarised"*, which is distinct from a summary whose
+    /// evidence was compacted: that one is `Some`, with `Degraded` coverage
+    /// and possibly no retained
+    /// aggregates. The store goes to real trouble to keep those apart —
+    /// a fully compacted subject used to vanish entirely — and collapsing them
+    /// here would undo it.
+    #[must_use]
+    pub fn summary(&self) -> Option<&SubjectSummaryAnswer> {
+        self.summary.as_ref()
+    }
+
+    /// Whether evidence behind this summary has been compacted away.
+    ///
+    /// Derived from `coverage` alone — never from whether reconciliation
+    /// succeeded. See the type's own note on why those differ.
+    ///
+    /// An unsummarised subject is NOT degraded: there is no evidence claimed
+    /// and none missing.
+    #[must_use]
+    pub fn is_degraded(&self) -> bool {
+        self.summary
+            .as_ref()
+            .is_some_and(|s| s.coverage.is_degraded())
+    }
+
+    /// The rules this answer was produced under.
+    #[must_use]
+    pub fn semantics(&self) -> &SemanticVersions {
+        &self.semantics
+    }
 }
 
 /// **A bitemporal answer and its completeness** — Tier 3 box 3g.

--- a/crates/kirra-world-service/src/read_view.rs
+++ b/crates/kirra-world-service/src/read_view.rs
@@ -769,18 +769,20 @@ impl<'a> WorldView<'a> {
     /// **The aggregate summary for `subject`, and how much of the evidence
     /// behind it survives** — the 3g follow-up.
     ///
+    /// The read is BOUNDED — see
+    /// [`WorldStore::subject_summary_with_coverage`], which narrows both of its
+    /// sources in SQL rather than scanning the store.
+    ///
     /// # Errors
     ///
     /// [`AskError::Store`] on any read failure.
     pub fn subject_summary(&self, subject: &str) -> Result<SummaryLookup, AskError> {
-        // Filtered by subject at the boundary, which is the one narrowing that
-        // cannot disagree with the store: it is an equality on the same string
-        // the store keyed by. Completeness is not touched.
-        let found = self
-            .store
-            .subject_summaries_with_coverage()?
-            .into_iter()
-            .find(|s| s.subject == subject);
+        // The BOUNDED per-subject read, not the bulk call filtered down. The
+        // bulk one loads every retained row and every citation in the store and
+        // groups once — right for "every subject", quadratically wrong as the
+        // basis for "this subject". Caught in review on #1441, and the same
+        // finding as #1440's unbounded lineage fetch against the same clause.
+        let found = self.store.subject_summary_with_coverage(subject)?;
 
         Ok(SummaryLookup {
             summary: found,

--- a/crates/kirra-world-service/src/semantics.rs
+++ b/crates/kirra-world-service/src/semantics.rs
@@ -199,6 +199,40 @@ impl SemanticVersions {
                     version: version_of(BoundaryRuleId::Admissibility),
                 },
             ]),
+            // 3g follow-up. `history` returns RAW confirmed claims in
+            // generation order — it does not fold and it does not resolve
+            // identity — so `world_current_fold` and `entity_fold` are both
+            // genuinely out, and their absence is asserted rather than assumed
+            // (`the_history_query_depends_on_exactly_one_rule`).
+            //
+            // `answer_admissibility` is IN for a reason worth stating, because
+            // the obvious reading of this set is wrong. History does NOT filter
+            // on admissibility: a claim that has since gone stale is still part
+            // of the historical record, and dropping it would make this family
+            // lie about the past exactly as an admissibility filter on lineage
+            // would hide the evidence an investigator came for.
+            //
+            // It is in the set because history still RESOLVES each claim's
+            // policy, so 3e's fail-closed refusal on unclassified semantics
+            // reaches this family too. Changing the admissibility rule can
+            // therefore change what this query does — it can turn an answer
+            // into a refusal — which is the membership test, and the test does
+            // not care that the rule is consulted for refusal rather than for
+            // filtering.
+            QueryKind::SubjectHistory => Self::new([RuleVersion {
+                rule: ADMISSIBILITY.to_string(),
+                version: version_of(BoundaryRuleId::Admissibility),
+            }]),
+            // 3g follow-up. The subject-summary fold is the whole derivation:
+            // the boundary reads the folded row and the coverage the fold
+            // recorded beside it, adds nothing, and refuses nothing.
+            // `answer_admissibility` is OUT because a summary is an aggregate
+            // over evidence, not a claim served to a caller — there is no
+            // per-claim freshness question to ask of a count.
+            QueryKind::SubjectSummary => Self::new([RuleVersion {
+                rule: RuleId::SubjectSummaryFold.as_str().to_string(),
+                version: store_semantics::version_of(RuleId::SubjectSummaryFold),
+            }]),
             // Box 3f. ONE rule, and the three absences are load-bearing claims
             // rather than an oversight — see `crate::lineage::lineage_semantics`
             // for the argument on each, and
@@ -536,6 +570,75 @@ mod tests {
              SERVE it is a different question from whether it happened, and a \
              lineage hiding rejected events is silent exactly when someone is \
              investigating one"
+        );
+    }
+
+    /// **The history family's set, and the two absences that define it.**
+    ///
+    /// The membership argument here is the subtlest in the module, because the
+    /// one rule present is present for a reason the obvious reading gets wrong.
+    #[test]
+    fn the_history_query_depends_on_exactly_one_rule() {
+        let v = SemanticVersions::for_query(QueryKind::SubjectHistory);
+        let names: Vec<&str> = v.entries().iter().map(|e| e.rule.as_str()).collect();
+        assert_eq!(names, vec![ADMISSIBILITY]);
+
+        assert!(
+            v.version_of("world_current_fold").is_none(),
+            "history returns the RAW confirmed claims in generation order — it \
+             never asks which claim won a key. If it ever returned folded \
+             state, this fold decides what it says and must join the set"
+        );
+        assert!(
+            v.version_of("entity_fold").is_none(),
+            "history is a replay and resolves no identity, which is why its \
+             answers carry NotResolvedInReplay. If it ever resolved objects \
+             through the equivalence graph, this fold must join the set"
+        );
+    }
+
+    /// **`answer_admissibility` is in history's set for REFUSAL, not filtering.**
+    ///
+    /// Separated from the set assertion above because the two would otherwise
+    /// pass as one fact, and they are not one fact. A future reader who sees
+    /// admissibility in this set will reasonably infer that history filters on
+    /// it — and "fixing" the boundary to match that inference would make
+    /// history hide claims that were genuinely made.
+    ///
+    /// The membership test is *"can changing this rule change what the query
+    /// does"*. It can: an unclassified claim turns a history answer into a
+    /// refusal. The test does not care that the rule is consulted for
+    /// fail-closed refusal rather than for dropping rows.
+    #[test]
+    fn history_shares_admissibility_with_the_answer_families_deliberately() {
+        let history = SemanticVersions::for_query(QueryKind::SubjectHistory);
+        let current = SemanticVersions::for_query(QueryKind::CurrentSubject);
+        assert_eq!(
+            history.version_of(ADMISSIBILITY),
+            current.version_of(ADMISSIBILITY),
+            "both families resolve the SAME admissibility rule, so a version \
+             bump must move both; they differ in what they do with the verdict, \
+             which is a property of the boundary and not of the rule"
+        );
+    }
+
+    /// The subject-summary family derives from the fold and nothing else.
+    #[test]
+    fn the_subject_summary_query_depends_on_exactly_one_rule() {
+        let v = SemanticVersions::for_query(QueryKind::SubjectSummary);
+        let names: Vec<&str> = v.entries().iter().map(|e| e.rule.as_str()).collect();
+        assert_eq!(names, vec!["subject_summary_fold"]);
+
+        assert!(
+            v.version_of(ADMISSIBILITY).is_none(),
+            "a summary is an aggregate over evidence, not a claim served to a \
+             caller — there is no per-claim freshness question to ask of a \
+             count, so there is nothing for this rule to decide"
+        );
+        assert!(
+            v.version_of("world_current_fold").is_none(),
+            "the subject summary folds events into aggregates directly; it does \
+             not read the claim projection"
         );
     }
 

--- a/crates/kirra-world-service/tests/completeness_propagation.rs
+++ b/crates/kirra-world-service/tests/completeness_propagation.rs
@@ -76,15 +76,18 @@
 //! `Full` has to describe the whole answer contract, not the two numbers that
 //! survived.
 //!
-//! # Two fixture facts that were measured, not assumed
+//! # Three fixture facts that were measured, not assumed
 //!
-//! Both cost a red test first, and both are recorded because the wrong version
+//! Each cost a red test first, and each is recorded because the wrong version
 //! looks entirely reasonable:
 //!
 //! * `fold()` does **not** build `subject_summary` — `fold_subject_summary()`
 //!   is a separate call. A fixture running only the first produces ZERO
 //!   summaries, and every subject-summary control would pass vacuously against
 //!   a store that had never summarised anything.
+//! * The summary must be rebuilt **after** compaction, not merely folded before
+//!   it — measured at `reconciled = 4` against a true 3. The argument is on
+//!   `holed_store`, which is where someone changing the fixture will be.
 //! * `is_admissible` drops `Expired` validity and `Inadmissible` grade — **not**
 //!   staleness. A stale claim is served by `ask`, carrying a `Stale` grade. The
 //!   first draft of `history_keeps_a_claim_that_ask_refuses_to_serve` used

--- a/crates/kirra-world-service/tests/completeness_propagation.rs
+++ b/crates/kirra-world-service/tests/completeness_propagation.rs
@@ -1,0 +1,488 @@
+//! **The 3g follow-up — completeness for `history` and `subject_summary`.**
+//!
+//! 3g closed with a stated limit: *"`history` and `subject_summary` remain
+//! unpropagated, and a boundary query for them is the follow-up."* This is that
+//! follow-up, held to one acceptance rule:
+//!
+//! > A boundary answer must never report `Full` when evidence required by that
+//! > family may have been removed. Conservative `Degraded` is allowed; silent
+//! > loss is not.
+//!
+//! # The two families needed DIFFERENT mechanisms, and that is the finding
+//!
+//! Both propagate rather than recompute — but they propagate different types,
+//! because the store computes their completeness from different things.
+//!
+//! | Family | Signal | Computed from |
+//! |---|---|---|
+//! | `history` | `Resolution` | citations overlapping a queried RANGE |
+//! | `subject_summary` | `SummaryCoverage` | the evidence behind ONE folded row |
+//!
+//! Coercing the second into the first would mean passing `spans: vec![]`, which
+//! reads as *"no compacted span bore on this"* — false, in the reassuring
+//! direction. So each crosses the boundary in its native type. One source of
+//! truth per family beats one type across families.
+//!
+//! # Why history's two arms need two SEPARATE stores
+//!
+//! Not tidiness. `WorldStore::resolution_for` checks citations **store-wide** —
+//! `load_citations()` takes no subject — so one retained citation degrades every
+//! subject's history, including subjects the compacted span never touched. The
+//! `Full` arm is therefore only reachable in a store with no citations at all.
+//!
+//! That conservatism is deliberate and this suite PINS it rather than sharpening
+//! it. Narrowing the check to the queried subject would turn a conservative
+//! signal into an exact-loss detector, and an exact-loss detector that is wrong
+//! is silent — the failure the acceptance rule forbids. A future reader who sees
+//! the two-store split and "simplifies" it into one store will find the Full arm
+//! unreachable, which is the intended tripwire.
+//!
+//! # Both history arms return non-empty claims, deliberately
+//!
+//! A forced-`Full` mutation must red for the RIGHT reason. If the compacted arm
+//! returned nothing, it could red for "no claims" while completeness propagation
+//! was entirely broken, and the control would be measuring emptiness.
+//!
+//! # The mutation battery
+//!
+//! Run against the shipped code, not reasoned about:
+//!
+//! | # | Mutation | Reds |
+//! |---|---|---|
+//! | 1 | history: force `Resolution::Full` in the carry | `a_compacted_history_reports_degraded` |
+//! | 2 | history: force `Degraded` everywhere | `an_uncompacted_history_reports_full` |
+//! | 3 | summary: `is_degraded` returns `false` | the two summary-degraded controls |
+//! | 4 | summary: `is_degraded` defers to reconciliation | the two summary-degraded controls |
+//! | 5 | history: swallow the `policy_for` refusal | `an_unruled_claim_refuses_the_whole_history` |
+//! | 6 | fixture: drop the post-compaction rebuild | `reconciliation_does_not_upgrade_completeness` ONLY |
+//!
+//! **Mutations 3 and 4 red the same pair**, so on mutation evidence alone
+//! `reconciliation_does_not_upgrade_completeness` looks redundant against
+//! `a_compacted_summary_reports_degraded`. It is not, and mutation 6 is the
+//! separating case: it reds that test alone, at `left: 4, right: 3`. What the
+//! extra test buys is the guarantee that the reconstruction genuinely
+//! SUCCEEDS in the fixture — so the degraded verdict is being held *despite*
+//! working reconciliation rather than alongside broken reconciliation. Without
+//! it, a fixture that quietly double-counted would still report `Degraded` and
+//! the control would be green for the wrong reason.
+//!
+//! Mutation 4 is the one worth keeping in view. `reconciled_observation_count`
+//! and `reconciled_first_observed_ms` genuinely DO reconstruct their
+//! pre-compaction values from citations — so an implementation reading "the
+//! numbers add up" as "nothing was lost" would look correct. It is wrong
+//! because a citation names a SPAN, not the events inside it:
+//! `provenance_head` and `last_event_id` cannot be reconstructed at all, and
+//! for a fully compacted subject `retained` is `None` and they do not exist.
+//! `Full` has to describe the whole answer contract, not the two numbers that
+//! survived.
+//!
+//! # Two fixture facts that were measured, not assumed
+//!
+//! Both cost a red test first, and both are recorded because the wrong version
+//! looks entirely reasonable:
+//!
+//! * `fold()` does **not** build `subject_summary` — `fold_subject_summary()`
+//!   is a separate call. A fixture running only the first produces ZERO
+//!   summaries, and every subject-summary control would pass vacuously against
+//!   a store that had never summarised anything.
+//! * `is_admissible` drops `Expired` validity and `Inadmissible` grade — **not**
+//!   staleness. A stale claim is served by `ask`, carrying a `Stale` grade. The
+//!   first draft of `history_keeps_a_claim_that_ask_refuses_to_serve` used
+//!   staleness and failed on its own premise.
+
+use kirra_world_service::freshness::FreshnessSource;
+use kirra_world_service::read_view::{AskError, WorldLookup, WorldView};
+use kirra_world_store::{ClaimStatus, EventId, NewEvent, ObservationId, WorldStore, WriterClass};
+
+const T0: i64 = 1_700_000_000_000;
+
+fn tmp(name: &str) -> std::path::PathBuf {
+    static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let n = NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "kirra-3gf-{name}-{}-{n}.sqlite",
+        std::process::id()
+    ));
+    for suffix in ["", "-wal", "-shm"] {
+        let mut q = p.as_os_str().to_os_string();
+        q.push(suffix);
+        let _ = std::fs::remove_file(std::path::PathBuf::from(q));
+    }
+    p
+}
+
+fn claim(store: &mut WorldStore, tag: &str, object: &str, at_ms: i64) {
+    store
+        .append(&NewEvent {
+            event_id: &EventId::new(format!("ev-{tag}")).expect("event id"),
+            observation_id: &ObservationId::new(format!("obs-{tag}")).expect("obs"),
+            txn_time_ms: at_ms,
+            valid_from_ms: at_ms,
+            valid_to_ms: None,
+            source: "warehouse-scanner",
+            source_version: "1.0.0",
+            writer_class: WriterClass::Sensor,
+            claim_status: ClaimStatus::Confirmed,
+            provenance: &[],
+            frame_id: None,
+            map_id: None,
+            kind: "mission",
+            subject: "package_17",
+            subject_ref: None,
+            predicate: Some("last_seen_at"),
+            object: Some(object),
+            payload: "{}",
+            payload_schema: 1,
+            retention_class: "raw",
+            trust: None,
+        })
+        .expect("append");
+}
+
+/// The RULED table classifies `mission`/`last_seen_at` with a five-minute
+/// budget, so this view is fail-closed AND the fixture's claims are classified.
+fn view(store: &WorldStore) -> WorldView<'_> {
+    WorldView::new(store, FreshnessSource::Ruled)
+}
+
+/// Three observations, all retained. No citations anywhere in the store.
+///
+/// `fold_subject_summary` is a SEPARATE call from `fold` and both are needed:
+/// the first builds `world_current`, the second builds `subject_summary`. A
+/// fixture that ran only `fold` produces zero summaries, and the
+/// subject-summary controls below would then pass vacuously against a store
+/// that has never summarised anything.
+fn intact_store(name: &str) -> (WorldStore, std::path::PathBuf) {
+    let path = tmp(name);
+    let mut store = WorldStore::open(&path).expect("open");
+    claim(&mut store, "alpha", "dock_alpha", T0);
+    claim(&mut store, "beta", "dock_beta", T0 + 100);
+    claim(&mut store, "gamma", "dock_gamma", T0 + 200);
+    store.fold().expect("fold");
+    store.fold_subject_summary().expect("summary fold");
+    (store, path)
+}
+
+/// The same three observations, with the superseded middle one compacted away.
+///
+/// # The rebuild after compaction is load-bearing, and was measured
+///
+/// The summary must be REBUILT after the compaction, not merely folded before
+/// it. Both orders were run:
+///
+/// | Order | `retained` | `reconciled_observation_count` |
+/// |---|---|---|
+/// | fold summary → compact | 3 | **4** — the removed event counted twice |
+/// | fold summary → compact → rebuild | 2 | 3 — the identity holds |
+///
+/// Folding first leaves the pre-compaction total in the row, and the citation
+/// then adds the removed event back on top of a count that never lost it. A
+/// fixture built that way would make `reconciliation_does_not_upgrade_completeness`
+/// assert a wrong number while still passing its completeness check — the
+/// control would look green and be measuring a double-count.
+fn holed_store(name: &str) -> (WorldStore, std::path::PathBuf) {
+    let path = tmp(name);
+    let mut store = WorldStore::open(&path).expect("open");
+    claim(&mut store, "alpha", "dock_alpha", T0);
+    claim(&mut store, "beta", "dock_beta", T0 + 100);
+    claim(&mut store, "gamma", "dock_gamma", T0 + 200);
+    store.fold().expect("fold");
+    store.fold_subject_summary().expect("summary fold");
+    let outcome = store
+        .compact_range(2, 2, T0 + 9_000)
+        .expect("generation 2 is superseded, so compactable");
+    assert_eq!(outcome.removed, 1, "the fixture must remove an observation");
+    store
+        .rebuild_subject_summary()
+        .expect("rebuild over surviving evidence");
+    (store, path)
+}
+
+fn answered(lookup: &WorldLookup) -> usize {
+    match lookup {
+        WorldLookup::Answered(a) => a.len(),
+        WorldLookup::Unknown(_) => 0,
+    }
+}
+
+// ---------------------------------------------------------------- history ---
+
+/// **CONTROL 1.** Compacted evidence must never read `Full`.
+///
+/// The load-bearing direction of the acceptance rule. Forcing `Full` in the
+/// boundary's carry reds this.
+#[test]
+fn a_compacted_history_reports_degraded() {
+    let (store, _p) = holed_store("hist-degraded");
+    let lookup = view(&store).history("package_17").expect("history");
+
+    assert!(
+        lookup.is_degraded(),
+        "evidence was compacted away, so this history is not the whole record"
+    );
+}
+
+/// **CONTROL 5.** Both arms answer non-emptily, so control 1 reds for the right
+/// reason.
+///
+/// Without this, forcing `Full` could be caught by an assertion that the
+/// compacted arm merely returned nothing — which would still pass with
+/// propagation completely broken.
+#[test]
+fn both_history_arms_return_a_plausible_non_empty_record() {
+    let (holed, _p1) = holed_store("hist-nonempty-holed");
+    let (intact, _p2) = intact_store("hist-nonempty-intact");
+
+    let degraded = view(&holed).history("package_17").expect("history");
+    let full = view(&intact).history("package_17").expect("history");
+
+    assert_eq!(
+        answered(full.lookup()),
+        3,
+        "the intact arm holds every observation"
+    );
+    assert_eq!(
+        answered(degraded.lookup()),
+        2,
+        "the compacted arm is SHORTER but still a real record — one observation \
+         was removed, and the two that remain are genuine history"
+    );
+}
+
+/// **CONTROL 2.** The `Full` arm is demonstrably reachable.
+///
+/// Non-vacuity. Without it, an implementation reporting `Degraded`
+/// unconditionally would satisfy every other history control here.
+///
+/// Uses its OWN store, because `resolution_for`'s citation check is store-wide:
+/// sharing a store with the compacted case would make this arm unreachable and
+/// the control silently untestable. See this file's header.
+#[test]
+fn an_uncompacted_history_reports_full() {
+    let (store, _p) = intact_store("hist-full");
+    let lookup = view(&store).history("package_17").expect("history");
+
+    assert!(
+        !lookup.is_degraded(),
+        "nothing was compacted in this store, so the record is whole"
+    );
+    assert!(
+        answered(lookup.lookup()) > 0,
+        "a Full arm over an empty answer would prove nothing"
+    );
+}
+
+/// **History does not FILTER on admissibility — a refused claim is still history.**
+///
+/// The trap the version set invites: `answer_admissibility` is in history's
+/// dependency set, so the natural inference is that history filters on it.
+///
+/// Pinned as a CONTRAST against `ask` over the same store, because a bare count
+/// would also pass if nothing in the fixture were inadmissible at all.
+///
+/// The claim is made EXPIRED rather than merely stale, and that distinction was
+/// measured rather than assumed: `is_admissible` drops a claim whose validity is
+/// `Expired` or whose grade is `Inadmissible`, and a *stale* claim is neither —
+/// `ask` serves it, carrying a `Stale` grade. A first draft of this test used
+/// staleness and failed, asserting `ask` returned nothing when it returned the
+/// claim. Expiry is what actually makes `ask` decline.
+#[test]
+fn history_keeps_a_claim_that_ask_refuses_to_serve() {
+    let path = tmp("hist-expired");
+    let mut store = WorldStore::open(&path).expect("open");
+    store
+        .append(&NewEvent {
+            event_id: &EventId::new("ev-expired").expect("event id"),
+            observation_id: &ObservationId::new("obs-expired").expect("obs"),
+            txn_time_ms: T0,
+            valid_from_ms: T0,
+            // Valid for one second, and the read below is an hour later.
+            valid_to_ms: Some(T0 + 1_000),
+            source: "warehouse-scanner",
+            source_version: "1.0.0",
+            writer_class: WriterClass::Sensor,
+            claim_status: ClaimStatus::Confirmed,
+            provenance: &[],
+            frame_id: None,
+            map_id: None,
+            kind: "mission",
+            subject: "package_17",
+            subject_ref: None,
+            predicate: Some("last_seen_at"),
+            object: Some("dock_alpha"),
+            payload: "{}",
+            payload_schema: 1,
+            retention_class: "raw",
+            trust: None,
+        })
+        .expect("append");
+    store.fold().expect("fold");
+
+    let v = view(&store);
+    let late = T0 + 3_600_000;
+
+    let served = v.ask("package_17", late).expect("ask");
+    assert_eq!(
+        answered(served.lookup()),
+        0,
+        "the claim must genuinely be inadmissible at this clock, or the \
+         contrast below is vacuous"
+    );
+
+    let record = v.history("package_17").expect("history");
+    assert_eq!(
+        answered(record.lookup()),
+        1,
+        "the claim is in the record even though `ask` declines to serve it; a \
+         history that hid it would be lying about the past"
+    );
+}
+
+/// **CONTROL for mutation 5.** An unruled claim refuses the whole history.
+///
+/// 3e's fail-closed rule reaches this family. This is the only reason
+/// `answer_admissibility` is in history's version set, so if the `policy_for`
+/// call were dropped as "unused" — it filters nothing — this is what catches it.
+#[test]
+fn an_unruled_claim_refuses_the_whole_history() {
+    let path = tmp("hist-unruled");
+    let mut store = WorldStore::open(&path).expect("open");
+    // A semantic class the RULED table does not name.
+    store
+        .append(&NewEvent {
+            event_id: &EventId::new("ev-unruled").expect("event id"),
+            observation_id: &ObservationId::new("obs-unruled").expect("obs"),
+            txn_time_ms: T0,
+            valid_from_ms: T0,
+            valid_to_ms: None,
+            source: "warehouse-scanner",
+            source_version: "1.0.0",
+            writer_class: WriterClass::Sensor,
+            claim_status: ClaimStatus::Confirmed,
+            provenance: &[],
+            frame_id: None,
+            map_id: None,
+            kind: "not_a_ruled_kind",
+            subject: "package_17",
+            subject_ref: None,
+            predicate: Some("whatever"),
+            object: Some("dock_alpha"),
+            payload: "{}",
+            payload_schema: 1,
+            retention_class: "raw",
+            trust: None,
+        })
+        .expect("append");
+    store.fold().expect("fold");
+
+    let err = view(&store)
+        .history("package_17")
+        .expect_err("an unclassified claim must refuse the whole query");
+    assert!(
+        matches!(err, AskError::UnclassifiedFreshness { .. }),
+        "expected a fail-closed refusal, got {err:?}"
+    );
+}
+
+// --------------------------------------------------------- subject summary ---
+
+/// **CONTROL 3.** Existing degraded coverage must not be swallowed.
+///
+/// The boundary propagates the fold's `SummaryCoverage` verbatim; mapping
+/// `Degraded` → `Complete` reds this.
+#[test]
+fn a_compacted_summary_reports_degraded() {
+    let (store, _p) = holed_store("sum-degraded");
+    let lookup = view(&store)
+        .subject_summary("package_17")
+        .expect("subject summary");
+
+    assert!(
+        lookup.summary().is_some(),
+        "the subject is summarised; a missing summary would make the coverage \
+         assertion below vacuous"
+    );
+    assert!(
+        lookup.is_degraded(),
+        "evidence behind these aggregates was compacted away"
+    );
+}
+
+/// **CONTROL 2's counterpart for summaries.** The `Complete` arm is reachable.
+#[test]
+fn an_uncompacted_summary_reports_complete() {
+    let (store, _p) = intact_store("sum-complete");
+    let lookup = view(&store)
+        .subject_summary("package_17")
+        .expect("subject summary");
+
+    assert!(lookup.summary().is_some(), "the subject is summarised");
+    assert!(
+        !lookup.is_degraded(),
+        "nothing was compacted, so the aggregates rest on all their evidence"
+    );
+}
+
+/// **CONTROL 4 — the invariant this half exists for.**
+///
+/// > Successful numerical reconciliation does not imply complete evidence
+/// > coverage.
+///
+/// `reconciled_observation_count` genuinely reconstructs the pre-compaction
+/// total from citations, and `reconciled_first_observed_ms` genuinely
+/// reconstructs the earliest transaction time. Both succeed here — asserted,
+/// so this test cannot pass because reconciliation quietly failed.
+///
+/// Completeness must remain `Degraded` anyway, because a citation names a span
+/// and not the events inside it: `provenance_head` and `last_event_id` are
+/// unrecoverable. An implementation reading "the counts agree" as "nothing was
+/// lost" passes every other control in this file and fails only here.
+#[test]
+fn reconciliation_does_not_upgrade_completeness() {
+    let (store, _p) = holed_store("sum-reconcile");
+    let lookup = view(&store)
+        .subject_summary("package_17")
+        .expect("subject summary");
+    let summary = lookup.summary().expect("summarised");
+
+    // The reconstruction really does work — otherwise the assertion below would
+    // hold for the boring reason rather than the load-bearing one.
+    assert_eq!(
+        summary.reconciled_observation_count(),
+        3,
+        "all three observations are accounted for: two retained, one via its \
+         citation — the reconstruction this test exists to NOT trust"
+    );
+    assert_eq!(
+        summary.reconciled_first_observed_ms(),
+        Some(T0),
+        "the earliest transaction time is recoverable too"
+    );
+
+    assert!(
+        lookup.is_degraded(),
+        "the counts reconcile and the answer is STILL degraded: provenance_head \
+         and last_event_id name events that no longer exist, and Full has to \
+         describe the whole answer contract rather than the two numbers that \
+         happened to survive"
+    );
+}
+
+/// An unsummarised subject is not degraded — there is no evidence missing.
+///
+/// Keeps "never heard of it" distinct from "its evidence was removed", which is
+/// a distinction the store goes to real trouble to preserve.
+#[test]
+fn an_unknown_subject_is_absent_rather_than_degraded() {
+    let (store, _p) = intact_store("sum-absent");
+    let lookup = view(&store)
+        .subject_summary("package_99")
+        .expect("subject summary");
+
+    assert!(lookup.summary().is_none(), "never observed");
+    assert!(
+        !lookup.is_degraded(),
+        "nothing was claimed about this subject, so nothing is missing"
+    );
+}

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -3736,20 +3736,15 @@ impl WorldStore {
                 .push(c);
         }
 
+        // Delegated to the SHARED derivation rather than restated, so this and
+        // the per-subject `subject_summary_with_coverage` cannot drift. The
+        // grouping above is a fetch narrowing; the verdict is the rule.
         let coverage_for = |kind: SummaryKind, subject: &str| -> SummaryCoverage {
             let Some(group) = citations_by_subject.get(subject) else {
                 return SummaryCoverage::Complete;
             };
-            let mine: Vec<_> = group
-                .iter()
-                .filter(|c| c.subject_kind.as_deref().is_none_or(|k| k == kind.as_str()))
-                .map(|c| (*c).clone())
-                .collect();
-            if mine.is_empty() {
-                SummaryCoverage::Complete
-            } else {
-                SummaryCoverage::Degraded { summaries: mine }
-            }
+            let owned: Vec<DegradedSummary> = group.iter().map(|c| (*c).clone()).collect();
+            subject_projection::coverage_from_citations(kind, &owned)
         };
 
         let mut out: Vec<SubjectSummaryAnswer> = retained
@@ -3776,11 +3771,7 @@ impl WorldStore {
             // The RECORDED kind when there is one. `Unlabelled` is the fallback
             // for a pre-migration citation only -- and it is a guess there,
             // which is why the column exists.
-            let kind = c
-                .subject_kind
-                .as_deref()
-                .and_then(|k| SummaryKind::from_projection_column(k).ok())
-                .unwrap_or(SummaryKind::Unlabelled);
+            let kind = subject_projection::kind_of_citation(c);
             if !known.contains(&(kind, c.subject.as_str())) {
                 cited_only.insert((kind, c.subject.as_str()));
             }
@@ -3795,6 +3786,76 @@ impl WorldStore {
         }
         out.sort_by(|a, b| a.subject.cmp(&b.subject));
         Ok(out)
+    }
+
+    /// **One subject's summary, with how complete it is** — the bounded
+    /// per-subject read.
+    ///
+    /// # Why this exists alongside the bulk call
+    ///
+    /// [`Self::subject_summaries_with_coverage`] is a BULK API and is optimised
+    /// as one: it loads every retained row and every citation in the store and
+    /// groups once, precisely because the per-subject rescan it replaced was
+    /// quadratic. Answering a single-subject question through it inverts that
+    /// optimisation — you pay `O(total subjects + total citations)` to read one
+    /// row, on a store where both tables grow for its whole life.
+    ///
+    /// `KIRRA-WM-ANSWER-IDENTITY-001` clause 2 is *"queries are bounded"*, and
+    /// a per-subject boundary query standing on a whole-store scan is not,
+    /// however correct its answer. Both narrowings here are SQL
+    /// (`subject_summaries_for`, `load_summaries(Some(..))`).
+    ///
+    /// # The verdict is the SAME code, not the same logic
+    ///
+    /// Coverage comes from [`subject_projection::coverage_from_citations`],
+    /// which the bulk path also calls. Two implementations that agree today
+    /// are two implementations that can disagree later, and a disagreement
+    /// here is a subject reported `Complete` by one path and `Degraded` by the
+    /// other. `the_narrowed_and_bulk_coverage_paths_agree` holds them together.
+    ///
+    /// Returns `None` when the store has neither a retained row nor a citation
+    /// for `subject` — *"never summarised"*, which is distinct from *"its
+    /// evidence was removed"*.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::Sqlite`] on any storage failure;
+    /// [`StoreError::CorruptRow`] if a stored kind token cannot be read.
+    pub fn subject_summary_with_coverage(
+        &self,
+        subject: &str,
+    ) -> Result<Option<subject_projection::SubjectSummaryAnswer>, StoreError> {
+        use subject_projection::SubjectSummaryAnswer;
+
+        let citations = self.load_summaries(Some(subject))?;
+        let retained = self.subject_summaries_for(subject)?;
+
+        // A retained row wins: it carries aggregates a citation cannot supply.
+        // `subject_summaries_for` orders by kind, so the first is deterministic
+        // rather than whichever SQLite happened to return.
+        if let Some(row) = retained.into_iter().next() {
+            let coverage =
+                subject_projection::coverage_from_citations(row.subject_kind, &citations);
+            return Ok(Some(SubjectSummaryAnswer {
+                subject_kind: row.subject_kind,
+                subject: row.subject.clone(),
+                coverage,
+                retained: Some(row),
+            }));
+        }
+
+        // Known only by citation — the case the bulk call was extended to stop
+        // losing, and which a naive per-subject read would drop again.
+        let Some(first) = citations.first() else {
+            return Ok(None);
+        };
+        let kind = subject_projection::kind_of_citation(first);
+        Ok(Some(SubjectSummaryAnswer {
+            subject_kind: kind,
+            subject: subject.to_owned(),
+            retained: None,
+            coverage: subject_projection::coverage_from_citations(kind, &citations),
+        }))
     }
 
     /// Every **resolved entity** this store has summarised.

--- a/crates/kirra-world-store/src/subject_projection.rs
+++ b/crates/kirra-world-store/src/subject_projection.rs
@@ -674,6 +674,55 @@ impl SummaryCoverage {
     }
 }
 
+/// **Whether a subject's evidence is whole, given the citations naming it.**
+///
+/// THE coverage derivation, extracted so both the bulk
+/// [`crate::WorldStore::subject_summaries_with_coverage`] and the per-subject
+/// [`crate::WorldStore::subject_summary_with_coverage`] reach the same verdict
+/// by calling the same code rather than by two implementations agreeing.
+///
+/// `citations` must already be narrowed to this subject — by SQL on the
+/// per-subject path, by grouping on the bulk path. Narrowing by SUBJECT is safe
+/// to do outside this function because it is an equality on the same string;
+/// narrowing by KIND is not, and is therefore done in here.
+///
+/// # A citation with no recorded kind matches EVERY kind
+///
+/// `subject_kind` post-dates `compaction_summaries`, so an older citation
+/// carries `None`. That means *"not recorded"*, which cannot be used to exclude
+/// — only to fail to distinguish. Treating it as a non-match would let a
+/// pre-migration citation stop degrading the subject it names, which is a
+/// silent loss in the one direction this tier forbids.
+#[must_use]
+pub fn coverage_from_citations(
+    kind: SummaryKind,
+    citations: &[crate::compaction::DegradedSummary],
+) -> SummaryCoverage {
+    let mine: Vec<_> = citations
+        .iter()
+        .filter(|c| c.subject_kind.as_deref().is_none_or(|k| k == kind.as_str()))
+        .cloned()
+        .collect();
+    if mine.is_empty() {
+        SummaryCoverage::Complete
+    } else {
+        SummaryCoverage::Degraded { summaries: mine }
+    }
+}
+
+/// The kind a citation names, falling back to [`SummaryKind::Unlabelled`].
+///
+/// The fallback is a GUESS and only legitimate for a pre-migration citation
+/// that recorded no discriminant — claiming `Entity` would be inventing one.
+/// Shared by both coverage paths for the same reason the derivation is.
+#[must_use]
+pub fn kind_of_citation(c: &crate::compaction::DegradedSummary) -> SummaryKind {
+    c.subject_kind
+        .as_deref()
+        .and_then(|k| SummaryKind::from_projection_column(k).ok())
+        .unwrap_or(SummaryKind::Unlabelled)
+}
+
 /// One subject's summary **and** how complete it is.
 ///
 /// # Why `retained` is an `Option`

--- a/crates/kirra-world-store/tests/subject_summary_coverage.rs
+++ b/crates/kirra-world-store/tests/subject_summary_coverage.rs
@@ -358,3 +358,68 @@ fn a_pre_migration_citation_still_degrades_its_subject() {
     assert_eq!(a.reconciled_observation_count(), 4);
     clean(&p);
 }
+
+/// **The tripwire that lets the per-subject path exist at all.**
+///
+/// `subject_summary_with_coverage` narrows both its sources in SQL;
+/// `subject_summaries_with_coverage` loads the whole store and groups. They
+/// share the coverage derivation (`coverage_from_citations`), so they SHOULD be
+/// identical — this asserts it rather than assuming it, because a disagreement
+/// means a subject reported `Complete` by one path and `Degraded` by the other,
+/// and nothing else in the system would notice.
+///
+/// Swept over EVERY subject the bulk call knows about — including
+/// `window-only`, which has no retained row at all and exists only through its
+/// citation, the case a naive per-subject read drops.
+///
+/// Added on #1441 review for the same reason #1440 added
+/// `narrowing_never_removes_what_the_rule_would_keep`: a narrowing is only safe
+/// when something watches it.
+#[test]
+fn the_narrowed_and_bulk_coverage_paths_agree() {
+    let path = tmp("coverage-agreement");
+    let mut s = WorldStore::open(&path).expect("open");
+    seed_mixed(&mut s);
+    // No `fold()`: building `world_current` creates a protected projection
+    // head that makes generations 1..=5 uncompactable. The sibling fixtures in
+    // this file omit it for the same reason.
+    s.fold_subject_summary().expect("fold");
+    s.compact_range(1, 5, T0 + 90_000).expect("compact");
+    s.rebuild_subject_summary().expect("rebuild");
+
+    let bulk = s.subject_summaries_with_coverage().expect("bulk coverage");
+    assert!(
+        bulk.iter().any(|a| a.coverage.is_degraded()),
+        "the fixture must degrade something, or agreement is trivial"
+    );
+    assert!(
+        bulk.iter().any(|a| a.retained.is_none()),
+        "the fixture must include a citation-only subject, or the hardest arm \
+         of the narrowed path is never exercised"
+    );
+
+    let mut checked = 0;
+    for expected in &bulk {
+        let narrowed = s
+            .subject_summary_with_coverage(&expected.subject)
+            .expect("narrowed coverage")
+            .expect("the bulk call named this subject, so the narrowed one must find it");
+        assert_eq!(
+            &narrowed, expected,
+            "narrowed and bulk disagree for {} — the two coverage paths have drifted",
+            expected.subject
+        );
+        checked += 1;
+    }
+    assert!(
+        checked >= 3,
+        "the sweep must cover several subjects, got {checked}"
+    );
+
+    assert!(
+        s.subject_summary_with_coverage("never_heard_of_it")
+            .expect("narrowed coverage")
+            .is_none(),
+        "a subject with neither a retained row nor a citation is absent, not degraded"
+    );
+}

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -2042,7 +2042,9 @@ pressure that produced every stale claim this box already documents.
       (`lineage_selection`, `RuleId`'s first non-reducer); compaction degrades
       rather than refusing; `provenance` is carried verbatim, since walking it
       is the Tier 4 structure `KIRRA-WM-EXPLAIN-TIER-001` keeps out.
-- [x] **3g — Degradation propagation.** ✅ **DONE 2026-08-11** — see *"3g:
+- [x] **3g — Degradation propagation.** ✅ **DONE 2026-08-11**, follow-up closed
+      **2026-08-12** (`history` + `subject_summary`; see *"3g follow-up closed:
+      two families, two mechanisms"*) — see *"3g:
       the boundary finally carries completeness"* below. Every answer family preserves
       `Full`/`Degraded` **independently of the payload outcome**, not just
       `subject_summary`. Retention may reduce answer precision; Tier 3 makes the
@@ -2973,8 +2975,8 @@ after evidence was lost.**
 **Scope, stated because it is narrower than the box's wording.** `ask_as_of` is
 one family. 3g says *every* family; the ones that exist at the boundary are `ask`
 (structurally `Full`, and now knowably so) and this. `history` and
-`subject_summary` remain unpropagated, and a boundary query for them is the
-follow-up. A replayed answer also does not resolve object identity —
+`subject_summary` were unpropagated at the time of writing; the follow-up below
+closed both. A replayed answer also does not resolve object identity —
 `ObjectIdentity::NotResolvedInReplay`, renamed from `NotResolvedAtPin` since it
 now covers both replay families. Here the axes would actually AGREE (both this
 query and `identity_view_at` cut on transaction time), so that is a scope
@@ -3405,6 +3407,120 @@ once an applicable entry exists. The `Caller` variant stays as the honest interi
 while `RULED` is small.
 
 ---
+
+### 3g follow-up closed: two families, two mechanisms — 2026-08-12
+
+3g shipped with a stated limit — `ask_as_of` carried completeness and `history`
+and `subject_summary` did not. This closes both, under one acceptance rule:
+
+> A boundary answer must never report `Full` when evidence required by that
+> family may have been removed. Conservative `Degraded` is allowed; silent loss
+> is not.
+
+#### Neither family lost completeness — neither family EXISTED at the boundary
+
+`WorldView` exposed exactly `ask` and `ask_as_of`, so "unpropagated" understated
+it: there was no `history` query and no `subject_summary` query to propagate
+through. That made the acceptance rule a construction constraint rather than a
+migration, and it is why this landed as two new queries rather than two patches.
+
+#### The two mechanisms are genuinely different, and forcing one type would have lied
+
+Both PROPAGATE rather than recompute — a second verdict at the boundary is a
+second implementation of the rule governing whether an answer can be trusted.
+But they propagate different types, because the store computes them from
+different things:
+
+| Family | Signal | Computed from |
+|---|---|---|
+| `history` | `Resolution` | citations overlapping a queried RANGE |
+| `subject_summary` | `SummaryCoverage` | the evidence behind ONE folded row |
+
+Coercing `SummaryCoverage::Degraded { summaries }` into
+`Resolution::Degraded { spans, summaries }` requires inventing `spans: vec![]`,
+which reads as *"no compacted span bore on this"* — false, and false in the
+reassuring direction. So `SummaryLookup` carries the native type. **One source
+of truth per family beats one type across families.**
+
+#### `answer_admissibility` is in history's version set for REFUSAL, not filtering
+
+The subtlest membership call in the module, and the one most likely to be
+"fixed" wrongly. History does **not** filter on admissibility: a claim `ask`
+declines to serve is still part of the record, and hiding it would make history
+lie about the past exactly as an admissibility filter on a lineage would hide
+the evidence an investigator came for.
+
+It is in the set because history still RESOLVES each claim's policy, so 3e's
+fail-closed refusal on unclassified semantics reaches this family. Changing the
+rule can turn a history answer into a refusal — that is the membership test, and
+the test does not care that the rule is consulted for refusal rather than for
+dropping rows. Two separate tests pin the two halves, because as one assertion
+they would read as one fact.
+
+`world_current_fold` and `entity_fold` are both OUT and asserted so: history
+returns raw confirmed claims in generation order, folding nothing and resolving
+no identity.
+
+#### The conservative citation rule is PINNED, not sharpened
+
+`resolution_for`'s citation check is store-wide, so one retained citation
+degrades every subject's history — including subjects the compacted span never
+touched. The tempting cleanup is to scope it to the queried subject. That would
+convert a conservative signal into an exact-loss detector, and an exact-loss
+detector that is wrong is silent.
+
+The consequence is structural rather than stylistic: the `Full` arm is only
+reachable in a store with **no citations at all**, so the two history controls
+need two separate stores. A reader who consolidates them will find the Full arm
+unreachable, which is the intended tripwire.
+
+#### Numerical reconciliation is not evidence coverage
+
+The invariant this half exists for:
+
+> Successful numerical reconciliation does not imply complete evidence coverage.
+
+`reconciled_observation_count` and `reconciled_first_observed_ms` genuinely
+reconstruct their pre-compaction values from citations. `provenance_head` and
+`last_event_id` cannot be reconstructed at all — a citation names a span, not
+the events inside it — and for a fully compacted subject `retained` is `None`
+and those fields do not exist. `SummaryLookup::is_degraded` therefore reads
+`coverage` and only `coverage`; there is deliberately no constructor taking a
+reconciliation result.
+
+#### Six mutations, and the one that separates two controls
+
+| # | Mutation | Reds |
+|---|---|---|
+| 1 | history: force `Full` | `a_compacted_history_reports_degraded` |
+| 2 | history: force `Degraded` | `an_uncompacted_history_reports_full` |
+| 3 | summary: `is_degraded` → `false` | both summary-degraded controls |
+| 4 | summary: `is_degraded` defers to reconciliation | both summary-degraded controls |
+| 5 | history: swallow the `policy_for` refusal | `an_unruled_claim_refuses_the_whole_history` |
+| 6 | fixture: drop the post-compaction rebuild | `reconciliation_does_not_upgrade_completeness` ONLY |
+
+Mutations 3 and 4 red the same pair, so on mutation evidence alone the
+reconciliation control looks redundant. Mutation 6 is the separating case,
+reddening it alone at `left: 4, right: 3`: what the extra control buys is proof
+that reconstruction genuinely SUCCEEDS in the fixture, so the degraded verdict
+is held *despite* working reconciliation rather than alongside broken
+reconciliation.
+
+#### Two fixture facts that cost a red test each
+
+Recorded because the wrong version of both looks entirely reasonable:
+
+* **`fold()` does not build `subject_summary`.** `fold_subject_summary()` is a
+  separate call, and a fixture running only the first produces ZERO summaries —
+  every subject-summary control would then pass vacuously against a store that
+  had never summarised anything.
+* **The summary must be rebuilt AFTER compaction.** Folding first leaves the
+  pre-compaction total in the row and the citation adds the removed event back
+  on top of a count that never lost it: measured at `reconciled = 4` against a
+  true 3. The fixture would have looked green while double-counting.
+* **`is_admissible` drops `Expired` and `Inadmissible`, not staleness.** A stale
+  claim is served by `ask` carrying a `Stale` grade, so the first draft of the
+  history/`ask` contrast failed on its own premise and now uses expiry.
 
 ### 3f closed: lineage is a query family, not a field — 2026-08-12
 

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -3506,7 +3506,50 @@ that reconstruction genuinely SUCCEEDS in the fixture, so the degraded verdict
 is held *despite* working reconciliation rather than alongside broken
 reconciliation.
 
-#### Two fixture facts that cost a red test each
+#### Review follow-up: the per-subject query stood on a whole-store scan
+
+Caught in review, and it is the SAME finding as #1440's unbounded lineage
+fetch — against the same clause, one PR later.
+
+`WorldView::subject_summary` called `subject_summaries_with_coverage()` and
+filtered. That call is a BULK API and optimised as one: it loads every retained
+row and every citation in the store and groups once, *because* the per-subject
+rescan it replaced was quadratic. Standing a single-subject query on it inverts
+that optimisation exactly — `O(total subjects + total citations)` to read one
+row, on tables that grow for a store's whole life.
+
+`KIRRA-WM-ANSWER-IDENTITY-001` clause 2 is *"queries are bounded"*, and it was
+violated the same invisible way as on #1440: the returned answer was correct and
+bounded, so only the WORK was unbounded and nothing showed it.
+
+That the same class of defect recurred one PR after being written up is the
+useful part. Fixing the instance did not generalise; **a per-query bound is not
+a property anything currently checks**, and both times it took a reviewer. A
+gate that flags a bounded-looking boundary query built on an unbounded store
+call would be the real remedy, and is recorded here as not built.
+
+The fix follows #1440's shape. `WorldStore::subject_summary_with_coverage`
+narrows both sources in SQL (`subject_summaries_for`,
+`load_summaries(Some(..))`), and the coverage verdict is EXTRACTED
+(`subject_projection::coverage_from_citations`) so the bulk and narrowed paths
+run the same code rather than two implementations agreeing.
+`the_narrowed_and_bulk_coverage_paths_agree` sweeps every subject the bulk call
+knows — including the citation-only one a naive per-subject read drops — plus a
+subject in neither.
+
+Three mutations, run:
+
+| Mutation | Reds |
+|---|---|
+| narrowed path drops citation-only subjects | the agreement test |
+| narrowed path reports `Complete` for a degraded subject | the agreement test |
+| the SHARED rule stops matching `None`-kind citations | **four pre-existing tests** |
+
+The third is the one that justifies the extraction: mutating the shared
+derivation reds the tests that guarded it when it was inline, so moving it out
+of `subject_summaries_with_coverage` weakened nothing.
+
+#### Three fixture facts that cost a red test each
 
 Recorded because the wrong version of both looks entirely reasonable:
 


### PR DESCRIPTION
Closes 3g's stated limit: *"`history` and `subject_summary` remain unpropagated, and a boundary query for them is the follow-up."*

One acceptance rule for both:

> A boundary answer must never report `Full` when evidence required by that family may have been removed. Conservative `Degraded` is allowed; silent loss is not.

## "Unpropagated" understated it

`WorldView` exposed exactly `ask` and `ask_as_of`. So neither family *lost* completeness — **neither had a boundary query at all.** That makes the rule a construction constraint rather than a migration: there was no existing `Full` to correct.

## The two families needed different mechanisms

Both **propagate rather than recompute** — a second verdict at the boundary is a second implementation of the rule governing whether an answer can be trusted. But they propagate *different types*, because the store computes them from different things:

| Family | Signal | Computed from |
|---|---|---|
| `history` | `Resolution` | citations overlapping a queried RANGE |
| `subject_summary` | `SummaryCoverage` | the evidence behind ONE folded row |

Coercing `SummaryCoverage::Degraded { summaries }` into `Resolution::Degraded { spans, summaries }` means inventing `spans: vec[]`, which reads as *"no compacted span bore on this"* — false, and false in the reassuring direction. `SummaryLookup` therefore carries the native type. **One source of truth per family beats one type across families.**

## `answer_admissibility` is in history's set for REFUSAL, not filtering

The subtlest membership call here, and the one most likely to be "fixed" wrongly.

History does **not** filter on admissibility: a claim `ask` declines to serve is still part of the record, and hiding it would make history lie about the past exactly as an admissibility filter on a lineage would hide the evidence an investigator came for.

It is in the set because history still **resolves** each claim's policy, so 3e's fail-closed refusal on unclassified semantics reaches this family. Changing the rule can turn a history answer into a refusal — that is the membership test, and it does not care that the rule is consulted for refusal rather than for dropping rows. **Two separate tests** pin the two halves, because as one assertion they would read as one fact.

`world_current_fold` and `entity_fold` are both out and asserted so: history returns raw confirmed claims in generation order, folding nothing and resolving no identity.

## The conservative citation rule is pinned, not sharpened

`resolution_for`'s citation check is **store-wide**, so one retained citation degrades every subject's history — including subjects the compacted span never touched. Scoping it to the queried subject would convert a conservative signal into an exact-loss detector, and an exact-loss detector that is wrong is silent.

The consequence is structural rather than stylistic: the `Full` arm is reachable **only in a store with no citations at all**, so the two history controls need two separate stores. A reader who consolidates them will find the Full arm unreachable — the intended tripwire.

## Numerical reconciliation is not evidence coverage

> Successful numerical reconciliation does not imply complete evidence coverage.

`reconciled_observation_count` and `reconciled_first_observed_ms` genuinely reconstruct their pre-compaction values from citations. `provenance_head` and `last_event_id` cannot be reconstructed at all — a citation names a *span*, not the events inside it — and for a fully compacted subject `retained` is `None` and those fields do not exist. `SummaryLookup::is_degraded` reads `coverage` and only `coverage`; there is deliberately no constructor taking a reconciliation result.

## Six mutations, and the one that separates two controls

| # | Mutation | Reds |
|---|---|---|
| 1 | history: force `Full` | `a_compacted_history_reports_degraded` |
| 2 | history: force `Degraded` | `an_uncompacted_history_reports_full` |
| 3 | summary: `is_degraded` → `false` | both summary-degraded controls |
| 4 | summary: `is_degraded` defers to reconciliation | both summary-degraded controls |
| 5 | history: swallow the `policy_for` refusal | `an_unruled_claim_refuses_the_whole_history` |
| 6 | fixture: drop the post-compaction rebuild | `reconciliation_does_not_upgrade_completeness` **only** |

Mutations 3 and 4 red the same pair, so on mutation evidence alone the reconciliation control looks redundant against the compacted-summary one. **Mutation 6 is the separating case**, reddening it alone at `left: 4, right: 3`. What the extra control buys is proof that reconstruction genuinely *succeeds* in the fixture — so the degraded verdict is held **despite** working reconciliation rather than alongside broken reconciliation.

## Three fixture facts that cost a red test each

Recorded because the wrong version of each looks entirely reasonable:

- **`fold()` does not build `subject_summary`.** `fold_subject_summary()` is a separate call; a fixture running only the first produces **zero** summaries, and every subject-summary control would pass vacuously against a store that had never summarised anything.
- **The summary must be rebuilt AFTER compaction.** Folding first leaves the pre-compaction total in the row and the citation adds the removed event back on top of a count that never lost it — measured at `reconciled = 4` against a true 3. Green, and double-counting.
- **`is_admissible` drops `Expired` and `Inadmissible`, not staleness.** A stale claim is served by `ask` carrying a `Stale` grade, so the first draft of the history/`ask` contrast failed on its own premise; it now uses expiry.

## The 3e gate caught this PR's own fixture

`check_freshness_coverage.py` flagged the deliberately-unruled negative-control class — the gate working as designed. It's baselined as knowingly unruled, with the reasoning recorded: ruling it would delete the test's premise.

## Verification

- `cargo test -p kirra-world-store -p kirra-world-service` — 34 suites green, 0 failures
- `check_world_semantics`, `check_freshness_coverage`, `check_world_answer_boundary`, `check_kirra_world_bidirectional_fence`, `check_reexport_shims` — all green
- `cargo build --workspace`, `cargo fmt --all --check`, `cargo clippy --all-targets` on both crates — clean

With this, **3d (the typed query engine) is the sole remaining Tier 3 implementation box.**

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_