### PR TITLE
3d — query boundedness closed with zero exceptions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1675,6 +1675,22 @@ jobs:
         run: |
           python3 ci/check_world_semantics.py --self-test
           python3 ci/check_world_semantics.py
+      - name: Kirra World query-boundedness gate (Tier 3 box 3d)
+        # THE RULE (KIRRA-WM-ANSWER-IDENTITY-001 clause 2): an interactive query
+        # may not hide an unbounded store operation behind a bounded-looking API.
+        #
+        # Three defects in three consecutive PRs violated this invisibly — each
+        # returned a correctly bounded ANSWER while doing unbounded WORK, so no
+        # behavioural test could see it and two took a reviewer to catch. The
+        # boundedness of a query is a STRUCTURAL property, not an observable one,
+        # which is why it needs a gate rather than tests.
+        #
+        # Self-test first: it proves the gate still rejects the historical defect
+        # shape (bounded public request -> unbounded store call -> post-fetch
+        # truncation) rather than merely passing on a clean tree.
+        run: |
+          python3 ci/check_query_boundedness.py --self-test
+          python3 ci/check_query_boundedness.py
       - name: Kirra World freshness-coverage gate (Tier 3 box 3e)
         # THE RULE (KIRRA-WM-FRESHNESS-POLICY-001): freshness semantics are
         # centrally ruled by claim kind. Timeless must be explicitly granted,

--- a/ci/check_query_boundedness.py
+++ b/ci/check_query_boundedness.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Tier 3 box 3d — an interactive query may not hide an unbounded store read.
+
+THE RULE
+--------
+    A Tier 3 boundary query that sits on a request path may call only store
+    methods whose result size is bounded by their arguments. Every public read
+    method on the store must be CLASSIFIED, and an unclassified one fails.
+
+WHY A GATE, AND WHY THIS SHAPE
+------------------------------
+`KIRRA-WM-ANSWER-IDENTITY-001` clause 2 is "queries are bounded", resting on
+D-9's measured 10.5 s p99 at 100 000 entities and ADR-0041 D-12's finding that
+an unbounded query has no bounded cost whatever its scaling verdict.
+
+Three defects in three consecutive PRs violated it, each invisibly:
+
+  #1440  lineage          a per-PAGE query over a whole-history fetch
+  #1441  subject_summary  a per-SUBJECT query over a whole-store scan
+  #1441  history          no bound at all
+
+All three returned a correctly bounded ANSWER, so only the WORK was unbounded
+and nothing showed it. Two were caught by a reviewer; the third was written in
+the same PR that documented the other two. That is the evidence that per-query
+vigilance does not enforce this invariant, and why it is now mechanical.
+
+FAIL-CLOSED, NOT A DENYLIST
+---------------------------
+A denylist of "known unbounded methods" fails exactly the way those three
+failed: a new store method is not on it, and nothing notices. So the baseline
+CLASSIFIES the whole surface, and an unclassified method reds this gate --
+adding a store method without deciding its boundedness becomes a red build
+naming the rule. That is 3e's pattern, which has caught two things including
+its own PR's fixture.
+
+WHAT "BOUNDED" MEANS
+--------------------
+Bounded by the ARGUMENTS, not small. `current` returns one row per predicate
+for one subject -- a STRUCTURAL bound from `PRIMARY KEY (subject,
+predicate_key)` rather than a page. That counts. Requiring a cursor there would
+be ceremony implying a growth dimension that does not exist; the structural
+bound is instead asserted by a test.
+
+Usage:
+  python3 ci/check_query_boundedness.py             # gate (CI)
+  python3 ci/check_query_boundedness.py --list      # show the classification
+  python3 ci/check_query_boundedness.py --self-test # prove non-vacuity
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BASELINE_PATH = REPO_ROOT / "ci" / "store_boundedness_baseline.json"
+
+STORE_LIB = REPO_ROOT / "crates" / "kirra-world-store" / "src" / "lib.rs"
+STORE_SNAPSHOT = REPO_ROOT / "crates" / "kirra-world-store" / "src" / "snapshot.rs"
+
+VALID_CLASSES = {"bounded", "unbounded", "operational"}
+
+# Methods compiled out of the production path. Auto-classified so the baseline
+# does not carry entries that buy no coverage.
+TEST_ONLY_SUFFIX = "_for_test"
+
+
+def _impl_bodies(text: str, header_re: str) -> list[str]:
+    """Every `impl` body matching `header_re`, brace-matched."""
+    bodies = []
+    for m in re.finditer(header_re, text, re.M):
+        i, depth = m.end(), 1
+        while i < len(text) and depth > 0:
+            if text[i] == "{":
+                depth += 1
+            elif text[i] == "}":
+                depth -= 1
+            i += 1
+        bodies.append(text[m.end() : i])
+    return bodies
+
+
+def public_methods(path: Path, header_re: str) -> set[str]:
+    """The public method names declared in the matching impl blocks."""
+    text = path.read_text()
+    found: set[str] = set()
+    for body in _impl_bodies(text, header_re):
+        for fm in re.finditer(r"\n    pub fn ([a-z_0-9]+)\s*(?:<[^>]*>)?\s*\(", body):
+            name = fm.group(1)
+            if not name.endswith(TEST_ONLY_SUFFIX):
+                found.add(name)
+    return found
+
+
+def discover() -> dict[str, set[str]]:
+    return {
+        "world_store": public_methods(STORE_LIB, r"^impl WorldStore \{"),
+        "read_snapshot": public_methods(
+            STORE_SNAPSHOT, r"^impl<'a> ReadSnapshot<'a> \{"
+        ),
+    }
+
+
+def unbounded_names(baseline: dict) -> set[str]:
+    out: set[str] = set()
+    for surface in ("world_store", "read_snapshot"):
+        for name, spec in baseline[surface].items():
+            if name.startswith("_"):
+                continue
+            if spec["class"] == "unbounded":
+                out.add(name)
+    return out
+
+
+def scan_interactive(text: str, forbidden: set[str]) -> list[tuple[int, str, str]]:
+    """Calls to forbidden methods, ignoring comments and doc comments.
+
+    Comment-stripping is load-bearing: this file and the boundary's own docs
+    NAME the unbounded methods while explaining why they are not called, and a
+    scanner that matched prose would make the explanation unwriteable.
+    """
+    call_re = re.compile(r"(?:\.|::)\s*(" + "|".join(sorted(forbidden)) + r")\s*\(")
+    hits = []
+    for n, line in enumerate(text.splitlines(), start=1):
+        code = line.split("//")[0]
+        for m in call_re.finditer(code):
+            hits.append((n, m.group(1), line.strip()))
+    return hits
+
+
+def run(verbose: bool = False) -> list[str]:
+    baseline = json.loads(BASELINE_PATH.read_text())
+    failures: list[str] = []
+    found = discover()
+
+    # 1. Every public read method must be classified. FAIL-CLOSED.
+    for surface, names in found.items():
+        declared = {k for k in baseline[surface] if not k.startswith("_")}
+        for name in sorted(names - declared):
+            failures.append(
+                f"{surface}::{name} is public but has no boundedness classification.\n"
+                f"    Add it to ci/store_boundedness_baseline.json as bounded / "
+                f"unbounded / operational, with the reasoning.\n"
+                f"    An unclassified method is how all three of the defects this "
+                f"gate exists for reached main."
+            )
+        for name in sorted(declared - names):
+            failures.append(
+                f"{surface}::{name} is classified but no longer exists — "
+                f"remove the stale entry."
+            )
+        for name, spec in baseline[surface].items():
+            if name.startswith("_"):
+                continue
+            if spec.get("class") not in VALID_CLASSES:
+                failures.append(
+                    f"{surface}::{name} has class {spec.get('class')!r}; "
+                    f"expected one of {sorted(VALID_CLASSES)}."
+                )
+            if not spec.get("why", "").strip():
+                failures.append(f"{surface}::{name} has no reason recorded.")
+
+    # 2. No interactive path may call an unbounded method.
+    forbidden = unbounded_names(baseline)
+    for rel, role in baseline["interactive_paths"].items():
+        if rel.startswith("_"):
+            continue
+        path = REPO_ROOT / rel
+        if not path.exists():
+            failures.append(f"{rel} is named as an interactive path but does not exist.")
+            continue
+        for line_no, method, line in scan_interactive(path.read_text(), forbidden):
+            failures.append(
+                f"{rel}:{line_no} — interactive path ({role}) calls the UNBOUNDED "
+                f"store method `{method}`.\n"
+                f"      {line}\n"
+                f"    A bounded-looking query standing on an unbounded read is the "
+                f"exact defect class of #1440 and #1441: the answer is bounded, the "
+                f"work is not, and nothing shows it.\n"
+                f"    Use the bounded equivalent, or narrow the fetch in SQL and add "
+                f"an agreement test."
+            )
+
+    if verbose:
+        for surface, names in sorted(found.items()):
+            print(f"\n{surface} ({len(names)} public read methods):")
+            for name in sorted(names):
+                spec = baseline[surface].get(name)
+                cls = spec["class"] if spec else "UNCLASSIFIED"
+                print(f"  [{cls:11}] {name}")
+        print(f"\nunbounded methods barred from interactive paths: {len(forbidden)}")
+        for rel, role in baseline["interactive_paths"].items():
+            if not rel.startswith("_"):
+                print(f"  interactive: {rel} — {role}")
+
+    return failures
+
+
+def self_test() -> int:
+    """Prove the gate is non-vacuous, on the SHAPE of the real defects.
+
+    The negative fixture is not invented: it is `subject_summary` exactly as it
+    shipped on #1441 and `lineage` as it first shipped on #1440 — a query
+    exposing a bound publicly, fetching unbounded underneath, and truncating
+    afterwards. If the gate cannot catch that, it cannot catch what it is for.
+    """
+    baseline = json.loads(BASELINE_PATH.read_text())
+    forbidden = unbounded_names(baseline)
+    failed = 0
+
+    # (a) THE historical defect shape: bounded-looking API, unbounded fetch.
+    fixture = """
+    pub fn subject_summary(&self, subject: &str, limit: usize) -> Answer {
+        let all = self.store.subject_summaries_with_coverage()?;
+        let mut rows: Vec<_> = all.into_iter().filter(|s| s.subject == subject).collect();
+        rows.truncate(limit);
+        Answer { rows }
+    }
+    """
+    hits = scan_interactive(fixture, forbidden)
+    if not hits:
+        print("SELF-TEST FAIL: the bounded-looking / unbounded-underneath fixture "
+              "was NOT caught — the gate cannot see its own defect class.")
+        failed = 1
+    else:
+        print(f"self-test: bounded-looking, unbounded-underneath → caught "
+              f"({hits[0][1]})")
+
+    # (b) The bounded replacement must NOT trip it, or the gate is unusable.
+    ok_fixture = """
+    pub fn subject_summary(&self, subject: &str) -> Answer {
+        let found = self.store.subject_summary_with_coverage(subject)?;
+        Answer { found }
+    }
+    """
+    if scan_interactive(ok_fixture, forbidden):
+        print("SELF-TEST FAIL: the BOUNDED replacement was flagged — the gate "
+              "would force callers away from the correct API.")
+        failed = 1
+    else:
+        print("self-test: bounded replacement → not flagged")
+
+    # (c) Prose naming an unbounded method must not trip it, or this file and
+    #     the boundary's own docs could not explain the rule.
+    prose = "    // never call subject_summaries_with_coverage() from here\n"
+    if scan_interactive(prose, forbidden):
+        print("SELF-TEST FAIL: a COMMENT naming an unbounded method was flagged.")
+        failed = 1
+    else:
+        print("self-test: prose naming an unbounded method → not flagged")
+
+    # (d) An unclassified method must fail, since that is the generalisation.
+    stripped = {k: v for k, v in baseline["world_store"].items() if k != "history"}
+    if "history" in stripped:
+        print("SELF-TEST FAIL: fixture construction error.")
+        failed = 1
+    else:
+        print("self-test: removing a classification leaves it undiscoverable → "
+              "the discover/declare diff is what reports it")
+
+    return failed
+
+
+def main() -> int:
+    if "--self-test" in sys.argv:
+        return self_test()
+    verbose = "--list" in sys.argv
+    failures = run(verbose=verbose)
+    if failures:
+        print("\nFAIL: query-boundedness gate\n")
+        for f in failures:
+            print(f"  - {f}\n")
+        return 1
+    print("Query-boundedness gate green.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/check_query_boundedness.py
+++ b/ci/check_query_boundedness.py
@@ -64,6 +64,11 @@ BOUNDARY_SRC = REPO_ROOT / "crates" / "kirra-world-service" / "src"
 
 VALID_CLASSES = {"bounded", "unbounded", "operational"}
 
+# A method that accepts a page/cursor bound, and one that runs a SELECT. Used
+# together to demand that a paginated bounded method bounds its own query.
+PAGE_PARAM_RE = re.compile(r"\bpage\s*:|LineagePage|\blimit\s*:")
+SELECT_RE = re.compile(r"\bSELECT\b", re.I)
+
 # Methods compiled out of the production path. Auto-classified so the baseline
 # does not carry entries that buy no coverage.
 TEST_ONLY_SUFFIX = "_for_test"
@@ -229,6 +234,42 @@ def run(verbose: bool = False) -> list[str]:
                             f"    A bounded classification standing on an unbounded "
                             f"call makes the classification a claim nobody checks, and "
                             f"lets the boundary violate the invariant in good faith."
+                        )
+
+    # 4. A `bounded` method that TAKES a page must BOUND its own SQL.
+    #
+    # The hole mutation M1 exposed, and it is the sharpest one: rewriting
+    # `history_page` to fetch every row and truncate in Rust produces an
+    # IDENTICAL answer, so no behavioural test can catch it — every pagination
+    # control still passed. Rule 3 missed it too, because the method calls no
+    # unbounded helper; it simply writes unbounded SQL.
+    #
+    # That is the whole defect class in one mutation: the answer is bounded, the
+    # work is not, and nothing observable differs. So the check is structural —
+    # if a bounded method accepts a page, its query must carry a LIMIT.
+    for path in sorted(STORE_SRC.rglob("*.rs")):
+        text = path.read_text()
+        for surface, header in (
+            ("world_store", r"^impl WorldStore \{"),
+            ("read_snapshot", r"^impl<'a> ReadSnapshot<'a> \{"),
+        ):
+            for body in _impl_bodies(text, header):
+                for fn_name, fn_body in _fn_bodies(body):
+                    spec = baseline[surface].get(fn_name)
+                    if not spec or spec["class"] != "bounded":
+                        continue
+                    if not PAGE_PARAM_RE.search(fn_body):
+                        continue
+                    if not SELECT_RE.search(fn_body):
+                        continue
+                    if "LIMIT" not in fn_body:
+                        failures.append(
+                            f"{surface}::{fn_name} is classified `bounded` and takes a "
+                            f"page, but its SQL has no LIMIT.\n"
+                            f"    Fetching the whole set and truncating in Rust returns "
+                            f"the IDENTICAL answer, so no behavioural test can catch it "
+                            f"— which is exactly how #1440 and #1441 reached main.\n"
+                            f"    The bound has to reach the query."
                         )
 
     if verbose:

--- a/ci/check_query_boundedness.py
+++ b/ci/check_query_boundedness.py
@@ -89,8 +89,16 @@ def _impl_bodies(text: str, header_re: str) -> list[str]:
     return bodies
 
 
-def _fn_bodies(impl_body: str) -> list[tuple[str, str]]:
-    """(name, body) for each `pub fn` in an impl body, brace-matched."""
+def _fn_bodies(impl_body: str) -> list[tuple[str, str, str]]:
+    """(name, signature, body) for each `pub fn` in an impl body, brace-matched.
+
+    The SIGNATURE is returned separately because rule 4 asks a question the body
+    cannot answer: *does this method accept a page?* That is declared in the
+    parameter list, and an earlier revision tested the body alone — so the rule
+    fired on `history_page` only because an unrelated code comment inside it
+    happened to contain the English phrase `the page:`. Deleting a comment
+    disarmed the check. A structural rule may not depend on prose.
+    """
     out = []
     for m in re.finditer(r"\n    pub fn ([a-z_0-9]+)\s*(?:<[^>]*>)?\s*\(", impl_body):
         i = impl_body.find("{", m.end())
@@ -103,8 +111,28 @@ def _fn_bodies(impl_body: str) -> list[tuple[str, str]]:
             elif impl_body[j] == "}":
                 depth -= 1
             j += 1
-        out.append((m.group(1), impl_body[i:j]))
+        out.append((m.group(1), impl_body[m.start() : i], impl_body[i:j]))
     return out
+
+
+def strip_comments(text: str) -> str:
+    """`text` with `//` comments removed, line structure preserved.
+
+    Used on BOTH halves of rule 4. Prose must be unable to arm the rule (a
+    comment reading `the page:` is not a page parameter) and equally unable to
+    disarm it (a comment mentioning `LIMIT` is not a bounded query).
+    """
+    return "\n".join(line.split("//")[0] for line in text.splitlines())
+
+
+def page_bound_violation(signature: str, body: str) -> bool:
+    """True when a method ACCEPTS a page bound but its own SQL carries none."""
+    sig, code = strip_comments(signature), strip_comments(body)
+    if not PAGE_PARAM_RE.search(sig):
+        return False
+    if not SELECT_RE.search(code):
+        return False
+    return "LIMIT" not in code
 
 
 def public_methods(path: Path, header_re: str) -> set[str]:
@@ -222,7 +250,7 @@ def run(verbose: bool = False) -> list[str]:
             ("read_snapshot", r"^impl<'a> ReadSnapshot<'a> \{"),
         ):
             for body in _impl_bodies(text, header):
-                for fn_name, fn_body in _fn_bodies(body):
+                for fn_name, _sig, fn_body in _fn_bodies(body):
                     spec = baseline[surface].get(fn_name)
                     if not spec or spec["class"] != "bounded":
                         continue
@@ -254,15 +282,11 @@ def run(verbose: bool = False) -> list[str]:
             ("read_snapshot", r"^impl<'a> ReadSnapshot<'a> \{"),
         ):
             for body in _impl_bodies(text, header):
-                for fn_name, fn_body in _fn_bodies(body):
+                for fn_name, fn_sig, fn_body in _fn_bodies(body):
                     spec = baseline[surface].get(fn_name)
                     if not spec or spec["class"] != "bounded":
                         continue
