### PR TITLE
3d closed — one sanctioned way to ask Kirra World

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1685,9 +1685,23 @@ jobs:
         # boundedness of a query is a STRUCTURAL property, not an observable one,
         # which is why it needs a gate rather than tests.
         #
+        # Rule 5 adds the other half: a domain query must go through the TYPED
+        # ENGINE. Boundedness does not imply that — a consumer holding a
+        # `&WorldStore` could build its own view, call a family directly, and be
+        # perfectly bounded while bypassing semantics versions, freshness
+        # classification and the no-bare-values rule. `mission_context` did
+        # exactly that, and it was the sanctioned route at the time.
+        #
+        # The primary enforcement for rule 5 is VISIBILITY, not this gate:
+        # `WorldView` and the two `resolve` methods are `pub(crate)`, so a
+        # consumer reaching past the engine gets a compile error at the point of
+        # the mistake. The gate covers what visibility cannot reach, and pins
+        # the visibility so widening it is itself a red build.
+        #
         # Self-test first: it proves the gate still rejects the historical defect
-        # shape (bounded public request -> unbounded store call -> post-fetch
-        # truncation) rather than merely passing on a clean tree.
+        # shapes rather than merely passing on a clean tree — the bounded public
+        # request over an unbounded store call, the page-taking method whose SQL
+        # carries no LIMIT, and the real pre-engine `mission_context` route.
         run: |
           python3 ci/check_query_boundedness.py --self-test
           python3 ci/check_query_boundedness.py

--- a/ci/check_query_boundedness.py
+++ b/ci/check_query_boundedness.py
@@ -1,11 +1,29 @@
 #!/usr/bin/env python3
-"""Tier 3 box 3d — an interactive query may not hide an unbounded store read.
+"""Tier 3 box 3d — bounded queries, and one sanctioned way to ask.
 
-THE RULE
---------
-    A Tier 3 boundary query that sits on a request path may call only store
-    methods whose result size is bounded by their arguments. Every public read
-    method on the store must be CLASSIFIED, and an unclassified one fails.
+THE RULES
+---------
+    1-4  A Tier 3 boundary query that sits on a request path may call only
+         store methods whose result size is bounded by their arguments. Every
+         public read method on the store must be CLASSIFIED, and an
+         unclassified one fails.
+
+    5    Every domain-query call outside the query-engine implementation must
+         route through the typed engine. Direct family, store or projection
+         reads are forbidden, except the store methods classified
+         `operational`.
+
+Rules 1-4 make a query bounded. Rule 5 makes a query the only way to ask, which
+boundedness does not imply: a consumer holding a `&WorldStore` could build its
+own view, call a family directly, and be perfectly bounded while bypassing
+semantics versions, freshness classification and the no-bare-values rule.
+
+Rule 5's PRIMARY enforcement is visibility rather than this file. `WorldView`
+and the `resolve` methods on `LineageRef`/`AnswerRef` are `pub(crate)`, so a
+consumer reaching past `QueryEngine::execute` gets a compile error at the point
+of the mistake. What is here covers the rest: a new `pub` family method nobody
+wrapped, a consumer reaching around the boundary into the store, and the
+visibility pins that make widening `pub(crate)` back to `pub` a red build.
 
 WHY A GATE, AND WHY THIS SHAPE
 ------------------------------
@@ -56,6 +74,42 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 BASELINE_PATH = REPO_ROOT / "ci" / "store_boundedness_baseline.json"
+
+# Rule 5. The crates that IMPLEMENT the boundary — everything else that touches
+# the world is a domain consumer and must go through the query engine.
+WORLD_CRATES = {"kirra-world", "kirra-world-store", "kirra-world-service"}
+
+# The boundary internals the engine exists to be the only route past. These are
+# `pub(crate)` in the source, so the compiler already refuses a consumer that
+# names them; rule 5 exists so the day someone widens the visibility is the day
+# CI says so, rather than the day a consumer quietly reaches past the engine.
+BOUNDARY_INTERNALS = {
+    "WorldView": "the boundary's internal view — the four non-lineage families",
+}
+
+# (file, exact source line that must still be present) — the visibility that
+# makes the engine load-bearing. Asserted rather than assumed, because a
+# one-word edit turns a compile error back into a convention.
+VISIBILITY_PINS = [
+    (
+        "crates/kirra-world-service/src/read_view.rs",
+        "pub(crate) struct WorldView<'a> {",
+        "WorldView must stay crate-internal, or a consumer can build its own "
+        "view and skip the engine entirely.",
+    ),
+    (
+        "crates/kirra-world-service/src/lineage.rs",
+        "pub(crate) fn resolve(&self, store: &WorldStore)",
+        "LineageRef::resolve must stay crate-internal — the `Lineage` request "
+        "is the sanctioned route to it.",
+    ),
+    (
+        "crates/kirra-world-service/src/answer_ref.rs",
+        "pub(crate) fn resolve(&self, store: &WorldStore)",
+        "AnswerRef::resolve must stay crate-internal — the `ReplayAnswer` "
+        "request is the sanctioned route to it.",
+    ),
+]
 
 STORE_LIB = REPO_ROOT / "crates" / "kirra-world-store" / "src" / "lib.rs"
 STORE_SNAPSHOT = REPO_ROOT / "crates" / "kirra-world-store" / "src" / "snapshot.rs"