-                    if not PAGE_PARAM_RE.search(fn_body):
-                        continue
-                    if not SELECT_RE.search(fn_body):
-                        continue
-                    if "LIMIT" not in fn_body:
+                    if page_bound_violation(fn_sig, fn_body):
                         failures.append(
                             f"{surface}::{fn_name} is classified `bounded` and takes a "
                             f"page, but its SQL has no LIMIT.\n"
@@ -361,7 +385,57 @@ def self_test() -> int:
     else:
         print("self-test: bounded-looking helper over an unbounded call → caught")
 
-    # (e) An unclassified method must fail, since that is the generalisation.
+    # (e) RULE 4, THE M1 SHAPE: a page-taking method whose SQL carries no bound.
+    #     Fetch everything, truncate in Rust — an identical answer, so no
+    #     behavioural test can see it. This fixture carries no prose at all,
+    #     which is the point: rule 4 shipped armed only by an unrelated comment
+    #     containing the words "the page:", and deleting that comment made an
+    #     unbounded `history_page` pass. Prose must not be load-bearing.
+    unbounded_page_sig = "\n    pub fn history_page(&self, subject: &str, page: LineagePage)"
+    unbounded_page_body = """{
+        let mut stmt = self.conn.prepare("SELECT * FROM world_events WHERE subject = ?1")?;
+        let mut claims = stmt.query_map(params![subject], claim_from_row)?.collect()?;
+        claims.truncate(page.limit());
+        Ok(claims)
+    }"""
+    if not page_bound_violation(unbounded_page_sig, unbounded_page_body):
+        print("SELF-TEST FAIL: a page-taking method with NO LIMIT was not caught "
+              "— rule 4 cannot see the mutation it exists for.")
+        failed = 1
+    else:
+        print("self-test: page-taking method, unbounded SQL → caught")
+
+    # (f) The bounded form must pass, or the rule forces nothing constructive.
+    bounded_page_body = """{
+        let mut stmt = self.conn.prepare(
+            "SELECT * FROM world_events WHERE subject = ?1 AND generation > ?2
+             ORDER BY generation ASC LIMIT ?3")?;
+        Ok(stmt.query_map(params![subject, after, probe], claim_from_row)?.collect()?)
+    }"""
+    if page_bound_violation(unbounded_page_sig, bounded_page_body):
+        print("SELF-TEST FAIL: a correctly bounded page query was flagged.")
+        failed = 1
+    else:
+        print("self-test: page-taking method, LIMIT in SQL → not flagged")
+
+    # (g) Prose must be inert in BOTH directions: a comment cannot arm the rule
+    #     (that is the bug this fixture set was written for), and a comment
+    #     mentioning LIMIT cannot disarm it.
+    if page_bound_violation("\n    pub fn whole_history(&self, subject: &str)",
+                            "{\n // narrowed to the page: see history_page\n"
+                            ' let s = self.conn.prepare("SELECT * FROM world_events")?;\n}'):
+        print("SELF-TEST FAIL: a COMMENT reading `the page:` armed rule 4 — the "
+              "check would depend on prose, which is how the hole was opened.")
+        failed = 1
+    elif not page_bound_violation(unbounded_page_sig,
+                                  "{\n // no LIMIT needed here\n"
+                                  ' let s = self.conn.prepare("SELECT * FROM world_events")?;\n}'):
+        print("SELF-TEST FAIL: a COMMENT mentioning LIMIT disarmed rule 4.")
+        failed = 1
+    else:
+        print("self-test: comments neither arm nor disarm rule 4")
+
+    # (h) An unclassified method must fail, since that is the generalisation.
     stripped = {k: v for k, v in baseline["world_store"].items() if k != "history"}
     if "history" in stripped:
         print("SELF-TEST FAIL: fixture construction error.")

--- a/ci/check_query_boundedness.py
+++ b/ci/check_query_boundedness.py
@@ -59,6 +59,8 @@ BASELINE_PATH = REPO_ROOT / "ci" / "store_boundedness_baseline.json"
 
 STORE_LIB = REPO_ROOT / "crates" / "kirra-world-store" / "src" / "lib.rs"
 STORE_SNAPSHOT = REPO_ROOT / "crates" / "kirra-world-store" / "src" / "snapshot.rs"
+STORE_SRC = REPO_ROOT / "crates" / "kirra-world-store" / "src"
+BOUNDARY_SRC = REPO_ROOT / "crates" / "kirra-world-service" / "src"
 
 VALID_CLASSES = {"bounded", "unbounded", "operational"}
 
@@ -80,6 +82,24 @@ def _impl_bodies(text: str, header_re: str) -> list[str]:
             i += 1
         bodies.append(text[m.end() : i])
     return bodies
+
+
+def _fn_bodies(impl_body: str) -> list[tuple[str, str]]:
+    """(name, body) for each `pub fn` in an impl body, brace-matched."""
+    out = []
+    for m in re.finditer(r"\n    pub fn ([a-z_0-9]+)\s*(?:<[^>]*>)?\s*\(", impl_body):
+        i = impl_body.find("{", m.end())
+        if i < 0:
+            continue
+        j, depth = i + 1, 1
+        while j < len(impl_body) and depth > 0:
+            if impl_body[j] == "{":
+                depth += 1
+            elif impl_body[j] == "}":
+                depth -= 1
+            j += 1
+        out.append((m.group(1), impl_body[i:j]))
+    return out
 
 
 def public_methods(path: Path, header_re: str) -> set[str]:
@@ -162,19 +182,20 @@ def run(verbose: bool = False) -> list[str]:
             if not spec.get("why", "").strip():
                 failures.append(f"{surface}::{name} has no reason recorded.")
 
-    # 2. No interactive path may call an unbounded method.
+    # 2. NOTHING in the boundary crate may call an unbounded method.
+    #
+    # The whole crate, not a list of "interactive" files. A per-file list is
+    # exactly the hole a relocated call slips through: move the unbounded fetch
+    # into a private helper in a fourth file and the gate goes green while the
+    # invariant stays false. The boundary crate IS the request path, so every
+    # file in it is checked and there is no file to move the call to.
     forbidden = unbounded_names(baseline)
-    for rel, role in baseline["interactive_paths"].items():
-        if rel.startswith("_"):
-            continue
-        path = REPO_ROOT / rel
-        if not path.exists():
-            failures.append(f"{rel} is named as an interactive path but does not exist.")
-            continue
+    for path in sorted(BOUNDARY_SRC.rglob("*.rs")):
+        rel = path.relative_to(REPO_ROOT)
         for line_no, method, line in scan_interactive(path.read_text(), forbidden):
             failures.append(
-                f"{rel}:{line_no} — interactive path ({role}) calls the UNBOUNDED "
-                f"store method `{method}`.\n"
+                f"{rel}:{line_no} — the answer boundary calls the UNBOUNDED store "
+                f"method `{method}`.\n"
                 f"      {line}\n"
                 f"    A bounded-looking query standing on an unbounded read is the "
                 f"exact defect class of #1440 and #1441: the answer is bounded, the "
@@ -182,6 +203,33 @@ def run(verbose: bool = False) -> list[str]:
                 f"    Use the bounded equivalent, or narrow the fetch in SQL and add "
                 f"an agreement test."
             )
+
+    # 3. A store method classified `bounded` may not CALL an unbounded one.
+    #
+    # The other half of the relocation hole, and the one that matters more:
+    # without it, `pub fn tidy(subject) { self.everything() }` could be declared
+    # bounded and the boundary could call it in good faith. The classification
+    # would be a claim nobody checks — which is what a denylist would have been.
+    for path in sorted(STORE_SRC.rglob("*.rs")):
+        text = path.read_text()
+        for surface, header in (
+            ("world_store", r"^impl WorldStore \{"),
+            ("read_snapshot", r"^impl<'a> ReadSnapshot<'a> \{"),
+        ):
+            for body in _impl_bodies(text, header):
+                for fn_name, fn_body in _fn_bodies(body):
+                    spec = baseline[surface].get(fn_name)
+                    if not spec or spec["class"] != "bounded":
+                        continue
+                    for line_no, method, line in scan_interactive(fn_body, forbidden):
+                        failures.append(
+                            f"{surface}::{fn_name} is classified `bounded` but calls "
+                            f"the UNBOUNDED `{method}`.\n"
+                            f"      {line}\n"
+                            f"    A bounded classification standing on an unbounded "
+                            f"call makes the classification a claim nobody checks, and "
+                            f"lets the boundary violate the invariant in good faith."
+                        )
 
     if verbose:
         for surface, names in sorted(found.items()):
@@ -251,7 +299,28 @@ def self_test() -> int:
     else:
         print("self-test: prose naming an unbounded method → not flagged")
 
-    # (d) An unclassified method must fail, since that is the generalisation.
+    # (d) THE RELOCATION FIXTURE: a store method that LOOKS bounded and calls an
+    #     unbounded one. Without this the invariant can be made green without
+    #     being made true — move the unbounded fetch behind a bounded-looking
+    #     helper and the boundary calls it in good faith.
+    #
+    #     Not hypothetical: `resolve_at(id, cut)` is exactly this shape and was
+    #     classified `bounded` from its signature on the first pass. This check
+    #     is what corrected it.
+    relocated = """
+    pub fn resolve_at(&self, id: &EntityId, as_known_at_ms: i64) -> Answer {
+        Ok(self.identity_view_at(as_known_at_ms)?.resolve_at(id))
+    }
+    """
+    if not scan_interactive(relocated, forbidden):
+        print("SELF-TEST FAIL: a bounded-LOOKING helper wrapping an unbounded "
+              "call was NOT caught — the invariant could be made green without "
+              "being made true.")
+        failed = 1
+    else:
+        print("self-test: bounded-looking helper over an unbounded call → caught")
+
+    # (e) An unclassified method must fail, since that is the generalisation.
     stripped = {k: v for k, v in baseline["world_store"].items() if k != "history"}
     if "history" in stripped:
         print("SELF-TEST FAIL: fixture construction error.")

--- a/ci/store_boundedness_baseline.json
+++ b/ci/store_boundedness_baseline.json
@@ -176,10 +176,6 @@
       "class": "operational",
       "why": "Returns a HANDLE, reading nothing. The rows come from `ReadSnapshot`'s own methods, which are classified separately below -- a snapshot must not become a way to reach an unbounded read without being seen."
     },
-    "resolve_at": {
-      "class": "unbounded",
-      "why": "SIGNATURE-BOUNDED, IMPLEMENTATION-UNBOUNDED \u2014 the literal defect shape, in the store. `resolve_at(id, cut)` takes one entity id and reads like a point lookup, but its body is `self.identity_view_at(cut)?.resolve_at(id)`: it materialises the WHOLE equivalence graph and then indexes it. Classified `bounded` on first pass from the signature alone, which is exactly the mistake the transitive check exists to catch, and it caught it."
-    },
     "resolved_entities": {
       "class": "unbounded",
       "why": "Every summarised entity in the store."
@@ -275,6 +271,14 @@
     "backfill_adjudication_affects": {
       "class": "operational",
       "why": "The one-time scan that fills the v6 reverse index on a migrated store. Deliberately a full scan and deliberately NOT on any request path \u2014 an explicit operational call rather than work hidden in `open`, so the cost lands where an operator can see it. This is exactly the trade box 3d is for: one operational scan buys bounded interactive reads."
+    },
+    "as_of_composed_bounded": {
+      "class": "bounded",
+      "why": "Box 3d. Both halves bounded inside ONE transaction: `as_of` was already subject-keyed, and the identity half now folds only the adjudications bearing on the objects those claims name, discovered through the affected-entity reverse index. Deliberately one primitive rather than two bounded calls \u2014 two would satisfy boundedness while reintroducing the cross-read incoherence box 3h closed."
+    },
+    "resolve_at_whole_graph": {
+      "class": "unbounded",
+      "why": "RENAMED from `resolve_at` on box 3d. Its body is `self.identity_view_at(cut)?.resolve_at(id)` \u2014 it materialises the WHOLE equivalence graph and then indexes it, so the old name read as a point lookup and was classified `bounded` from its signature on the first pass. The name now says what it does. Renaming also removes a real ambiguity in the gate's name-based scan: `HistoricalIdentityView::resolve_at` is a pure in-memory call on an already-loaded view, and sharing a name with an unbounded store method made every use of it look like a violation. `resolve_bounded_at` is the bounded form."
     }
   },
   "read_snapshot": {
@@ -309,6 +313,10 @@
     "identity_view_for": {
       "class": "bounded",
       "why": "Box 3d. Loads only the entities reachable from the seed ids within MAX_REDIRECT_EDGES hops, so `ask` pays O(predicates x budget) instead of O(entities) to resolve the objects its own claims name. Snapshot-scoped so the identity half of a composed answer is observed at the same point as the claims half \u2014 a WorldStore-level bounded resolve would be a second connection and would reintroduce the between-walks incoherence 3c closed."
+    },
+    "read_composed_subject_at_generation": {
+      "class": "bounded",
+      "why": "Box 3d. Re-executes a recorded reference with the identity half bounded to the adjudications bearing on the objects that subject's claims name, cut at the pinned GENERATION rather than a transaction time. Still ONE composed read taken from this snapshot's transaction: splitting it into a bounded claims read plus a bounded identity read would bound the work and reintroduce the cross-read incoherence box 3h closed. The reproducibility refusal is delegated to read_at_generation, so one refusal still covers both halves."
     }
   },
   "interactive_paths": {

--- a/ci/store_boundedness_baseline.json
+++ b/ci/store_boundedness_baseline.json
@@ -267,6 +267,14 @@
     "history_page": {
       "class": "bounded",
       "why": "Box 3d's bounded replacement for `history`. Narrows in SQL with `generation > cursor` and `LIMIT limit + 1` rather than fetching the record and truncating \u2014 #1440's lesson, since truncating after the fetch bounds the ANSWER while leaving the WORK unbounded, which is what made all three defects invisible. The boundary decision is `lineage::boundary_for`, shared with the lineage family so the off-by-one has one implementation."
+    },
+    "resolve_bounded_at": {
+      "class": "bounded",
+      "why": "Box 3d's bounded historical identity read. Discovers the adjudications affecting the queried id through the affected-entity reverse index, expands newly-named entities, and stops at the resolver's own MAX_REDIRECT_EDGES budget \u2014 so it folds the records bearing on one entity's identity rather than every adjudication in the log. The index supplies GENERATIONS only; every record is read from world_events and folded by the unchanged fold_adjudication, so the log remains the sole evidence."
+    },
+    "backfill_adjudication_affects": {
+      "class": "operational",
+      "why": "The one-time scan that fills the v6 reverse index on a migrated store. Deliberately a full scan and deliberately NOT on any request path \u2014 an explicit operational call rather than work hidden in `open`, so the cost lands where an operator can see it. This is exactly the trade box 3d is for: one operational scan buys bounded interactive reads."
     }
   },
   "read_snapshot": {

--- a/ci/store_boundedness_baseline.json
+++ b/ci/store_boundedness_baseline.json
@@ -293,6 +293,10 @@
     "read_composed_at_generation": {
       "class": "unbounded",
       "why": "Both projections at a generation."
+    },
+    "identity_view_for": {
+      "class": "bounded",
+      "why": "Box 3d. Loads only the entities reachable from the seed ids within MAX_REDIRECT_EDGES hops, so `ask` pays O(predicates x budget) instead of O(entities) to resolve the objects its own claims name. Snapshot-scoped so the identity half of a composed answer is observed at the same point as the claims half \u2014 a WorldStore-level bounded resolve would be a second connection and would reintroduce the between-walks incoherence 3c closed."
     }
   },
   "interactive_paths": {

--- a/ci/store_boundedness_baseline.json
+++ b/ci/store_boundedness_baseline.json
@@ -263,6 +263,10 @@
     "resolve_bounded": {
       "class": "bounded",
       "why": "Box 3d's identity primitive. Loads only the entities within MAX_REDIRECT_EDGES hops of the queried id and resolves over that subset, so the work is bounded by the traversal budget the resolver already enforces rather than by graph size. The resolution RULE is unchanged \u2014 the same `resolve` over a smaller view \u2014 which is what lets `bounded_resolution_agrees_with_whole_graph_resolution` assert the two are identical. Classified `bounded` and MEANT: the transitive check reads its body, so it stays honest."
+    },
+    "history_page": {
+      "class": "bounded",
+      "why": "Box 3d's bounded replacement for `history`. Narrows in SQL with `generation > cursor` and `LIMIT limit + 1` rather than fetching the record and truncating \u2014 #1440's lesson, since truncating after the fetch bounds the ANSWER while leaving the WORK unbounded, which is what made all three defects invisible. The boundary decision is `lineage::boundary_for`, shared with the lineage family so the off-by-one has one implementation."
     }
   },
   "read_snapshot": {

--- a/ci/store_boundedness_baseline.json
+++ b/ci/store_boundedness_baseline.json
@@ -1,0 +1,220 @@
+{
+  "_comment": [
+    "Tier 3 box 3d — the boundedness classification of the store's read surface.",
+    "",
+    "KIRRA-WM-ANSWER-IDENTITY-001 clause 2 is 'queries are bounded'. Three defects",
+    "in three consecutive PRs showed that per-query vigilance does not enforce it:",
+    "",
+    "  #1440  lineage      per-page query over a whole-history fetch   (review)",
+    "  #1441  subject_summary  per-subject query over a store scan     (review)",
+    "  #1441  history      no bound at all, in the same PR that wrote up the first two",
+    "",
+    "Each looked bounded at the API and called an unbounded store method underneath.",
+    "So boundedness is an ENGINE-level invariant, not per-query hygiene, and this",
+    "file is what makes it mechanical.",
+    "",
+    "WHY A CLASSIFICATION AND NOT A DENYLIST OF UNBOUNDED METHODS",
+    "",
+    "A denylist fails the way the three defects failed: a new store method simply",
+    "is not on it, and nothing notices. This is FAIL-CLOSED instead, on 3e's",
+    "pattern -- every public read method must appear here, and an unclassified one",
+    "REDS THE GATE. Adding a store method without deciding its boundedness becomes",
+    "a red build naming the rule.",
+    "",
+    "THE CATEGORIES",
+    "",
+    "  bounded      Result size is bounded by the ARGUMENTS. An interactive query",
+    "               may call this.",
+    "  unbounded    Result grows with store size or with a subject's accumulated",
+    "               history. An interactive query may NOT call this. Legitimate for",
+    "               operators, rebuilds and analysis -- none of which sit on a",
+    "               request path.",
+    "  operational  Not a domain read: mutations, folds, schema, diagnostics,",
+    "               counts. WM_SCOPE names these as legitimate readers below the",
+    "               engine, and a rule forbidding them 'would be false on the day",
+    "               it was written'.",
+    "",
+    "'Bounded' means bounded by the arguments, not small. `current` returns one row",
+    "per predicate for one subject -- bounded by the PRIMARY KEY, which is a",
+    "STRUCTURAL bound rather than a page. That counts, and is asserted rather than",
+    "assumed (see the structural-bound tests).",
+    "",
+    "Methods ending `_for_test` are classified automatically and are not listed:",
+    "they are compiled out of the production path, and listing them would be a",
+    "second thing to maintain for no coverage."
+  ],
+  "world_store": {
+    "as_of": {
+      "class": "bounded",
+      "why": "One subject at one bitemporal point. Same PRIMARY KEY bound as `current`."
+    },
+    "as_of_composed": {
+      "class": "bounded",
+      "why": "`as_of` plus the identity graph AT that cut, composed for one subject."
+    },
+    "candidates": {
+      "class": "unbounded",
+      "why": "Every candidate claim ever proposed about a subject, no page. The same shape as `history` and unbounded for the same reason -- an LLM proposing repeatedly grows this without limit."
+    },
+    "changed_since": {
+      "class": "unbounded",
+      "why": "Every change after a timestamp. The result grows with how long ago the caller asks about."
+    },
+    "citations": {
+      "class": "unbounded",
+      "why": "Every compaction citation in the store. Accumulates for the store's life."
+    },
+    "current": {
+      "class": "bounded",
+      "why": "STRUCTURAL bound: `world_current` is keyed by (subject, predicate_key), so one subject yields at most one row per predicate. Not a page, and does not need one -- a subject's predicate set does not grow without limit the way its event history does."
+    },
+    "current_all": {
+      "class": "unbounded",
+      "why": "The whole claims projection. Grows with the number of subjects."
+    },
+    "count": { "class": "operational", "why": "A scalar row count." },
+    "has_citations": { "class": "operational", "why": "Existence probe." },
+    "has_entity_projection": { "class": "operational", "why": "Existence probe." },
+    "has_projections": { "class": "operational", "why": "Existence probe." },
+    "has_subject_summary": { "class": "operational", "why": "Existence probe." },
+    "has_summaries": { "class": "operational", "why": "Existence probe." },
+    "head_chain": {
+      "class": "bounded",
+      "why": "One row: the log head."
+    },
+    "history": {
+      "class": "unbounded",
+      "why": "EVERY confirmed claim ever recorded about a subject, no page and no cursor. The third instance of the defect class this gate exists for, and the one that proves per-query vigilance does not work: it was written in the PR that documented the other two. Its bounded replacement is the paginated form."
+    },
+    "identity_view": {
+      "class": "unbounded",
+      "why": "The whole entity equivalence graph."
+    },
+    "identity_view_at": {
+      "class": "unbounded",
+      "why": "The whole entity graph as it stood at a cut. Pinning the coordinate bounds WHEN, not HOW MUCH."
+    },
+    "invalid_shape_rows": {
+      "class": "operational",
+      "why": "A schema-diagnostic sweep, not a domain question."
+    },
+    "largest_compactable_prefix": {
+      "class": "operational",
+      "why": "The compaction planner's own query. WM_SCOPE names the planner as a legitimate reader below the engine."
+    },
+    "lineage_at_generation": {
+      "class": "bounded",
+      "why": "Takes a validated `LineagePage`, and #1440 made the fetch itself narrow to limit+1 rather than fetching the history and truncating."
+    },
+    "load_entity_projection": {
+      "class": "operational",
+      "why": "The fold's own loader."
+    },
+    "minted_entity_id_count": { "class": "operational", "why": "A scalar count." },
+    "projected_row_count": { "class": "operational", "why": "A scalar count." },
+    "projection_coordinate": { "class": "operational", "why": "Checkpoint metadata." },
+    "projection_generation": { "class": "operational", "why": "Checkpoint metadata." },
+    "projection_state_digest": { "class": "operational", "why": "Checkpoint metadata." },
+    "entity_projection_generation": { "class": "operational", "why": "Checkpoint metadata." },
+    "entity_projection_state_digest": { "class": "operational", "why": "Checkpoint metadata." },
+    "subject_summary_generation": { "class": "operational", "why": "Checkpoint metadata." },
+    "subject_summary_state_digest": { "class": "operational", "why": "Checkpoint metadata." },
+    "read_at_generation": {
+      "class": "unbounded",
+      "why": "The whole claims projection reconstructed at a generation. Pinning the coordinate bounds WHEN, not HOW MUCH -- the same trap as `identity_view_at`."
+    },
+    "read_composed_at_generation": {
+      "class": "unbounded",
+      "why": "Both projections at a generation. Unbounded for the same reason as `read_at_generation`."
+    },
+    "read_snapshot": {
+      "class": "operational",
+      "why": "Returns a HANDLE, reading nothing. The rows come from `ReadSnapshot`'s own methods, which are classified separately below -- a snapshot must not become a way to reach an unbounded read without being seen."
+    },
+    "resolve_at": {
+      "class": "bounded",
+      "why": "One entity id at one cut."
+    },
+    "resolved_entities": {
+      "class": "unbounded",
+      "why": "Every summarised entity in the store."
+    },
+    "schema_version": { "class": "operational", "why": "PRAGMA read." },
+    "subject_summaries": {
+      "class": "unbounded",
+      "why": "Every retained summary row."
+    },
+    "subject_summaries_for": {
+      "class": "bounded",
+      "why": "One subject's summaries across kinds -- SQL-narrowed, at most one row per kind."
+    },
+    "subject_summaries_with_coverage": {
+      "class": "unbounded",
+      "why": "Every summary AND every citation, grouped once. A deliberate BULK api, optimised as one -- which is precisely why #1441's per-subject query standing on it was a defect rather than a slow path."
+    },
+    "subject_summary": {
+      "class": "bounded",
+      "why": "One (kind, subject) row."
+    },
+    "subject_summary_with_coverage": {
+      "class": "bounded",
+      "why": "One subject, both sources SQL-narrowed. The bounded replacement #1441's review produced."
+    },
+    "summaries": {
+      "class": "unbounded",
+      "why": "Every degraded-summary citation in the store."
+    },
+    "verify_chain": {
+      "class": "operational",
+      "why": "The audit walk. WM_SCOPE names it explicitly as a legitimate reader below the engine."
+    },
+    "append": { "class": "operational", "why": "Write path." },
+    "append_adjudication": { "class": "operational", "why": "Write path." },
+    "compact_range": { "class": "operational", "why": "Retention mutation." },
+    "fold": { "class": "operational", "why": "Projection fold." },
+    "fold_entity_projection": { "class": "operational", "why": "Projection fold." },
+    "fold_subject_summary": { "class": "operational", "why": "Projection fold." },
+    "mint_entity_id": { "class": "operational", "why": "Id minting." },
+    "open": { "class": "operational", "why": "Constructor." },
+    "rebuild_entity_projection": { "class": "operational", "why": "Projection rebuild." },
+    "rebuild_projections": { "class": "operational", "why": "Projection rebuild." },
+    "rebuild_subject_summary": { "class": "operational", "why": "Projection rebuild." }
+  },
+  "read_snapshot": {
+    "current": {
+      "class": "bounded",
+      "why": "The snapshot-scoped `current`; same PRIMARY KEY bound."
+    },
+    "coordinate": { "class": "operational", "why": "Checkpoint metadata." },
+    "identity_is_current": { "class": "operational", "why": "A boolean freshness probe." },
+    "identity_view": {
+      "class": "unbounded",
+      "why": "The whole entity graph, snapshot-scoped. A snapshot bounds COHERENCE, not size."
+    },
+    "lineage_at_generation": {
+      "class": "bounded",
+      "why": "Takes a validated `LineagePage`; narrows to limit+1 in SQL."
+    },
+    "read_at_generation": {
+      "class": "unbounded",
+      "why": "The whole claims projection at a generation."
+    },
+    "read_composed_at_generation": {
+      "class": "unbounded",
+      "why": "Both projections at a generation."
+    }
+  },
+  "interactive_paths": {
+    "_comment": [
+      "Files whose functions are INTERACTIVE query paths -- reached by a caller",
+      "asking a domain question, so subject to the bounded-only rule.",
+      "",
+      "Everything else in the boundary crate is free to call unbounded methods:",
+      "a test, a rebuild helper or an operator tool legitimately reads the store",
+      "whole. The rule is about what sits on a request path."
+    ],
+    "crates/kirra-world-service/src/read_view.rs": "WorldView -- the four non-lineage query families",
+    "crates/kirra-world-service/src/lineage.rs": "LineageRef::resolve -- the lineage family",
+    "crates/kirra-world-service/src/answer_ref.rs": "AnswerRef::resolve -- re-execution of a recorded reference"
+  }
+}

--- a/ci/store_boundedness_baseline.json
+++ b/ci/store_boundedness_baseline.json
@@ -259,6 +259,10 @@
     "rebuild_subject_summary": {
       "class": "operational",
       "why": "Projection rebuild."
+    },
+    "resolve_bounded": {
+      "class": "bounded",
+      "why": "Box 3d's identity primitive. Loads only the entities within MAX_REDIRECT_EDGES hops of the queried id and resolves over that subset, so the work is bounded by the traversal budget the resolver already enforces rather than by graph size. The resolution RULE is unchanged \u2014 the same `resolve` over a smaller view \u2014 which is what lets `bounded_resolution_agrees_with_whole_graph_resolution` assert the two are identical. Classified `bounded` and MEANT: the transitive check reads its body, so it stays honest."
     }
   },
   "read_snapshot": {

--- a/ci/store_boundedness_baseline.json
+++ b/ci/store_boundedness_baseline.json
@@ -1,6 +1,6 @@
 {
   "_comment": [
-    "Tier 3 box 3d — the boundedness classification of the store's read surface.",
+    "Tier 3 box 3d \u2014 the boundedness classification of the store's read surface.",
     "",
     "KIRRA-WM-ANSWER-IDENTITY-001 clause 2 is 'queries are bounded'. Three defects",
     "in three consecutive PRs showed that per-query vigilance does not enforce it:",
@@ -49,8 +49,8 @@
       "why": "One subject at one bitemporal point. Same PRIMARY KEY bound as `current`."
     },
     "as_of_composed": {
-      "class": "bounded",
-      "why": "`as_of` plus the identity graph AT that cut, composed for one subject."
+      "class": "unbounded",
+      "why": "Composes `as_of` (bounded) with `identity_view_at` (the whole graph). The claims half is bounded and the identity half is not, so the composition is not \u2014 a bounded half does not bound a composition."
     },
     "candidates": {
       "class": "unbounded",
@@ -72,12 +72,30 @@
       "class": "unbounded",
       "why": "The whole claims projection. Grows with the number of subjects."
     },
-    "count": { "class": "operational", "why": "A scalar row count." },
-    "has_citations": { "class": "operational", "why": "Existence probe." },
-    "has_entity_projection": { "class": "operational", "why": "Existence probe." },
-    "has_projections": { "class": "operational", "why": "Existence probe." },
-    "has_subject_summary": { "class": "operational", "why": "Existence probe." },
-    "has_summaries": { "class": "operational", "why": "Existence probe." },
+    "count": {
+      "class": "operational",
+      "why": "A scalar row count."
+    },
+    "has_citations": {
+      "class": "operational",
+      "why": "Existence probe."
+    },
+    "has_entity_projection": {
+      "class": "operational",
+      "why": "Existence probe."
+    },
+    "has_projections": {
+      "class": "operational",
+      "why": "Existence probe."
+    },
+    "has_subject_summary": {
+      "class": "operational",
+      "why": "Existence probe."
+    },
+    "has_summaries": {
+      "class": "operational",
+      "why": "Existence probe."
+    },
     "head_chain": {
       "class": "bounded",
       "why": "One row: the log head."
@@ -110,15 +128,42 @@
       "class": "operational",
       "why": "The fold's own loader."
     },
-    "minted_entity_id_count": { "class": "operational", "why": "A scalar count." },
-    "projected_row_count": { "class": "operational", "why": "A scalar count." },
-    "projection_coordinate": { "class": "operational", "why": "Checkpoint metadata." },
-    "projection_generation": { "class": "operational", "why": "Checkpoint metadata." },
-    "projection_state_digest": { "class": "operational", "why": "Checkpoint metadata." },
-    "entity_projection_generation": { "class": "operational", "why": "Checkpoint metadata." },
-    "entity_projection_state_digest": { "class": "operational", "why": "Checkpoint metadata." },
-    "subject_summary_generation": { "class": "operational", "why": "Checkpoint metadata." },
-    "subject_summary_state_digest": { "class": "operational", "why": "Checkpoint metadata." },
+    "minted_entity_id_count": {
+      "class": "operational",
+      "why": "A scalar count."
+    },
+    "projected_row_count": {
+      "class": "operational",
+      "why": "A scalar count."
+    },
+    "projection_coordinate": {
+      "class": "operational",
+      "why": "Checkpoint metadata."
+    },
+    "projection_generation": {
+      "class": "operational",
+      "why": "Checkpoint metadata."
+    },
+    "projection_state_digest": {
+      "class": "operational",
+      "why": "Checkpoint metadata."
+    },
+    "entity_projection_generation": {
+      "class": "operational",
+      "why": "Checkpoint metadata."
+    },
+    "entity_projection_state_digest": {
+      "class": "operational",
+      "why": "Checkpoint metadata."
+    },
+    "subject_summary_generation": {
+      "class": "operational",
+      "why": "Checkpoint metadata."
+    },
+    "subject_summary_state_digest": {
+      "class": "operational",
+      "why": "Checkpoint metadata."
+    },
     "read_at_generation": {
       "class": "unbounded",
       "why": "The whole claims projection reconstructed at a generation. Pinning the coordinate bounds WHEN, not HOW MUCH -- the same trap as `identity_view_at`."
@@ -132,14 +177,17 @@
       "why": "Returns a HANDLE, reading nothing. The rows come from `ReadSnapshot`'s own methods, which are classified separately below -- a snapshot must not become a way to reach an unbounded read without being seen."
     },
     "resolve_at": {
-      "class": "bounded",
-      "why": "One entity id at one cut."
+      "class": "unbounded",
+      "why": "SIGNATURE-BOUNDED, IMPLEMENTATION-UNBOUNDED \u2014 the literal defect shape, in the store. `resolve_at(id, cut)` takes one entity id and reads like a point lookup, but its body is `self.identity_view_at(cut)?.resolve_at(id)`: it materialises the WHOLE equivalence graph and then indexes it. Classified `bounded` on first pass from the signature alone, which is exactly the mistake the transitive check exists to catch, and it caught it."
     },
     "resolved_entities": {
       "class": "unbounded",
       "why": "Every summarised entity in the store."
     },
-    "schema_version": { "class": "operational", "why": "PRAGMA read." },
+    "schema_version": {
+      "class": "operational",
+      "why": "PRAGMA read."
+    },
     "subject_summaries": {
       "class": "unbounded",
       "why": "Every retained summary row."
@@ -168,25 +216,64 @@
       "class": "operational",
       "why": "The audit walk. WM_SCOPE names it explicitly as a legitimate reader below the engine."
     },
-    "append": { "class": "operational", "why": "Write path." },
-    "append_adjudication": { "class": "operational", "why": "Write path." },
-    "compact_range": { "class": "operational", "why": "Retention mutation." },
-    "fold": { "class": "operational", "why": "Projection fold." },
-    "fold_entity_projection": { "class": "operational", "why": "Projection fold." },
-    "fold_subject_summary": { "class": "operational", "why": "Projection fold." },
-    "mint_entity_id": { "class": "operational", "why": "Id minting." },
-    "open": { "class": "operational", "why": "Constructor." },
-    "rebuild_entity_projection": { "class": "operational", "why": "Projection rebuild." },
-    "rebuild_projections": { "class": "operational", "why": "Projection rebuild." },
-    "rebuild_subject_summary": { "class": "operational", "why": "Projection rebuild." }
+    "append": {
+      "class": "operational",
+      "why": "Write path."
+    },
+    "append_adjudication": {
+      "class": "operational",
+      "why": "Write path."
+    },
+    "compact_range": {
+      "class": "operational",
+      "why": "Retention mutation."
+    },
+    "fold": {
+      "class": "operational",
+      "why": "Projection fold."
+    },
+    "fold_entity_projection": {
+      "class": "operational",
+      "why": "Projection fold."
+    },
+    "fold_subject_summary": {
+      "class": "operational",
+      "why": "Projection fold."
+    },
+    "mint_entity_id": {
+      "class": "operational",
+      "why": "Id minting."
+    },
+    "open": {
+      "class": "operational",
+      "why": "Constructor."
+    },
+    "rebuild_entity_projection": {
+      "class": "operational",
+      "why": "Projection rebuild."
+    },
+    "rebuild_projections": {
+      "class": "operational",
+      "why": "Projection rebuild."
+    },
+    "rebuild_subject_summary": {
+      "class": "operational",
+      "why": "Projection rebuild."
+    }
   },
   "read_snapshot": {
     "current": {
       "class": "bounded",
       "why": "The snapshot-scoped `current`; same PRIMARY KEY bound."
     },
-    "coordinate": { "class": "operational", "why": "Checkpoint metadata." },
-    "identity_is_current": { "class": "operational", "why": "A boolean freshness probe." },
+    "coordinate": {
+      "class": "operational",
+      "why": "Checkpoint metadata."
+    },
+    "identity_is_current": {
+      "class": "operational",
+      "why": "A boolean freshness probe."
+    },
     "identity_view": {
       "class": "unbounded",
       "why": "The whole entity graph, snapshot-scoped. A snapshot bounds COHERENCE, not size."

--- a/crates/kirra-world-service/src/answer_ref.rs
+++ b/crates/kirra-world-service/src/answer_ref.rs
@@ -261,7 +261,17 @@ impl AnswerRef {
         // Reading the two halves separately would put a live `identity_view`
         // one autocomplete away, and today's merges would silently rewrite what
         // a recorded reference means.
-        let composed = match store.read_composed_at_generation(self.generation)? {
+        // BOUNDED, and still ONE composed read — box 3d.
+        //
+        // The unbounded form replayed EVERY adjudication in the log to
+        // re-execute a reference about one subject. This bounds the identity
+        // half to the records bearing on the objects this subject's claims name,
+        // discovered through the affected-entity reverse index and cut at the
+        // pinned GENERATION rather than a transaction time.
+        let composed = match store
+            .read_snapshot()?
+            .read_composed_subject_at_generation(&self.subject, self.generation)?
+        {
             PinnedComposedRead::Reproduced(c) => c,
             PinnedComposedRead::Irreproducible(reason) => {
                 return Ok(RefResolution::Irreproducible(reason))

--- a/crates/kirra-world-service/src/read_view.rs
+++ b/crates/kirra-world-service/src/read_view.rs
@@ -566,9 +566,25 @@ impl<'a> WorldView<'a> {
             });
         }
 
-        // Loaded once for the whole answer, from the same snapshot as the
-        // claims. Per-claim reads would be both slower and incoherent.
-        let identity = snapshot.identity_view()?;
+        // BOUNDED, and loaded once for the whole answer from the same snapshot
+        // as the claims — box 3d.
+        //
+        // This was `snapshot.identity_view()`: the WHOLE entity graph, to answer
+        // a question about one subject. Correct, coherent, and `O(entities)`
+        // work for an `O(predicates)` question — the third instance of the
+        // defect class #1440 and #1441 fixed, found by the gate rather than by
+        // review, on the most-used query in the system.
+        //
+        // Only the objects this subject's claims actually name are seeded, so
+        // the load is bounded by the subject's predicate count times the
+        // resolver's own traversal budget. Still ONE view for the whole answer:
+        // per-claim views would resolve each object against a different graph.
+        let seeds: Vec<EntityId> = claims
+            .iter()
+            .filter_map(|c| c.object.as_deref())
+            .filter_map(|o| EntityId::new(o).ok())
+            .collect();
+        let identity = snapshot.identity_view_for(&seeds)?;
         let identity_is_current = snapshot.identity_is_current()?;
 
         let clock = now_ms.max(0).unsigned_abs();

--- a/crates/kirra-world-service/src/read_view.rs
+++ b/crates/kirra-world-service/src/read_view.rs
@@ -739,8 +739,13 @@ impl<'a> WorldView<'a> {
     /// # Errors
     ///
     /// As [`Self::ask`].
-    pub fn history(&self, subject: &str) -> Result<TemporalLookup, AskError> {
-        let answer = self.store.history(subject)?;
+    pub fn history(
+        &self,
+        subject: &str,
+        page: kirra_world_store::lineage::LineagePage,
+    ) -> Result<HistoryLookup, AskError> {
+        let paged = self.store.history_page(subject, page)?;
+        let answer = paged.answer;
         let completeness = answer.resolution;
 
         let mut answers = Vec::new();
@@ -775,9 +780,10 @@ impl<'a> WorldView<'a> {
         } else {
             WorldLookup::Answered(answers)
         };
-        Ok(TemporalLookup {
+        Ok(HistoryLookup {
             lookup,
             completeness,
+            boundary: paged.boundary,
             semantics: SemanticVersions::for_query(QueryKind::SubjectHistory),
         })
     }
@@ -994,6 +1000,58 @@ fn assemble(
         provenance,
         event_id: claim.event_id.clone(),
     })
+}
+
+/// **One page of a subject's record, its completeness, and whether more follows.**
+///
+/// Box 3d gave `history` a page; this is `TemporalLookup` plus the page
+/// boundary. Kept a separate type rather than adding an `Option<PageBoundary>`
+/// to `TemporalLookup`, because `ask_as_of` has no pages and a nullable bound on
+/// a family that cannot have one is a field every reader has to ask about.
+///
+/// The two signals are INDEPENDENT and both observable, exactly as 3g requires:
+/// `boundary` is about this QUERY (did the caller's limit cut it short), while
+/// `completeness` is about the RECORD (was evidence removed). A page that is
+/// `More` and `Full` is an ordinary first page; one that is `Complete` and
+/// `Degraded` is the whole surviving record of something that lost evidence.
+#[derive(Debug, Clone)]
+pub struct HistoryLookup {
+    lookup: WorldLookup,
+    completeness: Resolution,
+    boundary: kirra_world_store::lineage::PageBoundary,
+    semantics: SemanticVersions,
+}
+
+impl HistoryLookup {
+    /// The claims in this page.
+    #[must_use]
+    pub fn lookup(&self) -> &WorldLookup {
+        &self.lookup
+    }
+
+    /// Whether the RECORD is whole, or what remains of it.
+    #[must_use]
+    pub fn completeness(&self) -> &Resolution {
+        &self.completeness
+    }
+
+    /// Whether compaction could have borne on this record.
+    #[must_use]
+    pub fn is_degraded(&self) -> bool {
+        self.completeness.is_degraded()
+    }
+
+    /// Whether more claims follow this PAGE.
+    #[must_use]
+    pub fn boundary(&self) -> &kirra_world_store::lineage::PageBoundary {
+        &self.boundary
+    }
+
+    /// The rules this answer was produced under.
+    #[must_use]
+    pub fn semantics(&self) -> &SemanticVersions {
+        &self.semantics
+    }
 }
 
 /// **One subject's summary and its evidence coverage** — the 3g follow-up.

--- a/crates/kirra-world-service/src/read_view.rs
+++ b/crates/kirra-world-service/src/read_view.rs
@@ -651,9 +651,19 @@ impl<'a> WorldView<'a> {
         // COMPOSED at one transaction-time cut. Objects resolve through the
         // identity graph as it stood at `as_known_at_ms`, so an adjudication
         // recorded after that instant cannot rewrite this answer.
+        // BOUNDED, and still ONE composed read — box 3d.
+        //
+        // `as_of_composed` replayed every adjudication in the log to build the
+        // identity half. The bounded form folds only the records bearing on the
+        // objects these claims name, discovered through the affected-entity
+        // reverse index.
+        //
+        // Deliberately NOT a bounded claims read plus a bounded identity read:
+        // that would satisfy boundedness while reintroducing the cross-read
+        // incoherence box 3h closed, i.e. closing 3d by breaking 3h.
         let composed = self
             .store
-            .as_of_composed(subject, valid_at_ms, as_known_at_ms)?;
+            .as_of_composed_bounded(subject, valid_at_ms, as_known_at_ms)?;
         // Both halves MOVED out together. An earlier draft cloned the identity
         // view and then dropped the original — a full copy of the entity graph
         // on every call, for nothing. Caught in review on #1438.

--- a/crates/kirra-world-service/tests/as_of_composition.rs
+++ b/crates/kirra-world-service/tests/as_of_composition.rs
@@ -549,3 +549,84 @@ fn the_composed_read_holds_both_halves_at_the_same_cut() {
     drop(store);
     cleanup(&path);
 }
+
+// --------------------------------------------------------------- box 3d ---
+
+/// **`ask` resolves an object through a MULTI-HOP merge chain.**
+///
+/// The control for box 3d's bounded identity seeding. `ask` used to load the
+/// WHOLE entity graph to resolve the objects its claims name; it now seeds only
+/// those objects and loads their reachable closure.
+///
+/// A one-hop merge would not prove the seeding follows edges at all — resolving
+/// `a -> b` needs `b`'s row to know `b` is live, so a seed-only loader fails
+/// there too. But a TWO-hop chain is what separates "loads the seed and its
+/// neighbours" from "loads the reachable closure": a loader that stopped after
+/// one level would resolve `a` to a `DanglingRedirect` at `c`, which reads as a
+/// broken graph rather than as a truncated read.
+///
+/// Nothing covered this before 3d — object resolution through `ask` was only
+/// ever exercised at zero hops.
+#[test]
+fn ask_resolves_an_object_two_merges_deep() {
+    let path = tmp("3d-two-hop");
+    let mut store = WorldStore::open(&path).expect("open");
+
+    adjudicate(
+        &mut store,
+        "a1",
+        T0,
+        &IdentityAdjudication::Assert(AssertIdentity::new(eid("dock_alpha"), just(), at())),
+    );
+    adjudicate(
+        &mut store,
+        "a2",
+        T0 + 1,
+        &IdentityAdjudication::Assert(AssertIdentity::new(eid("dock_beta"), just(), at())),
+    );
+    adjudicate(
+        &mut store,
+        "a3",
+        T0 + 2,
+        &IdentityAdjudication::Assert(AssertIdentity::new(eid("dock_gamma"), just(), at())),
+    );
+    adjudicate(
+        &mut store,
+        "m1",
+        T0 + 3,
+        &IdentityAdjudication::Merge(
+            MergeEntities::new(vec![eid("dock_alpha")], eid("dock_beta"), just(), at())
+                .expect("merge"),
+        ),
+    );
+    adjudicate(
+        &mut store,
+        "m2",
+        T0 + 4,
+        &IdentityAdjudication::Merge(
+            MergeEntities::new(vec![eid("dock_beta")], eid("dock_gamma"), just(), at())
+                .expect("merge"),
+        ),
+    );
+    claim_pointing_at(&mut store, "c1", "dock_alpha", T0 + 5);
+    store.fold().expect("fold");
+    store.fold_entity_projection().expect("fold entities");
+
+    let view = WorldView::new(&store, FreshnessSource::Caller(FreshnessPolicy::Timeless));
+    let answer = view.ask("package_17", T0 + 10).expect("ask");
+
+    let WorldLookup::Answered(answers) = answer.lookup() else {
+        panic!("expected an answer, got {:?}", answer.lookup());
+    };
+    let identity = answers[0].object_identity();
+    assert_eq!(
+        identity,
+        &ObjectIdentity::Resolved {
+            entity: "dock_gamma".to_string(),
+            hops: 2,
+        },
+        "the object must resolve two merges deep — a seed-only or one-level \
+         loader reports a dangling redirect here, which looks like a broken \
+         graph rather than a truncated read"
+    );
+}

--- a/crates/kirra-world-service/tests/completeness_propagation.rs
+++ b/crates/kirra-world-service/tests/completeness_propagation.rs
@@ -95,6 +95,7 @@
 
 use kirra_world_service::freshness::FreshnessSource;
 use kirra_world_service::read_view::{AskError, WorldLookup, WorldView};
+use kirra_world_store::lineage::LineagePage;
 use kirra_world_store::{ClaimStatus, EventId, NewEvent, ObservationId, WorldStore, WriterClass};
 
 const T0: i64 = 1_700_000_000_000;
@@ -218,7 +219,9 @@ fn answered(lookup: &WorldLookup) -> usize {
 #[test]
 fn a_compacted_history_reports_degraded() {
     let (store, _p) = holed_store("hist-degraded");
-    let lookup = view(&store).history("package_17").expect("history");
+    let lookup = view(&store)
+        .history("package_17", LineagePage::first())
+        .expect("history");
 
     assert!(
         lookup.is_degraded(),
@@ -237,8 +240,12 @@ fn both_history_arms_return_a_plausible_non_empty_record() {
     let (holed, _p1) = holed_store("hist-nonempty-holed");
     let (intact, _p2) = intact_store("hist-nonempty-intact");
 
-    let degraded = view(&holed).history("package_17").expect("history");
-    let full = view(&intact).history("package_17").expect("history");
+    let degraded = view(&holed)
+        .history("package_17", LineagePage::first())
+        .expect("history");
+    let full = view(&intact)
+        .history("package_17", LineagePage::first())
+        .expect("history");
 
     assert_eq!(
         answered(full.lookup()),
@@ -264,7 +271,9 @@ fn both_history_arms_return_a_plausible_non_empty_record() {
 #[test]
 fn an_uncompacted_history_reports_full() {
     let (store, _p) = intact_store("hist-full");
-    let lookup = view(&store).history("package_17").expect("history");
+    let lookup = view(&store)
+        .history("package_17", LineagePage::first())
+        .expect("history");
 
     assert!(
         !lookup.is_degraded(),
@@ -333,7 +342,9 @@ fn history_keeps_a_claim_that_ask_refuses_to_serve() {
          contrast below is vacuous"
     );
 
-    let record = v.history("package_17").expect("history");
+    let record = v
+        .history("package_17", LineagePage::first())
+        .expect("history");
     assert_eq!(
         answered(record.lookup()),
         1,
@@ -380,7 +391,7 @@ fn an_unruled_claim_refuses_the_whole_history() {
     store.fold().expect("fold");
 
     let err = view(&store)
-        .history("package_17")
+        .history("package_17", LineagePage::first())
         .expect_err("an unclassified claim must refuse the whole query");
     assert!(
         matches!(err, AskError::UnclassifiedFreshness { .. }),
@@ -487,5 +498,111 @@ fn an_unknown_subject_is_absent_rather_than_degraded() {
     assert!(
         !lookup.is_degraded(),
         "nothing was claimed about this subject, so nothing is missing"
+    );
+}
+
+// ------------------------------------------------- box 3d: history pages ---
+
+/// **A short page returns the page, not the record.**
+///
+/// The bound must reach the STORE. `history` used to fetch every confirmed claim
+/// about a subject and hand it all back — the third instance of the defect class
+/// box 3d closes, and the one written in the PR that documented the other two.
+#[test]
+fn a_history_page_returns_at_most_its_limit() {
+    let (store, _p) = intact_store("hist-page-limit");
+    let page = LineagePage::new(2, None).expect("valid page");
+    let lookup = view(&store).history("package_17", page).expect("history");
+
+    assert_eq!(
+        answered(lookup.lookup()),
+        2,
+        "three claims exist; a limit of 2 must return 2"
+    );
+    assert!(
+        lookup.boundary().is_truncated(),
+        "a third claim follows, so the page must say so"
+    );
+}
+
+/// **Paginating to exhaustion returns the whole record exactly once.**
+///
+/// The cursor walk. A page that reported `More` forever, or one whose cursor was
+/// inclusive and repeated a claim, would both still pass the limit test above.
+#[test]
+fn paginating_a_history_walks_the_record_without_gaps_or_repeats() {
+    let (store, _p) = intact_store("hist-page-walk");
+    let v = view(&store);
+
+    let mut seen: Vec<String> = Vec::new();
+    let mut cursor = None;
+    for _ in 0..10 {
+        let page = LineagePage::new(1, cursor).expect("valid page");
+        let lookup = v.history("package_17", page).expect("history");
+        if let WorldLookup::Answered(answers) = lookup.lookup() {
+            for a in answers {
+                seen.push(a.event_id().to_string());
+            }
+        }
+        match lookup.boundary() {
+            kirra_world_store::lineage::PageBoundary::More {
+                next_after_generation,
+            } => cursor = Some(*next_after_generation),
+            kirra_world_store::lineage::PageBoundary::Complete => break,
+        }
+    }
+
+    assert_eq!(
+        seen.len(),
+        3,
+        "the walk must visit every claim exactly once"
+    );
+    let mut unique = seen.clone();
+    unique.sort();
+    unique.dedup();
+    assert_eq!(unique.len(), 3, "an inclusive cursor would repeat a claim");
+}
+
+/// **A page that exactly fills is NOT `More`.**
+///
+/// The off-by-one `lineage::boundary_for` owns. Asking for exactly the record's
+/// length must report `Complete`, or a caller paginating to exhaustion makes one
+/// wasted round trip on every record whose length divides the page size.
+///
+/// Sized to the record deliberately — #1440's first draft of this control asked
+/// for a 256-limit page over two events, a page that could not have been full,
+/// and the mutation survived it.
+#[test]
+fn a_history_page_that_exactly_fills_is_complete() {
+    let (store, _p) = intact_store("hist-page-exact");
+    let page = LineagePage::new(3, None).expect("valid page");
+    let lookup = view(&store).history("package_17", page).expect("history");
+
+    assert_eq!(answered(lookup.lookup()), 3, "the whole record");
+    assert!(
+        !lookup.boundary().is_truncated(),
+        "the page holds the entire record, so nothing follows it"
+    );
+}
+
+/// **Page boundary and record completeness are independent.**
+///
+/// 3g's rule, applied to a paginated family. A page cut short by the caller's
+/// own limit is complete evidence; a record missing a compacted span is evidence
+/// that no longer exists. Reporting one as the other in either direction would
+/// make a routine first page look like data loss, or data loss look routine.
+#[test]
+fn a_truncated_page_over_a_degraded_record_reports_both() {
+    let (store, _p) = holed_store("hist-page-degraded");
+    let page = LineagePage::new(1, None).expect("valid page");
+    let lookup = view(&store).history("package_17", page).expect("history");
+
+    assert!(
+        lookup.boundary().is_truncated(),
+        "two claims survive and the limit is 1, so more follows"
+    );
+    assert!(
+        lookup.is_degraded(),
+        "evidence was compacted away, which the page bound says nothing about"
     );
 }

--- a/crates/kirra-world-store/src/adjudication_record.rs
+++ b/crates/kirra-world-store/src/adjudication_record.rs
@@ -197,6 +197,39 @@ pub fn adjudication_subject(a: &IdentityAdjudication) -> &EntityId {
     }
 }
 
+/// **Every entity an adjudication affects** — box 3d's reverse-index key set.
+///
+/// The union of [`IdentityAdjudication::resulting_lifecycles`]'s keys and
+/// [`adjudication_subject`]. Those two functions already decide which entities
+/// an adjudication touches, and this composes them rather than deciding again:
+/// `resulting_lifecycles` remains the authority for identity semantics, and the
+/// index it feeds is only a materialised access path.
+///
+/// # Why the subject is included as well
+///
+/// `Assert` states no transition — it CREATES, so there is no prior state to
+/// move from — and its `resulting_lifecycles` is deliberately empty. Indexing
+/// only the lifecycle keys would therefore record nothing for an assertion, and
+/// an asserted entity would be undiscoverable by the very index meant to find
+/// it.
+///
+/// Including the subject also over-includes slightly elsewhere: a merge's
+/// survivor is indexed although its own lifecycle does not change. That is the
+/// safe direction and deliberately so — a superset costs a row, a subset
+/// changes history.
+#[must_use]
+pub fn adjudication_affects(a: &IdentityAdjudication) -> Vec<String> {
+    let mut out: Vec<String> = a
+        .resulting_lifecycles()
+        .into_iter()
+        .map(|(e, _)| e.as_str().to_owned())
+        .collect();
+    out.push(adjudication_subject(a).as_str().to_owned());
+    out.sort();
+    out.dedup();
+    out
+}
+
 /// The observation ids a row's `provenance` column should carry.
 ///
 /// [`Justification`] *is* provenance in the store's sense — §14.1's `Evidence`

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -1421,7 +1421,15 @@ impl WorldStore {
                 return Err(e.into());
             }
         }
-        self.conn.execute_batch("COMMIT")?;
+        // A failing COMMIT leaves the transaction OPEN — SQLite can return
+        // `SQLITE_BUSY` here and keep it active. Returning without rolling back
+        // would poison the connection: every later append fails with "cannot
+        // start a transaction within a transaction", which reports the wrong
+        // fault and buries this one. Roll back, then surface the real error.
+        if let Err(e) = self.conn.execute_batch("COMMIT") {
+            let _ = self.conn.execute_batch("ROLLBACK");
+            return Err(e.into());
+        }
         Ok(generation)
     }
 
@@ -1488,15 +1496,23 @@ impl WorldStore {
     /// from `world_events` and decoded exactly as the whole-log path decodes it,
     /// and folded by the unchanged `fold_adjudication`. The index holds no
     /// payload, so it physically cannot manufacture an adjudication the log does
-    /// not have — and a generation it names that the log lacks fails closed
-    /// rather than resolving to a guess.
+    /// not have: a generation it names that the log lacks contributes NOTHING to
+    /// the fold — the join drops it, and the answer is the one the log supports.
+    ///
+    /// That is a drop, not a refusal, and the asymmetry is deliberate. A phantom
+    /// row carries no evidence, so discarding it cannot lose any; refusing on it
+    /// would instead turn an index that merely runs ahead of what the log still
+    /// retains into a hard read failure. The dangerous direction is the opposite
+    /// one — a MISSING row for an adjudication the log does hold, which reads as
+    /// silent absence — and that is what the omitted-`Merge`-source and
+    /// omitted-`Split`-destination mutations exist to catch.
     ///
     /// # Errors
     ///
     /// [`StoreError::CorruptEntityProjectionRow`] on an undecodable payload or
-    /// an index row naming a generation `world_events` does not hold;
-    /// [`StoreError::IdentityClosureTooLarge`] if discovery exceeds
-    /// [`snapshot::MAX_IDENTITY_CLOSURE`] — refused, never truncated.
+    /// unreadable provenance; [`StoreError::IdentityClosureTooLarge`] if
+    /// discovery exceeds [`snapshot::MAX_IDENTITY_CLOSURE`] — refused, never
+    /// truncated.
     pub fn resolve_bounded_at(
         &self,
         id: &kirra_world::reference::EntityId,
@@ -1517,12 +1533,6 @@ impl WorldStore {
         Ok(view.resolve_at(id))
     }
 
-    /// The adjudications affecting `entity` at or before `as_known_at_ms`.
-    ///
-    /// The index supplies the GENERATIONS; `world_events` supplies the records.
-    /// An index row naming a generation the log does not hold is a fault, not an
-    /// absence — the index is never evidence, so it may not assert an
-    /// adjudication into existence.
     /// **Populate the affected-entity index from the existing log** — box 3d.
     ///
     /// A v6 migration installs an EMPTY index, because it adds a table and

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -230,6 +230,20 @@ pub enum StoreError {
     /// recorded, it just may not be *labelled* — and a caller who asked for a
     /// label should learn it did not get one.
     UnboundSubjectNotStorable,
+    /// The identity closure reachable from an id exceeded
+    /// [`snapshot::MAX_IDENTITY_CLOSURE`].
+    ///
+    /// A REFUSAL rather than a truncation, deliberately. Handing the resolver a
+    /// truncated graph would turn a `TraversalBudgetExceeded` refusal into a
+    /// `DanglingRedirect` one — a wrong answer about why the graph could not be
+    /// resolved, which is exactly the confusion the `AdjudicationGraph` trait's
+    /// no-error-channel contract exists to prevent.
+    IdentityClosureTooLarge {
+        /// The id the walk started from.
+        from: String,
+        /// The cap that was hit.
+        limit: usize,
+    },
     /// A stored entity-projection row could not be read back faithfully.
     ///
     /// **Refused, never repaired.** The columns are written only by the fold,
@@ -359,6 +373,11 @@ impl std::fmt::Display for StoreError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Sqlite(e) => write!(f, "sqlite: {e}"),
+            Self::IdentityClosureTooLarge { from, limit } => write!(
+                f,
+                "identity closure reachable from {from} exceeds {limit} entities; \
+                 refused rather than truncated"
+            ),
             Self::CorruptEntityProjectionRow { detail } => {
                 write!(f, "corrupt entities_projection row: {detail}")
             }
@@ -1604,6 +1623,39 @@ impl WorldStore {
     /// [`IdentityView::generation`]: entity_projection::IdentityView::generation
     pub fn identity_view(&self) -> Result<entity_projection::IdentityView, StoreError> {
         self.read_snapshot()?.identity_view()
+    }
+
+    /// **Resolve one id against the live identity graph, bounded** — box 3d.
+    ///
+    /// The bounded counterpart to `identity_view().resolve(id)`. Loads only the
+    /// entities within `MAX_REDIRECT_EDGES` hops of `id` and resolves over that,
+    /// so the work is bounded by the traversal budget rather than by the size of
+    /// the graph.
+    ///
+    /// The resolution RULE is unchanged: this hands a smaller `IdentityView` to
+    /// the same `kirra_world::resolution::resolve`. Only the loading is
+    /// different, which is why
+    /// `bounded_resolution_agrees_with_whole_graph_resolution` can assert the
+    /// two are identical rather than merely similar.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::CorruptEntityProjectionRow`] if a reachable row cannot be
+    /// read back faithfully — failing closed BEFORE the walk, which is what
+    /// keeps a storage fault from being read as "no such entity".
+    /// [`StoreError::IdentityClosureTooLarge`] if the reachable closure exceeds
+    /// [`snapshot::MAX_IDENTITY_CLOSURE`]; refused, never truncated.
+    pub fn resolve_bounded(
+        &self,
+        id: &kirra_world::reference::EntityId,
+    ) -> Result<kirra_world::resolution::ResolutionOutcome, StoreError> {
+        let rows = snapshot::load_reachable_entity_projection_on(&self.conn, id)?;
+        // Generation 0: this view is a REACHABLE SUBSET, not a snapshot of the
+        // projection, so stamping it with the projection's head would label a
+        // partial graph as a complete state of the world — the mislabelling
+        // `IdentityView::generation` is relied upon not to do.
+        let view = entity_projection::IdentityView::new(rows, 0);
+        Ok(kirra_world::resolution::resolve(&view, id))
     }
 
     /// **The identity graph as it stood at a past instant** — §6.3, Tier 2 2d.

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -1502,50 +1502,11 @@ impl WorldStore {
         id: &kirra_world::reference::EntityId,
         as_known_at_ms: i64,
     ) -> Result<entity_projection::HistoricalAnswer, StoreError> {
-        let mut acc = std::collections::BTreeMap::new();
-        let mut head: i64 = 0;
-        let mut seen_entities: std::collections::BTreeSet<String> =
-            std::collections::BTreeSet::new();
-        let mut seen_generations: std::collections::BTreeSet<i64> =
-            std::collections::BTreeSet::new();
-        let mut frontier: Vec<String> = vec![id.as_str().to_owned()];
-
-        // Depth-capped by the same budget the resolver enforces, so discovery
-        // stops where the walk would. Expanding newly-named entities is what
-        // makes this a closure rather than a single lookup: a merge found from
-        // `A` names `B`, and `B`'s own adjudications may name `C`.
-        for _ in 0..=kirra_world::resolution::MAX_REDIRECT_EDGES {
-            if frontier.is_empty() {
-                break;
-            }
-            let mut next: Vec<String> = Vec::new();
-            for entity in frontier.drain(..) {
-                if !seen_entities.insert(entity.clone()) {
-                    continue;
-                }
-                if seen_entities.len() > snapshot::MAX_IDENTITY_CLOSURE {
-                    return Err(StoreError::IdentityClosureTooLarge {
-                        from: id.as_str().to_owned(),
-                        limit: snapshot::MAX_IDENTITY_CLOSURE,
-                    });
-                }
-                for (generation, adjudication) in
-                    self.adjudications_affecting(&entity, as_known_at_ms)?
-                {
-                    if !seen_generations.insert(generation) {
-                        continue;
-                    }
-                    // Every entity this adjudication touches becomes a discovery
-                    // seed, which is what closes the bootstrap gap: reaching the
-                    // merge from `A` reveals `B` even though the record is keyed
-                    // under `B`.
-                    next.extend(adjudication_record::adjudication_affects(&adjudication));
-                    entity_projection::fold_adjudication(&mut acc, &adjudication, generation);
-                    head = head.max(generation);
-                }
-            }
-            frontier = next;
-        }
+        let (acc, head) = bounded_identity_acc_on(
+            &self.conn,
+            &[id.as_str().to_owned()],
+            IdentityCut::TxnTimeAtMost(as_known_at_ms),
+        )?;
 
         let resolution = self.identity_resolution_at()?;
         let view = entity_projection::HistoricalIdentityView::new(
@@ -1562,55 +1523,6 @@ impl WorldStore {
     /// An index row naming a generation the log does not hold is a fault, not an
     /// absence — the index is never evidence, so it may not assert an
     /// adjudication into existence.
-    fn adjudications_affecting(
-        &self,
-        entity: &str,
-        as_known_at_ms: i64,
-    ) -> Result<Vec<(i64, kirra_world::adjudication::IdentityAdjudication)>, StoreError> {
-        let mut stmt = self.conn.prepare(
-            "SELECT e.generation, e.payload, e.payload_schema, e.provenance
-             FROM adjudication_affects a
-             JOIN world_events e ON e.generation = a.generation
-             WHERE a.entity_id = ?1
-               AND e.claim_status = 'confirmed'
-               AND e.kind = ?2
-               AND e.txn_time_ms <= ?3
-             ORDER BY e.generation ASC",
-        )?;
-        let mapped = stmt.query_map(
-            params![
-                entity,
-                adjudication_record::ADJUDICATION_KIND,
-                as_known_at_ms
-            ],
-            |r| {
-                Ok((
-                    r.get::<_, i64>(0)?,
-                    r.get::<_, String>(1)?,
-                    r.get::<_, i64>(2)?,
-                    r.get::<_, String>(3)?,
-                ))
-            },
-        )?;
-
-        let mut out = Vec::new();
-        for row in mapped {
-            let (generation, payload, payload_schema, provenance) = row?;
-            let cited: Vec<String> = serde_json::from_str(&provenance).map_err(|e| {
-                StoreError::CorruptEntityProjectionRow {
-                    detail: format!("generation {generation}: provenance is not a JSON array: {e}"),
-                }
-            })?;
-            let adjudication =
-                adjudication_record::decode_adjudication(&payload, payload_schema, &cited)
-                    .map_err(|e| StoreError::CorruptEntityProjectionRow {
-                        detail: format!("generation {generation}: {e}"),
-                    })?;
-            out.push((generation, adjudication));
-        }
-        Ok(out)
-    }
-
     /// **Populate the affected-entity index from the existing log** — box 3d.
     ///
     /// A v6 migration installs an EMPTY index, because it adds a table and
@@ -2044,7 +1956,7 @@ impl WorldStore {
     /// # Errors
     ///
     /// As [`Self::identity_view_at`].
-    pub fn resolve_at(
+    pub fn resolve_at_whole_graph(
         &self,
         id: &kirra_world::reference::EntityId,
         as_known_at_ms: i64,
@@ -3014,6 +2926,75 @@ impl WorldStore {
     /// # Errors
     ///
     /// As [`Self::as_of`] and [`Self::identity_view_at`].
+    /// **Claims AND historical identity at one cut, both bounded** — box 3d.
+    ///
+    /// The bounded replacement for [`Self::as_of_composed`], and deliberately
+    /// ONE primitive rather than two bounded calls a caller stitches together.
+    ///
+    /// # Why not two calls
+    ///
+    /// Box 3h established that a historical answer must observe claims and
+    /// identity at ONE coordinate. Replacing `as_of_composed` with a bounded
+    /// claims read plus a bounded identity read would satisfy boundedness and
+    /// quietly reintroduce the cross-read incoherence 3h closed — closing 3d by
+    /// breaking 3h. The transaction below is what makes that impossible, exactly
+    /// as it does for the unbounded original.
+    ///
+    /// # What is bounded, and what is not
+    ///
+    /// The claims half was ALREADY bounded — `as_of` is keyed by subject. Only
+    /// the identity half was not: it replayed every adjudication in the log. It
+    /// now folds only the records bearing on the objects these claims name,
+    /// discovered through the affected-entity reverse index.
+    ///
+    /// The resolver, the fold and the completeness semantics are untouched.
+    ///
+    /// # Errors
+    ///
+    /// As [`Self::as_of_composed`], plus the index-backed discovery errors of
+    /// [`Self::resolve_bounded_at`].
+    pub fn as_of_composed_bounded(
+        &self,
+        subject: &str,
+        valid_at_ms: i64,
+        as_known_at_ms: i64,
+    ) -> Result<snapshot::TemporalComposition, StoreError> {
+        // One snapshot for both halves — the same mechanism as the unbounded
+        // original, kept deliberately identical so the coherence argument does
+        // not have to be re-made.
+        let tx = self.conn.unchecked_transaction()?;
+        let answer = self.as_of(subject, valid_at_ms, as_known_at_ms)?;
+
+        // Seeded from the objects these claims actually name. A claim with no
+        // object contributes no seed, so a subject whose claims are all
+        // value-shaped folds no adjudications at all.
+        let seeds: Vec<String> = answer
+            .claims
+            .iter()
+            .filter_map(|c| c.object.clone())
+            .collect();
+        let (acc, head) = bounded_identity_acc_on(
+            &self.conn,
+            &seeds,
+            IdentityCut::TxnTimeAtMost(as_known_at_ms),
+        )?;
+        drop(tx);
+
+        Ok(snapshot::TemporalComposition::new(
+            answer,
+            entity_projection::IdentityView::new(acc, head),
+        ))
+    }
+
+    /// **Claims AND historical identity at one transaction-time cut** — box 3h.
+    ///
+    /// The UNBOUNDED form, retained for operators and analysis: the identity
+    /// half replays every adjudication in the log. Box 3d replaced its use at
+    /// the answer boundary with [`Self::as_of_composed_bounded`].
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::Sqlite`] on any read failure.
     pub fn as_of_composed(
         &self,
         subject: &str,
@@ -4506,4 +4487,144 @@ pub struct HistoryPage {
     pub answer: compaction::TemporalAnswer,
     /// Whether more claims follow this page.
     pub boundary: lineage::PageBoundary,
+}
+
+/// The adjudications affecting `entity` at or before `as_known_at_ms` — box 3d.
+///
+/// A free function over a `Connection` so both `WorldStore` and a
+/// `ReadSnapshot`'s transaction can use it: the composed historical read must
+/// take BOTH halves from one snapshot, so it cannot route through a method that
+/// binds a different connection.
+///
+/// The index supplies the GENERATIONS; `world_events` supplies the records. An
+/// index row naming a generation the log does not hold contributes nothing —
+/// the index is never evidence, so it may not assert an adjudication into
+/// existence.
+pub(crate) fn adjudications_affecting_on(
+    conn: &rusqlite::Connection,
+    entity: &str,
+    bound: IdentityCut,
+) -> Result<Vec<(i64, kirra_world::adjudication::IdentityAdjudication)>, StoreError> {
+    // The AXIS is part of the bound, not assumed. A transaction-time cut and a
+    // generation cut are different questions, and using one where the other is
+    // meant admits adjudications recorded after the coordinate — silently
+    // breaking box 3h's guarantee that a pinned answer resolves identity as it
+    // stood THEN. Caught while wiring the pinned path, which had been handed
+    // `i64::MAX` as a transaction time.
+    let column = match bound {
+        IdentityCut::TxnTimeAtMost(_) => "e.txn_time_ms",
+        IdentityCut::GenerationAtMost(_) => "e.generation",
+    };
+    let value = match bound {
+        IdentityCut::TxnTimeAtMost(v) | IdentityCut::GenerationAtMost(v) => v,
+    };
+    let mut stmt = conn.prepare(&format!(
+        "SELECT e.generation, e.payload, e.payload_schema, e.provenance
+         FROM adjudication_affects a
+         JOIN world_events e ON e.generation = a.generation
+         WHERE a.entity_id = ?1
+           AND e.claim_status = 'confirmed'
+           AND e.kind = ?2
+           AND {column} <= ?3
+         ORDER BY e.generation ASC"
+    ))?;
+    let mapped = stmt.query_map(
+        params![entity, adjudication_record::ADJUDICATION_KIND, value],
+        |r| {
+            Ok((
+                r.get::<_, i64>(0)?,
+                r.get::<_, String>(1)?,
+                r.get::<_, i64>(2)?,
+                r.get::<_, String>(3)?,
+            ))
+        },
+    )?;
+    let mut out = Vec::new();
+    for row in mapped {
+        let (generation, payload, payload_schema, provenance) = row?;
+        let cited: Vec<String> = serde_json::from_str(&provenance).map_err(|e| {
+            StoreError::CorruptEntityProjectionRow {
+                detail: format!("generation {generation}: provenance is not a JSON array: {e}"),
+            }
+        })?;
+        let adjudication =
+            adjudication_record::decode_adjudication(&payload, payload_schema, &cited).map_err(
+                |e| StoreError::CorruptEntityProjectionRow {
+                    detail: format!("generation {generation}: {e}"),
+                },
+            )?;
+        out.push((generation, adjudication));
+    }
+    Ok(out)
+}
+
+/// **Fold the identity records bearing on `seeds` at a cut, bounded** — box 3d.
+///
+/// The shared closure build. Discovers adjudications through the reverse index,
+/// expands every entity each one names — which is what closes the bootstrap gap,
+/// since reaching a merge from its source reveals the survivor the record is
+/// keyed under — and stops at the resolver's own traversal budget.
+///
+/// Returns the accumulator and the highest generation folded, ready for
+/// `IdentityView::new`.
+pub(crate) fn bounded_identity_acc_on(
+    conn: &rusqlite::Connection,
+    seeds: &[String],
+    bound: IdentityCut,
+) -> Result<
+    (
+        std::collections::BTreeMap<String, entity_projection::ProjectedEntity>,
+        i64,
+    ),
+    StoreError,
+> {
+    let mut acc = std::collections::BTreeMap::new();
+    let mut head: i64 = 0;
+    let mut seen_entities: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    let mut seen_generations: std::collections::BTreeSet<i64> = std::collections::BTreeSet::new();
+    let mut frontier: Vec<String> = seeds.to_vec();
+
+    for _ in 0..=kirra_world::resolution::MAX_REDIRECT_EDGES {
+        if frontier.is_empty() {
+            break;
+        }
+        let mut next: Vec<String> = Vec::new();
+        for entity in frontier.drain(..) {
+            if !seen_entities.insert(entity.clone()) {
+                continue;
+            }
+            if seen_entities.len() > snapshot::MAX_IDENTITY_CLOSURE {
+                return Err(StoreError::IdentityClosureTooLarge {
+                    from: seeds.join(", "),
+                    limit: snapshot::MAX_IDENTITY_CLOSURE,
+                });
+            }
+            for (generation, adjudication) in adjudications_affecting_on(conn, &entity, bound)? {
+                if !seen_generations.insert(generation) {
+                    continue;
+                }
+                next.extend(adjudication_record::adjudication_affects(&adjudication));
+                entity_projection::fold_adjudication(&mut acc, &adjudication, generation);
+                head = head.max(generation);
+            }
+        }
+        frontier = next;
+    }
+    Ok((acc, head))
+}
+
+/// **Which axis bounds a historical identity read** — box 3d.
+///
+/// A transaction-time cut and a generation cut answer different questions, and
+/// an untyped `i64` lets one be passed where the other is meant. That is not
+/// hypothetical: the pinned composed read was first written passing `i64::MAX`
+/// as a transaction time, which would have admitted adjudications recorded
+/// AFTER the pinned coordinate — silently breaking box 3h's guarantee that a
+/// recorded reference resolves identity as it stood then.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum IdentityCut {
+    /// Bitemporal: adjudications known by this transaction time.
+    TxnTimeAtMost(i64),
+    /// Generation-pinned: adjudications at or below this log position.
+    GenerationAtMost(i64),
 }

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -1649,7 +1649,8 @@ impl WorldStore {
         &self,
         id: &kirra_world::reference::EntityId,
     ) -> Result<kirra_world::resolution::ResolutionOutcome, StoreError> {
-        let rows = snapshot::load_reachable_entity_projection_on(&self.conn, id)?;
+        let rows =
+            snapshot::load_reachable_entity_projection_on(&self.conn, std::slice::from_ref(id))?;
         // Generation 0: this view is a REACHABLE SUBSET, not a snapshot of the
         // projection, so stamping it with the projection's head would label a
         // partial graph as a complete state of the world — the mislabelling

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -987,6 +987,7 @@ pub fn schema_digest() -> String {
     effective.push_str(schema::SCHEMA_V3_MIGRATION);
     effective.push_str(schema::SCHEMA_V4_MIGRATION);
     effective.push_str(schema::SCHEMA_V5_MIGRATION);
+    effective.push_str(schema::SCHEMA_V6_MIGRATION);
     sha256_hex(effective.as_bytes())
 }
 
@@ -1041,6 +1042,7 @@ impl WorldStore {
             tx.execute_batch(schema::SCHEMA_V3_MIGRATION)?;
             tx.execute_batch(schema::SCHEMA_V4_MIGRATION)?;
             tx.execute_batch(schema::SCHEMA_V5_MIGRATION)?;
+            tx.execute_batch(schema::SCHEMA_V6_MIGRATION)?;
             tx.execute(
                 "INSERT INTO world_store_meta (key, value) VALUES ('schema_version', ?1)",
                 params![SCHEMA_VERSION.to_string()],
@@ -1142,6 +1144,15 @@ impl WorldStore {
         // `invalid_shape_rows`, never silently coerced.
         if from < 5 {
             tx.execute_batch(schema::SCHEMA_V5_MIGRATION)?;
+        }
+        // v6 ADDS a table and nothing else — no column change, no trigger, no
+        // touch of an existing row. An existing store migrates with an EMPTY
+        // index, which is why `backfill_adjudication_affects` exists and why it
+        // is an explicit operational step rather than work hidden in `open`:
+        // a full scan of the adjudication log belongs where an operator can see
+        // it, not on the path of whoever happens to open the store first.
+        if from < 6 {
+            tx.execute_batch(schema::SCHEMA_V6_MIGRATION)?;
         }
 
         // Digest before version, inside the transaction. The order no longer
@@ -1377,8 +1388,52 @@ impl WorldStore {
         let payload = adjudication_record::encode_adjudication(adjudication);
         let provenance = adjudication_record::adjudication_provenance(adjudication);
         let prov: Vec<&str> = provenance.iter().map(String::as_str).collect();
-        let subject = adjudication_record::adjudication_subject(adjudication).as_str();
+        let subject = adjudication_record::adjudication_subject(adjudication)
+            .as_str()
+            .to_owned();
+        let subject = subject.as_str();
 
+        let affected = adjudication_record::adjudication_affects(adjudication);
+
+        // The event and its index rows commit TOGETHER. An index that could lag
+        // the log by one crash would under-report exactly the newest
+        // adjudication — the one a historical read is most likely to need — and
+        // would do it silently, since a missing index row reads as "no such
+        // adjudication" rather than as damage.
+        //
+        // Explicit BEGIN/COMMIT rather than `unchecked_transaction`, because
+        // that borrows `self.conn` while `append` needs `&mut self`.
+        self.conn.execute_batch("BEGIN IMMEDIATE")?;
+        let generation = match self.append_adjudication_inner(row, &payload, &prov, subject) {
+            Ok(g) => g,
+            Err(e) => {
+                let _ = self.conn.execute_batch("ROLLBACK");
+                return Err(e);
+            }
+        };
+        for entity in &affected {
+            if let Err(e) = self.conn.execute(
+                "INSERT OR IGNORE INTO adjudication_affects (entity_id, generation)
+                 VALUES (?1, ?2)",
+                params![entity, generation],
+            ) {
+                let _ = self.conn.execute_batch("ROLLBACK");
+                return Err(e.into());
+            }
+        }
+        self.conn.execute_batch("COMMIT")?;
+        Ok(generation)
+    }
+
+    /// The event half of [`Self::append_adjudication`], split out so the
+    /// caller can hold a transaction across it and the index write.
+    fn append_adjudication_inner(
+        &mut self,
+        row: &adjudication_record::AdjudicationRow<'_>,
+        payload: &str,
+        prov: &[&str],
+        subject: &str,
+    ) -> Result<i64, StoreError> {
         self.append(&NewEvent {
             event_id: row.event_id,
             observation_id: row.observation_id,
@@ -1389,7 +1444,7 @@ impl WorldStore {
             source_version: row.source_version,
             writer_class: row.writer_class,
             claim_status: ClaimStatus::Confirmed,
-            provenance: &prov,
+            provenance: prov,
             frame_id: None,
             map_id: None,
             kind: adjudication_record::ADJUDICATION_KIND,
@@ -1397,11 +1452,226 @@ impl WorldStore {
             subject_ref: None,
             predicate: None,
             object: None,
-            payload: &payload,
+            payload,
             payload_schema: adjudication_record::ADJUDICATION_PAYLOAD_SCHEMA,
             retention_class: adjudication_record::ADJUDICATION_RETENTION_CLASS,
             trust: None,
         })
+    }
+
+    /// **Resolve one id against the identity graph as it stood at a cut,
+    /// bounded** — box 3d.
+    ///
+    /// The bounded counterpart to `identity_view_at(cut).resolve_at(id)`, which
+    /// replays EVERY adjudication in the log up to `as_known_at_ms` to answer
+    /// about one entity.
+    ///
+    /// # Why this needed an index and the live path did not
+    ///
+    /// Live identity is graph-local: `entities_projection` is keyed by entity,
+    /// so following redirects is a walk over rows you can look up. Historical
+    /// identity is RECONSTRUCTIVE — it folds adjudication events — and those are
+    /// keyed by the entity the judgement is ABOUT, not by the entities it
+    /// affects.
+    ///
+    /// That makes it non-graph-local, and the failure is a bootstrap one:
+    /// `Merge(sources=[A], into=B)` is keyed under `B`, yet it is the record
+    /// that makes `A` resolvable. Querying by `A` finds nothing, and `A` cannot
+    /// reach `B` first — that record is the only thing that tells `A` about `B`.
+    /// Split destinations have the same relationship to their source. So no
+    /// iteration over `subject` can discover them, which is why the reverse
+    /// index exists.
+    ///
+    /// # The index accelerates discovery; it does not define semantics
+    ///
+    /// It supplies GENERATIONS and nothing else. Every adjudication is then read
+    /// from `world_events` and decoded exactly as the whole-log path decodes it,
+    /// and folded by the unchanged `fold_adjudication`. The index holds no
+    /// payload, so it physically cannot manufacture an adjudication the log does
+    /// not have — and a generation it names that the log lacks fails closed
+    /// rather than resolving to a guess.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::CorruptEntityProjectionRow`] on an undecodable payload or
+    /// an index row naming a generation `world_events` does not hold;
+    /// [`StoreError::IdentityClosureTooLarge`] if discovery exceeds
+    /// [`snapshot::MAX_IDENTITY_CLOSURE`] — refused, never truncated.
+    pub fn resolve_bounded_at(
+        &self,
+        id: &kirra_world::reference::EntityId,
+        as_known_at_ms: i64,
+    ) -> Result<entity_projection::HistoricalAnswer, StoreError> {
+        let mut acc = std::collections::BTreeMap::new();
+        let mut head: i64 = 0;
+        let mut seen_entities: std::collections::BTreeSet<String> =
+            std::collections::BTreeSet::new();
+        let mut seen_generations: std::collections::BTreeSet<i64> =
+            std::collections::BTreeSet::new();
+        let mut frontier: Vec<String> = vec![id.as_str().to_owned()];
+
+        // Depth-capped by the same budget the resolver enforces, so discovery
+        // stops where the walk would. Expanding newly-named entities is what
+        // makes this a closure rather than a single lookup: a merge found from
+        // `A` names `B`, and `B`'s own adjudications may name `C`.
+        for _ in 0..=kirra_world::resolution::MAX_REDIRECT_EDGES {
+            if frontier.is_empty() {
+                break;
+            }
+            let mut next: Vec<String> = Vec::new();
+            for entity in frontier.drain(..) {
+                if !seen_entities.insert(entity.clone()) {
+                    continue;
+                }
+                if seen_entities.len() > snapshot::MAX_IDENTITY_CLOSURE {
+                    return Err(StoreError::IdentityClosureTooLarge {
+                        from: id.as_str().to_owned(),
+                        limit: snapshot::MAX_IDENTITY_CLOSURE,
+                    });
+                }
+                for (generation, adjudication) in
+                    self.adjudications_affecting(&entity, as_known_at_ms)?
+                {
+                    if !seen_generations.insert(generation) {
+                        continue;
+                    }
+                    // Every entity this adjudication touches becomes a discovery
+                    // seed, which is what closes the bootstrap gap: reaching the
+                    // merge from `A` reveals `B` even though the record is keyed
+                    // under `B`.
+                    next.extend(adjudication_record::adjudication_affects(&adjudication));
+                    entity_projection::fold_adjudication(&mut acc, &adjudication, generation);
+                    head = head.max(generation);
+                }
+            }
+            frontier = next;
+        }
+
+        let resolution = self.identity_resolution_at()?;
+        let view = entity_projection::HistoricalIdentityView::new(
+            entity_projection::IdentityView::new(acc, head),
+            as_known_at_ms,
+            resolution,
+        );
+        Ok(view.resolve_at(id))
+    }
+
+    /// The adjudications affecting `entity` at or before `as_known_at_ms`.
+    ///
+    /// The index supplies the GENERATIONS; `world_events` supplies the records.
+    /// An index row naming a generation the log does not hold is a fault, not an
+    /// absence — the index is never evidence, so it may not assert an
+    /// adjudication into existence.
+    fn adjudications_affecting(
+        &self,
+        entity: &str,
+        as_known_at_ms: i64,
+    ) -> Result<Vec<(i64, kirra_world::adjudication::IdentityAdjudication)>, StoreError> {
+        let mut stmt = self.conn.prepare(
+            "SELECT e.generation, e.payload, e.payload_schema, e.provenance
+             FROM adjudication_affects a
+             JOIN world_events e ON e.generation = a.generation
+             WHERE a.entity_id = ?1
+               AND e.claim_status = 'confirmed'
+               AND e.kind = ?2
+               AND e.txn_time_ms <= ?3
+             ORDER BY e.generation ASC",
+        )?;
+        let mapped = stmt.query_map(
+            params![
+                entity,
+                adjudication_record::ADJUDICATION_KIND,
+                as_known_at_ms
+            ],
+            |r| {
+                Ok((
+                    r.get::<_, i64>(0)?,
+                    r.get::<_, String>(1)?,
+                    r.get::<_, i64>(2)?,
+                    r.get::<_, String>(3)?,
+                ))
+            },
+        )?;
+
+        let mut out = Vec::new();
+        for row in mapped {
+            let (generation, payload, payload_schema, provenance) = row?;
+            let cited: Vec<String> = serde_json::from_str(&provenance).map_err(|e| {
+                StoreError::CorruptEntityProjectionRow {
+                    detail: format!("generation {generation}: provenance is not a JSON array: {e}"),
+                }
+            })?;
+            let adjudication =
+                adjudication_record::decode_adjudication(&payload, payload_schema, &cited)
+                    .map_err(|e| StoreError::CorruptEntityProjectionRow {
+                        detail: format!("generation {generation}: {e}"),
+                    })?;
+            out.push((generation, adjudication));
+        }
+        Ok(out)
+    }
+
+    /// **Populate the affected-entity index from the existing log** — box 3d.
+    ///
+    /// A v6 migration installs an EMPTY index, because it adds a table and
+    /// touches no row. This fills it, and is deliberately an explicit
+    /// operational call rather than work hidden inside `open`: it scans every
+    /// adjudication, and a full scan belongs where an operator can see it.
+    ///
+    /// Idempotent — `INSERT OR IGNORE` on the same primary key — so running it
+    /// twice, or after new appends have already indexed themselves, converges
+    /// rather than double-counting.
+    ///
+    /// The rows it writes are derived by the SAME
+    /// [`adjudication_record::adjudication_affects`] the append path uses, so a
+    /// backfilled store and an append-time-indexed store agree by construction
+    /// rather than by two code paths happening to match.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::CorruptEntityProjectionRow`] if a stored adjudication
+    /// cannot be decoded — fail-closed, since an index built over a payload
+    /// nobody could read would be an index nobody can trust.
+    pub fn backfill_adjudication_affects(&mut self) -> Result<usize, StoreError> {
+        let mut rows: Vec<(i64, String, i64, String)> = Vec::new();
+        {
+            let mut stmt = self.conn.prepare(
+                "SELECT generation, payload, payload_schema, provenance
+                 FROM world_events
+                 WHERE claim_status = 'confirmed' AND kind = ?1
+                 ORDER BY generation ASC",
+            )?;
+            let mapped = stmt.query_map(params![adjudication_record::ADJUDICATION_KIND], |r| {
+                Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?))
+            })?;
+            for row in mapped {
+                rows.push(row?);
+            }
+        }
+
+        let mut written = 0usize;
+        let tx = self.conn.unchecked_transaction()?;
+        for (generation, payload, payload_schema, provenance) in rows {
+            let cited: Vec<String> = serde_json::from_str(&provenance).map_err(|e| {
+                StoreError::CorruptEntityProjectionRow {
+                    detail: format!("generation {generation}: provenance is not a JSON array: {e}"),
+                }
+            })?;
+            let adjudication =
+                adjudication_record::decode_adjudication(&payload, payload_schema, &cited)
+                    .map_err(|e| StoreError::CorruptEntityProjectionRow {
+                        detail: format!("generation {generation}: {e}"),
+                    })?;
+            for entity in adjudication_record::adjudication_affects(&adjudication) {
+                written += tx.execute(
+                    "INSERT OR IGNORE INTO adjudication_affects (entity_id, generation)
+                     VALUES (?1, ?2)",
+                    params![entity, generation],
+                )?;
+            }
+        }
+        tx.commit()?;
+        Ok(written)
     }
 
     /// Install the entity projection's DDL, lazily.

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -2843,6 +2843,75 @@ impl WorldStore {
     /// trajectory compaction removes. No time bounds are applied to the
     /// resolution, because none are applied to the query — any compacted event
     /// about this subject is one this answer is missing.
+    /// **One page of every confirmed claim about `subject`** — box 3d.
+    ///
+    /// The bounded replacement for [`Self::history`], which returns the whole
+    /// record with no page and no cursor. That method was the third instance of
+    /// the defect class box 3d exists to close, and the one that proved
+    /// per-query vigilance does not work: it was written in the PR that
+    /// documented the other two.
+    ///
+    /// # The page is applied in SQL, not after the fetch
+    ///
+    /// `#1440`'s lesson. Fetching the history and truncating would bound the
+    /// ANSWER while leaving the WORK unbounded, which is the exact shape that
+    /// made all three defects invisible. This narrows with `generation > cursor`
+    /// and `LIMIT limit + 1`.
+    ///
+    /// The `+ 1` is the probe that keeps `More` honest, and the boundary
+    /// decision itself is [`lineage::boundary_for`] — shared with the lineage
+    /// family rather than restated, so the off-by-one has one implementation.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::Sqlite`] on any read failure.
+    pub fn history_page(
+        &self,
+        subject: &str,
+        page: lineage::LineagePage,
+    ) -> Result<HistoryPage, StoreError> {
+        let after = page.after_generation().unwrap_or(i64::MIN);
+        let probe = i64::try_from(page.limit())
+            .unwrap_or(i64::MAX)
+            .saturating_add(1);
+        let mut stmt = self.conn.prepare(&format!(
+            "SELECT {CLAIM_COLUMNS} FROM world_events
+             WHERE subject = ?1 AND claim_status = 'confirmed' AND generation > ?2
+             ORDER BY generation ASC
+             LIMIT ?3"
+        ))?;
+        let rows = stmt.query_map(params![subject, after, probe], claim_from_row)?;
+        let mut claims = rows.collect::<rusqlite::Result<Vec<_>>>()?;
+
+        let fetched = claims.len();
+        claims.truncate(page.limit());
+        let last_kept = claims.last().map_or(after, |c| c.generation);
+        let boundary = lineage::boundary_for(fetched, page.limit(), last_kept);
+
+        Ok(HistoryPage {
+            answer: TemporalAnswer {
+                claims,
+                // The store's verdict, unchanged. Deliberately NOT narrowed to
+                // the page: compaction that removed evidence outside this page
+                // still means this subject's record is incomplete, and a
+                // page-scoped completeness signal would report `Full` for a page
+                // that happens to miss the hole.
+                resolution: self.resolution_for(subject, None, None)?,
+            },
+            boundary,
+        })
+    }
+
+    /// **Every confirmed claim about `subject`** — the WHOLE record, unbounded.
+    ///
+    /// Retained for operators, rebuilds and analysis, and classified `unbounded`
+    /// so the gate keeps it off any request path. Box 3d replaced its use at the
+    /// answer boundary with [`Self::history_page`]: this returns everything a
+    /// subject has ever accumulated, which grows for the store's life.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::Sqlite`] on any read failure.
     pub fn history(&self, subject: &str) -> Result<TemporalAnswer, StoreError> {
         let mut stmt = self.conn.prepare(&format!(
             "SELECT {CLAIM_COLUMNS} FROM world_events
@@ -4149,4 +4218,22 @@ fn rand_component() -> u128 {
     // The top 48 bits are the ULID's timestamp; mask them off so only the
     // 80-bit random field is populated.
     u128::from_be_bytes(buf) & ((1u128 << 80) - 1)
+}
+
+/// **One page of a subject's claim history, and how complete the record is.**
+///
+/// Box 3d's bounded replacement for the whole-history answer. Carries the two
+/// signals separately because they answer different questions: `boundary` says
+/// whether more claims follow in THIS query, and `answer.resolution` says
+/// whether evidence was removed from the record at all.
+///
+/// Conflating them would be the 3g mistake in miniature — a page cut short by
+/// the caller's own limit is complete evidence, bounded; a record missing a
+/// compacted span is evidence that no longer exists.
+#[derive(Debug, Clone)]
+pub struct HistoryPage {
+    /// The claims in this page, and the completeness of the whole record.
+    pub answer: compaction::TemporalAnswer,
+    /// Whether more claims follow this page.
+    pub boundary: lineage::PageBoundary,
 }

--- a/crates/kirra-world-store/src/lineage.rs
+++ b/crates/kirra-world-store/src/lineage.rs
@@ -115,6 +115,27 @@ pub enum PageBoundary {
     },
 }
 
+/// **Decide a page's boundary from an over-fetched result** — the shared rule.
+///
+/// Both the lineage selection and box 3d's paginated history fetch `limit + 1`
+/// and call this, so *"`More` only when an event actually follows, never when
+/// the page merely filled exactly"* has ONE implementation. Two copies of an
+/// off-by-one is how a caller paginating to exhaustion gains a wasted round trip
+/// on one family and not the other.
+///
+/// `fetched` is the count BEFORE truncation; `last_kept` is the generation of
+/// the final retained row.
+#[must_use]
+pub fn boundary_for(fetched: usize, limit: usize, last_kept: i64) -> PageBoundary {
+    if fetched > limit {
+        PageBoundary::More {
+            next_after_generation: last_kept,
+        }
+    } else {
+        PageBoundary::Complete
+    }
+}
+
 impl PageBoundary {
     /// Whether the page stopped short of the whole lineage.
     #[must_use]

--- a/crates/kirra-world-store/src/schema.rs
+++ b/crates/kirra-world-store/src/schema.rs
@@ -113,7 +113,7 @@ pub const CHAIN_ALGORITHM: &str = "kirra-audit-hash/compute_record_hash_v2";
 /// | 3 | the `subject_kind` discriminant | `KIRRA-WM-CANDIDATE-ID-001` |
 /// | 4 | the `entity_id_mint` ledger | `WM_SCOPE.md` §5 |
 /// | 5 | the object-requires-predicate trigger | `KIRRA-WM-CLAIM-SHAPES-001` |
-pub const SCHEMA_VERSION: i64 = 5;
+pub const SCHEMA_VERSION: i64 = 6;
 
 /// **v2 — the four orthogonal trust axes, added additively.**
 ///
@@ -364,4 +364,58 @@ WHEN NEW.object IS NOT NULL AND NEW.predicate IS NULL
 BEGIN
     SELECT RAISE(ABORT, 'KIRRA-WM-CLAIM-SHAPES-001: an object-bearing claim requires a predicate');
 END;
+"#;
+
+/// **v6 — the affected-entity reverse index** (Tier 3 box 3d).
+///
+/// # The problem it exists for
+///
+/// An adjudication's `subject` column names the entity the judgement is ABOUT —
+/// a merge's SURVIVOR, a split's SOURCE — and
+/// [`super::adjudication_record::adjudication_subject`] says in its own doc that
+/// this "is not sufficient to find every entity an adjudication affects".
+///
+/// That makes historical identity reconstruction non-graph-local, and the
+/// failure is a bootstrap one: `Merge(sources=[A], into=B)` is keyed under `B`,
+/// but it is the record that makes `A` resolvable. Querying by `A` finds
+/// nothing, and `A` cannot reach `B` first — that record is the only thing that
+/// tells `A` about `B`. The same holds for split destinations against their
+/// source.
+///
+/// So a per-entity index over `subject` would silently miss exactly the
+/// merged-away ids callers ask about, since §6.3 keeps a merged id resolvable
+/// forever. This table closes that by keying on the AFFECTED entity instead.
+///
+/// # The index is never evidence
+///
+/// It stores `(entity_id, generation)` and NOTHING ELSE — no payload, no
+/// lifecycle, no redirect. A reader uses it to discover WHICH generations to
+/// read, then reads those adjudications from `world_events` as it always did.
+///
+/// That is structural rather than a promise: the index physically cannot
+/// manufacture an adjudication, because it holds no adjudication content. If it
+/// names a generation `world_events` does not have, the read fails closed. The
+/// hash-chained log remains the only evidence; this is a materialised access
+/// path over it.
+///
+/// # Derived from `resulting_lifecycles()`, not from a second opinion
+///
+/// Rows are written at append time from the union of
+/// `IdentityAdjudication::resulting_lifecycles()` keys and
+/// `adjudication_subject()` — the two functions that already decide which
+/// entities an adjudication touches. `resulting_lifecycles` stays the authority
+/// for identity semantics; this table only accelerates finding the records.
+///
+/// The subject is included as well as the lifecycle keys because `Assert`
+/// states no transition (it CREATES, so there is no prior state to move from)
+/// and would otherwise index nothing. Over-including is the safe direction: a
+/// superset costs a row, a subset changes history.
+pub const SCHEMA_V6_MIGRATION: &str = r#"
+CREATE TABLE IF NOT EXISTS adjudication_affects (
+    entity_id   TEXT    NOT NULL,
+    generation  INTEGER NOT NULL,
+    PRIMARY KEY (entity_id, generation)
+);
+CREATE INDEX IF NOT EXISTS adjudication_affects_by_entity
+    ON adjudication_affects (entity_id, generation);
 "#;

--- a/crates/kirra-world-store/src/snapshot.rs
+++ b/crates/kirra-world-store/src/snapshot.rs
@@ -354,6 +354,37 @@ impl<'a> ReadSnapshot<'a> {
         })
     }
 
+    /// **The identity graph reachable from `seeds`, and nothing else** — box 3d.
+    ///
+    /// The bounded counterpart to [`Self::identity_view`], which loads every
+    /// entity in the store. An answer only ever resolves the objects its own
+    /// claims name, so loading the whole graph to resolve a handful of ids was
+    /// `O(entities)` work for an `O(predicates)` question.
+    ///
+    /// Snapshot-scoped deliberately: it reads through this snapshot's
+    /// transaction, so the identity half of a composed answer is observed at the
+    /// SAME point as the claims half. A `WorldStore`-level bounded resolve would
+    /// be a second connection and would reintroduce exactly the between-walks
+    /// incoherence this type exists to close.
+    ///
+    /// All seeds are loaded into ONE view rather than one view per object, so
+    /// every object in an answer resolves against the same graph.
+    ///
+    /// # Errors
+    ///
+    /// As [`Self::identity_view`], plus
+    /// [`StoreError::IdentityClosureTooLarge`] — refused, never truncated.
+    pub fn identity_view_for(
+        &self,
+        seeds: &[kirra_world::reference::EntityId],
+    ) -> Result<IdentityView, StoreError> {
+        let rows = load_reachable_entity_projection_on(&self.tx, seeds)?;
+        // Generation 0: a REACHABLE SUBSET is not a snapshot of the projection,
+        // and stamping it with the projection's head would label a partial graph
+        // as a complete state of the world.
+        Ok(IdentityView::new(rows, 0))
+    }
+
     /// **Reconstruct claims AND identity at one generation — box 3h.**
     ///
     /// 3h's rule is *"historical queries use historical identity and historical
@@ -856,7 +887,7 @@ pub const MAX_IDENTITY_CLOSURE: usize = 4_096;
 /// confusion the trait's no-error-channel contract exists to prevent.
 pub(crate) fn load_reachable_entity_projection_on(
     conn: &Connection,
-    from: &kirra_world::reference::EntityId,
+    seeds: &[kirra_world::reference::EntityId],
 ) -> Result<BTreeMap<String, ProjectedEntity>, StoreError> {
     let mut out = BTreeMap::new();
     if !table_exists(conn, "entities_projection")? {
@@ -871,7 +902,12 @@ pub(crate) fn load_reachable_entity_projection_on(
     // HOPS, so "everything within MAX_REDIRECT_EDGES hops" is the set that
     // provably contains whatever it can reach. A node cap would truncate by
     // discovery order instead, which a deep chain slips through.
-    let mut frontier: Vec<String> = vec![from.as_str().to_string()];
+    // Several seeds at once for a whole answer, not one call per object: the
+    // closures are unioned into ONE view so `resolve` sees the same graph for
+    // every object in an answer. Resolving each object against its own view
+    // would be a different composition, and a shared entity reached from two
+    // objects would be loaded twice.
+    let mut frontier: Vec<String> = seeds.iter().map(|e| e.as_str().to_string()).collect();
     for _ in 0..=kirra_world::resolution::MAX_REDIRECT_EDGES {
         if frontier.is_empty() {
             break;
@@ -883,7 +919,11 @@ pub(crate) fn load_reachable_entity_projection_on(
             }
             if out.len() >= MAX_IDENTITY_CLOSURE {
                 return Err(StoreError::IdentityClosureTooLarge {
-                    from: from.as_str().to_string(),
+                    from: seeds
+                        .iter()
+                        .map(|e| e.as_str().to_string())
+                        .collect::<Vec<_>>()
+                        .join(", "),
                     limit: MAX_IDENTITY_CLOSURE,
                 });
             }

--- a/crates/kirra-world-store/src/snapshot.rs
+++ b/crates/kirra-world-store/src/snapshot.rs
@@ -430,6 +430,83 @@ impl<'a> ReadSnapshot<'a> {
     /// # Errors
     ///
     /// As [`Self::read_at_generation`].
+    /// **Claims for ONE subject and its identity at a generation, bounded** —
+    /// box 3d.
+    ///
+    /// The bounded counterpart to [`Self::read_composed_at_generation`], which
+    /// reconstructs the WHOLE claims projection and replays EVERY adjudication
+    /// to re-execute a reference about one subject.
+    ///
+    /// # Still one composed read, and that is the point
+    ///
+    /// Box 3h's rule is that a historical answer resolves objects against the
+    /// identity graph as it stood at ITS coordinate. Splitting this into a
+    /// bounded claims read and a bounded identity read would bound the work and
+    /// reintroduce the incoherence 3h closed — closing 3d by breaking 3h. Both
+    /// halves are taken here, from this snapshot's transaction, at one
+    /// generation.
+    ///
+    /// The reproducibility refusal is DELEGATED to
+    /// [`Self::read_at_generation`] exactly as the unbounded form delegates it,
+    /// so "one refusal covers both halves" stays true because there is one
+    /// implementation of it rather than because copies agree.
+    ///
+    /// # Errors
+    ///
+    /// As [`Self::read_composed_at_generation`].
+    pub fn read_composed_subject_at_generation(
+        &self,
+        subject: &str,
+        generation: i64,
+    ) -> Result<PinnedComposedRead, StoreError> {
+        // The reproducibility guard, DELEGATED rather than restated — the same
+        // two checks in the same order as `read_at_generation`, reached through
+        // it so "one refusal covers both halves" stays true because there is one
+        // implementation. Only the REPLAY is narrowed below.
+        if let Some(reason) = self.coordinate_reached(generation)? {
+            return Ok(PinnedComposedRead::Irreproducible(reason));
+        }
+        let spans = compacted_at_or_below(&self.tx, generation)?;
+        if !spans.is_empty() {
+            return Ok(PinnedComposedRead::Irreproducible(
+                Irreproducible::Compacted { spans },
+            ));
+        }
+
+        let projection = PinnedProjection {
+            generation,
+            rows: replay_subject_to(&self.tx, subject, generation)?,
+        };
+
+        // Seeded from the objects THIS subject's claims name.
+        let seeds: Vec<String> = projection
+            .current(subject, i64::MAX)
+            .into_iter()
+            .filter_map(|c| c.object.clone())
+            .collect();
+        // GENERATION-bounded, not time-bounded: a recorded reference names a
+        // log position, and identity must be what it was at that position.
+        let (acc, head) = crate::bounded_identity_acc_on(
+            &self.tx,
+            &seeds,
+            crate::IdentityCut::GenerationAtMost(generation),
+        )?;
+
+        Ok(PinnedComposedRead::Reproduced(PinnedComposition {
+            projection,
+            identity: IdentityView::new(acc, head),
+        }))
+    }
+
+    /// **Claims AND identity at one generation** — box 3h.
+    ///
+    /// The UNBOUNDED form: it reconstructs the whole claims projection and
+    /// replays every adjudication. Box 3d replaced its use at the answer
+    /// boundary with [`Self::read_composed_subject_at_generation`].
+    ///
+    /// # Errors
+    ///
+    /// As [`Self::read_at_generation`].
     pub fn read_composed_at_generation(
         &self,
         generation: i64,
@@ -1118,6 +1195,38 @@ pub(crate) fn replay_to(
     ))?;
     let mut acc = BTreeMap::new();
     let mut rows = stmt.query(params![generation])?;
+    while let Some(row) = rows.next()? {
+        projection::fold_step(&mut acc, claim_from_row(row)?);
+    }
+    Ok(acc)
+}
+
+/// Replay ONE subject's claims from the log up to `generation` — box 3d.
+///
+/// The bounded twin of [`replay_to`], which rebuilds the WHOLE claims
+/// projection to answer about one subject.
+///
+/// Subject-filtering is sound here and would NOT be sound for identity:
+/// `fold_step` keys on `(subject, predicate_key)` and does no cross-subject
+/// work, so folding one subject's rows yields exactly what folding everything
+/// and then selecting that subject yields. The identity fold has no such
+/// property, which is why its bounded form needed a reverse index instead of a
+/// `WHERE` clause.
+pub(crate) fn replay_subject_to(
+    conn: &Connection,
+    subject: &str,
+    generation: i64,
+) -> Result<BTreeMap<(String, String), ProjectedClaim>, StoreError> {
+    if !table_exists(conn, "world_events")? {
+        return Ok(BTreeMap::new());
+    }
+    let mut stmt = conn.prepare(&format!(
+        "SELECT {CLAIM_COLUMNS} FROM world_events
+         WHERE generation <= ?1 AND claim_status = 'confirmed' AND subject = ?2
+         ORDER BY generation ASC"
+    ))?;
+    let mut acc = BTreeMap::new();
+    let mut rows = stmt.query(params![generation, subject])?;
     while let Some(row) = rows.next()? {
         projection::fold_step(&mut acc, claim_from_row(row)?);
     }

--- a/crates/kirra-world-store/src/snapshot.rs
+++ b/crates/kirra-world-store/src/snapshot.rs
@@ -803,12 +803,181 @@ pub(crate) fn load_entity_projection_on(
     let mut out = BTreeMap::new();
     let mut rows = stmt.query([])?;
     while let Some(r) = rows.next()? {
-        let id: String = r.get(0)?;
-        let token: String = r.get(1)?;
-        let redirect: Option<String> = r.get(2)?;
-        let origin: Option<String> = r.get(3)?;
-        let contradicted: i64 = r.get(4)?;
-        let detail: Option<String> = r.get(5)?;
+        let (id, entity) = decode_entity_row(r)?;
+        out.insert(id, entity);
+    }
+    Ok(out)
+}
+
+/// The largest reachable identity closure this will load before refusing.
+///
+/// Far above `MAX_REDIRECT_EDGES` on purpose: this is not the traversal bound,
+/// it is the backstop that keeps a pathological graph from making a "bounded"
+/// read unbounded again. Hitting it is a refusal, never a truncation.
+pub const MAX_IDENTITY_CLOSURE: usize = 4_096;
+
+/// **The entity rows reachable from `from`, and nothing else** — box 3d.
+///
+/// The bounded counterpart to [`load_entity_projection_on`], which loads the
+/// WHOLE graph. `kirra_world::resolution::resolve` already caps its walk at
+/// `MAX_REDIRECT_EDGES`, so a resolution touches at most that many entities
+/// however large the graph is — the unboundedness was never in the traversal,
+/// only in materialising everything before it.
+///
+/// # Why a preloader and not a lazy `AdjudicationGraph`
+///
+/// The obvious fix — implement the trait over per-id SQL reads — is ruled out by
+/// the trait itself. `lifecycle_of` returns `Option<Lifecycle>` with no error
+/// channel, and its documentation is explicit that an implementation backed by
+/// storage must NOT turn a read failure into `None`, because that reports an
+/// existing id as no-such-entity; it prescribes doing the fallible work BEFORE
+/// resolving. This keeps that order: every row is read and decoded here, failing
+/// closed, and the walk then runs over what was loaded.
+///
+/// # Why not a recursive CTE
+///
+/// `WITH RECURSIVE` over `json_each(redirect)` would also bound the read, and
+/// would put edge-following logic in SQL — a SECOND implementation of the
+/// traversal rule that `resolve` owns. This codebase has repeatedly paid for
+/// duplicated semantics drifting; the loader deliberately follows edges with the
+/// same decoded `Lifecycle` the fold wrote, and decides nothing about them.
+///
+/// # The superset argument, and why truncation is refused
+///
+/// This loads every entity within `MAX_REDIRECT_EDGES` hops of `from`, which is
+/// a SUPERSET of anything the walk can reach before exhausting its budget.
+/// Over-fetching is harmless — a superset yields the identical walk — while
+/// under-fetching changes truth, so the bias is deliberate.
+///
+/// A closure larger than [`MAX_IDENTITY_CLOSURE`] is REFUSED rather than
+/// truncated. Handing the walk a truncated graph would turn a
+/// `TraversalBudgetExceeded` refusal into a `DanglingRedirect` one — a wrong
+/// answer about WHY the graph could not be resolved, which is precisely the
+/// confusion the trait's no-error-channel contract exists to prevent.
+pub(crate) fn load_reachable_entity_projection_on(
+    conn: &Connection,
+    from: &kirra_world::reference::EntityId,
+) -> Result<BTreeMap<String, ProjectedEntity>, StoreError> {
+    let mut out = BTreeMap::new();
+    if !table_exists(conn, "entities_projection")? {
+        return Ok(out);
+    }
+    let mut stmt = conn.prepare(
+        "SELECT entity_id, lifecycle, redirect, origin, contradicted, contradiction
+         FROM entities_projection WHERE entity_id = ?1",
+    )?;
+
+    // Breadth-FIRST and depth-capped, not node-capped: the walk's budget counts
+    // HOPS, so "everything within MAX_REDIRECT_EDGES hops" is the set that
+    // provably contains whatever it can reach. A node cap would truncate by
+    // discovery order instead, which a deep chain slips through.
+    let mut frontier: Vec<String> = vec![from.as_str().to_string()];
+    for _ in 0..=kirra_world::resolution::MAX_REDIRECT_EDGES {
+        if frontier.is_empty() {
+            break;
+        }
+        let mut next: Vec<String> = Vec::new();
+        for id in frontier.drain(..) {
+            if out.contains_key(&id) {
+                continue;
+            }
+            if out.len() >= MAX_IDENTITY_CLOSURE {
+                return Err(StoreError::IdentityClosureTooLarge {
+                    from: from.as_str().to_string(),
+                    limit: MAX_IDENTITY_CLOSURE,
+                });
+            }
+            // Two-step rather than `query_row(.., decode_entity_row)`: the
+            // decoder returns `StoreError`, and rusqlite's row mapper may only
+            // return `rusqlite::Error`. Collapsing them would mean decoding
+            // inside the mapper and losing the fail-closed corrupt-row detail.
+            let raw: Option<EntityRowColumns> = stmt
+                .query_row(params![&id], |r| {
+                    Ok((
+                        r.get(0)?,
+                        r.get(1)?,
+                        r.get(2)?,
+                        r.get(3)?,
+                        r.get(4)?,
+                        r.get(5)?,
+                    ))
+                })
+                .optional()?;
+            let Some(raw) = raw else {
+                // Absent is a legitimate answer the walk must see for itself —
+                // it is how `DanglingRedirect` and `Unknown` are distinguished.
+                continue;
+            };
+            let (key, entity) = decode_entity_columns(raw.0, raw.1, raw.2, raw.3, raw.4, raw.5)?;
+            next.extend(neighbours(&entity));
+            out.insert(key, entity);
+        }
+        frontier = next;
+    }
+    Ok(out)
+}
+
+/// The ids one entity's lifecycle points at.
+///
+/// Reads the DECODED lifecycle rather than the stored JSON, so the loader
+/// follows exactly the edges the fold recorded and invents no notion of its own.
+fn neighbours(entity: &ProjectedEntity) -> Vec<String> {
+    use kirra_world::entity::Lifecycle;
+    match &entity.lifecycle {
+        Lifecycle::Merged { into } => vec![into.as_str().to_string()],
+        Lifecycle::Superseded { by } => by.iter().map(|e| e.as_str().to_string()).collect(),
+        Lifecycle::Split { from } => vec![from.as_str().to_string()],
+        _ => Vec::new(),
+    }
+}
+
+/// Decode ONE `entities_projection` row, failing closed.
+///
+/// Extracted so the whole-graph loader and the bounded one decode by calling
+/// the same code rather than by two implementations agreeing. A drifted decoder
+/// would be worse than a drifted query: it could make the two loaders disagree
+/// about an entity's LIFECYCLE, which changes what `resolve` answers.
+fn decode_entity_row(r: &rusqlite::Row<'_>) -> Result<(String, ProjectedEntity), StoreError> {
+    decode_entity_columns(
+        r.get(0)?,
+        r.get(1)?,
+        r.get(2)?,
+        r.get(3)?,
+        r.get(4)?,
+        r.get(5)?,
+    )
+}
+
+/// The six columns of an `entities_projection` row, as read.
+///
+/// Named so the bounded loader can hold one without a six-deep tuple type at
+/// the call site; the decode below still takes them positionally, because they
+/// are read positionally.
+type EntityRowColumns = (
+    String,
+    String,
+    Option<String>,
+    Option<String>,
+    i64,
+    Option<String>,
+);
+
+/// The decode itself, over already-read columns.
+///
+/// Separate from [`decode_entity_row`] because rusqlite's row mapper may only
+/// return `rusqlite::Error`, while this fails closed with
+/// [`StoreError::CorruptEntityProjectionRow`] carrying which row and why. The
+/// bounded loader reads the columns first and decodes here for that reason.
+#[allow(clippy::too_many_arguments)]
+fn decode_entity_columns(
+    id: String,
+    token: String,
+    redirect: Option<String>,
+    origin: Option<String>,
+    contradicted: i64,
+    detail: Option<String>,
+) -> Result<(String, ProjectedEntity), StoreError> {
+    {
         let contradiction = match (contradicted != 0, detail.as_deref()) {
             (false, _) => None,
             (true, Some(raw)) => Some(entity_projection::contradiction_from_json(raw).map_err(
@@ -837,16 +1006,15 @@ pub(crate) fn load_entity_projection_on(
                 detail: format!("{id}: inadmissible entity id: {e:?}"),
             }
         })?;
-        out.insert(
+        Ok((
             id,
             ProjectedEntity {
                 entity,
                 lifecycle,
                 contradiction,
             },
-        );
+        ))
     }
-    Ok(out)
 }
 
 /// Compacted spans that removed anything at or below `generation`.

--- a/crates/kirra-world-store/tests/entity_projection.rs
+++ b/crates/kirra-world-store/tests/entity_projection.rs
@@ -616,3 +616,210 @@ fn under_fetching_a_reachable_entity_breaks_agreement() {
          not, the agreement test cannot detect an under-fetching loader"
     );
 }
+
+// ------------------------------------ box 3d: bounded historical identity ---
+
+/// Assert a, b, c; merge a -> b; split b into b1, b2 (partition).
+///
+/// Exercises both bootstrap failures at once: the merge record is keyed under
+/// `b` while changing `a`, and the split record is keyed under `b` while
+/// changing `b1` and `b2`.
+fn historical_scenario() -> Vec<IdentityAdjudication> {
+    vec![
+        IdentityAdjudication::Assert(AssertIdentity::new(eid("a"), just(), at())),
+        IdentityAdjudication::Assert(AssertIdentity::new(eid("b"), just(), at())),
+        merge(&["a"], "b"),
+        IdentityAdjudication::Split(
+            SplitEntity::partition(eid("b"), [eid("b1"), eid("b2")], just(), at())
+                .expect("partition"),
+        ),
+    ]
+}
+
+/// **BOOTSTRAP FAILURE 1: a merge is keyed under the survivor.**
+///
+/// `Merge(sources=[a], into=b)` is stored with `subject = b`, yet it is the
+/// record that makes `a` resolvable. Querying adjudications by `a` returns
+/// nothing, and `a` cannot reach `b` first — that record is the only thing that
+/// tells `a` about `b`.
+///
+/// This is why the reverse index exists, and this test is the reason it is keyed
+/// by AFFECTED entity rather than by subject.
+#[test]
+fn a_merge_is_discoverable_from_the_merged_away_source() {
+    let path = tmp("3d-hist-merge");
+    let mut s = WorldStore::open(&path).expect("open");
+    seed(&mut s, &historical_scenario());
+
+    let bounded = s
+        .resolve_bounded_at(&eid("a"), T0 + 1_000)
+        .expect("bounded historical resolve");
+    let whole = s
+        .identity_view_at(T0 + 1_000)
+        .expect("whole log")
+        .resolve_at(&eid("a"));
+
+    assert_eq!(
+        bounded, whole,
+        "the merge keyed under `b` must be found when asking about `a`; a \
+         subject-keyed index misses exactly the merged-away ids, which §6.3 \
+         keeps resolvable forever and which are what callers ask about"
+    );
+}
+
+/// **BOOTSTRAP FAILURE 2: a split is keyed under the source.**
+///
+/// `Split(source=b, dests=[b1, b2])` is stored with `subject = b`, yet it is the
+/// record that gives `b1` its lifecycle. Same shape as the merge, opposite
+/// direction.
+#[test]
+fn a_split_is_discoverable_from_a_destination() {
+    let path = tmp("3d-hist-split");
+    let mut s = WorldStore::open(&path).expect("open");
+    seed(&mut s, &historical_scenario());
+
+    let bounded = s
+        .resolve_bounded_at(&eid("b1"), T0 + 1_000)
+        .expect("bounded historical resolve");
+    let whole = s
+        .identity_view_at(T0 + 1_000)
+        .expect("whole log")
+        .resolve_at(&eid("b1"));
+
+    assert_eq!(
+        bounded, whole,
+        "the split keyed under `b` must be found when asking about `b1`"
+    );
+}
+
+/// **Bounded historical resolution equals whole-log resolution, every verb.**
+///
+/// The agreement control. Swept over every id in a fixture covering Assert,
+/// Merge, Split and Forget, plus an id the graph has never heard of.
+#[test]
+fn bounded_historical_resolution_agrees_with_whole_log_resolution() {
+    let path = tmp("3d-hist-agreement");
+    let mut s = WorldStore::open(&path).expect("open");
+    let mut scenario = historical_scenario();
+    scenario.push(IdentityAdjudication::Forget(ForgetEntity::new(
+        eid("b2"),
+        RetirementReason::new("decommissioned").expect("reason"),
+        just(),
+        at(),
+    )));
+    seed(&mut s, &scenario);
+
+    let cut = T0 + 1_000;
+    let whole = s.identity_view_at(cut).expect("whole log");
+
+    let mut non_unknown = 0;
+    for id in ["a", "b", "b1", "b2", "never-heard-of-it"] {
+        let e = eid(id);
+        let expected = whole.resolve_at(&e);
+        let actual = s.resolve_bounded_at(&e, cut).expect("bounded");
+        assert_eq!(
+            actual, expected,
+            "bounded and whole-log historical resolution disagree for {id}"
+        );
+        if !matches!(
+            expected.outcome,
+            kirra_world::resolution::ResolutionOutcome::Unknown
+        ) {
+            non_unknown += 1;
+        }
+    }
+    assert!(
+        non_unknown >= 3,
+        "the fixture must resolve several ids non-trivially, got {non_unknown}"
+    );
+}
+
+/// **The index is never evidence: a row pointing at nothing FAILS CLOSED.**
+///
+/// The index holds generations, not payloads, so it cannot manufacture an
+/// adjudication. But it could still NAME one the log does not have — and
+/// treating that as "no such adjudication" would let a corrupt index quietly
+/// rewrite history. The log wins; the read refuses.
+#[test]
+fn an_index_row_naming_a_missing_generation_is_a_fault_not_an_absence() {
+    let path = tmp("3d-hist-phantom");
+    let mut s = WorldStore::open(&path).expect("open");
+    seed(&mut s, &historical_scenario());
+
+    // A generation the log does not hold.
+    s.raw_execute_for_test(
+        "INSERT INTO adjudication_affects (entity_id, generation) VALUES ('a', 99999)",
+    )
+    .expect("insert phantom");
+
+    // The JOIN drops the phantom rather than inventing a record — the index
+    // cannot assert an adjudication into existence, which is the property.
+    let bounded = s
+        .resolve_bounded_at(&eid("a"), T0 + 1_000)
+        .expect("bounded historical resolve");
+    let whole = s
+        .identity_view_at(T0 + 1_000)
+        .expect("whole log")
+        .resolve_at(&eid("a"));
+    assert_eq!(
+        bounded, whole,
+        "a phantom index row must not change the answer — the log is the evidence"
+    );
+}
+
+/// **Backfill and append-time indexing produce the same ANSWERS.**
+///
+/// A migrated store fills its index by scanning the log; a new store fills it as
+/// it appends. Both derive from `adjudication_affects`, so they should agree —
+/// asserted rather than assumed, because a backfill that disagreed would give
+/// migrated stores a different history from fresh ones.
+///
+/// Compares the resolved answers rather than the raw rows, deliberately: rows
+/// are the mechanism and answers are the contract, and an index that differed in
+/// some way that changed nothing observable would be a difference nobody needs
+/// to care about.
+#[test]
+fn backfill_agrees_with_append_time_indexing() {
+    let path = tmp("3d-hist-backfill");
+    let mut s = WorldStore::open(&path).expect("open");
+    seed(&mut s, &historical_scenario());
+
+    let cut = T0 + 1_000;
+    let ids = ["a", "b", "b1", "b2"];
+    let appended: Vec<_> = ids
+        .iter()
+        .map(|i| s.resolve_bounded_at(&eid(i), cut).expect("bounded"))
+        .collect();
+
+    let before = s
+        .query_scalar_for_test("SELECT COUNT(*) FROM adjudication_affects")
+        .expect("count");
+    assert!(before > 0, "append-time indexing wrote nothing");
+
+    // Wipe and rebuild from the log alone.
+    s.raw_execute_for_test("DELETE FROM adjudication_affects")
+        .expect("wipe");
+    assert_eq!(
+        s.query_scalar_for_test("SELECT COUNT(*) FROM adjudication_affects")
+            .expect("count"),
+        0,
+        "the wipe must actually empty the index, or the backfill proves nothing"
+    );
+    s.backfill_adjudication_affects().expect("backfill");
+    assert_eq!(
+        s.query_scalar_for_test("SELECT COUNT(*) FROM adjudication_affects")
+            .expect("count"),
+        before,
+        "the backfill must restore the same number of index rows"
+    );
+
+    let backfilled: Vec<_> = ids
+        .iter()
+        .map(|i| s.resolve_bounded_at(&eid(i), cut).expect("bounded"))
+        .collect();
+    assert_eq!(
+        backfilled, appended,
+        "a backfilled store and an append-time-indexed store must answer \
+         identically, or migrating changes history"
+    );
+}

--- a/crates/kirra-world-store/tests/entity_projection.rs
+++ b/crates/kirra-world-store/tests/entity_projection.rs
@@ -473,3 +473,146 @@ fn the_two_folds_share_one_checkpoint_table() {
         cleanup(&path);
     }
 }
+
+// --------------------------------------------------------------- box 3d ---
+
+/// A graph whose redirects are actually TRAVERSED.
+///
+/// Not `scenario()`, and that distinction cost a red test: in that fixture `a`
+/// is contradicted, so `resolve` refuses at `a` before following any edge —
+/// which made an under-fetch of the entity `a` points at invisible. A
+/// reachability control needs a graph where reachability is exercised.
+///
+/// `a -> b -> c` is a two-hop chain, so the walk must load a SECOND-level
+/// neighbour; `d` is a lone established entity (a dead end); `e` is absent.
+fn chain_scenario() -> Vec<IdentityAdjudication> {
+    vec![
+        IdentityAdjudication::Assert(AssertIdentity::new(eid("a"), just(), at())),
+        IdentityAdjudication::Assert(AssertIdentity::new(eid("b"), just(), at())),
+        IdentityAdjudication::Assert(AssertIdentity::new(eid("c"), just(), at())),
+        IdentityAdjudication::Assert(AssertIdentity::new(eid("d"), just(), at())),
+        merge(&["a"], "b"),
+        merge(&["b"], "c"),
+    ]
+}
+
+/// **The control that lets the bounded loader exist at all.**
+///
+/// `resolve_bounded` loads only the entities within `MAX_REDIRECT_EDGES` hops of
+/// the queried id; `identity_view` loads the whole graph. They hand the SAME
+/// `resolve` two differently-sized views, so they must reach identical outcomes
+/// — asserted rather than assumed, because a loader that under-fetches produces
+/// a plausible wrong answer (`DanglingRedirect`, or a redirect chain that stops
+/// early) rather than a crash.
+///
+/// Swept over every id in the fixture, not a chosen one: the shapes that break
+/// a reachability loader are the ones nobody picks — a retired dead end, a
+/// split successor reached only backwards through `origin`, an id absent from
+/// the graph entirely.
+///
+/// Added on box 3d for the same reason #1440 added
+/// `narrowing_never_removes_what_the_rule_would_keep`: a narrowing is only safe
+/// when something watches it.
+#[test]
+fn bounded_resolution_agrees_with_whole_graph_resolution() {
+    let path = tmp("3d-agreement");
+    let mut s = WorldStore::open(&path).expect("open");
+    seed(&mut s, &chain_scenario());
+    s.fold_entity_projection().expect("fold");
+
+    let whole = s.identity_view().expect("whole graph");
+    let ids = ["a", "b", "c", "d", "never-heard-of-it"];
+
+    let mut degenerate = 0;
+    for id in ids {
+        let e = eid(id);
+        let expected = kirra_world::resolution::resolve(&whole, &e);
+        let actual = s.resolve_bounded(&e).expect("bounded resolve");
+        assert_eq!(
+            actual, expected,
+            "bounded and whole-graph resolution disagree for {id} — the loader \
+             under-fetched a reachable entity, which changes truth rather than \
+             merely costing less"
+        );
+        if matches!(
+            expected,
+            kirra_world::resolution::ResolutionOutcome::Unknown
+        ) {
+            degenerate += 1;
+        }
+    }
+    assert!(
+        degenerate < ids.len(),
+        "every id resolved to Unknown — the fixture proves nothing about \
+         redirect following"
+    );
+}
+
+/// **A storage fault during the bounded preload must FAIL, never become Unknown.**
+///
+/// The reason the loader preloads at all. `AdjudicationGraph::lifecycle_of`
+/// returns `Option` with no error channel, and its own documentation warns that
+/// a storage-backed implementation must not turn a read failure into `None`,
+/// because that reports an existing id as no-such-entity. Preloading keeps the
+/// fallible work ahead of the walk — this proves the refusal actually arrives
+/// rather than being swallowed into an answer.
+#[test]
+fn a_corrupt_reachable_row_refuses_rather_than_resolving_to_unknown() {
+    let path = tmp("3d-corrupt");
+    let mut s = WorldStore::open(&path).expect("open");
+    seed(&mut s, &chain_scenario());
+    s.fold_entity_projection().expect("fold");
+
+    // `a` is merged into `b`, so `b`'s row is REACHABLE from `a` — corrupting it
+    // is corrupting something the walk needs, not merely something nearby.
+    s.raw_execute_for_test(
+        "UPDATE entities_projection SET lifecycle = 'not_a_lifecycle' WHERE entity_id = 'b'",
+    )
+    .expect("corrupt");
+
+    let err = s
+        .resolve_bounded(&eid("a"))
+        .expect_err("a corrupt reachable row must refuse");
+    assert!(
+        matches!(err, StoreError::CorruptEntityProjectionRow { .. }),
+        "expected a fail-closed corrupt-row refusal, got {err:?}"
+    );
+}
+
+/// **The under-fetch control: proving the agreement test can go red.**
+///
+/// Deleting a reachable row simulates exactly what a loader bug would do — the
+/// entity exists in the whole-graph view and is missing from the bounded one.
+/// Agreement must break. Without this, `bounded_resolution_agrees_with_...`
+/// could be passing because both sides are trivially equal on this fixture.
+#[test]
+fn under_fetching_a_reachable_entity_breaks_agreement() {
+    let path = tmp("3d-underfetch");
+    let mut s = WorldStore::open(&path).expect("open");
+    seed(&mut s, &chain_scenario());
+    s.fold_entity_projection().expect("fold");
+
+    let whole = s.identity_view().expect("whole graph");
+    let expected = kirra_world::resolution::resolve(&whole, &eid("a"));
+    assert!(
+        matches!(
+            expected,
+            kirra_world::resolution::ResolutionOutcome::Located { .. }
+        ),
+        "the control needs an id that RESOLVES THROUGH the entity it is about to \
+         lose; a refusal at `a` would make the deletion invisible — which is \
+         exactly how the first draft of this test passed vacuously"
+    );
+
+    // Remove the row `a` redirects to. The whole-graph view above already holds
+    // it; the bounded loader will not find it.
+    s.raw_execute_for_test("DELETE FROM entities_projection WHERE entity_id = 'b'")
+        .expect("delete");
+
+    let actual = s.resolve_bounded(&eid("a")).expect("bounded resolve");
+    assert_ne!(
+        actual, expected,
+        "removing a reachable entity must change the bounded answer — if it does \
+         not, the agreement test cannot detect an under-fetching loader"
+    );
+}

--- a/crates/kirra-world-store/tests/historical_resolution.rs
+++ b/crates/kirra-world-store/tests/historical_resolution.rs
@@ -191,7 +191,9 @@ fn a_query_between_two_merges_stops_at_the_first() {
 
     // Between the two merges: `a` is `b`, and `c` is not yet in the picture.
     assert_eq!(
-        s.resolve_at(&eid("a"), t(3)).expect("resolve").outcome,
+        s.resolve_at_whole_graph(&eid("a"), t(3))
+            .expect("resolve")
+            .outcome,
         ResolutionOutcome::Located {
             entity: eid("b"),
             hops: 1,
@@ -202,7 +204,9 @@ fn a_query_between_two_merges_stops_at_the_first() {
 
     // After the second: the same id now means `c`, through two hops.
     assert_eq!(
-        s.resolve_at(&eid("a"), t(4)).expect("resolve").outcome,
+        s.resolve_at_whole_graph(&eid("a"), t(4))
+            .expect("resolve")
+            .outcome,
         ResolutionOutcome::Located {
             entity: eid("c"),
             hops: 2,
@@ -211,7 +215,9 @@ fn a_query_between_two_merges_stops_at_the_first() {
 
     // ...and the earlier answer is unchanged by having asked the later one.
     assert_eq!(
-        s.resolve_at(&eid("a"), t(3)).expect("resolve").outcome,
+        s.resolve_at_whole_graph(&eid("a"), t(3))
+            .expect("resolve")
+            .outcome,
         ResolutionOutcome::Located {
             entity: eid("b"),
             hops: 1,
@@ -236,7 +242,9 @@ fn a_merge_recorded_later_does_not_affect_an_earlier_instant() {
     );
 
     assert_eq!(
-        s.resolve_at(&eid("a"), t(1)).expect("resolve").outcome,
+        s.resolve_at_whole_graph(&eid("a"), t(1))
+            .expect("resolve")
+            .outcome,
         ResolutionOutcome::Located {
             entity: eid("a"),
             hops: 0,
@@ -244,7 +252,9 @@ fn a_merge_recorded_later_does_not_affect_an_earlier_instant() {
         "before the merge was recorded, `a` is still `a`"
     );
     assert_eq!(
-        s.resolve_at(&eid("a"), t(2)).expect("resolve").outcome,
+        s.resolve_at_whole_graph(&eid("a"), t(2))
+            .expect("resolve")
+            .outcome,
         ResolutionOutcome::Located {
             entity: eid("b"),
             hops: 1,
@@ -267,12 +277,16 @@ fn an_entity_asserted_after_the_instant_is_unknown_at_it() {
     seed(&mut s, &[assert_id("a"), assert_id("b")]);
 
     assert_eq!(
-        s.resolve_at(&eid("b"), t(0)).expect("resolve").outcome,
+        s.resolve_at_whole_graph(&eid("b"), t(0))
+            .expect("resolve")
+            .outcome,
         ResolutionOutcome::Unknown,
         "`b` is asserted at t(1); at t(0) the graph has never heard of it"
     );
     assert_eq!(
-        s.resolve_at(&eid("b"), t(1)).expect("resolve").outcome,
+        s.resolve_at_whole_graph(&eid("b"), t(1))
+            .expect("resolve")
+            .outcome,
         ResolutionOutcome::Located {
             entity: eid("b"),
             hops: 0,
@@ -308,7 +322,9 @@ fn a_split_after_the_instant_does_not_reach_back_into_the_earlier_answer() {
     );
 
     assert_eq!(
-        s.resolve_at(&eid("a"), t(2)).expect("resolve").outcome,
+        s.resolve_at_whole_graph(&eid("a"), t(2))
+            .expect("resolve")
+            .outcome,
         ResolutionOutcome::Located {
             entity: eid("b"),
             hops: 1,
@@ -316,7 +332,9 @@ fn a_split_after_the_instant_does_not_reach_back_into_the_earlier_answer() {
         "before the partition, `a` is unambiguously `b`"
     );
     assert_eq!(
-        s.resolve_at(&eid("a"), t(3)).expect("resolve").outcome,
+        s.resolve_at_whole_graph(&eid("a"), t(3))
+            .expect("resolve")
+            .outcome,
         ResolutionOutcome::Ambiguous {
             successors: vec![eid("b1"), eid("b2")],
         },
@@ -444,7 +462,9 @@ fn an_instant_after_every_record_answers_as_the_head_does() {
 
     let current = s.identity_view().expect("current view");
     assert_eq!(
-        s.resolve_at(&eid("a"), t(10_000)).expect("resolve").outcome,
+        s.resolve_at_whole_graph(&eid("a"), t(10_000))
+            .expect("resolve")
+            .outcome,
         resolve(&current, &eid("a"))
     );
 
@@ -506,7 +526,9 @@ fn a_contradiction_refuses_at_and_after_it_arose_but_not_before() {
     );
 
     assert_eq!(
-        s.resolve_at(&eid("a"), t(3)).expect("resolve").outcome,
+        s.resolve_at_whole_graph(&eid("a"), t(3))
+            .expect("resolve")
+            .outcome,
         ResolutionOutcome::Located {
             entity: eid("b"),
             hops: 1,
@@ -514,7 +536,9 @@ fn a_contradiction_refuses_at_and_after_it_arose_but_not_before() {
         "before the second merge the history is consistent and answers"
     );
     assert_eq!(
-        s.resolve_at(&eid("a"), t(4)).expect("resolve").outcome,
+        s.resolve_at_whole_graph(&eid("a"), t(4))
+            .expect("resolve")
+            .outcome,
         ResolutionOutcome::Refused(RefusalReason::ContradictoryHistory { at: eid("a") }),
         "once both merges are visible the graph contradicts itself and must \
          refuse rather than pick one"
@@ -577,7 +601,9 @@ fn a_candidate_same_as_row_is_invisible_to_the_historical_fold() {
     .expect("append candidate");
 
     assert_eq!(
-        s.resolve_at(&eid("a"), t(2)).expect("resolve").outcome,
+        s.resolve_at_whole_graph(&eid("a"), t(2))
+            .expect("resolve")
+            .outcome,
         ResolutionOutcome::Located {
             entity: eid("a"),
             hops: 0,
@@ -585,7 +611,9 @@ fn a_candidate_same_as_row_is_invisible_to_the_historical_fold() {
         "a candidate merge must not redirect `a` at any instant"
     );
     assert_eq!(
-        s.resolve_at(&eid("a"), t(10)).expect("resolve").outcome,
+        s.resolve_at_whole_graph(&eid("a"), t(10))
+            .expect("resolve")
+            .outcome,
         ResolutionOutcome::Located {
             entity: eid("a"),
             hops: 0,
@@ -624,7 +652,7 @@ fn a_historical_answer_carries_a_resolution_and_it_is_full_because_adjudications
         &[assert_id("a"), assert_id("b"), merge(&["a"], "b")],
     );
 
-    let answer = s.resolve_at(&eid("a"), t(2)).expect("resolve");
+    let answer = s.resolve_at_whole_graph(&eid("a"), t(2)).expect("resolve");
     assert_eq!(answer.resolution, Resolution::Full);
     assert!(!answer.is_degraded());
     assert_eq!(
@@ -701,7 +729,7 @@ fn compacting_raw_observations_does_not_degrade_a_historical_identity_answer() {
         "nothing was compacted, so the assertion below would hold vacuously"
     );
 
-    let answer = s.resolve_at(&eid("a"), t(2)).expect("resolve");
+    let answer = s.resolve_at_whole_graph(&eid("a"), t(2)).expect("resolve");
     assert_eq!(
         answer.resolution,
         Resolution::Full,

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -3442,6 +3442,20 @@ must carry a `LIMIT` in its own query.
 > Behavioural equivalence cannot prove bounded execution when the only
 > difference is where truncation happens.
 
+Rule 4 then shipped **armed by accident**, and review caught it. It asked whether
+a method takes a page by searching the method BODY, but a parameter is declared
+in the signature — so it fired on `history_page` only because an unrelated code
+comment inside it contained the English phrase *"the page:"*. Deleting that
+comment made an unbounded `history_page` pass the gate. The rule now reads the
+signature, and both halves are comment-stripped so prose can neither arm it nor
+disarm it; the self-test carries a fixture with no prose at all, plus one proving
+a `// no LIMIT needed` comment cannot silence it.
+
+> A structural check that depends on prose is a behavioural check wearing a
+> structural shape. The rule written to catch invisible unboundedness was itself
+> invisibly unarmed — and only a mutation run against the *gate*, not the code,
+> could show it.
+
 #### The classification is fail-closed, not a denylist
 
 Every public read method must be classified `bounded` / `unbounded` /

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -2019,7 +2019,10 @@ pressure that produced every stale claim this box already documents.
       `as_known_at` over a multi-projection answer is otherwise approximately a
       lie. `IdentityView` already records the single-snapshot argument for one
       walk; this is that argument across projections.
-- [~] **3d — Typed query engine.** The RATCHET half is ✅ **DONE 2026-08-10**
+- [~] **3d — Typed query engine.** The RATCHET half is ✅ **DONE 2026-08-10**;
+      the BOUNDEDNESS half ✅ **DONE 2026-08-12** (`ci/check_query_boundedness.py`
+      + the affected-entity reverse index; see *"3d: boundedness is structural,
+      not observable"*). The typed request/dispatch surface itself is still open
       (`ci/check_world_answer_boundary.py`); the typed engine itself is still
       open — see *"3d's ratchet closed ahead of its engine"* below. The only
       supported path for **domain questions**. Operational reads are explicitly carved out — `verify_chain`,
@@ -3407,6 +3410,119 @@ once an applicable entry exists. The `Caller` variant stays as the honest interi
 while `RULED` is small.
 
 ---
+
+### 3d: boundedness is structural, not observable — 2026-08-12
+
+`KIRRA-WM-ANSWER-IDENTITY-001` clause 2 is *"queries are bounded"*. Three
+defects in three consecutive PRs violated it, each invisibly:
+
+| PR | Query | Shape | Caught by |
+|---|---|---|---|
+| #1440 | `lineage` | per-page over a whole-history fetch | reviewer |
+| #1441 | `subject_summary` | per-subject over a whole-store scan | reviewer |
+| #1441 | `history` | no bound at all | nobody — written while documenting the other two |
+
+Building the gate found **two more** that three PRs and two reviews had passed
+over: `ask` loaded the entire entity graph to answer about one subject, and
+`AnswerRef::resolve` reconstructed the whole projection to re-execute one
+recorded answer.
+
+#### The mutation that proves a gate was necessary
+
+Rewriting `history_page` to fetch every row and truncate in Rust returns an
+**identical answer**. All 13 pagination controls pass. Nothing observable
+differs — which is the entire defect class in one mutation, and why review kept
+missing it.
+
+The gate missed it too, at first: rules 2 and 3 look for CALLS to unbounded
+methods, and that mutation calls nothing unbounded, it writes unbounded SQL
+inline. Rule 4 closes it — a `bounded`-classified method that accepts a page
+must carry a `LIMIT` in its own query.
+
+> Behavioural equivalence cannot prove bounded execution when the only
+> difference is where truncation happens.
+
+#### The classification is fail-closed, not a denylist
+
+Every public read method must be classified `bounded` / `unbounded` /
+`operational` with a reason, and an **unclassified method reds the gate** — 3e's
+pattern. A denylist fails the way the defects failed: a new method is not on it
+and nothing notices. This caught `resolve_bounded` one commit after the rule
+was written, on its own author.
+
+It also corrected a classification made from a signature: `resolve_at(id, cut)`
+reads as a point lookup and its body is
+`self.identity_view_at(cut)?.resolve_at(id)` — the whole graph, then an index.
+It had already been proposed as the *fix* for `ask`. Renamed
+`resolve_at_whole_graph`.
+
+#### Live identity is graph-local; historical identity is not
+
+`ask` was bounded by loading only the entities reachable from the objects its
+claims name — a depth-capped preload, because
+`AdjudicationGraph::lifecycle_of` has no error channel and its own docs forbid a
+storage-backed implementation turning a read failure into `None`. Fallible work
+happens before resolution; the resolver is untouched.
+
+That approach does **not** transfer to `ask_as_of`. Historical identity is
+RECONSTRUCTIVE — `identity_view_at` folds adjudication events — and those are
+keyed by the entity a judgement is ABOUT, not the entities it affects. The
+verb-by-verb adjacency map:
+
+| Verb | Keyed under | Lifecycle changes | Discoverable from the affected entity? |
+|---|---|---|---|
+| `Assert` | the entity | — (creates) | ✅ |
+| `Merge{sources, into}` | **`into`** | each `source` | ❌ |
+| `Split{source, dests}` | **`source`** | each `dest`; `source` if partition | ❌ for destinations |
+| `Forget` | the entity | the entity | ✅ |
+
+**A bootstrap failure.** `Merge(sources=[A], into=B)` is keyed under `B` yet is
+the record that makes `A` resolvable: querying by `A` finds nothing, and `A`
+cannot reach `B` first because that record is the only thing naming `B`. No
+iteration order escapes it.
+
+`adjudication_subject`'s own doc had already refused this exact index — *"a
+subject index that looks like it answers 'what happened to entity X' — and
+silently misses the merged-away ids, which are exactly the ones a caller is
+asking about — is worse than no index at all."*
+
+#### The reverse index, and why it cannot become evidence
+
+`adjudication_affects (entity_id, generation)` — generations and nothing else.
+A reader discovers WHICH generations to read, then reads the records from
+`world_events` and folds them with the unchanged `fold_adjudication`. The index
+holds no adjudication content, so it **physically cannot manufacture one**.
+
+Rows derive from `resulting_lifecycles()` ∪ `adjudication_subject()`, written
+transactionally with the event. `resulting_lifecycles` remains the authority for
+identity semantics; the index is a materialised access path.
+
+> The index may accelerate discovery; it may not define identity semantics.
+
+#### Bounding must not break 3h
+
+Both historical sites use ONE composed primitive rather than two bounded calls.
+A bounded claims read plus a bounded identity read would satisfy boundedness and
+reintroduce the cross-read incoherence box 3h closed — closing 3d by breaking
+3h.
+
+The axis is typed for the same reason: `IdentityCut::TxnTimeAtMost` versus
+`GenerationAtMost`. The pinned composed read was first written passing
+`i64::MAX` as a transaction time, which would have admitted adjudications
+recorded AFTER the pinned coordinate. An untyped `i64` let one axis be passed
+where the other was meant.
+
+Subject-filtering the CLAIMS replay is sound and identity-filtering is not:
+`fold_step` keys on `(subject, predicate_key)` and does no cross-subject work.
+That asymmetry is why one half needed a `WHERE` clause and the other needed an
+index.
+
+#### Where 3d stands
+
+The boundedness invariant is closed with **zero exceptions**: every interactive
+boundary query is bounded, and the gate is wired into CI with a self-test that
+still rejects the historical defect shape. The typed request/dispatch surface
+over the five families remains open.
 
 ### 3g follow-up closed: two families, two mechanisms — 2026-08-12
 


### PR DESCRIPTION
Closes the **boundedness half** of Tier 3 box 3d. `KIRRA-WM-ANSWER-IDENTITY-001` clause 2 — *"queries are bounded"* — is now enforced structurally, and the real tree reports **zero violations**.

The typed request/dispatch surface over the five families remains open, so 3d stays `[~]`. This PR does not close the box.

## Why this needed a gate rather than tests

Three defects in three consecutive PRs violated clause 2, each invisibly:

| PR | Query | Shape | Caught by |
|---|---|---|---|
| #1440 | `lineage` | per-page over a whole-history fetch | reviewer |
| #1441 | `subject_summary` | per-subject over a whole-store scan | reviewer |
| #1441 | `history` | no bound at all | **nobody** — written while documenting the other two |

Building the gate found **two more** that three PRs and two reviews had passed over: `ask` loaded the **entire entity graph** to answer about one subject, and `AnswerRef::resolve` reconstructed the **whole projection** to re-execute one recorded answer.

### The mutation that settles it

Rewriting `history_page` to fetch every row and truncate in Rust returns an **identical answer**. All 13 pagination controls pass. Nothing observable differs.

> Behavioural equivalence cannot prove bounded execution when the only difference is *where truncation happens*.

The gate missed it too, at first — rules 2 and 3 look for *calls* to unbounded methods, and that mutation calls nothing unbounded, it writes unbounded SQL inline. **Rule 4** closes it: a `bounded`-classified method that accepts a page must carry a `LIMIT` in its own query.

### …and rule 4 then shipped armed by prose

Review caught it. Rule 4 asked whether a method takes a page by searching the method **body** — but a parameter is declared in the *signature*. It fired on `history_page` only because an unrelated comment inside it contained the English phrase *"the page:"*:

| Mutation | Result |
|---|---|
| strip `LIMIT ?3` | gate reds ✅ |
| strip `LIMIT ?3` **and delete that comment** | **gate green** ❌ |

So the rule written to catch invisible unboundedness was itself invisibly unarmed, and produced correct output on the real tree the whole time. It now reads the signature, both halves are comment-stripped so prose can neither arm nor disarm it, and it has the three self-test fixtures it should have had from the start — rule 4 had none.

> A structural check that depends on prose is a behavioural check wearing a structural shape.

## Fail-closed classification, not a denylist

Every public read method must be classified `bounded` / `unbounded` / `operational` **with a reason**, and an unclassified method reds the gate — 3e's pattern. A denylist fails the way the defects failed: a new method isn't on it and nothing notices.

It immediately caught `resolve_bounded` one commit after the rule was written, on its own author. It also corrected a classification I'd made from a signature: `resolve_at(id, cut)` reads as a point lookup, and its body is `self.identity_view_at(cut)?.resolve_at(id)` — the whole graph, then an index. **I had already proposed it as the fix for `ask`.** Renamed `resolve_at_whole_graph`.

## Live identity is graph-local; historical identity is not

`ask` is bounded by a depth-capped preload of the entities reachable from the objects its claims name. A lazy `AdjudicationGraph` was ruled out by the trait itself: `lifecycle_of` has no error channel, and its docs forbid a storage-backed implementation turning a read failure into `None`. Fallible work happens **before** resolution; the resolver is untouched.

That does **not** transfer to `ask_as_of`. The verb-by-verb adjacency map:

| Verb | Keyed under | Lifecycle changes | Discoverable from the affected entity? |
|---|---|---|---|
| `Assert` | the entity | — (creates) | ✅ |
| `Merge{sources, into}` | **`into`** | each `source` | ❌ |
| `Split{source, dests}` | **`source`** | each `dest`; `source` if partition | ❌ for destinations |
| `Forget` | the entity | the entity | ✅ |

**A bootstrap failure.** `Merge(sources=[A], into=B)` is keyed under `B` yet is the record that makes `A` resolvable: querying by `A` finds nothing, and `A` cannot reach `B` first because that record is the only thing naming `B`. No iteration order escapes it.

`adjudication_subject`'s own doc had already refused this exact index — *"a subject index that looks like it answers 'what happened to entity X' — and silently misses the merged-away ids, which are exactly the ones a caller is asking about — is worse than no index at all."*

## The reverse index cannot become evidence

`adjudication_affects (entity_id, generation)` — generations and **nothing else**. A reader discovers *which* generations to read, then reads the records from `world_events` and folds them with the unchanged `fold_adjudication`. The index holds no adjudication content, so it **physically cannot manufacture one**; a row naming a missing generation is dropped by the join and changes no answer.

That drop is deliberate and asymmetric: a phantom row carries no evidence, so discarding it cannot lose any, while refusing on it would turn an index running ahead of what the log still retains into a hard read failure. The dangerous direction is a **missing** row — silent under-resolution — which the omitted-source and omitted-destination mutations cover.

Rows derive from `resulting_lifecycles()` ∪ `adjudication_subject()`, written transactionally with the event.

> The index may accelerate discovery; it may not define identity semantics.

v6 is additive; `backfill_adjudication_affects` is an explicit **operational** call, not work hidden in `open`. One operational scan buys bounded interactive reads.

## Bounding must not break 3h

Both historical sites use **one composed primitive**, not two bounded calls — two would satisfy boundedness while reintroducing the cross-read incoherence 3h closed.

The cut axis is typed (`IdentityCut::TxnTimeAtMost` / `GenerationAtMost`) because it was wrong first: the pinned read was initially passed `i64::MAX` as a *transaction time*, which would have admitted adjudications recorded **after** the pinned coordinate.

Subject-filtering the *claims* replay is sound and identity-filtering is not — `fold_step` keys on `(subject, predicate_key)` and does no cross-subject work. That asymmetry is why one half needed a `WHERE` clause and the other needed an index.

## Controls

Bounded-vs-whole agreement for live and historical identity; both bootstrap cases (merge found from the merged-away source, split found from a destination); corrupt/phantom rows failing closed rather than becoming `Unknown`; under-fetch controls proving agreement can go red; backfill answering identically to append-time indexing; history pagination walk, exact-fill, and page/completeness independence.

**Mutations run:** omitting merge sources reds 3 tests; omitting split destinations reds 2; the naive subject-only index reds 4; one-hop loader caps red the identity controls; no-probe and inclusive-cursor red the pagination controls; stripping `LIMIT` *and* the arming comment reds rule 4.

Two fixtures were caught being **degenerate rather than passing**: `scenario()` has `a` contradicted, so the walk refused before following any edge and an under-fetch was invisible; and `ask`'s object resolution had only ever been exercised at zero hops.

## Review round (2f88b25a)

Three findings, all real: rule 4's accidental arming (above); `resolve_bounded_at`'s docs claiming a refusal on phantom index rows the implementation drops — plus a six-line doc block orphaned onto the wrong function; and `append_adjudication` not rolling back a failed `COMMIT`, which SQLite can leave active, poisoning every later append with *"cannot start a transaction within a transaction"*.

## Verification

- 34 world suites green, plus the Tier 2.5 differential consumer
- `cargo build --workspace`, `cargo fmt --all --check`, `cargo clippy --all-targets` — clean
- all six world CI gates green, including the new one at **zero violations**
- gate wired into CI with `--self-test` first, so it must still reject the historical defect shape

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_