@@ -183,6 +237,40 @@ def scan_interactive(text: str, forbidden: set[str]) -> list[tuple[int, str, str
     return hits
 
 
+def domain_consumer_crates() -> list[Path]:
+    """Crates that touch Kirra World but do not implement its boundary.
+
+    Membership is read from the manifests rather than listed here, so a NEW
+    consumer is covered the day it is added. Over-inclusion is the safe
+    direction: a crate that merely mentions the world in a comment gets scanned
+    and finds nothing.
+    """
+    out = []
+    for manifest in sorted((REPO_ROOT / "crates").glob("*/Cargo.toml")):
+        if manifest.parent.name in WORLD_CRATES:
+            continue
+        text = manifest.read_text()
+        if "kirra-world-service" in text or "kirra-world-store" in text:
+            out.append(manifest.parent)
+    return out
+
+
+def scan_consumer(text: str, forbidden: set[str]) -> list[tuple[int, str, str]]:
+    """Rule-5 violations in one consumer file: internals named, or reads called.
+
+    Comment-stripped for the same reason every other scan here is — a consumer's
+    docs should be able to say *"this used to call `WorldView::ask`"* without
+    the sentence becoming the violation it describes.
+    """
+    hits = list(scan_interactive(text, forbidden))
+    for n, line in enumerate(text.splitlines(), start=1):
+        code = line.split("//")[0]
+        for name in BOUNDARY_INTERNALS:
+            if re.search(r"\b" + name + r"\b", code):
+                hits.append((n, name, line.strip()))
+    return sorted(hits)
+
+
 def run(verbose: bool = False) -> list[str]:
     baseline = json.loads(BASELINE_PATH.read_text())
     failures: list[str] = []
@@ -295,6 +383,60 @@ def run(verbose: bool = False) -> list[str]:
                             f"— which is exactly how #1440 and #1441 reached main.\n"
                             f"    The bound has to reach the query."
                         )
+
+    # 5. A DOMAIN QUERY MUST GO THROUGH THE TYPED ENGINE.
+    #
+    # Rules 1-4 make a query bounded. They do not make the query the only way to
+    # ask: a consumer holding a `&WorldStore` could build its own view, call a
+    # family directly, and be perfectly bounded while bypassing semantics
+    # versions, freshness classification and the no-bare-values rule.
+    # `mission_context` did exactly that, and it was the sanctioned route at the
+    # time — which is why the negative fixture in the self-test is that real
+    # call and not an invented one.
+    #
+    # The PRIMARY enforcement is visibility, not this rule: `WorldView` and the
+    # two `resolve` methods are `pub(crate)`, so a consumer reaching past the
+    # engine gets a compile error at the point of the mistake. This rule is
+    # defence in depth for what visibility cannot reach — a new `pub` family
+    # method nobody wrapped, a consumer reaching into the store directly — plus
+    # the pins below, so widening the visibility is itself the red build.
+    #
+    # `operational` reads are the named carve-outs, and they are named by the
+    # SAME classification rules 1-4 already require: integrity verification,
+    # migration, folding, retention and measurement legitimately read the store
+    # outside a query. A new store method cannot slip through as a carve-out,
+    # because an unclassified one already reds rule 1.
+    domain_reads = {
+        name
+        for surface in ("world_store", "read_snapshot")
+        for name, spec in baseline[surface].items()
+        if not name.startswith("_") and spec["class"] in ("bounded", "unbounded")
+    }
+    for crate in domain_consumer_crates():
+        for path in sorted(crate.rglob("*.rs")):
+            rel = path.relative_to(REPO_ROOT)
+            for line_no, what, line in scan_consumer(path.read_text(), domain_reads):
+                detail = BOUNDARY_INTERNALS.get(what, f"the store read `{what}`")
+                failures.append(
+                    f"{rel}:{line_no} — a domain consumer reaches past the query "
+                    f"engine: {detail}.\n"
+                    f"      {line}\n"
+                    f"    Tier 3 box 3d: there is ONE sanctioned way for "
+                    f"application code to ask Kirra World a domain question.\n"
+                    f"    Use `QueryEngine::execute(..)` with the typed request "
+                    f"for the family you want."
+                )
+
+    for rel, needle, why in VISIBILITY_PINS:
+        text = (REPO_ROOT / rel).read_text()
+        if needle not in text:
+            failures.append(
+                f"{rel} — the visibility pin `{needle}` is gone.\n"
+                f"    {why}\n"
+                f"    A compile error at the point of the mistake is stronger "
+                f"than a gate finding after the fact; widening this trades the "
+                f"first for the second."
+            )
 
     if verbose:
         for surface, names in sorted(found.items()):
@@ -435,7 +577,83 @@ def self_test() -> int:
     else:
         print("self-test: comments neither arm nor disarm rule 4")
 
-    # (h) An unclassified method must fail, since that is the generalisation.
+    # (h) RULE 5, THE HISTORICAL ROUTE: `mission_context` as it actually shipped
+    #     before the query engine existed. Copied from the commit that this box
+    #     migrated, not invented — a synthetic spelling would only prove the
+    #     regex matches itself, whereas this proves the rule rejects the exact
+    #     code that WAS the sanctioned way to consume Kirra World.
+    domain_reads = {
+        name
+        for surface in ("world_store", "read_snapshot")
+        for name, spec in baseline[surface].items()
+        if not name.startswith("_") and spec["class"] in ("bounded", "unbounded")
+    }
+    pre_engine_mission_context = """
+    let view = WorldView::new(
+        store,
+        FreshnessSource::Caller(match staleness_budget_ms {
+            Some(max_age_ms) => FreshnessPolicy::Bounded { max_age_ms },
+            None => FreshnessPolicy::Timeless,
+        }),
+    );
+
+    let answers = match view.ask(subject.as_str(), now_ms)?.into_lookup() {
+        WorldLookup::Answered(answers) => answers,
+        WorldLookup::Unknown(reason) => return Ok(ProposalContext::silent(candidates, reason)),
+    };
+    """
+    if not scan_consumer(pre_engine_mission_context, domain_reads):
+        print("SELF-TEST FAIL: the pre-engine mission_context route was NOT "
+              "caught — rule 5 does not reject the real code it exists for.")
+        failed = 1
+    else:
+        print("self-test: pre-engine mission_context → WorldView::ask → caught")
+
+    # (i) The migrated form must pass, or the rule forbids the fix as well as
+    #     the defect and there is nowhere for a consumer to go.
+    engine_mission_context = """
+    let engine = QueryEngine::new(store, FreshnessSource::Caller(policy));
+    let answers = match engine.execute(Ask { subject, now_ms })?.into_lookup() {
+        WorldLookup::Answered(answers) => answers,
+        WorldLookup::Unknown(reason) => return Ok(ProposalContext::silent(candidates, reason)),
+    };
+    """
+    if scan_consumer(engine_mission_context, domain_reads):
+        print("SELF-TEST FAIL: the MIGRATED mission_context was flagged — the "
+              "rule would leave consumers with no sanctioned route.")
+        failed = 1
+    else:
+        print("self-test: migrated mission_context → QueryEngine::execute → "
+              "not flagged")
+
+    # (j) A consumer reaching around the boundary INTO the store must fail too.
+    #     Visibility cannot catch this one: `WorldStore` is legitimately public
+    #     for operational use, so only the classification distinguishes a
+    #     domain read from a rebuild.
+    around_the_side = """
+    let claims = store.current("package_17", now_ms)?;
+    """
+    if not scan_consumer(around_the_side, domain_reads):
+        print("SELF-TEST FAIL: a consumer calling a bounded STORE read directly "
+              "was not caught — the engine can be bypassed underneath.")
+        failed = 1
+    else:
+        print("self-test: consumer reading the store directly → caught")
+
+    # (k) …while an OPERATIONAL store call from a consumer must be allowed, or
+    #     the rule bans fixture seeding and rebuild tooling.
+    operational_use = """
+    store.fold().expect("fold");
+    store.verify_chain().expect("chain");
+    """
+    if scan_consumer(operational_use, domain_reads):
+        print("SELF-TEST FAIL: an operational store call was flagged — the "
+              "named carve-outs are not actually carved out.")
+        failed = 1
+    else:
+        print("self-test: operational store calls from a consumer → allowed")
+
+    # (l) An unclassified method must fail, since that is the generalisation.
     stripped = {k: v for k, v in baseline["world_store"].items() if k != "history"}
     if "history" in stripped:
         print("SELF-TEST FAIL: fixture construction error.")

--- a/ci/check_query_boundedness.py
+++ b/ci/check_query_boundedness.py
@@ -237,6 +237,43 @@ def scan_interactive(text: str, forbidden: set[str]) -> list[tuple[int, str, str
     return hits
 
 
+def classification_failures(found: dict[str, set[str]], baseline: dict) -> list[str]:
+    """Rule 1: the discovered read surface and the baseline must agree, exactly.
+
+    A FUNCTION rather than inline in `run`, so the self-test can drive the real
+    rule against a doctored baseline. It was inline, and the fixture that was
+    supposed to prove it worked never called it — it removed a key from a dict
+    and then asserted the key was absent, which is true by construction.
+    """
+    failures: list[str] = []
+    for surface, names in found.items():
+        declared = {k for k in baseline[surface] if not k.startswith("_")}
+        for name in sorted(names - declared):
+            failures.append(
+                f"{surface}::{name} is public but has no boundedness classification.\n"
+                f"    Add it to ci/store_boundedness_baseline.json as bounded / "
+                f"unbounded / operational, with the reasoning.\n"
+                f"    An unclassified method is how all three of the defects this "
+                f"gate exists for reached main."
+            )
+        for name in sorted(declared - names):
+            failures.append(
+                f"{surface}::{name} is classified but no longer exists — "
+                f"remove the stale entry."
+            )
+        for name, spec in baseline[surface].items():
+            if name.startswith("_"):
+                continue
+            if spec.get("class") not in VALID_CLASSES:
+                failures.append(
+                    f"{surface}::{name} has class {spec.get('class')!r}; "
+                    f"expected one of {sorted(VALID_CLASSES)}."
+                )
+            if not spec.get("why", "").strip():
+                failures.append(f"{surface}::{name} has no reason recorded.")
+    return failures
+
+
 def domain_consumer_crates() -> list[Path]:
     """Crates that touch Kirra World but do not implement its boundary.
 
@@ -277,31 +314,7 @@ def run(verbose: bool = False) -> list[str]:
     found = discover()
 
     # 1. Every public read method must be classified. FAIL-CLOSED.
-    for surface, names in found.items():
-        declared = {k for k in baseline[surface] if not k.startswith("_")}
-        for name in sorted(names - declared):
-            failures.append(
-                f"{surface}::{name} is public but has no boundedness classification.\n"
-                f"    Add it to ci/store_boundedness_baseline.json as bounded / "
-                f"unbounded / operational, with the reasoning.\n"
-                f"    An unclassified method is how all three of the defects this "
-                f"gate exists for reached main."
-            )
-        for name in sorted(declared - names):
-            failures.append(
-                f"{surface}::{name} is classified but no longer exists — "
-                f"remove the stale entry."
-            )
-        for name, spec in baseline[surface].items():
-            if name.startswith("_"):
-                continue
-            if spec.get("class") not in VALID_CLASSES:
-                failures.append(
-                    f"{surface}::{name} has class {spec.get('class')!r}; "
-                    f"expected one of {sorted(VALID_CLASSES)}."
-                )
-            if not spec.get("why", "").strip():
-                failures.append(f"{surface}::{name} has no reason recorded.")
+    failures.extend(classification_failures(found, baseline))
 
     # 2. NOTHING in the boundary crate may call an unbounded method.
     #
@@ -653,14 +666,41 @@ def self_test() -> int:
     else:
         print("self-test: operational store calls from a consumer → allowed")
 
-    # (l) An unclassified method must fail, since that is the generalisation.
-    stripped = {k: v for k, v in baseline["world_store"].items() if k != "history"}
-    if "history" in stripped:
-        print("SELF-TEST FAIL: fixture construction error.")
+    # (l) RULE 1, THE GENERALISATION: an unclassified method must fail.
+    #
+    #     This fixture was broken twice over, and review caught it. It used to
+    #     build `{k: v for k, v in baseline if k != "history"}` and then assert
+    #     `"history" not in` the result — true by construction, so it never ran
+    #     rule 1 at all. Then this box renamed `history` to `history_whole` and
+    #     it stopped even removing anything, which is what made the emptiness
+    #     visible.
+    #
+    #     So it now (a) runs the REAL rule via `classification_failures`, and
+    #     (b) DERIVES the method to strip instead of naming one. A hardcoded
+    #     name rots the moment that method is renamed — this box renamed two —
+    #     and a rotted fixture reports success. The empty-pool guard is the
+    #     other half: a fixture with nothing to strip must fail, not pass.
+    found = discover()
+    strippable = sorted(found["world_store"] & set(baseline["world_store"]))
+    if not strippable:
+        print("SELF-TEST FAIL: no classified method was discoverable to strip — "
+              "the fixture has nothing to remove and would pass vacuously.")
         failed = 1
     else:
-        print("self-test: removing a classification leaves it undiscoverable → "
-              "the discover/declare diff is what reports it")
+        probe = strippable[0]
+        doctored = {
+            **baseline,
+            "world_store": {
+                k: v for k, v in baseline["world_store"].items() if k != probe
+            },
+        }
+        if not classification_failures(found, doctored):
+            print(f"SELF-TEST FAIL: dropping the classification for `{probe}` was "
+                  f"NOT reported — rule 1 is not fail-closed.")
+            failed = 1
+        else:
+            print(f"self-test: dropping a classification ({probe}) → rule 1 "
+                  f"reports it")
 
     return failed
 

--- a/ci/store_boundedness_baseline.json
+++ b/ci/store_boundedness_baseline.json
@@ -44,6 +44,14 @@
     "second thing to maintain for no coverage."
   ],
   "world_store": {
+    "append": {
+      "class": "operational",
+      "why": "Write path."
+    },
+    "append_adjudication": {
+      "class": "operational",
+      "why": "Write path."
+    },
     "as_of": {
       "class": "bounded",
       "why": "One subject at one bitemporal point. Same PRIMARY KEY bound as `current`."
@@ -51,6 +59,14 @@
     "as_of_composed": {
       "class": "unbounded",
       "why": "Composes `as_of` (bounded) with `identity_view_at` (the whole graph). The claims half is bounded and the identity half is not, so the composition is not \u2014 a bounded half does not bound a composition."
+    },
+    "as_of_composed_bounded": {
+      "class": "bounded",
+      "why": "Box 3d. Both halves bounded inside ONE transaction: `as_of` was already subject-keyed, and the identity half now folds only the adjudications bearing on the objects those claims name, discovered through the affected-entity reverse index. Deliberately one primitive rather than two bounded calls \u2014 two would satisfy boundedness while reintroducing the cross-read incoherence box 3h closed."
+    },
+    "backfill_adjudication_affects": {
+      "class": "operational",
+      "why": "The one-time scan that fills the v6 reverse index on a migrated store. Deliberately a full scan and deliberately NOT on any request path \u2014 an explicit operational call rather than work hidden in `open`, so the cost lands where an operator can see it. This is exactly the trade box 3d is for: one operational scan buys bounded interactive reads."
     },
     "candidates": {
       "class": "unbounded",
@@ -64,6 +80,14 @@
       "class": "unbounded",
       "why": "Every compaction citation in the store. Accumulates for the store's life."
     },
+    "compact_range": {
+      "class": "operational",
+      "why": "Retention mutation."
+    },
+    "count": {
+      "class": "operational",
+      "why": "A scalar row count."
+    },
     "current": {
       "class": "bounded",
       "why": "STRUCTURAL bound: `world_current` is keyed by (subject, predicate_key), so one subject yields at most one row per predicate. Not a page, and does not need one -- a subject's predicate set does not grow without limit the way its event history does."
@@ -72,9 +96,25 @@
       "class": "unbounded",
       "why": "The whole claims projection. Grows with the number of subjects."
     },
-    "count": {
+    "entity_projection_generation": {
       "class": "operational",
-      "why": "A scalar row count."
+      "why": "Checkpoint metadata."
+    },
+    "entity_projection_state_digest": {
+      "class": "operational",
+      "why": "Checkpoint metadata."
+    },
+    "fold": {
+      "class": "operational",
+      "why": "Projection fold."
+    },
+    "fold_entity_projection": {
+      "class": "operational",
+      "why": "Projection fold."
+    },
+    "fold_subject_summary": {
+      "class": "operational",
+      "why": "Projection fold."
     },
     "has_citations": {
       "class": "operational",
@@ -100,9 +140,13 @@
       "class": "bounded",
       "why": "One row: the log head."
     },
-    "history": {
+    "history_page": {
+      "class": "bounded",
+      "why": "Box 3d's bounded replacement for `history`. Narrows in SQL with `generation > cursor` and `LIMIT limit + 1` rather than fetching the record and truncating \u2014 #1440's lesson, since truncating after the fetch bounds the ANSWER while leaving the WORK unbounded, which is what made all three defects invisible. The boundary decision is `lineage::boundary_for`, shared with the lineage family so the off-by-one has one implementation."
+    },
+    "history_whole": {
       "class": "unbounded",
-      "why": "EVERY confirmed claim ever recorded about a subject, no page and no cursor. The third instance of the defect class this gate exists for, and the one that proves per-query vigilance does not work: it was written in the PR that documented the other two. Its bounded replacement is the paginated form."
+      "why": "EVERY confirmed claim ever recorded about a subject, no page and no cursor. The third instance of the defect class this gate exists for, and the one that proves per-query vigilance does not work: it was written in the PR that documented the other two. Its bounded replacement is the paginated form. RENAMED from `history` in the 3d dispatch slice: `WorldView::history` is the BOUNDED family of the same name, and the collision made the gate read the engine's dispatch into the bounded family as a call to this one. The same correction `resolve_at` -> `resolve_at_whole_graph` already took \u2014 a name that does not say `whole` is how a whole-record read gets called by mistake."
     },
     "identity_view": {
       "class": "unbounded",
@@ -128,9 +172,17 @@
       "class": "operational",
       "why": "The fold's own loader."
     },
+    "mint_entity_id": {
+      "class": "operational",
+      "why": "Id minting."
+    },
     "minted_entity_id_count": {
       "class": "operational",
       "why": "A scalar count."
+    },
+    "open": {
+      "class": "operational",
+      "why": "Constructor."
     },
     "projected_row_count": {
       "class": "operational",
@@ -148,22 +200,6 @@
       "class": "operational",
       "why": "Checkpoint metadata."
     },
-    "entity_projection_generation": {
-      "class": "operational",
-      "why": "Checkpoint metadata."
-    },
-    "entity_projection_state_digest": {
-      "class": "operational",
-      "why": "Checkpoint metadata."
-    },
-    "subject_summary_generation": {
-      "class": "operational",
-      "why": "Checkpoint metadata."
-    },
-    "subject_summary_state_digest": {
-      "class": "operational",
-      "why": "Checkpoint metadata."
-    },
     "read_at_generation": {
       "class": "unbounded",
       "why": "The whole claims projection reconstructed at a generation. Pinning the coordinate bounds WHEN, not HOW MUCH -- the same trap as `identity_view_at`."
@@ -175,6 +211,30 @@
     "read_snapshot": {
       "class": "operational",
       "why": "Returns a HANDLE, reading nothing. The rows come from `ReadSnapshot`'s own methods, which are classified separately below -- a snapshot must not become a way to reach an unbounded read without being seen."
+    },
+    "rebuild_entity_projection": {
+      "class": "operational",
+      "why": "Projection rebuild."
+    },
+    "rebuild_projections": {
+      "class": "operational",
+      "why": "Projection rebuild."
+    },
+    "rebuild_subject_summary": {
+      "class": "operational",
+      "why": "Projection rebuild."
+    },
+    "resolve_at_whole_graph": {
+      "class": "unbounded",
+      "why": "RENAMED from `resolve_at` on box 3d. Its body is `self.identity_view_at(cut)?.resolve_at(id)` \u2014 it materialises the WHOLE equivalence graph and then indexes it, so the old name read as a point lookup and was classified `bounded` from its signature on the first pass. The name now says what it does. Renaming also removes a real ambiguity in the gate's name-based scan: `HistoricalIdentityView::resolve_at` is a pure in-memory call on an already-loaded view, and sharing a name with an unbounded store method made every use of it look like a violation. `resolve_bounded_at` is the bounded form."
+    },
+    "resolve_bounded": {
+      "class": "bounded",
+      "why": "Box 3d's identity primitive. Loads only the entities within MAX_REDIRECT_EDGES hops of the queried id and resolves over that subset, so the work is bounded by the traversal budget the resolver already enforces rather than by graph size. The resolution RULE is unchanged \u2014 the same `resolve` over a smaller view \u2014 which is what lets `bounded_resolution_agrees_with_whole_graph_resolution` assert the two are identical. Classified `bounded` and MEANT: the transitive check reads its body, so it stays honest."
+    },
+    "resolve_bounded_at": {
+      "class": "bounded",
+      "why": "Box 3d's bounded historical identity read. Discovers the adjudications affecting the queried id through the affected-entity reverse index, expands newly-named entities, and stops at the resolver's own MAX_REDIRECT_EDGES budget \u2014 so it folds the records bearing on one entity's identity rather than every adjudication in the log. The index supplies GENERATIONS only; every record is read from world_events and folded by the unchanged fold_adjudication, so the log remains the sole evidence."
     },
     "resolved_entities": {
       "class": "unbounded",
@@ -200,6 +260,14 @@
       "class": "bounded",
       "why": "One (kind, subject) row."
     },
+    "subject_summary_generation": {
+      "class": "operational",
+      "why": "Checkpoint metadata."
+    },
+    "subject_summary_state_digest": {
+      "class": "operational",
+      "why": "Checkpoint metadata."
+    },
     "subject_summary_with_coverage": {
       "class": "bounded",
       "why": "One subject, both sources SQL-narrowed. The bounded replacement #1441's review produced."
@@ -211,74 +279,6 @@
     "verify_chain": {
       "class": "operational",
       "why": "The audit walk. WM_SCOPE names it explicitly as a legitimate reader below the engine."
-    },
-    "append": {
-      "class": "operational",
-      "why": "Write path."
-    },
-    "append_adjudication": {
-      "class": "operational",
-      "why": "Write path."
-    },
-    "compact_range": {
-      "class": "operational",
-      "why": "Retention mutation."
-    },
-    "fold": {
-      "class": "operational",
-      "why": "Projection fold."
-    },
-    "fold_entity_projection": {
-      "class": "operational",
-      "why": "Projection fold."
-    },
-    "fold_subject_summary": {
-      "class": "operational",
-      "why": "Projection fold."
-    },
-    "mint_entity_id": {
-      "class": "operational",
-      "why": "Id minting."
-    },
-    "open": {
-      "class": "operational",
-      "why": "Constructor."
-    },
-    "rebuild_entity_projection": {
-      "class": "operational",
-      "why": "Projection rebuild."
-    },
-    "rebuild_projections": {
-      "class": "operational",
-      "why": "Projection rebuild."
-    },
-    "rebuild_subject_summary": {
-      "class": "operational",
-      "why": "Projection rebuild."
-    },
-    "resolve_bounded": {
-      "class": "bounded",
-      "why": "Box 3d's identity primitive. Loads only the entities within MAX_REDIRECT_EDGES hops of the queried id and resolves over that subset, so the work is bounded by the traversal budget the resolver already enforces rather than by graph size. The resolution RULE is unchanged \u2014 the same `resolve` over a smaller view \u2014 which is what lets `bounded_resolution_agrees_with_whole_graph_resolution` assert the two are identical. Classified `bounded` and MEANT: the transitive check reads its body, so it stays honest."
-    },
-    "history_page": {
-      "class": "bounded",
-      "why": "Box 3d's bounded replacement for `history`. Narrows in SQL with `generation > cursor` and `LIMIT limit + 1` rather than fetching the record and truncating \u2014 #1440's lesson, since truncating after the fetch bounds the ANSWER while leaving the WORK unbounded, which is what made all three defects invisible. The boundary decision is `lineage::boundary_for`, shared with the lineage family so the off-by-one has one implementation."
-    },
-    "resolve_bounded_at": {
-      "class": "bounded",
-      "why": "Box 3d's bounded historical identity read. Discovers the adjudications affecting the queried id through the affected-entity reverse index, expands newly-named entities, and stops at the resolver's own MAX_REDIRECT_EDGES budget \u2014 so it folds the records bearing on one entity's identity rather than every adjudication in the log. The index supplies GENERATIONS only; every record is read from world_events and folded by the unchanged fold_adjudication, so the log remains the sole evidence."
-    },
-    "backfill_adjudication_affects": {
-      "class": "operational",
-      "why": "The one-time scan that fills the v6 reverse index on a migrated store. Deliberately a full scan and deliberately NOT on any request path \u2014 an explicit operational call rather than work hidden in `open`, so the cost lands where an operator can see it. This is exactly the trade box 3d is for: one operational scan buys bounded interactive reads."
-    },
-    "as_of_composed_bounded": {
-      "class": "bounded",
-      "why": "Box 3d. Both halves bounded inside ONE transaction: `as_of` was already subject-keyed, and the identity half now folds only the adjudications bearing on the objects those claims name, discovered through the affected-entity reverse index. Deliberately one primitive rather than two bounded calls \u2014 two would satisfy boundedness while reintroducing the cross-read incoherence box 3h closed."
-    },
-    "resolve_at_whole_graph": {
-      "class": "unbounded",
-      "why": "RENAMED from `resolve_at` on box 3d. Its body is `self.identity_view_at(cut)?.resolve_at(id)` \u2014 it materialises the WHOLE equivalence graph and then indexes it, so the old name read as a point lookup and was classified `bounded` from its signature on the first pass. The name now says what it does. Renaming also removes a real ambiguity in the gate's name-based scan: `HistoricalIdentityView::resolve_at` is a pure in-memory call on an already-loaded view, and sharing a name with an unbounded store method made every use of it look like a violation. `resolve_bounded_at` is the bounded form."
     }
   },
   "read_snapshot": {
@@ -330,6 +330,7 @@
     ],
     "crates/kirra-world-service/src/read_view.rs": "WorldView -- the four non-lineage query families",
     "crates/kirra-world-service/src/lineage.rs": "LineageRef::resolve -- the lineage family",
-    "crates/kirra-world-service/src/answer_ref.rs": "AnswerRef::resolve -- re-execution of a recorded reference"
+    "crates/kirra-world-service/src/answer_ref.rs": "AnswerRef::resolve -- re-execution of a recorded reference",
+    "crates/kirra-world-service/src/query.rs": "QueryEngine + the typed requests -- the ONE sanctioned entry point. Every request dispatches into the family implementations below it and adds no query logic of its own, so this file is on the request path by definition."
   }
 }

--- a/crates/kirra-proposal-context/src/lib.rs
+++ b/crates/kirra-proposal-context/src/lib.rs
@@ -59,9 +59,8 @@
 use kirra_world::resolution::RefusalReason;
 use kirra_world::trust::{TrustGrade, Validity};
 use kirra_world_service::freshness::{FreshnessPolicy, FreshnessSource};
-use kirra_world_service::read_view::{
-    AskError, ObjectIdentity, UnknownReason, WorldLookup, WorldView,
-};
+use kirra_world_service::query::{Ask, QueryEngine};
+use kirra_world_service::read_view::{AskError, ObjectIdentity, UnknownReason, WorldLookup};
 use kirra_world_store::WorldStore;
 
 /// An opaque symbolic identity — a destination, a task, a package, a relation.
@@ -416,9 +415,9 @@ fn mirror_resolution(identity: &ObjectIdentity) -> ObjectResolution {
 ///
 /// # What this reads, and what it does not
 ///
-/// It goes through the sanctioned answer boundary — `WorldView::ask` — so every
-/// value it sees arrives with validity, trust axes, grade and provenance
-/// attached. It does NOT touch `ProjectedClaim`'s public fields, which was the
+/// It goes through the sanctioned answer boundary — one
+/// `QueryEngine::execute(Ask { .. })` — so every value it sees arrives with
+/// validity, trust axes, grade and provenance attached. It does NOT touch `ProjectedClaim`'s public fields, which was the
 /// 3a defect this migration closes.
 ///
 /// It also does not resolve the object through the identity graph, even though
@@ -438,7 +437,7 @@ pub fn mission_context(
     // is what this signature already meant ("I have considered this and this
     // fact is genuinely timeless"), now said in a type where the alternative
     // reading is unrepresentable.
-    let view = WorldView::new(
+    let engine = QueryEngine::new(
         store,
         FreshnessSource::Caller(match staleness_budget_ms {
             Some(max_age_ms) => FreshnessPolicy::Bounded { max_age_ms },
@@ -446,7 +445,17 @@ pub fn mission_context(
         }),
     );
 
-    let answers = match view.ask(subject.as_str(), now_ms)?.into_lookup() {
+    // Box 3d: through the ONE sanctioned surface. This read `WorldView::ask`
+    // directly until the query engine landed — which was the blessed route at
+    // the time, and is the exact call rule 5's negative fixture is built from.
+    // It is not a style change: `WorldView` is `pub(crate)` now, so the old
+    // spelling does not compile from here, and the migration was forced by the
+    // compiler rather than remembered.
+    let ask = Ask {
+        subject: subject.as_str().to_owned(),
+        now_ms,
+    };
+    let answers = match engine.execute(ask)?.into_lookup() {
         WorldLookup::Answered(answers) => answers,
         WorldLookup::Unknown(reason) => {
             let silence = match reason {
@@ -503,7 +512,7 @@ pub fn mission_context(
     // Both mappings below FAIL CLOSED on the one state that has no honest
     // symbol, rather than reaching for the nearest one.
     //
-    // Neither arm can be reached today: `WorldView::is_admissible` refuses
+    // Neither arm can be reached today: the boundary's `is_admissible` refuses
     // `Expired` and `Inadmissible` before an answer is ever built, and the
     // filters that guarantee it are pinned by
     // `kirra-world-store/tests/inadmissible_never_read.rs`. They are here

--- a/crates/kirra-world-service/src/answer_ref.rs
+++ b/crates/kirra-world-service/src/answer_ref.rs
@@ -248,7 +248,7 @@ impl AnswerRef {
     /// Only on a storage fault, or `StoreError::InvalidGeneration` for a ref
     /// carrying a negative generation. Irreproducibility is an OUTCOME, not an
     /// error: *"we deleted the evidence"* is a fact about the data.
-    pub fn resolve(&self, store: &WorldStore) -> Result<RefResolution, AskError> {
+    pub(crate) fn resolve(&self, store: &WorldStore) -> Result<RefResolution, AskError> {
         let differences = self
             .semantics
             .differences(&SemanticVersions::for_query(self.kind));

--- a/crates/kirra-world-service/src/lib.rs
+++ b/crates/kirra-world-service/src/lib.rs
@@ -33,6 +33,7 @@
 pub mod answer_ref;
 pub mod freshness;
 pub mod lineage;
+pub mod query;
 pub mod read_view;
 pub mod semantics;
 

--- a/crates/kirra-world-service/src/lineage.rs
+++ b/crates/kirra-world-service/src/lineage.rs
@@ -195,7 +195,7 @@ impl LineageRef {
     /// is not a digest — see [`AskError::CorruptProvenance`], which this family
     /// raises for the same reason the answer family does: an entry that cannot
     /// be cited is not lineage.
-    pub fn resolve(&self, store: &WorldStore) -> Result<LineageResolution, AskError> {
+    pub(crate) fn resolve(&self, store: &WorldStore) -> Result<LineageResolution, AskError> {
         let differences = self
             .semantics
             .differences(&SemanticVersions::for_query(QueryKind::SubjectLineage));

--- a/crates/kirra-world-service/src/query.rs
+++ b/crates/kirra-world-service/src/query.rs
@@ -1,0 +1,317 @@
+//! **The one sanctioned way to ask Kirra World a domain question** — box 3d.
+//!
+//! Box 3d's boundedness half made it impossible for a query to hide an
+//! unbounded store read. This half makes it impossible to ask *without going
+//! through a query at all*.
+//!
+//! Those are different properties, and the first does not imply the second. A
+//! consumer holding a `&WorldStore` could build its own [`WorldView`], call a
+//! family method directly, and be perfectly bounded while bypassing every other
+//! contract the boundary carries — semantics versions, freshness classification,
+//! the no-bare-values rule. `mission_context` did exactly that until this
+//! module existed, and it was the sanctioned route at the time.
+//!
+//! # The property this adds
+//!
+//! > There is ONE mechanically enforced way for application code to ask Kirra
+//! > World a domain question.
+//!
+//! Not *"a typed engine exists"* — that is satisfied by an engine nobody has to
+//! use. The enforcement is primarily **visibility**: [`WorldView`], and the
+//! `resolve` methods on [`LineageRef`] and [`AnswerRef`], are `pub(crate)`. A
+//! consumer that reaches past the engine does not produce a gate finding after
+//! the fact; it produces a compile error, at the point of the mistake, naming
+//! the item it cannot see.
+//!
+//! `ci/check_query_boundedness.py` rule 5 is defence in depth behind that, for
+//! the cases visibility cannot reach: a *new* family method added as `pub`
+//! without being wrapped, or a consumer reaching into the store directly rather
+//! than into this crate.
+//!
+//! # Typed requests, not one enum
+//!
+//! Five families with five genuinely different result shapes — different
+//! payload outcomes, completeness types, pagination state, historical
+//! coordinates and refusal semantics. A single `WorldQuery` enum returning a
+//! single `WorldAnswer` would flatten all five axes back together and force
+//! every caller to `match` over families it did not ask about, undoing the work
+//! that kept those axes honest. So the surface is one entry point with
+//! **compile-time output types**:
+//!
+//! ```ignore
+//! engine.execute(Ask { subject, now_ms })?;          // -> ComposedLookup
+//! engine.execute(History { subject, page })?;        // -> HistoryLookup
+//! ```
+//!
+//! # The trait is sealed
+//!
+//! [`WorldQuery`] cannot be implemented outside this crate. Without that, the
+//! engine would be a suggestion: a consumer could write its own implementation,
+//! close over a `&WorldStore` or an arbitrary predicate, and route it through
+//! `execute` — arriving at the ad-hoc queries the whole box exists to prevent,
+//! while looking like sanctioned use.
+//!
+//! Sealing also preserves the [`AnswerRef`] ruling. A public domain query stays
+//! a **serializable, named value** rather than a closure: it can be recorded,
+//! shipped, replayed and compared. An open trait would admit query types that
+//! are none of those things.
+//!
+//! # This is orchestration, and deliberately nothing more
+//!
+//! Every request dispatches into the already-proven family implementation. No
+//! request re-derives a bound, re-implements a fold, or re-decides freshness.
+//! If a boundedness argument or a completeness rule lived in here, there would
+//! be a second query engine hiding inside the query engine, and the proofs
+//! behind the first would stop covering what callers actually run.
+//!
+//! The controls for that claim are the family test suites themselves, which now
+//! drive their assertions through [`QueryEngine::execute`]. They pass unchanged,
+//! which is what "wrapped without changing semantics" has to mean.
+
+use kirra_world_store::lineage::LineagePage;
+use kirra_world_store::WorldStore;
+
+use crate::answer_ref::{AnswerRef, RefResolution};
+use crate::freshness::FreshnessSource;
+use crate::lineage::{LineageRef, LineageResolution};
+use crate::read_view::{
+    AskError, ComposedLookup, HistoryLookup, SummaryLookup, TemporalLookup, WorldView,
+};
+
+mod sealed {
+    /// Closes [`super::WorldQuery`] to this crate.
+    ///
+    /// A consumer cannot name this trait, so it cannot implement the public one
+    /// either — the standard sealing idiom, used here for the reason in the
+    /// module docs rather than for API-stability hygiene.
+    pub trait Sealed {}
+}
+
+/// **A domain question, as a value.**
+///
+/// Implemented only by the request types in this module (the trait is sealed).
+/// The associated [`Output`](WorldQuery::Output) is what keeps five families
+/// from collapsing into one union: `Ask` yields a [`ComposedLookup`] and
+/// `History` a [`HistoryLookup`], checked at compile time, with no runtime arm
+/// a caller could get wrong.
+pub trait WorldQuery: sealed::Sealed {
+    /// What answering this question produces.
+    type Output;
+
+    /// Run this question against `engine`.
+    ///
+    /// Prefer [`QueryEngine::execute`] at call sites — it reads in the order the
+    /// work happens and keeps the engine the subject of the sentence. This is
+    /// the dispatch target, not the intended spelling.
+    ///
+    /// # Errors
+    ///
+    /// Whatever the underlying family raises; see [`AskError`].
+    fn execute(self, engine: &QueryEngine<'_>) -> Result<Self::Output, AskError>;
+}
+
+/// **The entry point.**
+///
+/// Holds a `&WorldStore` and a [`FreshnessSource`], and offers no mutation:
+/// read-only is structural here for the same reason it is on [`WorldView`] —
+/// Kirra World is evidence, and an answer boundary serves it rather than
+/// adjudicating it.
+///
+/// The freshness source is bound to the ENGINE, not to each request, and that
+/// placement is deliberate. It is a property of the asking context — who is
+/// asking and under what recency contract — not of the individual question, and
+/// putting it on every request would invite two questions in one context to
+/// disagree about whether a fact had expired.
+pub struct QueryEngine<'a> {
+    view: WorldView<'a>,
+    store: &'a WorldStore,
+}
+
+impl<'a> QueryEngine<'a> {
+    /// Bind an engine to a store and a freshness contract.
+    ///
+    /// [`FreshnessSource`] has no variant meaning "nothing supplied" — see box
+    /// 3e. Either the ruled table decides, or the caller states a policy.
+    #[must_use]
+    pub fn new(store: &'a WorldStore, freshness: FreshnessSource) -> Self {
+        Self {
+            view: WorldView::new(store, freshness),
+            store,
+        }
+    }
+
+    /// **Ask one typed question.**
+    ///
+    /// ```ignore
+    /// let engine = QueryEngine::new(&store, FreshnessSource::Ruled);
+    /// let answer = engine.execute(Ask { subject: "robot-1".into(), now_ms })?;
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Whatever the family raises; see [`AskError`].
+    pub fn execute<Q: WorldQuery>(&self, query: Q) -> Result<Q::Output, AskError> {
+        query.execute(self)
+    }
+
+    /// The view the requests dispatch into.
+    ///
+    /// `pub(crate)` and no wider: this is the thing the module exists to stop
+    /// consumers from reaching.
+    pub(crate) fn view(&self) -> &WorldView<'a> {
+        &self.view
+    }
+
+    /// The store, for the two families that resolve a recorded reference.
+    ///
+    /// [`LineageRef`] and [`AnswerRef`] carry their own coordinates and resolve
+    /// against the store rather than through a view, so they need it directly.
+    pub(crate) fn store(&self) -> &'a WorldStore {
+        self.store
+    }
+}
+
+/// **What is currently known about one subject.**
+///
+/// Bounded by construction — one subject, never the whole projection.
+#[derive(Debug, Clone)]
+pub struct Ask {
+    /// The subject to ask about.
+    pub subject: String,
+    /// The instant the question is asked at, for freshness.
+    pub now_ms: i64,
+}
+
+impl sealed::Sealed for Ask {}
+
+impl WorldQuery for Ask {
+    type Output = ComposedLookup;
+
+    fn execute(self, engine: &QueryEngine<'_>) -> Result<Self::Output, AskError> {
+        engine.view().ask(&self.subject, self.now_ms)
+    }
+}
+
+/// **What was known about one subject, at a past coordinate.**
+///
+/// Two independent axes, which is why they are two fields rather than one
+/// "time": `valid_at_ms` asks *when the fact held*, `as_known_at_ms` asks *what
+/// the store had recorded by then*. Collapsing them would make it impossible to
+/// ask what we believed last week about last year.
+#[derive(Debug, Clone)]
+pub struct AskAsOf {
+    /// The subject to ask about.
+    pub subject: String,
+    /// The valid-time instant the fact must hold at.
+    pub valid_at_ms: i64,
+    /// The transaction-time cut: knowledge recorded after this is not consulted.
+    pub as_known_at_ms: i64,
+}
+
+impl sealed::Sealed for AskAsOf {}
+
+impl WorldQuery for AskAsOf {
+    type Output = TemporalLookup;
+
+    fn execute(self, engine: &QueryEngine<'_>) -> Result<Self::Output, AskError> {
+        engine
+            .view()
+            .ask_as_of(&self.subject, self.valid_at_ms, self.as_known_at_ms)
+    }
+}
+
+/// **One page of a subject's recorded history.**
+///
+/// The page is a FIELD of the request rather than an argument threaded past it,
+/// which is the structural half of clause 2: a history question that carries no
+/// bound is not constructible. `LineagePage` validates its own limit, so an
+/// unbounded page is unrepresentable rather than merely discouraged.
+#[derive(Debug, Clone)]
+pub struct History {
+    /// The subject whose history to read.
+    pub subject: String,
+    /// The page bound and cursor.
+    pub page: LineagePage,
+}
+
+impl sealed::Sealed for History {}
+
+impl WorldQuery for History {
+    type Output = HistoryLookup;
+
+    fn execute(self, engine: &QueryEngine<'_>) -> Result<Self::Output, AskError> {
+        engine.view().history(&self.subject, self.page)
+    }
+}
+
+/// **The folded summary for one subject, with its evidence coverage.**
+///
+/// Carries no page because it has no growth dimension to bound: the answer is
+/// one row per subject. Adding a cursor here would be ceremony implying a
+/// dimension that does not exist — the same judgement the boundedness baseline
+/// records for the structurally-bounded reads.
+#[derive(Debug, Clone)]
+pub struct SubjectSummary {
+    /// The subject to summarise.
+    pub subject: String,
+}
+
+impl sealed::Sealed for SubjectSummary {}
+
+impl WorldQuery for SubjectSummary {
+    type Output = SummaryLookup;
+
+    fn execute(self, engine: &QueryEngine<'_>) -> Result<Self::Output, AskError> {
+        engine.view().subject_summary(&self.subject)
+    }
+}
+
+/// **The evidence behind an answer, one page at a time.**
+///
+/// The bound rides on the [`LineageRef`] rather than sitting beside it, and that
+/// is the correct placement rather than an omission: the reference is the
+/// serializable recorded value — subject, generation AND page together are what
+/// gets stored, shipped and replayed. A second `page` field on the request would
+/// create two sources of truth for one bound, and the recorded one would win
+/// silently whenever they disagreed.
+#[derive(Debug, Clone)]
+pub struct Lineage {
+    /// The recorded reference, carrying its own page.
+    pub reference: LineageRef,
+}
+
+impl sealed::Sealed for Lineage {}
+
+impl WorldQuery for Lineage {
+    type Output = LineageResolution;
+
+    fn execute(self, engine: &QueryEngine<'_>) -> Result<Self::Output, AskError> {
+        self.reference.resolve(engine.store())
+    }
+}
+
+/// **Re-execute a recorded answer at the coordinate it was taken.**
+///
+/// Not a sixth family: this is the [`Ask`] family's REPLAY form, pinned to a
+/// generation instead of asked at now, which is why it shares `ask`'s bounded
+/// composed primitive rather than owning one.
+///
+/// It is here rather than in a carve-out because it is unambiguously a domain
+/// read — it returns the same answers `Ask` does. Leaving it out would have
+/// meant exempting a domain read from rule 5, and an exemption is exactly the
+/// shape the five earlier defects took.
+#[derive(Debug, Clone)]
+pub struct ReplayAnswer {
+    /// The recorded reference to re-execute.
+    pub reference: AnswerRef,
+}
+
+impl sealed::Sealed for ReplayAnswer {}
+
+impl WorldQuery for ReplayAnswer {
+    type Output = RefResolution;
+
+    fn execute(self, engine: &QueryEngine<'_>) -> Result<Self::Output, AskError> {
+        self.reference.resolve(engine.store())
+    }
+}

--- a/crates/kirra-world-service/src/read_view.rs
+++ b/crates/kirra-world-service/src/read_view.rs
@@ -505,7 +505,7 @@ impl ComposedLookup {
 /// Read-only is structural, not a convention: this type holds a `&WorldStore`
 /// and offers no mutation. Kirra World is evidence; an answer boundary serves it
 /// and never adjudicates it.
-pub struct WorldView<'a> {
+pub(crate) struct WorldView<'a> {
     store: &'a WorldStore,
     freshness: FreshnessSource,
 }

--- a/crates/kirra-world-service/tests/answer_ref.rs
+++ b/crates/kirra-world-service/tests/answer_ref.rs
@@ -22,9 +22,35 @@
 //! bound wholesale, so it is re-asserted here at the level a caller sees.
 
 use kirra_world_service::answer_ref::{current_semantics, AnswerRef, QueryKind, RefResolution};
+use kirra_world_service::freshness::FreshnessSource;
+use kirra_world_service::query::{QueryEngine, ReplayAnswer};
+use kirra_world_service::read_view::AskError;
 use kirra_world_service::semantics::{RuleVersion, SemanticVersions};
 use kirra_world_store::snapshot::Irreproducible;
 use kirra_world_store::{ClaimStatus, EventId, NewEvent, ObservationId, WorldStore, WriterClass};
+
+/// Replay a recorded answer through the sanctioned surface — box 3d.
+///
+/// `AnswerRef::resolve` became `pub(crate)` when the query engine landed, so
+/// this file cannot reach it any more than a consumer crate can. The shim keeps
+/// the call shape these tests were written in while routing every one of them
+/// through `QueryEngine::execute`, which is the point: the assertions below are
+/// unchanged, and they now pin the ENGINE's behaviour rather than a path only
+/// this crate could take.
+trait ReplayThroughEngine {
+    fn replay(&self, store: &WorldStore) -> Result<RefResolution, AskError>;
+}
+
+impl ReplayThroughEngine for AnswerRef {
+    fn replay(&self, store: &WorldStore) -> Result<RefResolution, AskError> {
+        // The engine's freshness source is inert for this family on purpose: a
+        // recorded reference carries its own staleness budget, which is the
+        // contract that was in force when the answer was taken.
+        QueryEngine::new(store, FreshnessSource::Ruled).execute(ReplayAnswer {
+            reference: self.clone(),
+        })
+    }
+}
 
 const T0: i64 = 1_700_000_000_000;
 const LATER: i64 = T0 + 1_000;
@@ -111,8 +137,8 @@ fn the_same_ref_resolves_identically_and_to_the_pinned_answer() {
     let (store, path) = store_that_changed_its_mind("stable");
     let r = AnswerRef::current_subject("package_17", LATER, None, 1);
 
-    let first = r.resolve(&store).expect("resolve");
-    let second = r.resolve(&store).expect("resolve again");
+    let first = r.replay(&store).expect("resolve");
+    let second = r.replay(&store).expect("resolve again");
 
     assert_eq!(objects(&first), vec!["dock_old".to_string()]);
     assert_eq!(
@@ -125,7 +151,7 @@ fn the_same_ref_resolves_identically_and_to_the_pinned_answer() {
     // "resolved correctly" is distinguishing something.
     let live = AnswerRef::current_subject("package_17", LATER, None, 2);
     assert_eq!(
-        objects(&live.resolve(&store).expect("resolve")),
+        objects(&live.replay(&store).expect("resolve")),
         vec!["dock_a"]
     );
 
@@ -236,7 +262,7 @@ fn a_future_generation_refuses() {
     let (store, path) = store_that_changed_its_mind("future");
     let r = AnswerRef::current_subject("package_17", LATER, None, 9_999);
 
-    match r.resolve(&store).expect("resolve") {
+    match r.replay(&store).expect("resolve") {
         RefResolution::Irreproducible(Irreproducible::NotYetReached { .. }) => {}
         other => panic!("a future coordinate must refuse, got {other:?}"),
     }
@@ -257,13 +283,13 @@ fn compaction_below_the_pin_makes_the_ref_irreproducible() {
     let r = AnswerRef::current_subject("package_17", LATER, None, 1);
 
     assert_eq!(
-        objects(&r.resolve(&store).expect("resolve")),
+        objects(&r.replay(&store).expect("resolve")),
         vec!["dock_old"]
     );
 
     store.compact_range(1, 1, T0 + 5_000).expect("compact");
 
-    match r.resolve(&store).expect("resolve") {
+    match r.replay(&store).expect("resolve") {
         RefResolution::Irreproducible(Irreproducible::Compacted { spans }) => {
             assert!(!spans.is_empty(), "the refusal must name what was removed");
         }
@@ -297,7 +323,7 @@ fn compaction_above_the_pin_leaves_the_ref_resolvable() {
     store.compact_range(2, 2, T0 + 5_000).expect("compact");
 
     assert_eq!(
-        objects(&r.resolve(&store).expect("resolve")),
+        objects(&r.replay(&store).expect("resolve")),
         vec!["dock_old"],
         "a span removed above the pin took none of the events the ref folds"
     );
@@ -323,7 +349,7 @@ fn a_version_mismatch_refuses_rather_than_replaying() {
     let current = AnswerRef::current_subject("package_17", LATER, None, 1);
     assert!(
         current
-            .resolve(&store)
+            .replay(&store)
             .expect("resolve")
             .resolved()
             .is_some(),
@@ -335,7 +361,7 @@ fn a_version_mismatch_refuses_rather_than_replaying() {
     // said only "the rules changed" would leave an operator holding a reference
     // they cannot act on.
     let stale = current.clone().recorded_with("world_current_fold", 0);
-    match stale.resolve(&store).expect("resolve") {
+    match stale.replay(&store).expect("resolve") {
         RefResolution::VersionMismatch { differences } => {
             assert_eq!(differences.len(), 1, "only one rule moved: {differences:?}");
             assert_eq!(differences[0].rule, "world_current_fold");
@@ -353,7 +379,7 @@ fn a_version_mismatch_refuses_rather_than_replaying() {
     match current
         .clone()
         .recorded_with("answer_admissibility", 99)
-        .resolve(&store)
+        .replay(&store)
         .expect("resolve")
     {
         RefResolution::VersionMismatch { differences } => {
@@ -368,7 +394,7 @@ fn a_version_mismatch_refuses_rather_than_replaying() {
     match current
         .clone()
         .recorded_with("world_current_fold", u32::MAX)
-        .resolve(&store)
+        .replay(&store)
         .expect("resolve")
     {
         RefResolution::VersionMismatch { .. } => {}
@@ -381,7 +407,7 @@ fn a_version_mismatch_refuses_rather_than_replaying() {
     match current
         .clone()
         .recorded_with("subject_summary_fold", 1)
-        .resolve(&store)
+        .replay(&store)
         .expect("resolve")
     {
         RefResolution::VersionMismatch { differences } => {
@@ -400,7 +426,7 @@ fn a_version_mismatch_refuses_rather_than_replaying() {
     match current
         .clone()
         .recorded_with("entity_fold", 99)
-        .resolve(&store)
+        .replay(&store)
         .expect("resolve")
     {
         RefResolution::VersionMismatch { differences } => {
@@ -418,7 +444,7 @@ fn a_version_mismatch_refuses_rather_than_replaying() {
     // at an irreproducible coordinate reports the version, not the compaction.
     match AnswerRef::current_subject("package_17", LATER, None, 99_999)
         .recorded_with("world_current_fold", 0)
-        .resolve(&store)
+        .replay(&store)
         .expect("resolve")
     {
         RefResolution::VersionMismatch { .. } => {}
@@ -545,7 +571,7 @@ fn a_refs_recorded_versions_are_pinned_to_what_it_resolves_to() {
         .world_current()
         .generation();
     let resolved = AnswerRef::current_subject("package_17", T0 + 100, None, head)
-        .resolve(&store)
+        .replay(&store)
         .expect("resolve");
 
     let rendered: Vec<String> = resolved

--- a/crates/kirra-world-service/tests/as_of_composition.rs
+++ b/crates/kirra-world-service/tests/as_of_composition.rs
@@ -44,7 +44,8 @@ use kirra_world::observation::{ClockDomain, DomainInstant};
 use kirra_world::reference::{EntityId, EventId, ObservationId};
 use kirra_world_service::answer_ref::QueryKind;
 use kirra_world_service::freshness::{FreshnessPolicy, FreshnessSource};
-use kirra_world_service::read_view::{ObjectIdentity, WorldLookup, WorldView};
+use kirra_world_service::query::{Ask, AskAsOf, QueryEngine};
+use kirra_world_service::read_view::{ObjectIdentity, WorldLookup};
 use kirra_world_service::semantics::SemanticVersions;
 use kirra_world_store::adjudication_record::AdjudicationRow;
 use kirra_world_store::{ClaimStatus, NewEvent, WorldStore, WriterClass};
@@ -178,9 +179,13 @@ fn store_where_the_graph_moved_after_the_cut(name: &str) -> (WorldStore, std::pa
 }
 
 fn sole_identity(store: &WorldStore, as_known_at_ms: i64) -> ObjectIdentity {
-    let view = WorldView::new(store, FreshnessSource::Caller(FreshnessPolicy::Timeless));
+    let view = QueryEngine::new(store, FreshnessSource::Caller(FreshnessPolicy::Timeless));
     let temporal = view
-        .ask_as_of("package_17", VALID_AT, as_known_at_ms)
+        .execute(AskAsOf {
+            subject: "package_17".to_owned(),
+            valid_at_ms: VALID_AT,
+            as_known_at_ms,
+        })
         .expect("ask_as_of");
     let WorldLookup::Answered(answers) = temporal.lookup() else {
         panic!(
@@ -265,11 +270,15 @@ fn the_two_cuts_genuinely_differ() {
 #[test]
 fn the_claim_is_the_same_in_both_arms_only_its_object_resolution_moves() {
     let (store, path) = store_where_the_graph_moved_after_the_cut("sameclaim");
-    let view = WorldView::new(&store, FreshnessSource::Caller(FreshnessPolicy::Timeless));
+    let view = QueryEngine::new(&store, FreshnessSource::Caller(FreshnessPolicy::Timeless));
 
     let render = |as_known_at: i64| {
         let t = view
-            .ask_as_of("package_17", VALID_AT, as_known_at)
+            .execute(AskAsOf {
+                subject: "package_17".to_owned(),
+                valid_at_ms: VALID_AT,
+                as_known_at_ms: as_known_at,
+            })
             .expect("ask_as_of");
         let WorldLookup::Answered(a) = t.lookup() else {
             panic!("must answer");
@@ -451,10 +460,14 @@ fn a_historically_ambiguous_object_is_not_matchable() {
 #[test]
 fn an_as_of_answer_carries_the_familys_version_set() {
     let (store, path) = store_where_the_graph_moved_after_the_cut("versions");
-    let view = WorldView::new(&store, FreshnessSource::Caller(FreshnessPolicy::Timeless));
+    let view = QueryEngine::new(&store, FreshnessSource::Caller(FreshnessPolicy::Timeless));
 
     let temporal = view
-        .ask_as_of("package_17", VALID_AT, CUT)
+        .execute(AskAsOf {
+            subject: "package_17".to_owned(),
+            valid_at_ms: VALID_AT,
+            as_known_at_ms: CUT,
+        })
         .expect("ask_as_of");
 
     assert_eq!(
@@ -486,10 +499,14 @@ fn an_as_of_answer_carries_the_familys_version_set() {
 #[test]
 fn completeness_still_rides_on_the_answer() {
     let (store, path) = store_where_the_graph_moved_after_the_cut("completeness");
-    let view = WorldView::new(&store, FreshnessSource::Caller(FreshnessPolicy::Timeless));
+    let view = QueryEngine::new(&store, FreshnessSource::Caller(FreshnessPolicy::Timeless));
 
     let temporal = view
-        .ask_as_of("package_17", VALID_AT, CUT)
+        .execute(AskAsOf {
+            subject: "package_17".to_owned(),
+            valid_at_ms: VALID_AT,
+            as_known_at_ms: CUT,
+        })
         .expect("ask_as_of");
     assert!(
         !temporal.is_degraded(),
@@ -612,8 +629,13 @@ fn ask_resolves_an_object_two_merges_deep() {
     store.fold().expect("fold");
     store.fold_entity_projection().expect("fold entities");
 
-    let view = WorldView::new(&store, FreshnessSource::Caller(FreshnessPolicy::Timeless));
-    let answer = view.ask("package_17", T0 + 10).expect("ask");
+    let view = QueryEngine::new(&store, FreshnessSource::Caller(FreshnessPolicy::Timeless));
+    let answer = view
+        .execute(Ask {
+            subject: "package_17".to_owned(),
+            now_ms: T0 + 10,
+        })
+        .expect("ask");
 
     let WorldLookup::Answered(answers) = answer.lookup() else {
         panic!("expected an answer, got {:?}", answer.lookup());

--- a/crates/kirra-world-service/tests/completeness_propagation.rs
+++ b/crates/kirra-world-service/tests/completeness_propagation.rs
@@ -94,7 +94,8 @@
 //!   staleness and failed on its own premise.
 
 use kirra_world_service::freshness::FreshnessSource;
-use kirra_world_service::read_view::{AskError, WorldLookup, WorldView};
+use kirra_world_service::query::{Ask, History, QueryEngine, SubjectSummary};
+use kirra_world_service::read_view::{AskError, WorldLookup};
 use kirra_world_store::lineage::LineagePage;
 use kirra_world_store::{ClaimStatus, EventId, NewEvent, ObservationId, WorldStore, WriterClass};
 
@@ -146,8 +147,8 @@ fn claim(store: &mut WorldStore, tag: &str, object: &str, at_ms: i64) {
 
 /// The RULED table classifies `mission`/`last_seen_at` with a five-minute
 /// budget, so this view is fail-closed AND the fixture's claims are classified.
-fn view(store: &WorldStore) -> WorldView<'_> {
-    WorldView::new(store, FreshnessSource::Ruled)
+fn view(store: &WorldStore) -> QueryEngine<'_> {
+    QueryEngine::new(store, FreshnessSource::Ruled)
 }
 
 /// Three observations, all retained. No citations anywhere in the store.
@@ -220,7 +221,10 @@ fn answered(lookup: &WorldLookup) -> usize {
 fn a_compacted_history_reports_degraded() {
     let (store, _p) = holed_store("hist-degraded");
     let lookup = view(&store)
-        .history("package_17", LineagePage::first())
+        .execute(History {
+            subject: "package_17".to_owned(),
+            page: LineagePage::first(),
+        })
         .expect("history");
 
     assert!(
@@ -241,10 +245,16 @@ fn both_history_arms_return_a_plausible_non_empty_record() {
     let (intact, _p2) = intact_store("hist-nonempty-intact");
 
     let degraded = view(&holed)
-        .history("package_17", LineagePage::first())
+        .execute(History {
+            subject: "package_17".to_owned(),
+            page: LineagePage::first(),
+        })
         .expect("history");
     let full = view(&intact)
-        .history("package_17", LineagePage::first())
+        .execute(History {
+            subject: "package_17".to_owned(),
+            page: LineagePage::first(),
+        })
         .expect("history");
 
     assert_eq!(
@@ -272,7 +282,10 @@ fn both_history_arms_return_a_plausible_non_empty_record() {
 fn an_uncompacted_history_reports_full() {
     let (store, _p) = intact_store("hist-full");
     let lookup = view(&store)
-        .history("package_17", LineagePage::first())
+        .execute(History {
+            subject: "package_17".to_owned(),
+            page: LineagePage::first(),
+        })
         .expect("history");
 
     assert!(
@@ -334,7 +347,12 @@ fn history_keeps_a_claim_that_ask_refuses_to_serve() {
     let v = view(&store);
     let late = T0 + 3_600_000;
 
-    let served = v.ask("package_17", late).expect("ask");
+    let served = v
+        .execute(Ask {
+            subject: "package_17".to_owned(),
+            now_ms: late,
+        })
+        .expect("ask");
     assert_eq!(
         answered(served.lookup()),
         0,
@@ -343,7 +361,10 @@ fn history_keeps_a_claim_that_ask_refuses_to_serve() {
     );
 
     let record = v
-        .history("package_17", LineagePage::first())
+        .execute(History {
+            subject: "package_17".to_owned(),
+            page: LineagePage::first(),
+        })
         .expect("history");
     assert_eq!(
         answered(record.lookup()),
@@ -391,7 +412,10 @@ fn an_unruled_claim_refuses_the_whole_history() {
     store.fold().expect("fold");
 
     let err = view(&store)
-        .history("package_17", LineagePage::first())
+        .execute(History {
+            subject: "package_17".to_owned(),
+            page: LineagePage::first(),
+        })
         .expect_err("an unclassified claim must refuse the whole query");
     assert!(
         matches!(err, AskError::UnclassifiedFreshness { .. }),
@@ -409,7 +433,9 @@ fn an_unruled_claim_refuses_the_whole_history() {
 fn a_compacted_summary_reports_degraded() {
     let (store, _p) = holed_store("sum-degraded");
     let lookup = view(&store)
-        .subject_summary("package_17")
+        .execute(SubjectSummary {
+            subject: "package_17".to_owned(),
+        })
         .expect("subject summary");
 
     assert!(
@@ -428,7 +454,9 @@ fn a_compacted_summary_reports_degraded() {
 fn an_uncompacted_summary_reports_complete() {
     let (store, _p) = intact_store("sum-complete");
     let lookup = view(&store)
-        .subject_summary("package_17")
+        .execute(SubjectSummary {
+            subject: "package_17".to_owned(),
+        })
         .expect("subject summary");
 
     assert!(lookup.summary().is_some(), "the subject is summarised");
@@ -456,7 +484,9 @@ fn an_uncompacted_summary_reports_complete() {
 fn reconciliation_does_not_upgrade_completeness() {
     let (store, _p) = holed_store("sum-reconcile");
     let lookup = view(&store)
-        .subject_summary("package_17")
+        .execute(SubjectSummary {
+            subject: "package_17".to_owned(),
+        })
         .expect("subject summary");
     let summary = lookup.summary().expect("summarised");
 
@@ -491,7 +521,9 @@ fn reconciliation_does_not_upgrade_completeness() {
 fn an_unknown_subject_is_absent_rather_than_degraded() {
     let (store, _p) = intact_store("sum-absent");
     let lookup = view(&store)
-        .subject_summary("package_99")
+        .execute(SubjectSummary {
+            subject: "package_99".to_owned(),
+        })
         .expect("subject summary");
 
     assert!(lookup.summary().is_none(), "never observed");
@@ -512,7 +544,12 @@ fn an_unknown_subject_is_absent_rather_than_degraded() {
 fn a_history_page_returns_at_most_its_limit() {
     let (store, _p) = intact_store("hist-page-limit");
     let page = LineagePage::new(2, None).expect("valid page");
-    let lookup = view(&store).history("package_17", page).expect("history");
+    let lookup = view(&store)
+        .execute(History {
+            subject: "package_17".to_owned(),
+            page,
+        })
+        .expect("history");
 
     assert_eq!(
         answered(lookup.lookup()),
@@ -538,7 +575,12 @@ fn paginating_a_history_walks_the_record_without_gaps_or_repeats() {
     let mut cursor = None;
     for _ in 0..10 {
         let page = LineagePage::new(1, cursor).expect("valid page");
-        let lookup = v.history("package_17", page).expect("history");
+        let lookup = v
+            .execute(History {
+                subject: "package_17".to_owned(),
+                page,
+            })
+            .expect("history");
         if let WorldLookup::Answered(answers) = lookup.lookup() {
             for a in answers {
                 seen.push(a.event_id().to_string());
@@ -576,7 +618,12 @@ fn paginating_a_history_walks_the_record_without_gaps_or_repeats() {
 fn a_history_page_that_exactly_fills_is_complete() {
     let (store, _p) = intact_store("hist-page-exact");
     let page = LineagePage::new(3, None).expect("valid page");
-    let lookup = view(&store).history("package_17", page).expect("history");
+    let lookup = view(&store)
+        .execute(History {
+            subject: "package_17".to_owned(),
+            page,
+        })
+        .expect("history");
 
     assert_eq!(answered(lookup.lookup()), 3, "the whole record");
     assert!(
@@ -595,7 +642,12 @@ fn a_history_page_that_exactly_fills_is_complete() {
 fn a_truncated_page_over_a_degraded_record_reports_both() {
     let (store, _p) = holed_store("hist-page-degraded");
     let page = LineagePage::new(1, None).expect("valid page");
-    let lookup = view(&store).history("package_17", page).expect("history");
+    let lookup = view(&store)
+        .execute(History {
+            subject: "package_17".to_owned(),
+            page,
+        })
+        .expect("history");
 
     assert!(
         lookup.boundary().is_truncated(),

--- a/crates/kirra-world-service/tests/degradation_propagation.rs
+++ b/crates/kirra-world-service/tests/degradation_propagation.rs
@@ -67,7 +67,8 @@
 //! reveals that, which is precisely the loss 3g exists to make observable.
 
 use kirra_world_service::freshness::{FreshnessPolicy, FreshnessSource};
-use kirra_world_service::read_view::{WorldLookup, WorldView};
+use kirra_world_service::query::{AskAsOf, QueryEngine};
+use kirra_world_service::read_view::WorldLookup;
 use kirra_world_store::{ClaimStatus, EventId, NewEvent, ObservationId, WorldStore, WriterClass};
 
 const T0: i64 = 1_700_000_000_000;
@@ -166,10 +167,14 @@ fn objects(lookup: &WorldLookup) -> Vec<String> {
 #[test]
 fn evidence_outside_the_compacted_span_is_full_and_still_answers() {
     let (store, path) = store_with_a_hole("full");
-    let view = WorldView::new(&store, FreshnessSource::Caller(FreshnessPolicy::Timeless));
+    let view = QueryEngine::new(&store, FreshnessSource::Caller(FreshnessPolicy::Timeless));
 
     let out = view
-        .ask_as_of("package_17", T0 + 50, T0 + 50)
+        .execute(AskAsOf {
+            subject: "package_17".to_owned(),
+            valid_at_ms: T0 + 50,
+            as_known_at_ms: T0 + 50,
+        })
         .expect("ask_as_of");
 
     assert_eq!(
@@ -201,10 +206,14 @@ fn evidence_outside_the_compacted_span_is_full_and_still_answers() {
 #[test]
 fn evidence_inside_the_compacted_span_is_degraded_and_the_answer_looks_fine() {
     let (store, path) = store_with_a_hole("degraded");
-    let view = WorldView::new(&store, FreshnessSource::Caller(FreshnessPolicy::Timeless));
+    let view = QueryEngine::new(&store, FreshnessSource::Caller(FreshnessPolicy::Timeless));
 
     let out = view
-        .ask_as_of("package_17", T0 + 150, T0 + 9_000)
+        .execute(AskAsOf {
+            subject: "package_17".to_owned(),
+            valid_at_ms: T0 + 150,
+            as_known_at_ms: T0 + 9_000,
+        })
         .expect("ask_as_of");
 
     assert_eq!(
@@ -226,7 +235,11 @@ fn evidence_inside_the_compacted_span_is_degraded_and_the_answer_looks_fine() {
     // The two arms genuinely differ, so the pair is distinguishing completeness
     // rather than agreeing by accident.
     let full = view
-        .ask_as_of("package_17", T0 + 50, T0 + 50)
+        .execute(AskAsOf {
+            subject: "package_17".to_owned(),
+            valid_at_ms: T0 + 50,
+            as_known_at_ms: T0 + 50,
+        })
         .expect("ask_as_of");
     assert_ne!(full.is_degraded(), out.is_degraded());
     assert_eq!(
@@ -266,9 +279,13 @@ fn an_empty_answer_still_reports_that_evidence_was_lost() {
     store.fold().expect("fold");
     store.compact_range(1, 1, T0 + 9_000).expect("compact");
 
-    let view = WorldView::new(&store, FreshnessSource::Caller(FreshnessPolicy::Timeless));
+    let view = QueryEngine::new(&store, FreshnessSource::Caller(FreshnessPolicy::Timeless));
     let out = view
-        .ask_as_of("package_17", T0 + 150, T0 + 9_000)
+        .execute(AskAsOf {
+            subject: "package_17".to_owned(),
+            valid_at_ms: T0 + 150,
+            as_known_at_ms: T0 + 9_000,
+        })
         .expect("ask_as_of");
 
     assert!(
@@ -328,9 +345,13 @@ fn a_subject_the_compacted_window_never_held_is_full() {
     store.fold().expect("fold");
     store.compact_range(1, 1, T0 + 9_000).expect("compact");
 
-    let view = WorldView::new(&store, FreshnessSource::Caller(FreshnessPolicy::Timeless));
+    let view = QueryEngine::new(&store, FreshnessSource::Caller(FreshnessPolicy::Timeless));
     let out = view
-        .ask_as_of("pallet_9", T0 + 1_000, T0 + 9_000)
+        .execute(AskAsOf {
+            subject: "pallet_9".to_owned(),
+            valid_at_ms: T0 + 1_000,
+            as_known_at_ms: T0 + 9_000,
+        })
         .expect("ask_as_of");
 
     assert_eq!(objects(out.lookup()), vec!["bay_3".to_string()]);
@@ -353,14 +374,18 @@ fn a_subject_the_compacted_window_never_held_is_full() {
 #[test]
 fn the_boundary_verdict_equals_the_stores_verdict() {
     let (store, path) = store_with_a_hole("propagates");
-    let view = WorldView::new(&store, FreshnessSource::Caller(FreshnessPolicy::Timeless));
+    let view = QueryEngine::new(&store, FreshnessSource::Caller(FreshnessPolicy::Timeless));
 
     for (valid_at, known_at) in [(T0 + 50, T0 + 50), (T0 + 150, T0 + 9_000)] {
         let store_side = store
             .as_of("package_17", valid_at, known_at)
             .expect("store as_of");
         let boundary = view
-            .ask_as_of("package_17", valid_at, known_at)
+            .execute(AskAsOf {
+                subject: "package_17".to_owned(),
+                valid_at_ms: valid_at,
+                as_known_at_ms: known_at,
+            })
             .expect("ask_as_of");
         assert_eq!(
             &store_side.resolution,

--- a/crates/kirra-world-service/tests/freshness_policy.rs
+++ b/crates/kirra-world-service/tests/freshness_policy.rs
@@ -31,7 +31,8 @@
 //! about the table.
 
 use kirra_world_service::freshness::{FreshnessPolicy, FreshnessSource};
-use kirra_world_service::read_view::{AskError, WorldLookup, WorldView};
+use kirra_world_service::query::{Ask, AskAsOf, QueryEngine};
+use kirra_world_service::read_view::{AskError, WorldLookup};
 use kirra_world_store::{
     ClaimStatus, EventId, NewEvent, ObservationId, Validity, WorldStore, WriterClass,
 };
@@ -101,13 +102,18 @@ fn store_with_both_dispositions(name: &str) -> (WorldStore, std::path::PathBuf) 
 }
 
 /// A view under the RULED source — the configuration every refusal test needs.
-fn store_view(store: &WorldStore) -> WorldView<'_> {
-    WorldView::new(store, FreshnessSource::Ruled)
+fn store_view(store: &WorldStore) -> QueryEngine<'_> {
+    QueryEngine::new(store, FreshnessSource::Ruled)
 }
 
 fn validity_of(store: &WorldStore, predicate: &str) -> Validity {
     let view = store_view(store);
-    let composed = view.ask("package_17", MUCH_LATER).expect("ask");
+    let composed = view
+        .execute(Ask {
+            subject: "package_17".to_owned(),
+            now_ms: MUCH_LATER,
+        })
+        .expect("ask");
     let WorldLookup::Answered(answers) = composed.lookup() else {
         panic!("the fixture must answer, got {:?}", composed.lookup());
     };
@@ -181,8 +187,11 @@ fn an_unclassified_claim_refuses_rather_than_defaulting_to_timeless() {
     claim(&mut store, "unruled", "mission", "invented_predicate");
     store.fold().expect("fold");
 
-    let view = WorldView::new(&store, FreshnessSource::Ruled);
-    match view.ask("package_17", MUCH_LATER) {
+    let view = QueryEngine::new(&store, FreshnessSource::Ruled);
+    match view.execute(Ask {
+        subject: "package_17".to_owned(),
+        now_ms: MUCH_LATER,
+    }) {
         Err(AskError::UnclassifiedFreshness { kind, predicate }) => {
             assert_eq!(kind, "mission");
             assert_eq!(predicate.as_deref(), Some("invented_predicate"));
@@ -210,9 +219,13 @@ fn the_refusal_is_an_error_not_an_unknown_answer() {
     claim(&mut store, "unruled", "mission", "invented_predicate");
     store.fold().expect("fold");
 
-    let view = WorldView::new(&store, FreshnessSource::Ruled);
+    let view = QueryEngine::new(&store, FreshnessSource::Ruled);
     assert!(
-        view.ask("package_17", MUCH_LATER).is_err(),
+        view.execute(Ask {
+            subject: "package_17".to_owned(),
+            now_ms: MUCH_LATER
+        })
+        .is_err(),
         "a missing policy is a policy-resolution failure, not a freshness state \
          and not an absence of knowledge"
     );
@@ -234,9 +247,13 @@ fn one_unruled_claim_refuses_the_whole_query_rather_than_narrowing_it() {
     claim(&mut store, "unruled", "mission", "invented_predicate"); // not
     store.fold().expect("fold");
 
-    let view = WorldView::new(&store, FreshnessSource::Ruled);
+    let view = QueryEngine::new(&store, FreshnessSource::Ruled);
     assert!(
-        view.ask("package_17", MUCH_LATER).is_err(),
+        view.execute(Ask {
+            subject: "package_17".to_owned(),
+            now_ms: MUCH_LATER
+        })
+        .is_err(),
         "a partially-ruled subject must refuse, not serve the ruled half and \
          quietly omit the rest"
     );
@@ -263,7 +280,11 @@ fn the_bitemporal_family_refuses_an_unclassified_claim_as_well() {
     claim(&mut store, "unruled", "mission", "invented_predicate");
     store.fold().expect("fold");
 
-    match store_view(&store).ask_as_of("package_17", MUCH_LATER, MUCH_LATER) {
+    match store_view(&store).execute(AskAsOf {
+        subject: "package_17".to_owned(),
+        valid_at_ms: MUCH_LATER,
+        as_known_at_ms: MUCH_LATER,
+    }) {
         Err(AskError::UnclassifiedFreshness { kind, predicate }) => {
             assert_eq!(kind, "mission");
             assert_eq!(predicate.as_deref(), Some("invented_predicate"));
@@ -291,7 +312,11 @@ fn the_bitemporal_family_refuses_rather_than_narrowing() {
 
     assert!(
         store_view(&store)
-            .ask_as_of("package_17", MUCH_LATER, MUCH_LATER)
+            .execute(AskAsOf {
+                subject: "package_17".to_owned(),
+                valid_at_ms: MUCH_LATER,
+                as_known_at_ms: MUCH_LATER
+            })
             .is_err(),
         "a partially-ruled subject must refuse on the historical axis too, not \
          serve the ruled half and quietly omit the rest"
@@ -307,7 +332,11 @@ fn the_bitemporal_family_refuses_rather_than_narrowing() {
 fn the_bitemporal_family_answers_when_every_claim_is_ruled() {
     let (store, path) = store_with_both_dispositions("asof-ok");
     let lookup = store_view(&store)
-        .ask_as_of("package_17", MUCH_LATER, MUCH_LATER)
+        .execute(AskAsOf {
+            subject: "package_17".to_owned(),
+            valid_at_ms: MUCH_LATER,
+            as_known_at_ms: MUCH_LATER,
+        })
         .expect("a fully-ruled subject must answer");
     let WorldLookup::Answered(answers) = lookup.lookup() else {
         panic!("the fixture must answer, got {:?}", lookup.lookup());
@@ -334,12 +363,15 @@ fn the_caller_source_can_classify_what_the_table_has_not_ruled() {
     claim(&mut store, "unruled", "mission", "invented_predicate");
     store.fold().expect("fold");
 
-    let view = WorldView::new(
+    let view = QueryEngine::new(
         &store,
         FreshnessSource::Caller(FreshnessPolicy::Bounded { max_age_ms: 1_000 }),
     );
     let composed = view
-        .ask("package_17", MUCH_LATER)
+        .execute(Ask {
+            subject: "package_17".to_owned(),
+            now_ms: MUCH_LATER,
+        })
         .expect("caller classified it");
     let WorldLookup::Answered(answers) = composed.lookup() else {
         panic!("must answer");
@@ -365,8 +397,13 @@ fn timeless_is_always_traceable_to_a_grant() {
 
     // From an explicit caller grant, on a class the table rules BOUNDED — so
     // the value cannot have leaked from the table.
-    let view = WorldView::new(&store, FreshnessSource::Caller(FreshnessPolicy::Timeless));
-    let composed = view.ask("package_17", MUCH_LATER).expect("ask");
+    let view = QueryEngine::new(&store, FreshnessSource::Caller(FreshnessPolicy::Timeless));
+    let composed = view
+        .execute(Ask {
+            subject: "package_17".to_owned(),
+            now_ms: MUCH_LATER,
+        })
+        .expect("ask");
     let WorldLookup::Answered(answers) = composed.lookup() else {
         panic!("must answer");
     };

--- a/crates/kirra-world-service/tests/historical_composition.rs
+++ b/crates/kirra-world-service/tests/historical_composition.rs
@@ -47,7 +47,8 @@ use kirra_world::observation::{ClockDomain, DomainInstant};
 use kirra_world::reference::{EntityId, EventId, ObservationId};
 use kirra_world_service::answer_ref::{AnswerRef, RefResolution};
 use kirra_world_service::freshness::{FreshnessPolicy, FreshnessSource};
-use kirra_world_service::read_view::{ObjectIdentity, WorldLookup, WorldView};
+use kirra_world_service::query::{Ask, QueryEngine, ReplayAnswer};
+use kirra_world_service::read_view::{AskError, ObjectIdentity, WorldLookup};
 use kirra_world_store::adjudication_record::AdjudicationRow;
 use kirra_world_store::snapshot::PinnedComposedRead;
 use kirra_world_store::{ClaimStatus, NewEvent, WorldStore, WriterClass};
@@ -185,6 +186,16 @@ fn store_where_the_graph_moved_after_the_pin(name: &str) -> (WorldStore, std::pa
     (store, path, pin)
 }
 
+/// Replay a recorded answer through the sanctioned surface — box 3d.
+///
+/// `AnswerRef::resolve` is `pub(crate)`, so a test cannot reach it directly any
+/// more than a consumer can. The engine's freshness source is inert here on
+/// purpose: a recorded reference carries its OWN staleness budget, which is the
+/// contract that was in force when the answer was taken.
+fn replay(store: &WorldStore, reference: AnswerRef) -> Result<RefResolution, AskError> {
+    QueryEngine::new(store, FreshnessSource::Ruled).execute(ReplayAnswer { reference })
+}
+
 fn sole_identity(res: &RefResolution) -> ObjectIdentity {
     let answers = res.resolved().expect("the ref must resolve");
     assert_eq!(answers.len(), 1, "fixture holds one claim for the subject");
@@ -203,9 +214,14 @@ fn sole_identity(res: &RefResolution) -> ObjectIdentity {
 #[test]
 fn the_live_read_resolves_the_object_through_the_merge() {
     let (store, path, _pin) = store_where_the_graph_moved_after_the_pin("live");
-    let view = WorldView::new(&store, FreshnessSource::Caller(FreshnessPolicy::Timeless));
+    let view = QueryEngine::new(&store, FreshnessSource::Caller(FreshnessPolicy::Timeless));
 
-    let composed = view.ask("package_17", LATER).expect("ask");
+    let composed = view
+        .execute(Ask {
+            subject: "package_17".to_owned(),
+            now_ms: LATER,
+        })
+        .expect("ask");
     let WorldLookup::Answered(answers) = composed.lookup() else {
         panic!("the fixture must answer, got {:?}", composed.lookup());
     };
@@ -233,9 +249,11 @@ fn the_live_read_resolves_the_object_through_the_merge() {
 fn a_ref_pinned_before_the_merge_resolves_identity_as_it_stood_then() {
     let (store, path, pin) = store_where_the_graph_moved_after_the_pin("pinned");
 
-    let resolved = AnswerRef::current_subject("package_17", LATER, None, pin)
-        .resolve(&store)
-        .expect("resolve");
+    let resolved = replay(
+        &store,
+        AnswerRef::current_subject("package_17", LATER, None, pin),
+    )
+    .expect("resolve");
 
     assert_eq!(
         sole_identity(&resolved),
@@ -263,13 +281,20 @@ fn the_historical_and_live_identities_genuinely_differ() {
     let (store, path, pin) = store_where_the_graph_moved_after_the_pin("differ");
 
     let historical = sole_identity(
-        &AnswerRef::current_subject("package_17", LATER, None, pin)
-            .resolve(&store)
-            .expect("resolve"),
+        &replay(
+            &store,
+            AnswerRef::current_subject("package_17", LATER, None, pin),
+        )
+        .expect("resolve"),
     );
 
-    let view = WorldView::new(&store, FreshnessSource::Caller(FreshnessPolicy::Timeless));
-    let composed = view.ask("package_17", LATER).expect("ask");
+    let view = QueryEngine::new(&store, FreshnessSource::Caller(FreshnessPolicy::Timeless));
+    let composed = view
+        .execute(Ask {
+            subject: "package_17".to_owned(),
+            now_ms: LATER,
+        })
+        .expect("ask");
     let WorldLookup::Answered(live) = composed.lookup() else {
         panic!("the fixture must answer");
     };
@@ -300,9 +325,11 @@ fn a_ref_pinned_after_the_merge_does_follow_it() {
         .world_current()
         .generation();
 
-    let resolved = AnswerRef::current_subject("package_17", LATER, None, head)
-        .resolve(&store)
-        .expect("resolve");
+    let resolved = replay(
+        &store,
+        AnswerRef::current_subject("package_17", LATER, None, head),
+    )
+    .expect("resolve");
 
     assert_eq!(
         sole_identity(&resolved),

--- a/crates/kirra-world-service/tests/lineage_retrieval.rs
+++ b/crates/kirra-world-service/tests/lineage_retrieval.rs
@@ -47,7 +47,9 @@
 //! redundant would remove the only coverage there is.
 
 use kirra_world_service::answer_ref::QueryKind;
+use kirra_world_service::freshness::FreshnessSource;
 use kirra_world_service::lineage::{LineageRef, LineageResolution};
+use kirra_world_service::query::{Lineage, QueryEngine};
 use kirra_world_service::semantics::{RuleVersion, SemanticVersions};
 use kirra_world_store::lineage::LineagePage;
 use kirra_world_store::{ClaimStatus, EventId, NewEvent, ObservationId, WorldStore, WriterClass};
@@ -127,7 +129,15 @@ fn store_with(n: i64, name: &str) -> (WorldStore, std::path::PathBuf, i64) {
 }
 
 fn resolve(store: &WorldStore, r: &LineageRef) -> LineageResolution {
-    r.resolve(store).expect("lineage resolves")
+    // Through the sanctioned surface — box 3d. `LineageRef::resolve` is
+    // `pub(crate)` now, so this helper could not call it directly even if it
+    // wanted to: the engine is the only route, and that is enforced by the
+    // compiler rather than by this comment.
+    QueryEngine::new(store, FreshnessSource::Ruled)
+        .execute(Lineage {
+            reference: r.clone(),
+        })
+        .expect("lineage resolves")
 }
 
 fn generations(res: &LineageResolution) -> Vec<i64> {

--- a/crates/kirra-world-service/tests/read_view.rs
+++ b/crates/kirra-world-service/tests/read_view.rs
@@ -7,7 +7,8 @@
 
 use kirra_world::evidence::DigestError;
 use kirra_world_service::freshness::{FreshnessPolicy, FreshnessSource};
-use kirra_world_service::read_view::{AskError, UnknownReason, WorldLookup, WorldView};
+use kirra_world_service::query::{Ask, QueryEngine};
+use kirra_world_service::read_view::{AskError, UnknownReason, WorldLookup};
 use kirra_world_store::{
     Adjudication, ClaimStatus, Corroboration, EventId, NewEvent, ObservationId, Origin, TrustAxes,
     TrustGrade, Validity, WorldStore, WriterClass,
@@ -129,11 +130,18 @@ fn an_answer_carries_validity_trust_and_provenance() {
     let a = axes(Corroboration::Corroborated(2), Adjudication::Confirmed);
     seed(&mut s, 1, "cup-1", None, Some(&a), ClaimStatus::Confirmed);
 
-    let view = WorldView::new(
+    let view = QueryEngine::new(
         &s,
         FreshnessSource::Caller(FreshnessPolicy::Bounded { max_age_ms: 60_000 }),
     );
-    let WorldLookup::Answered(answers) = view.ask("cup-1", T0).expect("ask").into_lookup() else {
+    let WorldLookup::Answered(answers) = view
+        .execute(Ask {
+            subject: "cup-1".to_owned(),
+            now_ms: T0,
+        })
+        .expect("ask")
+        .into_lookup()
+    else {
         panic!("expected an answer");
     };
     assert_eq!(answers.len(), 1);
@@ -195,11 +203,18 @@ fn an_answer_carries_the_axes_not_only_the_collapsed_grade() {
     let a = axes(Corroboration::Corroborated(2), Adjudication::Confirmed);
     seed(&mut s, 1, "cup-1", None, Some(&a), ClaimStatus::Confirmed);
 
-    let view = WorldView::new(
+    let view = QueryEngine::new(
         &s,
         FreshnessSource::Caller(FreshnessPolicy::Bounded { max_age_ms: 60_000 }),
     );
-    let WorldLookup::Answered(answers) = view.ask("cup-1", T0).expect("ask").into_lookup() else {
+    let WorldLookup::Answered(answers) = view
+        .execute(Ask {
+            subject: "cup-1".to_owned(),
+            now_ms: T0,
+        })
+        .expect("ask")
+        .into_lookup()
+    else {
         panic!("expected an answer");
     };
     let got = answers[0]
@@ -249,15 +264,29 @@ fn two_claims_can_share_a_grade_for_different_reasons() {
         ClaimStatus::Confirmed,
     );
 
-    let view = WorldView::new(
+    let view = QueryEngine::new(
         &s,
         FreshnessSource::Caller(FreshnessPolicy::Bounded { max_age_ms: 60_000 }),
     );
 
-    let WorldLookup::Answered(a1) = view.ask("a", T0).expect("ask").into_lookup() else {
+    let WorldLookup::Answered(a1) = view
+        .execute(Ask {
+            subject: "a".to_owned(),
+            now_ms: T0,
+        })
+        .expect("ask")
+        .into_lookup()
+    else {
         panic!("expected an answer");
     };
-    let WorldLookup::Answered(a2) = view.ask("b", T0).expect("ask").into_lookup() else {
+    let WorldLookup::Answered(a2) = view
+        .execute(Ask {
+            subject: "b".to_owned(),
+            now_ms: T0,
+        })
+        .expect("ask")
+        .into_lookup()
+    else {
         panic!("expected an answer");
     };
 
@@ -286,11 +315,18 @@ fn an_unlabelled_claim_has_no_grade_rather_than_a_default() {
     let mut s = open("unlabelled");
     seed(&mut s, 1, "cup-1", None, None, ClaimStatus::Confirmed);
 
-    let view = WorldView::new(
+    let view = QueryEngine::new(
         &s,
         FreshnessSource::Caller(FreshnessPolicy::Bounded { max_age_ms: 60_000 }),
     );
-    let WorldLookup::Answered(answers) = view.ask("cup-1", T0).expect("ask").into_lookup() else {
+    let WorldLookup::Answered(answers) = view
+        .execute(Ask {
+            subject: "cup-1".to_owned(),
+            now_ms: T0,
+        })
+        .expect("ask")
+        .into_lookup()
+    else {
         panic!("expected an answer");
     };
     assert_eq!(answers[0].grade(), None);
@@ -313,12 +349,15 @@ fn an_unlabelled_claim_has_no_grade_rather_than_a_default() {
 #[test]
 fn an_unknown_subject_is_a_success_not_an_error() {
     let s = open("unknown");
-    let view = WorldView::new(
+    let view = QueryEngine::new(
         &s,
         FreshnessSource::Caller(FreshnessPolicy::Bounded { max_age_ms: 60_000 }),
     );
 
-    let out = view.ask("never-heard-of-it", T0);
+    let out = view.execute(Ask {
+        subject: "never-heard-of-it".to_owned(),
+        now_ms: T0,
+    });
     assert!(
         out.is_ok(),
         "absence of knowledge must not use the error channel"
@@ -352,16 +391,26 @@ fn an_expired_claim_is_not_served() {
         ClaimStatus::Confirmed,
     );
 
-    let view = WorldView::new(
+    let view = QueryEngine::new(
         &s,
         FreshnessSource::Caller(FreshnessPolicy::Bounded { max_age_ms: 60_000 }),
     );
     assert!(matches!(
-        view.ask("cup-1", T0 + 500).expect("ask").into_lookup(),
+        view.execute(Ask {
+            subject: "cup-1".to_owned(),
+            now_ms: T0 + 500
+        })
+        .expect("ask")
+        .into_lookup(),
         WorldLookup::Answered(_)
     ));
     assert!(matches!(
-        view.ask("cup-1", T0 + 5_000).expect("ask").into_lookup(),
+        view.execute(Ask {
+            subject: "cup-1".to_owned(),
+            now_ms: T0 + 5_000
+        })
+        .expect("ask")
+        .into_lookup(),
         WorldLookup::Unknown(UnknownReason::NoClaim)
     ));
 }
@@ -385,12 +434,17 @@ fn an_inadmissible_claim_never_reaches_the_boundary() {
         ClaimStatus::Candidate,
     );
 
-    let view = WorldView::new(
+    let view = QueryEngine::new(
         &s,
         FreshnessSource::Caller(FreshnessPolicy::Bounded { max_age_ms: 60_000 }),
     );
     assert!(matches!(
-        view.ask("cup-1", T0).expect("ask").into_lookup(),
+        view.execute(Ask {
+            subject: "cup-1".to_owned(),
+            now_ms: T0
+        })
+        .expect("ask")
+        .into_lookup(),
         WorldLookup::Unknown(UnknownReason::NoClaim)
     ));
 }
@@ -419,23 +473,36 @@ fn the_staleness_budget_belongs_to_the_asking_caller() {
 
     let later = T0 + 120_000;
 
-    let impatient = WorldView::new(
+    let impatient = QueryEngine::new(
         &s,
         FreshnessSource::Caller(FreshnessPolicy::Bounded { max_age_ms: 60_000 }),
     );
-    let WorldLookup::Answered(a1) = impatient.ask("cup-1", later).expect("ask").into_lookup()
+    let WorldLookup::Answered(a1) = impatient
+        .execute(Ask {
+            subject: "cup-1".to_owned(),
+            now_ms: later,
+        })
+        .expect("ask")
+        .into_lookup()
     else {
         panic!("expected an answer");
     };
     assert_eq!(a1[0].validity(), Validity::Stale);
 
-    let patient = WorldView::new(
+    let patient = QueryEngine::new(
         &s,
         FreshnessSource::Caller(FreshnessPolicy::Bounded {
             max_age_ms: 600_000,
         }),
     );
-    let WorldLookup::Answered(a2) = patient.ask("cup-1", later).expect("ask").into_lookup() else {
+    let WorldLookup::Answered(a2) = patient
+        .execute(Ask {
+            subject: "cup-1".to_owned(),
+            now_ms: later,
+        })
+        .expect("ask")
+        .into_lookup()
+    else {
         panic!("expected an answer");
     };
     assert_eq!(a2[0].validity(), Validity::Fresh);
@@ -472,12 +539,17 @@ fn an_unreadable_provenance_handle_is_refused_rather_than_served() {
 
     // Answerable to begin with -- so the refusal below is caused by the
     // corruption and not by the fixture never having worked.
-    let view = WorldView::new(
+    let view = QueryEngine::new(
         &s,
         FreshnessSource::Caller(FreshnessPolicy::Bounded { max_age_ms: 60_000 }),
     );
     assert!(matches!(
-        view.ask("cup-1", T0).expect("ask").into_lookup(),
+        view.execute(Ask {
+            subject: "cup-1".to_owned(),
+            now_ms: T0
+        })
+        .expect("ask")
+        .into_lookup(),
         WorldLookup::Answered(_)
     ));
 
@@ -487,11 +559,14 @@ fn an_unreadable_provenance_handle_is_refused_rather_than_served() {
     ))
     .expect("plant the corruption");
 
-    let view = WorldView::new(
+    let view = QueryEngine::new(
         &s,
         FreshnessSource::Caller(FreshnessPolicy::Bounded { max_age_ms: 60_000 }),
     );
-    match view.ask("cup-1", T0) {
+    match view.execute(Ask {
+        subject: "cup-1".to_owned(),
+        now_ms: T0,
+    }) {
         Err(AskError::CorruptProvenance {
             subject,
             predicate,
@@ -542,11 +617,18 @@ fn the_error_identifies_which_of_a_subject_s_rows_is_damaged() {
 
     // Two rows, both answerable, so the refusal below is caused by the
     // corruption rather than by a fixture that never worked.
-    let view = WorldView::new(
+    let view = QueryEngine::new(
         &s,
         FreshnessSource::Caller(FreshnessPolicy::Bounded { max_age_ms: 60_000 }),
     );
-    let WorldLookup::Answered(before) = view.ask("cup-1", T0).expect("ask").into_lookup() else {
+    let WorldLookup::Answered(before) = view
+        .execute(Ask {
+            subject: "cup-1".to_owned(),
+            now_ms: T0,
+        })
+        .expect("ask")
+        .into_lookup()
+    else {
         panic!("expected answers");
     };
     assert_eq!(before.len(), 2, "one row per predicate");
@@ -558,11 +640,14 @@ fn the_error_identifies_which_of_a_subject_s_rows_is_damaged() {
     ))
     .expect("plant the corruption in ONE row");
 
-    let view = WorldView::new(
+    let view = QueryEngine::new(
         &s,
         FreshnessSource::Caller(FreshnessPolicy::Bounded { max_age_ms: 60_000 }),
     );
-    match view.ask("cup-1", T0) {
+    match view.execute(Ask {
+        subject: "cup-1".to_owned(),
+        now_ms: T0,
+    }) {
         Err(AskError::CorruptProvenance {
             subject, predicate, ..
         }) => {
@@ -613,11 +698,14 @@ fn a_corrupt_handle_is_not_reported_as_absence_of_knowledge() {
     s.raw_execute_for_test("UPDATE world_current SET chain_digest = ''")
         .expect("plant the corruption");
 
-    let view = WorldView::new(
+    let view = QueryEngine::new(
         &s,
         FreshnessSource::Caller(FreshnessPolicy::Bounded { max_age_ms: 60_000 }),
     );
-    let out = view.ask("cup-1", T0);
+    let out = view.execute(Ask {
+        subject: "cup-1".to_owned(),
+        now_ms: T0,
+    });
     assert!(
         !matches!(&out, Ok(c) if matches!(c.lookup(), WorldLookup::Unknown(_))),
         "damage must not be reported as absence"

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -3173,7 +3173,7 @@ impl WorldStore {
     /// # Errors
     ///
     /// [`StoreError::Sqlite`] on any read failure.
-    pub fn history(&self, subject: &str) -> Result<TemporalAnswer, StoreError> {
+    pub fn history_whole(&self, subject: &str) -> Result<TemporalAnswer, StoreError> {
         let mut stmt = self.conn.prepare(&format!(
             "SELECT {CLAIM_COLUMNS} FROM world_events
              WHERE subject = ?1 AND claim_status = 'confirmed'

--- a/crates/kirra-world-store/tests/degraded_answers.rs
+++ b/crates/kirra-world-store/tests/degraded_answers.rs
@@ -167,7 +167,7 @@ fn history_across_a_compacted_window_is_degraded_and_carries_the_summary() {
     let mut s = seeded(&p);
     let out = s.compact_range(1, 6, T0 + 9_000).expect("compact");
 
-    let h = s.history("cup-0").unwrap();
+    let h = s.history_whole("cup-0").unwrap();
     assert!(h.is_empty(), "every cup-0 observation was in the window");
     assert!(
         h.is_degraded(),
@@ -215,7 +215,7 @@ fn a_subject_the_window_never_held_is_not_degraded() {
     let mut s = seeded(&p);
     s.compact_range(1, 6, T0 + 9_000).expect("compact");
 
-    let h = s.history("cup-1").unwrap();
+    let h = s.history_whole("cup-1").unwrap();
     assert_eq!(h.len(), 6, "cup-1 was not in the window");
     assert_eq!(
         h.resolution,
@@ -302,7 +302,7 @@ fn a_store_compacted_before_summaries_existed_reports_degraded_with_nothing_to_s
     // Even a subject the window never held is degraded here — with the
     // summaries gone there is no longer any evidence of what it did hold.
     for subject in ["cup-0", "cup-1"] {
-        let h = s.history(subject).unwrap();
+        let h = s.history_whole(subject).unwrap();
         assert!(
             h.is_degraded(),
             "{subject}: a citation with no summary must still degrade the answer"
@@ -334,11 +334,11 @@ fn a_summary_whose_citation_is_missing_fails_closed() {
     let p = tmp("orphan-summary");
     let mut s = seeded(&p);
     s.compact_range(1, 6, T0 + 9_000).expect("compact");
-    s.history("cup-0").expect("healthy before");
+    s.history_whole("cup-0").expect("healthy before");
 
     s.delete_citation_for_test(1).unwrap();
 
-    match s.history("cup-0") {
+    match s.history_whole("cup-0") {
         Err(StoreError::CitationBroken { lo_generation, .. }) => assert_eq!(lo_generation, 1),
         other => panic!("expected a fail-closed citation error, got {other:?}"),
     }
@@ -532,7 +532,7 @@ fn successive_compactions_each_retain_their_own_summary() {
     s.compact_range(5, 8, T0 + 20_100).expect("second");
     s.verify_chain().expect("chain still verifies across both");
 
-    let h = s.history("cup-0").unwrap();
+    let h = s.history_whole("cup-0").unwrap();
     assert!(h.is_empty() && h.is_degraded());
     let sums = h.resolution.summaries();
     assert_eq!(sums.len(), 2, "one per span");
@@ -587,7 +587,7 @@ fn a_refused_compaction_retains_no_summary() {
     assert!(s.summaries().unwrap().is_empty());
     assert_eq!(s.count().unwrap(), 3, "nothing was removed");
     assert_eq!(
-        s.history("cup-0").unwrap().resolution,
+        s.history_whole("cup-0").unwrap().resolution,
         Resolution::Full,
         "a refusal must not make later answers read as degraded"
     );
@@ -630,7 +630,7 @@ fn current_state_survives_compaction() {
         "current state is untouched by compaction, by construction"
     );
     // And the trajectory that led there is gone, and says so.
-    let h = s.history("cup-0").unwrap();
+    let h = s.history_whole("cup-0").unwrap();
     assert_eq!(h.len(), 1, "only the head survives");
     assert!(h.is_degraded());
     assert_eq!(h.resolution.summaries()[0].event_count, 5);

--- a/crates/kirra-world-store/tests/read_path.rs
+++ b/crates/kirra-world-store/tests/read_path.rs
@@ -503,7 +503,7 @@ fn history_is_every_confirmed_event_oldest_first() {
         ))
         .expect("append");
     }
-    let h = s.history("cup-1").unwrap().claims;
+    let h = s.history_whole("cup-1").unwrap().claims;
     assert_eq!(h.len(), 4);
     assert!(
         h.windows(2).all(|w| w[0].generation < w[1].generation),

--- a/crates/kirra-world-store/tests/retention.rs
+++ b/crates/kirra-world-store/tests/retention.rs
@@ -544,10 +544,10 @@ fn successive_compactions_chain_correctly() {
 fn surviving_events_are_unchanged() {
     let p = tmp("survivors");
     let mut s = seeded(&p);
-    let before = s.history("cup-0").unwrap().claims;
+    let before = s.history_whole("cup-0").unwrap().claims;
 
     s.compact_range(1, 6, T0 + 9_000).expect("compact");
-    let after = s.history("cup-0").unwrap();
+    let after = s.history_whole("cup-0").unwrap();
     assert!(
         after.is_degraded(),
         "compaction removed events about this subject; the answer must say so"

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -2019,12 +2019,15 @@ pressure that produced every stale claim this box already documents.
       `as_known_at` over a multi-projection answer is otherwise approximately a
       lie. `IdentityView` already records the single-snapshot argument for one
       walk; this is that argument across projections.
-- [~] **3d — Typed query engine.** The RATCHET half is ✅ **DONE 2026-08-10**;
-      the BOUNDEDNESS half ✅ **DONE 2026-08-12** (`ci/check_query_boundedness.py`
-      + the affected-entity reverse index; see *"3d: boundedness is structural,
-      not observable"*). The typed request/dispatch surface itself is still open
-      (`ci/check_world_answer_boundary.py`); the typed engine itself is still
-      open — see *"3d's ratchet closed ahead of its engine"* below. The only
+- [x] **3d — Typed query engine.** ✅ **DONE 2026-08-13**, in three slices: the
+      RATCHET half 2026-08-10 (`ci/check_world_answer_boundary.py`), the
+      BOUNDEDNESS half 2026-08-12 (`ci/check_query_boundedness.py` + the
+      affected-entity reverse index; see *"3d: boundedness is structural, not
+      observable"*), and the DISPATCH surface 2026-08-13 —
+      `kirra_world_service::query`: `QueryEngine::execute` over five sealed
+      typed requests, made load-bearing by VISIBILITY (`WorldView` and the two
+      `resolve` methods are `pub(crate)`) with gate rule 5 behind it. See
+      *"3d closed: one way to ask"*. The only
       supported path for **domain questions**. Operational reads are explicitly carved out — `verify_chain`,
       `schema_version`, backup/export, the retention driver, the compaction
       planner and the WM-2 measurement harness all legitimately read below it,
@@ -3536,7 +3539,91 @@ index.
 The boundedness invariant is closed with **zero exceptions**: every interactive
 boundary query is bounded, and the gate is wired into CI with a self-test that
 still rejects the historical defect shape. The typed request/dispatch surface
-over the five families remains open.
+over the five families remains open — closed the following day, below.
+
+### 3d closed: one way to ask — 2026-08-13
+
+The boundedness half made it impossible for a query to hide an unbounded store
+read. It did **not** make a query the only way to ask, and those are different
+properties. A consumer holding a `&WorldStore` could build its own `WorldView`,
+call a family directly, and be perfectly bounded while bypassing semantics
+versions, freshness classification and the no-bare-values rule.
+
+That was not hypothetical. `mission_context` did exactly that, and it was the
+*sanctioned* route at the time — which is why the negative fixture for the new
+rule is that real call rather than an invented spelling.
+
+#### Five typed requests, not one enum
+
+The five families have genuinely different result shapes: different payload
+outcomes, completeness types, pagination state, historical coordinates and
+refusal semantics. A single `WorldQuery` enum returning a single `WorldAnswer`
+would flatten all five axes back together and force every caller to `match` over
+families it did not ask about — undoing the work that kept those axes honest.
+
+So the surface is one entry point with compile-time output types: an associated
+`Output` on a **sealed** `WorldQuery` trait. `Ask` yields a `ComposedLookup`,
+`History` a `HistoryLookup`, checked by the compiler, with no runtime arm a
+caller could get wrong.
+
+Sealing is not API hygiene here. Without it the engine would be a suggestion: a
+consumer could implement `WorldQuery` itself, close over a `&WorldStore` or an
+arbitrary predicate, and route it through `execute` — arriving at exactly the
+ad-hoc queries the box exists to prevent, while looking like sanctioned use. It
+also preserves the `AnswerRef` ruling that a public domain query stays a
+serializable named value rather than a closure.
+
+#### Visibility first, gate second
+
+> A compile error at the point of the mistake is stronger than a gate finding
+> after the fact.
+
+`WorldView`, `LineageRef::resolve` and `AnswerRef::resolve` are `pub(crate)`.
+The migration of `mission_context` was therefore **forced by the compiler**, not
+remembered: the old spelling stopped building, in the consumer, naming the item
+it could no longer see.
+
+Gate rule 5 sits behind that for what visibility cannot reach — a new `pub`
+family method nobody wrapped, or a consumer reaching around the boundary into
+the store — plus three visibility PINS, so the day someone widens `pub(crate)`
+back to `pub` is the day CI says so rather than the day a consumer slips past.
+
+Rule 5's carve-outs are not a hand-written list: a consumer may call store
+methods classified `operational` and no others. Integrity verification,
+migration, folding, retention and measurement legitimately read the store
+outside a query, and they are already classified that way for rules 1–4. A new
+store method cannot arrive as an unnoticed carve-out, because an unclassified
+one already reds rule 1.
+
+#### The engine adds no query logic, and the tests are what prove it
+
+Every request dispatches into the already-proven family implementation. Nothing
+in the engine re-derives a bound, re-implements a fold or re-decides freshness —
+that would be a second query engine hiding inside the query engine, and the
+proofs behind the first would stop covering what callers actually run.
+
+The control is that **112 family assertions now drive through
+`QueryEngine::execute` and pass unchanged**. "Wrapped without changing
+semantics" has to mean something falsifiable, and that is the falsifier.
+
+#### A name collision the gate found
+
+Wiring the dispatch reded rule 2: `WorldView::history` is the BOUNDED family and
+`WorldStore::history` was the UNBOUNDED whole-record read, so the engine's
+dispatch *into the bounded family* read as a call to the unbounded one.
+
+Renamed `history_whole` — the same correction `resolve_at` →
+`resolve_at_whole_graph` already took in this box. A read that returns
+everything should say so in its name; that is how it gets called by mistake.
+
+#### One deviation from the five
+
+`AnswerRef::resolve` is wrapped too, as `ReplayAnswer`. It is not a sixth
+family — it is `ask`'s replay form, pinned to a generation instead of asked at
+now, sharing the same bounded composed primitive. It is wrapped because it is
+unambiguously a domain read, and leaving it out would have meant exempting a
+domain read from a rule that is supposed to have no exceptions on domain reads.
+An exemption is the shape all five earlier defects took.
 
 ### 3g follow-up closed: two families, two mechanisms — 2026-08-12
 


### PR DESCRIPTION
Closes Tier 3 box **3d**. `WM_SCOPE` moves it to `[x]`.

The boundedness half (#1442) made it impossible for a query to **hide** an unbounded store read. It did not make a query the only way to **ask**, and those are different properties.

## The gap this closes

A consumer holding a `&WorldStore` could build its own `WorldView`, call a family directly, and be perfectly bounded while bypassing semantics versions, freshness classification and the no-bare-values rule.

Not hypothetical: `mission_context` did exactly that, and it was the **sanctioned route at the time**. That is why rule 5's negative fixture is that real call rather than an invented spelling.

> There is ONE mechanically enforced way for application code to ask Kirra World a domain question.

Not *"a typed engine exists"* — that is satisfied by an engine nobody has to use.

## Five typed requests, not one enum

The families have genuinely different result shapes: payload outcomes, completeness types, pagination state, historical coordinates, refusal semantics. One `WorldQuery` enum returning one `WorldAnswer` would flatten all five axes back together and force every caller to `match` over families it did not ask about.

A **sealed** `WorldQuery` trait with an associated `Output` instead:

```rust
engine.execute(Ask { subject, now_ms })?;      // -> ComposedLookup
engine.execute(History { subject, page })?;    // -> HistoryLookup
```

Sealing is not API hygiene. Without it a consumer could implement the trait itself, close over a store or an arbitrary predicate, and route it through `execute` — the ad-hoc queries the box exists to prevent, wearing sanctioned clothes. It also keeps a public domain query a **serializable named value** rather than a closure, per the `AnswerRef` ruling.

Bounds sit on the request types. `History` carries its `LineagePage`, so a history question with no bound is not constructible. `Lineage` keeps its page on the `LineageRef` rather than beside it: the reference *is* the recorded value, and a second `page` field would give one bound two sources of truth with the recorded one winning silently on disagreement.

## Visibility first, gate second

> A compile error at the point of the mistake is stronger than a gate finding after the fact.

`WorldView`, `LineageRef::resolve` and `AnswerRef::resolve` are now `pub(crate)`. The `mission_context` migration was therefore **forced by the compiler**, not remembered:

```
error[E0603]: struct `WorldView` is private
  --> crates/kirra-proposal-context/src/lib.rs:63:59
```

Gate **rule 5** covers what visibility cannot reach — a new `pub` family method nobody wrapped, a consumer reaching around the boundary into the store — plus three visibility **pins**, so widening `pub(crate)` back to `pub` is itself a red build.

Rule 5's carve-outs are **not hand-written**: a consumer may call store methods classified `operational` and no others. Verification, migration, folding, retention and measurement are already classified that way for rules 1–4, so a new store method cannot arrive as an unnoticed carve-out — an unclassified one already reds rule 1.

## The engine adds no query logic

Every request dispatches into the already-proven family implementation. Nothing re-derives a bound, re-implements a fold or re-decides freshness — that would be a second query engine hiding inside the query engine, and the proofs behind the first would stop covering what callers actually run.

**The control: 112 family assertions now drive through `QueryEngine::execute` and pass unchanged.** Migrating the suites was the only way to make "wrapped without changing semantics" falsifiable, and it also meant `pub(crate)` could bite without a test-only escape hatch.

## A name collision the gate found

Wiring the dispatch **reded rule 2**, correctly. `WorldView::history` is the BOUNDED family; `WorldStore::history` was the UNBOUNDED whole-record read — so dispatch *into* the bounded family scanned as a call to the unbounded one.

Renamed `history_whole`, the same correction `resolve_at` → `resolve_at_whole_graph` already took in this box. A read that returns everything should say so in its name; that is how it gets called by mistake.

## One deviation from five

`AnswerRef::resolve` is wrapped as `ReplayAnswer` — six requests, not five. It is not a sixth family (it is `ask`'s replay form on the same bounded composed primitive), but it **is** unambiguously a domain read, and leaving it out would have meant exempting a domain read from a rule specified as zero-exception on domain reads. An exemption is the shape all five earlier defects took, so the invariant won over the count.

## Verification

- **39 suites green** across the world crates and the Tier 2.5 differential consumer
- `cargo build --workspace`, `cargo fmt --all --check`, `cargo clippy --all-targets` — clean
- every world CI gate green, including the boundedness gate at **zero violations**
- rule 5 fires on a real-tree mutation (a consumer calling `store.current`) and on widening the `WorldView` visibility pin
- self-test grew from 8 checks to 12: the pre-engine `mission_context` route must red, the migrated form must pass, a consumer reading the store directly must red, and operational store calls must stay allowed

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_