### PR TITLE
Tier 3 cross-cutting cursor contract — opaque, family-bound, semantics-versioned, retention-aware, fail-closed

### DIFF
--- a/ci/store_boundedness_baseline.json
+++ b/ci/store_boundedness_baseline.json
@@ -96,6 +96,10 @@
       "class": "unbounded",
       "why": "The whole claims projection. Grows with the number of subjects."
     },
+    "cursor_anchor": {
+      "class": "bounded",
+      "why": "Two point reads: one row by primary key, and the log head via ORDER BY generation DESC LIMIT 1. Structurally bounded \u2014 the result is two scalars regardless of log size. It exists so a continuation cursor can be REFUSED rather than silently continued from a coordinate the log no longer holds."
+    },
     "entity_projection_generation": {
       "class": "operational",
       "why": "Checkpoint metadata."

--- a/crates/kirra-world-service/src/cursor.rs
+++ b/crates/kirra-world-service/src/cursor.rs
@@ -1,0 +1,323 @@
+//! **Opaque continuation cursors** — Tier 3 §6 cross-cutting.
+//!
+//! The rule:
+//!
+//! > A cursor names a continuation of ONE query contract under ONE
+//! > semantic-version set, not merely a position in SQLite.
+//!
+//! # What this replaces, and why it was a leak
+//!
+//! Pagination shipped with the cursor as a bare `i64` — the SQLite `generation`
+//! — handed out by `PageBoundary::More { next_after_generation }` and taken back
+//! by `LineagePage::after_generation`. Every page of every family passed a raw
+//! log position across the domain boundary.
+//!
+//! That is not a naming complaint. A bare integer is a value a caller can do
+//! *arithmetic* on, persist for a month, replay after a compaction removed the
+//! row it names, or hand to a different query family — and every one of those
+//! returns a page rather than an error. The answer looks correct: right shape,
+//! right subject, plausible contents. It is the same defect class box 3d spent
+//! two PRs on, one level up — the ANSWER is well-formed and the QUESTION it
+//! answers is not the one that was asked.
+//!
+//! # Opaque means capability, not wrapping
+//!
+//! Wrapping the integer in a newtype and calling it opaque would fix nothing:
+//! the hazard is not that callers can *read* the generation, it is that a cursor
+//! carries no evidence of what it continues. So a [`PageCursor`] binds three
+//! things and validates all three before a page is served:
+//!
+//! | Bound | Refusal when it does not match |
+//! |---|---|
+//! | the query FAMILY | [`CursorError::WrongFamily`] |
+//! | the SEMANTIC VERSIONS in force when it was minted | [`CursorError::SemanticsChanged`] |
+//! | a generation this store still RETAINS | [`CursorError::Unreproducible`] |
+//!
+//! plus [`CursorError::BeyondHead`] and [`CursorError::ImpossibleGeneration`]
+//! for a coordinate that cannot have come from this log at all.
+//!
+//! The family binding is the one that proves "opaque" means capability: a
+//! `History` cursor and a `Lineage` cursor can hold byte-identical generation
+//! and version data, and presenting one where the other belongs is still
+//! refused. A test does exactly that substitution.
+//!
+//! # Every failure is a REFUSAL
+//!
+//! Never a reset to page 1, and never a jump to the next surviving generation.
+//! Both are available, both look like recovery, and both silently answer a
+//! different question than the caller asked — re-serving rows already seen, or
+//! skipping the ones that vanished. A caller who is told *"this cursor no longer
+//! names a continuation"* can start over deliberately; a caller silently handed
+//! page 1 cannot tell it happened.
+
+use kirra_world_store::WorldStore;
+
+use crate::answer_ref::QueryKind;
+use crate::semantics::{SemanticVersions, VersionDifference};
+
+/// Which query family a cursor continues.
+///
+/// Separate from [`QueryKind`] on purpose: only families that PAGINATE can mint
+/// a cursor, and a type that could name `CurrentSubject` would imply a
+/// continuation that does not exist.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CursorFamily {
+    /// [`crate::query::History`] — a subject's recorded claims, in order.
+    History,
+    /// [`crate::query::Lineage`] — the evidence behind an answer.
+    Lineage,
+}
+
+impl CursorFamily {
+    /// The query whose semantic-version set governs this family.
+    #[must_use]
+    pub fn query_kind(self) -> QueryKind {
+        match self {
+            Self::History => QueryKind::SubjectHistory,
+            Self::Lineage => QueryKind::SubjectLineage,
+        }
+    }
+
+    /// The name used in refusals.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::History => "history",
+            Self::Lineage => "lineage",
+        }
+    }
+}
+
+/// **Where a page stopped, and how to continue it.**
+///
+/// The boundary's replacement for `PageBoundary`, and the same shape for the
+/// same reason: an enum rather than a `truncated: bool` beside an
+/// `Option<cursor>`, because those two fields can disagree silently. A value
+/// that could say *"complete, and here is where to continue"* has already lost
+/// the visibility the ruling asks for.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Continuation {
+    /// Everything the query selects is in this page.
+    Complete,
+    /// More follows. Present this cursor to continue.
+    More(PageCursor),
+}
+
+impl Continuation {
+    /// The cursor to continue with, or `None` when the page is complete.
+    #[must_use]
+    pub fn cursor(&self) -> Option<&PageCursor> {
+        match self {
+            Self::Complete => None,
+            Self::More(c) => Some(c),
+        }
+    }
+
+    /// Whether more follows this page.
+    #[must_use]
+    pub fn is_truncated(&self) -> bool {
+        matches!(self, Self::More(_))
+    }
+}
+
+/// **An opaque continuation token.**
+///
+/// Carries no public accessor for its generation. That is deliberate rather
+/// than fastidious: a caller who can read the coordinate can compute a
+/// neighbouring one, and a computed cursor is exactly what the family and
+/// version bindings cannot detect — it would be well-formed, in-family,
+/// in-version, and name a position the caller invented.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PageCursor {
+    family: CursorFamily,
+    semantics: SemanticVersions,
+    /// The exclusive lower bound.
+    ///
+    /// Private to this MODULE, not merely to the crate: the only code that
+    /// reads it is [`resolve_cursor`], which reads it in order to validate it.
+    /// Nothing else in the boundary can see a raw coordinate, so nothing else
+    /// can accidentally pass one on.
+    generation: i64,
+}
+
+impl PageCursor {
+    /// Mint a cursor for the page that follows `generation`.
+    ///
+    /// `pub(crate)`: only the boundary may mint, and it stamps the versions from
+    /// the live declarations rather than accepting them. A caller able to mint
+    /// could claim any semantics — the same reasoning
+    /// [`crate::answer_ref::AnswerRef`] states for its own version stamp.
+    pub(crate) fn mint(family: CursorFamily, generation: i64) -> Self {
+        Self {
+            family,
+            semantics: SemanticVersions::for_query(family.query_kind()),
+            generation,
+        }
+    }
+
+    /// Which family this continues.
+    ///
+    /// Readable because it is not exploitable: knowing the family does not let a
+    /// caller construct one, and an error naming the family is more useful than
+    /// one that will not say.
+    #[must_use]
+    pub fn family(&self) -> CursorFamily {
+        self.family
+    }
+
+    /// The semantics in force when this was minted.
+    #[must_use]
+    pub fn semantics(&self) -> &SemanticVersions {
+        &self.semantics
+    }
+
+    /// Rebuild a cursor recorded under a different semantic-version set.
+    ///
+    /// The deliberately-explicit escape hatch [`crate::answer_ref::AnswerRef`]
+    /// and [`crate::lineage::LineageRef`] both provide, for tests and for a
+    /// reader decoding a persisted value. It cannot be used to FORGE a valid
+    /// cursor: whatever it stamps is what the version check compares against, so
+    /// a wrong set produces a refusal rather than an accepted page.
+    #[must_use]
+    pub fn recorded_under(mut self, semantics: SemanticVersions) -> Self {
+        self.semantics = semantics;
+        self
+    }
+}
+
+/// Why a presented cursor cannot be continued.
+///
+/// Every variant is a REFUSAL. None of them has a recovery arm that serves a
+/// page anyway — see the module docs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CursorError {
+    /// Presented to a family other than the one that minted it.
+    WrongFamily {
+        /// The family the cursor carries.
+        presented: CursorFamily,
+        /// The family it was presented to.
+        expected: CursorFamily,
+    },
+    /// The rules that produced the earlier page have changed.
+    ///
+    /// Continuing would splice pages from two different query contracts into one
+    /// sequence, which is the failure box 3b's versioning exists to make
+    /// visible. The differences are carried so an operator can see WHICH rule
+    /// moved rather than only that something did.
+    SemanticsChanged {
+        /// Per-rule differences between the cursor's set and the live one.
+        differences: Vec<VersionDifference>,
+    },
+    /// The generation is no longer retained — compaction removed it.
+    ///
+    /// Refused rather than continued from the nearest survivor: the cursor names
+    /// a position in a sequence, and the sequence it named no longer exists.
+    Unreproducible {
+        /// The coordinate the cursor names.
+        generation: i64,
+    },
+    /// The generation is past this log's head.
+    ///
+    /// A cursor from a different store, or a computed one.
+    BeyondHead {
+        /// The coordinate the cursor names.
+        generation: i64,
+        /// The highest generation this log holds.
+        head: i64,
+    },
+    /// The generation is not a position any log could hold.
+    ImpossibleGeneration {
+        /// The coordinate the cursor names.
+        generation: i64,
+    },
+}
+
+impl std::fmt::Display for CursorError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::WrongFamily {
+                presented,
+                expected,
+            } => write!(
+                f,
+                "cursor continues the {} query, presented to {}",
+                presented.as_str(),
+                expected.as_str()
+            ),
+            Self::SemanticsChanged { differences } => write!(
+                f,
+                "query semantics changed since this cursor was minted ({} rule(s) differ)",
+                differences.len()
+            ),
+            Self::Unreproducible { generation } => write!(
+                f,
+                "generation {generation} is no longer retained; this continuation cannot be reproduced"
+            ),
+            Self::BeyondHead { generation, head } => {
+                write!(f, "generation {generation} is past the log head {head}")
+            }
+            Self::ImpossibleGeneration { generation } => {
+                write!(f, "generation {generation} is not a valid log position")
+            }
+        }
+    }
+}
+
+impl std::error::Error for CursorError {}
+
+/// **Validate a presented cursor and yield its coordinate** — or refuse.
+///
+/// # Order of refusals
+///
+/// Family and semantics are checked BEFORE the store is touched, for the reason
+/// [`crate::lineage::LineageRef::resolve`] gives about its own ordering: a
+/// cursor that cannot be continued should say so without a read, and the cheap
+/// structural refusals should not be reachable only when a read happens to
+/// succeed.
+///
+/// # Errors
+///
+/// [`CursorError`] — every variant, and never a fallback page.
+pub(crate) fn resolve_cursor(
+    store: &WorldStore,
+    cursor: &PageCursor,
+    expected: CursorFamily,
+) -> Result<i64, CursorError> {
+    if cursor.family != expected {
+        return Err(CursorError::WrongFamily {
+            presented: cursor.family,
+            expected,
+        });
+    }
+
+    let live = SemanticVersions::for_query(expected.query_kind());
+    let differences = cursor.semantics.differences(&live);
+    if !differences.is_empty() {
+        return Err(CursorError::SemanticsChanged { differences });
+    }
+
+    let generation = cursor.generation;
+    if generation < 1 {
+        return Err(CursorError::ImpossibleGeneration { generation });
+    }
+
+    // The store read is LAST, and its failure is treated as unreproducible
+    // rather than propagated: a cursor whose anchor cannot be read is a cursor
+    // that cannot be shown to name a real position, which is the same refusal
+    // by a different route. Serving the page instead would be the fall-forward
+    // this module exists to forbid.
+    let anchor = store
+        .cursor_anchor(generation)
+        .map_err(|_| CursorError::Unreproducible { generation })?;
+
+    if generation > anchor.head {
+        return Err(CursorError::BeyondHead {
+            generation,
+            head: anchor.head,
+        });
+    }
+    if !anchor.retained {
+        return Err(CursorError::Unreproducible { generation });
+    }
+    Ok(generation)
+}

--- a/crates/kirra-world-service/src/cursor.rs
+++ b/crates/kirra-world-service/src/cursor.rs
@@ -36,10 +36,19 @@
 //! plus [`CursorError::BeyondHead`] and [`CursorError::ImpossibleGeneration`]
 //! for a coordinate that cannot have come from this log at all.
 //!
-//! The family binding is the one that proves "opaque" means capability: a
-//! `History` cursor and a `Lineage` cursor can hold byte-identical generation
-//! and version data, and presenting one where the other belongs is still
-//! refused. A test does exactly that substitution.
+//! The family binding is the one that proves "opaque" means capability, and its
+//! test had to be built carefully to show it. `SubjectHistory` and
+//! `SubjectLineage` declare DIFFERENT rule sets today, so simply swapping two
+//! minted cursors is refused by the VERSION check and never exercises the family
+//! at all — deleting the family check entirely still refuses the swap. The real
+//! control re-stamps the cursor with the target family's live semantics first,
+//! so the coordinate and the versions match and the family is the only
+//! difference. All three bindings are then independently necessary: dropping any
+//! one reds exactly one test.
+//!
+//! That the two families' version sets differ today is not a defence. It is a
+//! coincidence of which rules each depends on, and a future family sharing a
+//! rule set would collapse it.
 //!
 //! # Every failure is a REFUSAL
 //!

--- a/crates/kirra-world-service/src/cursor.rs
+++ b/crates/kirra-world-service/src/cursor.rs
@@ -62,6 +62,7 @@
 use kirra_world_store::WorldStore;
 
 use crate::answer_ref::QueryKind;
+use crate::read_view::AskError;
 use crate::semantics::{SemanticVersions, VersionDifference};
 
 /// Which query family a cursor continues.
@@ -284,49 +285,62 @@ impl std::error::Error for CursorError {}
 /// structural refusals should not be reachable only when a read happens to
 /// succeed.
 ///
+/// # Why this returns [`AskError`] rather than [`CursorError`]
+///
+/// A failure to READ the anchor is not a stale cursor. The first draft mapped
+/// any store error to [`CursorError::Unreproducible`], which contradicted this
+/// crate's own documentation — [`AskError::Cursor`] states that a cursor refusal
+/// means the store is healthy and the cursor is what does not apply — and it
+/// misled in the operationally worst direction: an unhealthy database would tell
+/// an operator to restart the query.
+///
+/// So a store fault travels [`AskError::Store`], every cursor refusal travels
+/// [`AskError::Cursor`], and [`CursorError`] keeps meaning exactly what its name
+/// says: reasons a cursor cannot be continued **against a store that is working**.
+/// Both are still fail-closed; they simply say different true things.
+///
 /// # Errors
 ///
-/// [`CursorError`] — every variant, and never a fallback page.
+/// [`AskError::Cursor`] for every [`CursorError`] variant, [`AskError::Store`]
+/// when the anchor cannot be read. Never a fallback page.
 pub(crate) fn resolve_cursor(
     store: &WorldStore,
     cursor: &PageCursor,
     expected: CursorFamily,
-) -> Result<i64, CursorError> {
+) -> Result<i64, AskError> {
     if cursor.family != expected {
         return Err(CursorError::WrongFamily {
             presented: cursor.family,
             expected,
-        });
+        }
+        .into());
     }
 
     let live = SemanticVersions::for_query(expected.query_kind());
     let differences = cursor.semantics.differences(&live);
     if !differences.is_empty() {
-        return Err(CursorError::SemanticsChanged { differences });
+        return Err(CursorError::SemanticsChanged { differences }.into());
     }
 
     let generation = cursor.generation;
     if generation < 1 {
-        return Err(CursorError::ImpossibleGeneration { generation });
+        return Err(CursorError::ImpossibleGeneration { generation }.into());
     }
 
-    // The store read is LAST, and its failure is treated as unreproducible
-    // rather than propagated: a cursor whose anchor cannot be read is a cursor
-    // that cannot be shown to name a real position, which is the same refusal
-    // by a different route. Serving the page instead would be the fall-forward
-    // this module exists to forbid.
-    let anchor = store
-        .cursor_anchor(generation)
-        .map_err(|_| CursorError::Unreproducible { generation })?;
+    // The store read is LAST, and its failure PROPAGATES as a store fault. It
+    // is still fail-closed — no page is served either way — but it reports the
+    // fault that actually happened rather than blaming the caller's cursor.
+    let anchor = store.cursor_anchor(generation)?;
 
     if generation > anchor.head {
         return Err(CursorError::BeyondHead {
             generation,
             head: anchor.head,
-        });
+        }
+        .into());
     }
     if !anchor.retained {
-        return Err(CursorError::Unreproducible { generation });
+        return Err(CursorError::Unreproducible { generation }.into());
     }
     Ok(generation)
 }

--- a/crates/kirra-world-service/src/lib.rs
+++ b/crates/kirra-world-service/src/lib.rs
@@ -31,6 +31,7 @@
 #![warn(missing_docs)]
 
 pub mod answer_ref;
+pub mod cursor;
 pub mod freshness;
 pub mod lineage;
 pub mod query;

--- a/crates/kirra-world-service/src/lineage.rs
+++ b/crates/kirra-world-service/src/lineage.rs
@@ -40,7 +40,10 @@
 
 use kirra_world::evidence::{DigestError, EvidenceDigest};
 use kirra_world_store::compaction::Resolution;
-use kirra_world_store::lineage::{LineageEvent, LineagePage, PageBoundary};
+use kirra_world_store::lineage::{LineageEvent, LineagePage};
+
+use crate::cursor::{resolve_cursor, Continuation, CursorFamily, PageCursor};
+use crate::read_view::to_continuation;
 use kirra_world_store::snapshot::{Irreproducible, PinnedLineage};
 use kirra_world_store::{ClaimStatus, WorldStore, WriterClass};
 
@@ -89,7 +92,14 @@ pub fn lineage_semantics() -> SemanticVersions {
 pub struct LineageRef {
     subject: String,
     generation: i64,
-    page: LineagePage,
+    limit: usize,
+    /// Where to continue from — an OPAQUE cursor, never a log position.
+    ///
+    /// The reference used to carry a `LineagePage`, whose `after_generation` was
+    /// the raw SQLite coordinate. That made a recorded reference a value a
+    /// holder could do arithmetic on, and made a reference from a different
+    /// family or a superseded rule set indistinguishable from a valid one.
+    after: Option<PageCursor>,
     semantics: SemanticVersions,
 }
 
@@ -103,11 +113,12 @@ impl LineageRef {
     ///
     /// [`AnswerRef`]: crate::answer_ref::AnswerRef
     #[must_use]
-    pub fn subject_lineage(subject: impl Into<String>, generation: i64, page: LineagePage) -> Self {
+    pub fn subject_lineage(subject: impl Into<String>, generation: i64, limit: usize) -> Self {
         Self {
             subject: subject.into(),
             generation,
-            page,
+            limit,
+            after: None,
             semantics: SemanticVersions::for_query(QueryKind::SubjectLineage),
         }
     }
@@ -130,10 +141,16 @@ impl LineageRef {
         self.generation
     }
 
-    /// The page bound this reference names.
+    /// How many entries this reference's page may hold.
     #[must_use]
-    pub fn page(&self) -> LineagePage {
-        self.page
+    pub fn limit(&self) -> usize {
+        self.limit
+    }
+
+    /// Where this reference continues from, if it is not the first page.
+    #[must_use]
+    pub fn after(&self) -> Option<&PageCursor> {
+        self.after.as_ref()
     }
 
     /// The semantics this reference's answer was produced under.
@@ -154,6 +171,23 @@ impl LineageRef {
         self
     }
 
+    /// **Rebuild a continuing reference from a cursor held across a restart.**
+    ///
+    /// [`Self::next_page`] covers the in-flight case, where the previous
+    /// resolution is still to hand. This covers the other one: a caller that
+    /// persisted a cursor, came back later, and wants the page after it.
+    ///
+    /// Accepting a cursor is not a hole in the opacity. The cursor still cannot
+    /// be constructed or edited by a caller, and it is still validated on
+    /// presentation — family, semantics and reproducibility — so a reference
+    /// built here from the wrong cursor refuses at resolution rather than
+    /// serving someone else's page.
+    #[must_use]
+    pub fn continuing_from(mut self, cursor: PageCursor) -> Self {
+        self.after = Some(cursor);
+        self
+    }
+
     /// **The reference for the page that follows this one**, if any follows.
     ///
     /// Minted from a *resolution* rather than from a page number, and that is
@@ -168,13 +202,14 @@ impl LineageRef {
     /// paginate past the end.
     #[must_use]
     pub fn next_page(&self, resolved: &LineagePageAnswer) -> Option<Self> {
-        let next = resolved.boundary().next_after_generation()?;
-        Some(Self::subject_lineage(
-            self.subject.clone(),
-            self.generation,
-            LineagePage::new(self.page.limit(), Some(next))
-                .expect("a validated limit stays valid when only the cursor moves"),
-        ))
+        let cursor = resolved.continuation().cursor()?.clone();
+        Some(Self {
+            subject: self.subject.clone(),
+            generation: self.generation,
+            limit: self.limit,
+            after: Some(cursor),
+            semantics: SemanticVersions::for_query(QueryKind::SubjectLineage),
+        })
     }
 
     /// **Re-execute this exact lineage query against the same coordinate.**
@@ -203,8 +238,17 @@ impl LineageRef {
             return Ok(LineageResolution::VersionMismatch { differences });
         }
 
+        // The cursor is validated BEFORE the store page is built, and after the
+        // version check above — a reference that cannot be continued says so
+        // without a read, and says WHY in the caller's own terms.
+        let after = match &self.after {
+            None => None,
+            Some(cursor) => Some(resolve_cursor(store, cursor, CursorFamily::Lineage)?),
+        };
+        let page = LineagePage::new(self.limit, after)?;
+
         let (selection, completeness) =
-            match store.lineage_at_generation(&self.subject, self.generation, self.page)? {
+            match store.lineage_at_generation(&self.subject, self.generation, page)? {
                 PinnedLineage::Reproduced {
                     selection,
                     completeness,
@@ -220,7 +264,7 @@ impl LineageRef {
         }
         Ok(LineageResolution::Resolved(LineagePageAnswer {
             entries,
-            boundary: selection.boundary,
+            continuation: to_continuation(&selection.boundary, CursorFamily::Lineage),
             completeness,
             semantics: SemanticVersions::for_query(QueryKind::SubjectLineage),
         }))
@@ -366,7 +410,7 @@ impl LineageEntry {
 #[derive(Debug, Clone)]
 pub struct LineagePageAnswer {
     entries: Vec<LineageEntry>,
-    boundary: PageBoundary,
+    continuation: Continuation,
     completeness: Resolution,
     semantics: SemanticVersions,
 }
@@ -384,14 +428,14 @@ impl LineagePageAnswer {
     /// learn where the next page starts — so a caller that paginates cannot do
     /// it without seeing that the last page said `Complete`.
     #[must_use]
-    pub fn boundary(&self) -> &PageBoundary {
-        &self.boundary
+    pub fn continuation(&self) -> &Continuation {
+        &self.continuation
     }
 
     /// Whether this page stopped short of the whole lineage.
     #[must_use]
     pub fn is_truncated(&self) -> bool {
-        self.boundary.is_truncated()
+        self.continuation.is_truncated()
     }
 
     /// **Whether compaction removed evidence at or below this coordinate.**

--- a/crates/kirra-world-service/src/query.rs
+++ b/crates/kirra-world-service/src/query.rs
@@ -72,6 +72,7 @@ use kirra_world_store::lineage::LineagePage;
 use kirra_world_store::WorldStore;
 
 use crate::answer_ref::{AnswerRef, RefResolution};
+use crate::cursor::{resolve_cursor, CursorFamily, PageCursor};
 use crate::freshness::FreshnessSource;
 use crate::lineage::{LineageRef, LineageResolution};
 use crate::read_view::{
@@ -222,16 +223,22 @@ impl WorldQuery for AskAsOf {
 
 /// **One page of a subject's recorded history.**
 ///
-/// The page is a FIELD of the request rather than an argument threaded past it,
-/// which is the structural half of clause 2: a history question that carries no
-/// bound is not constructible. `LineagePage` validates its own limit, so an
-/// unbounded page is unrepresentable rather than merely discouraged.
+/// The bound is a FIELD of the request rather than an argument threaded past
+/// it, which is the structural half of clause 2: a history question that
+/// carries no bound is not constructible.
+///
+/// `after` is an OPAQUE [`PageCursor`], never a log position. A caller cannot
+/// compute one, cannot hand a [`Lineage`] cursor to it, and cannot continue
+/// across a semantics change or a compaction that removed the coordinate — each
+/// of those is a refusal rather than a plausible page. See [`crate::cursor`].
 #[derive(Debug, Clone)]
 pub struct History {
     /// The subject whose history to read.
     pub subject: String,
-    /// The page bound and cursor.
-    pub page: LineagePage,
+    /// How many claims this page may hold.
+    pub limit: usize,
+    /// Where to continue from, or `None` for the first page.
+    pub after: Option<PageCursor>,
 }
 
 impl sealed::Sealed for History {}
@@ -240,7 +247,20 @@ impl WorldQuery for History {
     type Output = HistoryLookup;
 
     fn execute(self, engine: &QueryEngine<'_>) -> Result<Self::Output, AskError> {
-        engine.view().history(&self.subject, self.page)
+        // Cursor FIRST, page second. A refused continuation must not depend on
+        // the limit also being valid — the caller's mistake is the cursor, and
+        // reporting a limit error for a stale cursor sends them to the wrong
+        // fix.
+        let after = match &self.after {
+            None => None,
+            Some(cursor) => Some(resolve_cursor(
+                engine.store(),
+                cursor,
+                CursorFamily::History,
+            )?),
+        };
+        let page = LineagePage::new(self.limit, after)?;
+        engine.view().history(&self.subject, page)
     }
 }
 

--- a/crates/kirra-world-service/src/read_view.rs
+++ b/crates/kirra-world-service/src/read_view.rs
@@ -102,6 +102,7 @@ use kirra_world_store::subject_projection::SubjectSummaryAnswer;
 use kirra_world_store::{ProjectedClaim, StoreError, TrustAxes, TrustGrade, Validity, WorldStore};
 
 use crate::answer_ref::QueryKind;
+use crate::cursor::{Continuation, CursorError, CursorFamily, PageCursor};
 use crate::freshness::{resolve_policy, FreshnessPolicy, FreshnessSource};
 use crate::semantics::SemanticVersions;
 
@@ -113,6 +114,20 @@ use crate::semantics::SemanticVersions;
 pub enum AskError {
     /// The store could not be read.
     Store(StoreError),
+    /// The requested page bound is not a valid one.
+    ///
+    /// A zero limit, or one over `MAX_LINEAGE_PAGE`. A caller-side fault like
+    /// [`Self::Cursor`], and separate from it because the fixes differ: a bad
+    /// limit is corrected in the request, a stale cursor by restarting the
+    /// query.
+    PageSpec(kirra_world_store::lineage::PageSpecError),
+    /// A presented continuation cursor cannot be continued.
+    ///
+    /// Its own channel rather than folded into [`Self::Store`], because it is
+    /// not a storage fault: the store is healthy and the cursor is the thing
+    /// that does not apply. Collapsing the two would make *"your cursor is from
+    /// a previous rule version"* read as *"the database is broken"*.
+    Cursor(CursorError),
     /// A stored chain digest is not a digest.
     ///
     /// **Refused rather than served**, and the reasoning is this module's own:
@@ -168,6 +183,8 @@ impl fmt::Display for AskError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Store(e) => write!(f, "store: {e:?}"),
+            Self::PageSpec(e) => write!(f, "invalid page bound: {e:?}"),
+            Self::Cursor(e) => write!(f, "continuation refused: {e}"),
             Self::CorruptProvenance {
                 subject,
                 predicate,
@@ -193,6 +210,18 @@ impl fmt::Display for AskError {
 }
 
 impl std::error::Error for AskError {}
+
+impl From<kirra_world_store::lineage::PageSpecError> for AskError {
+    fn from(e: kirra_world_store::lineage::PageSpecError) -> Self {
+        Self::PageSpec(e)
+    }
+}
+
+impl From<CursorError> for AskError {
+    fn from(e: CursorError) -> Self {
+        Self::Cursor(e)
+    }
+}
 
 impl From<StoreError> for AskError {
     fn from(e: StoreError) -> Self {
@@ -793,7 +822,10 @@ impl<'a> WorldView<'a> {
         Ok(HistoryLookup {
             lookup,
             completeness,
-            boundary: paged.boundary,
+            // The store's raw `PageBoundary` is turned into an OPAQUE cursor
+            // here and never escapes: a caller receives a continuation it can
+            // present back, not a log position it can compute on.
+            continuation: to_continuation(&paged.boundary, CursorFamily::History),
             semantics: SemanticVersions::for_query(QueryKind::SubjectHistory),
         })
     }
@@ -1028,7 +1060,7 @@ fn assemble(
 pub struct HistoryLookup {
     lookup: WorldLookup,
     completeness: Resolution,
-    boundary: kirra_world_store::lineage::PageBoundary,
+    continuation: Continuation,
     semantics: SemanticVersions,
 }
 
@@ -1051,16 +1083,36 @@ impl HistoryLookup {
         self.completeness.is_degraded()
     }
 
-    /// Whether more claims follow this PAGE.
+    /// Whether more claims follow this PAGE, and how to continue.
+    ///
+    /// A [`Continuation`] rather than the store's `PageBoundary`: the caller
+    /// receives an opaque cursor bound to this family and these semantics, not
+    /// the raw generation the store paginates on.
     #[must_use]
-    pub fn boundary(&self) -> &kirra_world_store::lineage::PageBoundary {
-        &self.boundary
+    pub fn continuation(&self) -> &Continuation {
+        &self.continuation
     }
 
     /// The rules this answer was produced under.
     #[must_use]
     pub fn semantics(&self) -> &SemanticVersions {
         &self.semantics
+    }
+}
+
+/// **Turn a store page boundary into an opaque continuation** — the one place
+/// a raw generation becomes a cursor.
+///
+/// Shared by both paginated families so the minting rule cannot drift between
+/// them, and so there is a single site to look at when asking whether a raw
+/// coordinate can reach a caller.
+pub(crate) fn to_continuation(
+    boundary: &kirra_world_store::lineage::PageBoundary,
+    family: CursorFamily,
+) -> Continuation {
+    match boundary.next_after_generation() {
+        None => Continuation::Complete,
+        Some(generation) => Continuation::More(PageCursor::mint(family, generation)),
     }
 }
 

--- a/crates/kirra-world-service/tests/completeness_propagation.rs
+++ b/crates/kirra-world-service/tests/completeness_propagation.rs
@@ -96,7 +96,7 @@
 use kirra_world_service::freshness::FreshnessSource;
 use kirra_world_service::query::{Ask, History, QueryEngine, SubjectSummary};
 use kirra_world_service::read_view::{AskError, WorldLookup};
-use kirra_world_store::lineage::LineagePage;
+use kirra_world_store::lineage::MAX_LINEAGE_PAGE;
 use kirra_world_store::{ClaimStatus, EventId, NewEvent, ObservationId, WorldStore, WriterClass};
 
 const T0: i64 = 1_700_000_000_000;
@@ -223,7 +223,8 @@ fn a_compacted_history_reports_degraded() {
     let lookup = view(&store)
         .execute(History {
             subject: "package_17".to_owned(),
-            page: LineagePage::first(),
+            limit: MAX_LINEAGE_PAGE,
+            after: None,
         })
         .expect("history");
 
@@ -247,13 +248,15 @@ fn both_history_arms_return_a_plausible_non_empty_record() {
     let degraded = view(&holed)
         .execute(History {
             subject: "package_17".to_owned(),
-            page: LineagePage::first(),
+            limit: MAX_LINEAGE_PAGE,
+            after: None,
         })
         .expect("history");
     let full = view(&intact)
         .execute(History {
             subject: "package_17".to_owned(),
-            page: LineagePage::first(),
+            limit: MAX_LINEAGE_PAGE,
+            after: None,
         })
         .expect("history");
 
@@ -284,7 +287,8 @@ fn an_uncompacted_history_reports_full() {
     let lookup = view(&store)
         .execute(History {
             subject: "package_17".to_owned(),
-            page: LineagePage::first(),
+            limit: MAX_LINEAGE_PAGE,
+            after: None,
         })
         .expect("history");
 
@@ -363,7 +367,8 @@ fn history_keeps_a_claim_that_ask_refuses_to_serve() {
     let record = v
         .execute(History {
             subject: "package_17".to_owned(),
-            page: LineagePage::first(),
+            limit: MAX_LINEAGE_PAGE,
+            after: None,
         })
         .expect("history");
     assert_eq!(
@@ -414,7 +419,8 @@ fn an_unruled_claim_refuses_the_whole_history() {
     let err = view(&store)
         .execute(History {
             subject: "package_17".to_owned(),
-            page: LineagePage::first(),
+            limit: MAX_LINEAGE_PAGE,
+            after: None,
         })
         .expect_err("an unclassified claim must refuse the whole query");
     assert!(
@@ -543,11 +549,11 @@ fn an_unknown_subject_is_absent_rather_than_degraded() {
 #[test]
 fn a_history_page_returns_at_most_its_limit() {
     let (store, _p) = intact_store("hist-page-limit");
-    let page = LineagePage::new(2, None).expect("valid page");
     let lookup = view(&store)
         .execute(History {
             subject: "package_17".to_owned(),
-            page,
+            limit: 2,
+            after: None,
         })
         .expect("history");
 
@@ -557,7 +563,7 @@ fn a_history_page_returns_at_most_its_limit() {
         "three claims exist; a limit of 2 must return 2"
     );
     assert!(
-        lookup.boundary().is_truncated(),
+        lookup.continuation().is_truncated(),
         "a third claim follows, so the page must say so"
     );
 }
@@ -572,13 +578,13 @@ fn paginating_a_history_walks_the_record_without_gaps_or_repeats() {
     let v = view(&store);
 
     let mut seen: Vec<String> = Vec::new();
-    let mut cursor = None;
+    let mut cursor: Option<kirra_world_service::cursor::PageCursor> = None;
     for _ in 0..10 {
-        let page = LineagePage::new(1, cursor).expect("valid page");
         let lookup = v
             .execute(History {
                 subject: "package_17".to_owned(),
-                page,
+                limit: 1,
+                after: cursor.clone(),
             })
             .expect("history");
         if let WorldLookup::Answered(answers) = lookup.lookup() {
@@ -586,11 +592,9 @@ fn paginating_a_history_walks_the_record_without_gaps_or_repeats() {
                 seen.push(a.event_id().to_string());
             }
         }
-        match lookup.boundary() {
-            kirra_world_store::lineage::PageBoundary::More {
-                next_after_generation,
-            } => cursor = Some(*next_after_generation),
-            kirra_world_store::lineage::PageBoundary::Complete => break,
+        match lookup.continuation().cursor() {
+            Some(next) => cursor = Some(next.clone()),
+            None => break,
         }
     }
 
@@ -617,17 +621,17 @@ fn paginating_a_history_walks_the_record_without_gaps_or_repeats() {
 #[test]
 fn a_history_page_that_exactly_fills_is_complete() {
     let (store, _p) = intact_store("hist-page-exact");
-    let page = LineagePage::new(3, None).expect("valid page");
     let lookup = view(&store)
         .execute(History {
             subject: "package_17".to_owned(),
-            page,
+            limit: 3,
+            after: None,
         })
         .expect("history");
 
     assert_eq!(answered(lookup.lookup()), 3, "the whole record");
     assert!(
-        !lookup.boundary().is_truncated(),
+        !lookup.continuation().is_truncated(),
         "the page holds the entire record, so nothing follows it"
     );
 }
@@ -641,16 +645,16 @@ fn a_history_page_that_exactly_fills_is_complete() {
 #[test]
 fn a_truncated_page_over_a_degraded_record_reports_both() {
     let (store, _p) = holed_store("hist-page-degraded");
-    let page = LineagePage::new(1, None).expect("valid page");
     let lookup = view(&store)
         .execute(History {
             subject: "package_17".to_owned(),
-            page,
+            limit: 1,
+            after: None,
         })
         .expect("history");
 
     assert!(
-        lookup.boundary().is_truncated(),
+        lookup.continuation().is_truncated(),
         "two claims survive and the limit is 1, so more follows"
     );
     assert!(

--- a/crates/kirra-world-service/tests/cursor_contract.rs
+++ b/crates/kirra-world-service/tests/cursor_contract.rs
@@ -18,13 +18,18 @@
 //! rather than an error — right shape, right subject, plausible contents, wrong
 //! question.
 //!
-//! # The decisive control
+//! # The decisive control, and how it was nearly vacuous
 //!
-//! `a_history_cursor_is_refused_by_lineage` takes a cursor minted by one family
-//! and presents it to the other. Both carry the same kind of coordinate, and on
-//! this fixture the same VALUE. If "opaque" meant only "an integer in a struct",
-//! it would be accepted. It is refused, which is what makes the opacity a
-//! capability rather than a spelling.
+//! `a_history_cursor_is_refused_by_lineage` presents a cursor minted by one
+//! family to the other. The first version of it passed for the WRONG REASON: the
+//! two families declare different rule sets today, so the swap was refused by
+//! the version check and the family binding was never reached. Deleting the
+//! family check entirely still refused it.
+//!
+//! The test now re-stamps the cursor with the target family's live semantics
+//! first, leaving the family as the only difference. Each binding is verified
+//! independently necessary by mutation — dropping family, semantics or the
+//! retention anchor reds exactly one test each, and no two mask one another.
 //!
 //! # Every failure is a refusal
 //!

--- a/crates/kirra-world-service/tests/cursor_contract.rs
+++ b/crates/kirra-world-service/tests/cursor_contract.rs
@@ -421,3 +421,57 @@ fn a_refused_cursor_yields_no_answer_at_all() {
     );
     cleanup(&path);
 }
+
+// ---------------------------------------------------------------------------
+// A broken store is not a stale cursor
+// ---------------------------------------------------------------------------
+
+/// **An unreadable anchor reports a STORE fault, not a cursor refusal.**
+///
+/// Review caught this as a contradiction rather than a crash: `resolve_cursor`
+/// mapped every `cursor_anchor` failure to `Unreproducible`, while
+/// `AskError::Cursor`'s own documentation said a cursor refusal means the store
+/// is healthy and the cursor is what does not apply. Both statements shipped in
+/// the same PR.
+///
+/// The operational consequence is the reason it matters. `Unreproducible` tells
+/// an operator *"this continuation is stale, restart the query"* — which is
+/// exactly the wrong instruction when the database is the thing that is broken,
+/// and restarting produces the same failure with the same misleading label.
+///
+/// Fail-closed either way: no page is served on either path. This pins WHICH
+/// true thing is said.
+#[test]
+fn an_unreadable_anchor_is_a_store_fault_not_a_stale_cursor() {
+    let (store, path, _g) = store_with_four("anchor-unreadable");
+    let cursor = history_cursor(&store);
+
+    // The same cursor must work first, or this proves nothing about the fault.
+    engine(&store)
+        .execute(History {
+            subject: SUBJECT.to_owned(),
+            limit: 2,
+            after: Some(cursor.clone()),
+        })
+        .expect("control: the cursor is valid before the store is broken");
+
+    // Break the read the anchor depends on.
+    store
+        .raw_execute_for_test("DROP TABLE world_events")
+        .expect("plant the fault");
+
+    let err = engine(&store)
+        .execute(History {
+            subject: SUBJECT.to_owned(),
+            limit: 2,
+            after: Some(cursor),
+        })
+        .expect_err("an unreadable store must not serve a page");
+
+    assert!(
+        matches!(err, AskError::Store(_)),
+        "a store fault must travel the store channel, not be reported as a \
+         stale cursor telling the operator to restart the query; got {err:?}"
+    );
+    cleanup(&path);
+}

--- a/crates/kirra-world-service/tests/cursor_contract.rs
+++ b/crates/kirra-world-service/tests/cursor_contract.rs
@@ -1,0 +1,418 @@
+//! **Continuation cursors are opaque, query-bound, versioned, and fail closed.**
+//!
+//! Tier 3 §6 cross-cutting. The rule these pin:
+//!
+//! > A cursor names a continuation of ONE query contract under ONE
+//! > semantic-version set, not merely a position in SQLite.
+//!
+//! # What was wrong, and why it needed more than a newtype
+//!
+//! Pagination shipped with the cursor as a bare `i64` generation, handed out by
+//! `PageBoundary::More` and taken back by `LineagePage::after_generation`. Every
+//! page of every family passed a raw log position across the domain boundary.
+//!
+//! Wrapping that integer in a struct would have satisfied the word "opaque" and
+//! fixed nothing. The hazard was never that a caller could READ the coordinate;
+//! it is that a cursor carried no evidence of what it continued, so a cursor
+//! from another family, another rule version, or another store returned a page
+//! rather than an error — right shape, right subject, plausible contents, wrong
+//! question.
+//!
+//! # The decisive control
+//!
+//! `a_history_cursor_is_refused_by_lineage` takes a cursor minted by one family
+//! and presents it to the other. Both carry the same kind of coordinate, and on
+//! this fixture the same VALUE. If "opaque" meant only "an integer in a struct",
+//! it would be accepted. It is refused, which is what makes the opacity a
+//! capability rather than a spelling.
+//!
+//! # Every failure is a refusal
+//!
+//! No test here asserts a fallback, because there is no fallback to assert. A
+//! reset to page 1 and a jump to the next surviving generation are both
+//! available, both look like recovery, and both silently answer a different
+//! question — re-serving rows already seen, or skipping the ones that vanished.
+
+use kirra_world_service::answer_ref::QueryKind;
+use kirra_world_service::cursor::{CursorError, CursorFamily, PageCursor};
+use kirra_world_service::freshness::FreshnessSource;
+use kirra_world_service::lineage::LineageRef;
+use kirra_world_service::query::{History, Lineage, QueryEngine};
+use kirra_world_service::read_view::AskError;
+use kirra_world_service::semantics::{RuleVersion, SemanticVersions};
+use kirra_world_store::{ClaimStatus, EventId, NewEvent, ObservationId, WorldStore, WriterClass};
+
+const T0: i64 = 1_700_000_000_000;
+const SUBJECT: &str = "package_17";
+
+fn tmp(name: &str) -> std::path::PathBuf {
+    static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let n = NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "kirra-cursor-{name}-{}-{n}.sqlite",
+        std::process::id()
+    ));
+    cleanup(&p);
+    p
+}
+
+fn cleanup(path: &std::path::Path) {
+    for suffix in ["", "-wal", "-shm"] {
+        let mut q = path.as_os_str().to_os_string();
+        q.push(suffix);
+        let _ = std::fs::remove_file(std::path::PathBuf::from(q));
+    }
+}
+
+fn append(store: &mut WorldStore, tag: &str, offset: i64) {
+    store
+        .append(&NewEvent {
+            event_id: &EventId::new(format!("ev-{tag}")).expect("event id"),
+            observation_id: &ObservationId::new(format!("obs-{tag}")).expect("obs"),
+            txn_time_ms: T0 + offset,
+            valid_from_ms: T0 + offset,
+            valid_to_ms: None,
+            source: "warehouse-scanner",
+            source_version: "1.0.0",
+            writer_class: WriterClass::Sensor,
+            claim_status: ClaimStatus::Confirmed,
+            provenance: &[],
+            frame_id: None,
+            map_id: None,
+            kind: "mission",
+            subject: SUBJECT,
+            subject_ref: None,
+            predicate: Some("last_seen_at"),
+            object: Some("dock_b"),
+            payload: "{}",
+            payload_schema: 1,
+            retention_class: "raw",
+            trust: None,
+        })
+        .expect("append");
+}
+
+/// Four confirmed events about `SUBJECT`, folded. Returns the fold coordinate.
+fn store_with_four(name: &str) -> (WorldStore, std::path::PathBuf, i64) {
+    let path = tmp(name);
+    let mut store = WorldStore::open(&path).expect("open");
+    for i in 1..=4 {
+        append(&mut store, &format!("{i}"), i);
+    }
+    let generation = store.fold().expect("fold");
+    (store, path, generation)
+}
+
+fn engine(store: &WorldStore) -> QueryEngine<'_> {
+    QueryEngine::new(store, FreshnessSource::Ruled)
+}
+
+/// The cursor a first `History` page hands back.
+fn history_cursor(store: &WorldStore) -> PageCursor {
+    engine(store)
+        .execute(History {
+            subject: SUBJECT.to_owned(),
+            limit: 2,
+            after: None,
+        })
+        .expect("history")
+        .continuation()
+        .cursor()
+        .expect("four events over a limit of two must continue")
+        .clone()
+}
+
+/// The cursor a first `Lineage` page hands back.
+fn lineage_cursor(store: &WorldStore, generation: i64) -> PageCursor {
+    let reference = LineageRef::subject_lineage(SUBJECT, generation, 2);
+    let resolution = engine(store)
+        .execute(Lineage { reference })
+        .expect("lineage");
+    resolution
+        .resolved()
+        .expect("a resolved page")
+        .continuation()
+        .cursor()
+        .expect("four events over a limit of two must continue")
+        .clone()
+}
+
+fn cursor_error(e: AskError) -> CursorError {
+    match e {
+        AskError::Cursor(c) => c,
+        other => panic!("expected a cursor refusal, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Non-vacuity: the happy path must work, or every refusal below is trivial
+// ---------------------------------------------------------------------------
+
+/// **A cursor round-trips.** The control for every refusal in this file.
+///
+/// Without it, a `PageCursor` that refused EVERYTHING would pass the whole
+/// suite. Every negative test below is only meaningful because this one shows
+/// the positive path is reachable.
+#[test]
+fn a_minted_cursor_continues_its_own_query() {
+    let (store, path, _g) = store_with_four("roundtrip");
+    let cursor = history_cursor(&store);
+
+    let second = engine(&store)
+        .execute(History {
+            subject: SUBJECT.to_owned(),
+            limit: 2,
+            after: Some(cursor),
+        })
+        .expect("a cursor minted by this family must continue it");
+
+    // Four events, two per page: the second page completes the record.
+    assert!(
+        !second.continuation().is_truncated(),
+        "the second page holds the rest, so nothing follows it"
+    );
+    cleanup(&path);
+}
+
+// ---------------------------------------------------------------------------
+// THE decisive control — opacity is capability, not wrapping
+// ---------------------------------------------------------------------------
+
+/// **A cursor differing ONLY in family is refused.**
+///
+/// The decisive control, and it took a mutation to get right. The obvious
+/// version — mint from each family, swap them — passes for the wrong reason:
+/// `SubjectHistory` and `SubjectLineage` happen to declare DIFFERENT rule sets
+/// today, so a naive swap is caught by the version check and the family binding
+/// is never exercised. Deleting the family check entirely still refused the
+/// swap, with `SemanticsChanged` instead of `WrongFamily`.
+///
+/// So the cursor here is stamped with the TARGET family's live semantics before
+/// being presented. Coordinate: identical. Versions: identical, and current.
+/// Family: the only thing that differs. A newtype-only cursor would be accepted,
+/// because nothing about its value would be wrong.
+///
+/// That the two families' version sets differ today is not a defence — it is a
+/// coincidence of which rules each depends on, and a future family sharing a
+/// rule set would collapse it. The family binding is what holds when it does.
+#[test]
+fn a_history_cursor_is_refused_by_lineage() {
+    let (store, path, generation) = store_with_four("family-swap");
+
+    let from_history = history_cursor(&store);
+    let from_lineage = lineage_cursor(&store, generation);
+
+    assert_eq!(
+        from_history.family(),
+        CursorFamily::History,
+        "fixture: the history cursor must name its own family"
+    );
+    assert_eq!(from_lineage.family(), CursorFamily::Lineage);
+
+    // The HISTORY cursor, re-stamped with LINEAGE's live semantics, presented
+    // to LINEAGE. Every field the validator inspects now matches except one.
+    let disguised = from_history
+        .clone()
+        .recorded_under(SemanticVersions::for_query(QueryKind::SubjectLineage));
+    let reference = LineageRef::subject_lineage(SUBJECT, generation, 2).continuing_from(disguised);
+    let err = cursor_error(
+        engine(&store)
+            .execute(Lineage { reference })
+            .expect_err("a history cursor must not continue a lineage query"),
+    );
+    assert_eq!(
+        err,
+        CursorError::WrongFamily {
+            presented: CursorFamily::History,
+            expected: CursorFamily::Lineage,
+        },
+        "the ONLY difference was the family, so the family is what must refuse"
+    );
+
+    // And the mirror: the LINEAGE cursor, re-stamped with HISTORY's semantics.
+    let disguised =
+        from_lineage.recorded_under(SemanticVersions::for_query(QueryKind::SubjectHistory));
+    let err = cursor_error(
+        engine(&store)
+            .execute(History {
+                subject: SUBJECT.to_owned(),
+                limit: 2,
+                after: Some(disguised),
+            })
+            .expect_err("a lineage cursor must not continue a history query"),
+    );
+    assert_eq!(
+        err,
+        CursorError::WrongFamily {
+            presented: CursorFamily::Lineage,
+            expected: CursorFamily::History,
+        }
+    );
+    cleanup(&path);
+}
+
+// ---------------------------------------------------------------------------
+// Semantic-version binding
+// ---------------------------------------------------------------------------
+
+/// **A cursor minted under different rules is refused.**
+///
+/// Continuing would splice pages from two query contracts into one sequence —
+/// box 3b's failure, arrived at through pagination. The refusal carries WHICH
+/// rules differ, so an operator sees the cause rather than only the effect.
+#[test]
+fn a_cursor_from_a_superseded_rule_set_is_refused() {
+    let (store, path, _g) = store_with_four("stale-semantics");
+    let cursor = history_cursor(&store);
+
+    let stale = cursor.recorded_under(SemanticVersions::new([RuleVersion {
+        rule: "world_current_fold".to_string(),
+        version: 1,
+    }]));
+
+    let err = cursor_error(
+        engine(&store)
+            .execute(History {
+                subject: SUBJECT.to_owned(),
+                limit: 2,
+                after: Some(stale),
+            })
+            .expect_err("a cursor from another rule set must not continue"),
+    );
+    match err {
+        CursorError::SemanticsChanged { differences } => assert!(
+            !differences.is_empty(),
+            "a version refusal must name which rules moved"
+        ),
+        other => panic!("expected SemanticsChanged, got {other:?}"),
+    }
+    cleanup(&path);
+}
+
+// ---------------------------------------------------------------------------
+// Reproducibility — the compaction case
+// ---------------------------------------------------------------------------
+
+/// **A cursor whose coordinate compaction removed is refused, not advanced.**
+///
+/// The tempting alternative is to continue from the nearest surviving
+/// generation. It returns a page, and it is wrong: the caller asked to continue
+/// a sequence, and the position they named no longer exists, so what follows it
+/// is undefined rather than merely later.
+#[test]
+fn a_cursor_whose_generation_was_compacted_is_refused() {
+    let (mut store, path, _g) = store_with_four("compacted");
+    let cursor = history_cursor(&store);
+
+    // Remove the span the cursor's coordinate falls in. The cursor named the
+    // last generation of page one, so compacting the early span takes it.
+    store.compact_range(1, 2, T0 + 10_000).expect("compact");
+
+    let err = cursor_error(
+        engine(&store)
+            .execute(History {
+                subject: SUBJECT.to_owned(),
+                limit: 2,
+                after: Some(cursor),
+            })
+            .expect_err("a cursor naming a removed generation must not continue"),
+    );
+    assert!(
+        matches!(err, CursorError::Unreproducible { .. }),
+        "expected Unreproducible, got {err:?}"
+    );
+    cleanup(&path);
+}
+
+/// **The compaction refusal is not vacuous** — the same page succeeds intact.
+///
+/// Without this, a `compact_range` that failed, or a cursor that was already
+/// invalid, would produce the same refusal above and prove nothing about
+/// compaction.
+#[test]
+fn the_same_cursor_continues_before_the_compaction() {
+    let (store, path, _g) = store_with_four("compaction-control");
+    let cursor = history_cursor(&store);
+
+    engine(&store)
+        .execute(History {
+            subject: SUBJECT.to_owned(),
+            limit: 2,
+            after: Some(cursor),
+        })
+        .expect("before compaction the identical cursor must continue");
+    cleanup(&path);
+}
+
+// ---------------------------------------------------------------------------
+// Coordinates that cannot have come from this log
+// ---------------------------------------------------------------------------
+
+/// **A cursor from another store — one whose coordinate is past this head — is
+/// refused.**
+///
+/// Built by minting against a LONGER log and presenting it to a shorter one,
+/// which is what a cursor carried between environments looks like.
+#[test]
+fn a_cursor_past_this_logs_head_is_refused() {
+    let (long_store, long_path, _g) = store_with_four("beyond-head-source");
+    let cursor = history_cursor(&long_store);
+
+    // A different, shorter store: two events, so the cursor's coordinate is
+    // past its head.
+    let short_path = tmp("beyond-head-target");
+    let mut short = WorldStore::open(&short_path).expect("open");
+    append(&mut short, "s1", 1);
+    short.fold().expect("fold");
+
+    let err = cursor_error(
+        engine(&short)
+            .execute(History {
+                subject: SUBJECT.to_owned(),
+                limit: 2,
+                after: Some(cursor),
+            })
+            .expect_err("a coordinate past this log's head must not continue"),
+    );
+    assert!(
+        matches!(err, CursorError::BeyondHead { .. }),
+        "expected BeyondHead, got {err:?}"
+    );
+    cleanup(&long_path);
+    cleanup(&short_path);
+}
+
+// ---------------------------------------------------------------------------
+// No fallback, in the one place a fallback would be invisible
+// ---------------------------------------------------------------------------
+
+/// **A refused cursor returns NO page — not page 1.**
+///
+/// The failure mode this whole module exists to prevent. A reset to the first
+/// page is the most natural-looking recovery there is, and a caller cannot
+/// distinguish it from a legitimate continuation: same shape, same subject,
+/// plausible contents, silently re-serving rows they have already processed.
+///
+/// Asserting on the error alone would not catch it — a fallback implementation
+/// could return `Ok(page_one)`, and `expect_err` would be the only thing that
+/// noticed.
+#[test]
+fn a_refused_cursor_yields_no_answer_at_all() {
+    let (store, path, generation) = store_with_four("no-fallback");
+    let lineage = lineage_cursor(&store, generation);
+
+    let outcome = engine(&store).execute(History {
+        subject: SUBJECT.to_owned(),
+        limit: 2,
+        after: Some(lineage),
+    });
+
+    assert!(
+        outcome.is_err(),
+        "a refused continuation must not serve a page; \
+         resetting to page 1 would re-serve rows the caller already has, \
+         and nothing in the answer would say so"
+    );
+    cleanup(&path);
+}

--- a/crates/kirra-world-service/tests/lineage_retrieval.rs
+++ b/crates/kirra-world-service/tests/lineage_retrieval.rs
@@ -51,7 +51,7 @@ use kirra_world_service::freshness::FreshnessSource;
 use kirra_world_service::lineage::{LineageRef, LineageResolution};
 use kirra_world_service::query::{Lineage, QueryEngine};
 use kirra_world_service::semantics::{RuleVersion, SemanticVersions};
-use kirra_world_store::lineage::LineagePage;
+use kirra_world_store::lineage::{LineagePage, MAX_LINEAGE_PAGE};
 use kirra_world_store::{ClaimStatus, EventId, NewEvent, ObservationId, WorldStore, WriterClass};
 
 const T0: i64 = 1_700_000_000_000;
@@ -162,7 +162,7 @@ fn generations(res: &LineageResolution) -> Vec<i64> {
 #[test]
 fn an_event_appended_after_the_pin_is_not_in_the_lineage() {
     let (mut store, path, generation) = store_with(3, "historical");
-    let reference = LineageRef::subject_lineage(SUBJECT, generation, LineagePage::first());
+    let reference = LineageRef::subject_lineage(SUBJECT, generation, MAX_LINEAGE_PAGE);
 
     let before = generations(&resolve(&store, &reference));
     assert_eq!(before.len(), 3, "the fixture must have three events");
@@ -185,7 +185,7 @@ fn an_event_appended_after_the_pin_is_not_in_the_lineage() {
 
     // The positive control: the SAME query at the NEW coordinate does see it.
     // Without this, a resolver that returned nothing at all would pass above.
-    let now = LineageRef::subject_lineage(SUBJECT, later_generation, LineagePage::first());
+    let now = LineageRef::subject_lineage(SUBJECT, later_generation, MAX_LINEAGE_PAGE);
     assert_eq!(
         generations(&resolve(&store, &now)).len(),
         4,
@@ -202,7 +202,7 @@ fn an_event_appended_after_the_pin_is_not_in_the_lineage() {
 #[test]
 fn a_coordinate_beyond_the_log_refuses() {
     let (store, path, generation) = store_with(2, "unreached");
-    let reference = LineageRef::subject_lineage(SUBJECT, generation + 1_000, LineagePage::first());
+    let reference = LineageRef::subject_lineage(SUBJECT, generation + 1_000, MAX_LINEAGE_PAGE);
     assert!(
         matches!(
             resolve(&store, &reference),
@@ -223,11 +223,7 @@ fn a_coordinate_beyond_the_log_refuses() {
 #[test]
 fn a_truncated_page_is_visibly_truncated() {
     let (store, path, generation) = store_with(5, "truncated");
-    let reference = LineageRef::subject_lineage(
-        SUBJECT,
-        generation,
-        LineagePage::new(2, None).expect("valid page"),
-    );
+    let reference = LineageRef::subject_lineage(SUBJECT, generation, 2);
     let res = resolve(&store, &reference);
     let page = res.resolved().expect("resolved");
     assert_eq!(page.entries().len(), 2);
@@ -236,7 +232,7 @@ fn a_truncated_page_is_visibly_truncated() {
         "a page that stopped short must say so — a lineage response that \
          silently stops is worse than one that says it stopped"
     );
-    assert!(page.boundary().next_after_generation().is_some());
+    assert!(page.continuation().is_truncated());
     drop(store);
     cleanup(&path);
 }
@@ -249,11 +245,7 @@ fn a_truncated_page_is_visibly_truncated() {
 #[test]
 fn paginating_through_references_visits_every_event_exactly_once() {
     let (store, path, generation) = store_with(7, "paginate");
-    let mut reference = LineageRef::subject_lineage(
-        SUBJECT,
-        generation,
-        LineagePage::new(3, None).expect("valid page"),
-    );
+    let mut reference = LineageRef::subject_lineage(SUBJECT, generation, 3);
 
     let mut seen: Vec<i64> = Vec::new();
     let mut pages = 0;
@@ -286,7 +278,7 @@ fn paginating_through_references_visits_every_event_exactly_once() {
 ///
 /// # The bound is EXACTLY the event count, deliberately
 ///
-/// A first draft asked for `LineagePage::first()` (limit 256) over two events,
+/// A first draft asked for `MAX_LINEAGE_PAGE` (limit 256) over two events,
 /// which is a page that could not have been full — so it passed against a rule
 /// that reported `More` on every merely-full page. Measured: the eager-`More`
 /// mutation survived this test and was caught only at the store level.
@@ -297,11 +289,7 @@ fn paginating_through_references_visits_every_event_exactly_once() {
 #[test]
 fn the_final_page_yields_no_next_reference() {
     let (store, path, generation) = store_with(2, "final");
-    let reference = LineageRef::subject_lineage(
-        SUBJECT,
-        generation,
-        LineagePage::new(2, None).expect("valid page"),
-    );
+    let reference = LineageRef::subject_lineage(SUBJECT, generation, 2);
     let res = resolve(&store, &reference);
     let page = res.resolved().expect("resolved");
     assert_eq!(page.entries().len(), 2, "the page must be exactly full");
@@ -324,7 +312,7 @@ fn the_final_page_yields_no_next_reference() {
 #[test]
 fn an_oversized_page_bound_is_refused_rather_than_clamped() {
     assert!(
-        LineagePage::new(kirra_world_store::lineage::MAX_LINEAGE_PAGE + 1, None).is_err(),
+        LineagePage::new(MAX_LINEAGE_PAGE + 1, None).is_err(),
         "a clamp would answer a smaller question and report it as the one asked"
     );
 }
@@ -345,7 +333,7 @@ fn an_unconfirmed_candidate_is_lineage_though_it_is_never_an_answer() {
     append(&mut store, "c2", SUBJECT, ClaimStatus::Candidate, 2);
     let generation = store.fold().expect("fold");
 
-    let reference = LineageRef::subject_lineage(SUBJECT, generation, LineagePage::first());
+    let reference = LineageRef::subject_lineage(SUBJECT, generation, MAX_LINEAGE_PAGE);
     let res = resolve(&store, &reference);
     let page = res.resolved().expect("resolved");
     assert_eq!(page.entries().len(), 2);
@@ -370,7 +358,7 @@ fn another_subjects_evidence_is_not_in_this_lineage() {
     append(&mut store, "theirs", "pallet_9", ClaimStatus::Confirmed, 2);
     let generation = store.fold().expect("fold");
 
-    let reference = LineageRef::subject_lineage(SUBJECT, generation, LineagePage::first());
+    let reference = LineageRef::subject_lineage(SUBJECT, generation, MAX_LINEAGE_PAGE);
     let res = resolve(&store, &reference);
     let page = res.resolved().expect("resolved");
     assert_eq!(page.entries().len(), 1);
@@ -384,7 +372,7 @@ fn another_subjects_evidence_is_not_in_this_lineage() {
 #[test]
 fn every_entry_is_citable() {
     let (store, path, generation) = store_with(3, "citable");
-    let reference = LineageRef::subject_lineage(SUBJECT, generation, LineagePage::first());
+    let reference = LineageRef::subject_lineage(SUBJECT, generation, MAX_LINEAGE_PAGE);
     let res = resolve(&store, &reference);
     for entry in res.resolved().expect("resolved").entries() {
         assert_eq!(
@@ -412,7 +400,7 @@ fn every_entry_is_citable() {
 #[test]
 fn a_reference_recorded_under_another_selection_version_refuses() {
     let (store, path, generation) = store_with(3, "version");
-    let reference = LineageRef::subject_lineage(SUBJECT, generation, LineagePage::first())
+    let reference = LineageRef::subject_lineage(SUBJECT, generation, MAX_LINEAGE_PAGE)
         .recorded_under(SemanticVersions::new([RuleVersion {
             rule: "lineage_selection".to_string(),
             version: 99,
@@ -440,7 +428,7 @@ fn a_reference_recorded_under_another_selection_version_refuses() {
 #[test]
 fn the_version_check_precedes_the_coordinate_check() {
     let (store, path, generation) = store_with(1, "order");
-    let reference = LineageRef::subject_lineage(SUBJECT, generation + 1_000, LineagePage::first())
+    let reference = LineageRef::subject_lineage(SUBJECT, generation + 1_000, MAX_LINEAGE_PAGE)
         .recorded_under(SemanticVersions::new([RuleVersion {
             rule: "lineage_selection".to_string(),
             version: 99,
@@ -462,7 +450,7 @@ fn the_version_check_precedes_the_coordinate_check() {
 /// A reference declares the family it belongs to, and stamps live versions.
 #[test]
 fn a_fresh_reference_carries_this_builds_semantics() {
-    let reference = LineageRef::subject_lineage(SUBJECT, 1, LineagePage::first());
+    let reference = LineageRef::subject_lineage(SUBJECT, 1, MAX_LINEAGE_PAGE);
     assert_eq!(reference.kind(), QueryKind::SubjectLineage);
     assert_eq!(
         reference.semantics(),
@@ -478,16 +466,25 @@ fn a_fresh_reference_carries_this_builds_semantics() {
 /// one lineage must not compare equal.
 #[test]
 fn the_page_bound_is_part_of_a_references_identity() {
-    let a = LineageRef::subject_lineage(SUBJECT, 7, LineagePage::new(10, None).expect("valid"));
-    let b = LineageRef::subject_lineage(SUBJECT, 7, LineagePage::new(10, None).expect("valid"));
-    let second_page =
-        LineageRef::subject_lineage(SUBJECT, 7, LineagePage::new(10, Some(3)).expect("valid"));
-    let smaller =
-        LineageRef::subject_lineage(SUBJECT, 7, LineagePage::new(5, None).expect("valid"));
+    let (store, path, generation) = store_with(4, "ref-identity");
+
+    let a = LineageRef::subject_lineage(SUBJECT, generation, 2);
+    let b = LineageRef::subject_lineage(SUBJECT, generation, 2);
+    let smaller = LineageRef::subject_lineage(SUBJECT, generation, 1);
+
+    // The continuing reference is built from a REAL resolution rather than
+    // assembled from a coordinate, because a cursor can no longer be assembled:
+    // minting is crate-internal, which is the property under test as much as the
+    // inequality below.
+    let resolved = resolve(&store, &a);
+    let second_page = a
+        .next_page(resolved.resolved().expect("a resolved page"))
+        .expect("four events over a limit of two must continue");
 
     assert_eq!(a, b, "the same query must produce the same reference");
     assert_ne!(a, second_page, "a different page is a different reference");
     assert_ne!(a, smaller, "a different bound is a different reference");
+    cleanup(&path);
 }
 
 // ---------------------------------------------------------------------------
@@ -503,11 +500,7 @@ fn the_page_bound_is_part_of_a_references_identity() {
 #[test]
 fn a_truncated_page_of_intact_evidence_is_not_degraded() {
     let (store, path, generation) = store_with(5, "notdegraded");
-    let reference = LineageRef::subject_lineage(
-        SUBJECT,
-        generation,
-        LineagePage::new(2, None).expect("valid page"),
-    );
+    let reference = LineageRef::subject_lineage(SUBJECT, generation, 2);
     let res = resolve(&store, &reference);
     let page = res.resolved().expect("resolved");
     assert!(page.is_truncated(), "the fixture must truncate");
@@ -542,7 +535,7 @@ fn a_compacted_span_degrades_the_page_instead_of_refusing_it() {
     assert_eq!(outcome.removed, 1, "the fixture must remove evidence");
     let generation = store.fold().expect("fold");
 
-    let reference = LineageRef::subject_lineage(SUBJECT, generation, LineagePage::first());
+    let reference = LineageRef::subject_lineage(SUBJECT, generation, MAX_LINEAGE_PAGE);
     let res = resolve(&store, &reference);
     let page = res
         .resolved()
@@ -573,7 +566,7 @@ fn a_compacted_span_degrades_the_page_instead_of_refusing_it() {
 #[test]
 fn a_resolved_page_carries_its_semantics() {
     let (store, path, generation) = store_with(1, "semantics");
-    let reference = LineageRef::subject_lineage(SUBJECT, generation, LineagePage::first());
+    let reference = LineageRef::subject_lineage(SUBJECT, generation, MAX_LINEAGE_PAGE);
     let res = resolve(&store, &reference);
     assert_eq!(
         res.resolved().expect("resolved").semantics(),

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -1225,10 +1225,17 @@ impl WorldStore {
     /// **Whether `generation` still names a live event, and where the log ends.**
     ///
     /// The anchor a continuation cursor is validated against — see
-    /// `kirra_world_service::cursor`. Both facts come back together because they
-    /// answer one question (*"can this coordinate still be continued from?"*)
-    /// and reading them separately would let a concurrent append land between
-    /// them, making a cursor look past the head that was not.
+    /// `kirra_world_service::cursor`. Both facts answer one question (*"can this
+    /// coordinate still be continued from?"*), and they come back from ONE
+    /// statement so they describe one state of the log.
+    ///
+    /// The single statement is load-bearing, not tidiness. Two `query_row` calls
+    /// on the same connection outside a transaction can observe different
+    /// snapshots: another connection appending or compacting between them would
+    /// pair `retained` from before with `head` from after, and a cursor could be
+    /// judged past a head that had not yet moved when its row was checked. This
+    /// shipped as two statements under a doc comment claiming otherwise, and
+    /// review caught the claim rather than the code.
     ///
     /// `retained` is false for a generation compaction has removed AND for one
     /// that never existed. The distinction is not available here — a deleted row
@@ -1237,26 +1244,17 @@ impl WorldStore {
     ///
     /// # Errors
     ///
-    /// [`StoreError::Sqlite`] on any read failure.
+    /// [`StoreError::Sqlite`] on any read failure. A read failure is NOT a stale
+    /// cursor, and the caller must not report it as one — see
+    /// `kirra_world_service::cursor::resolve_cursor`.
     pub fn cursor_anchor(&self, generation: i64) -> Result<CursorAnchor, StoreError> {
-        let head: i64 = self
-            .conn
-            .query_row(
-                "SELECT generation FROM world_events ORDER BY generation DESC LIMIT 1",
-                [],
-                |r| r.get(0),
-            )
-            .optional()?
-            .unwrap_or(0);
-        let retained: bool = self
-            .conn
-            .query_row(
-                "SELECT 1 FROM world_events WHERE generation = ?1",
-                params![generation],
-                |_| Ok(true),
-            )
-            .optional()?
-            .unwrap_or(false);
+        let (head, retained) = self.conn.query_row(
+            "SELECT
+                 (SELECT COALESCE(MAX(generation), 0) FROM world_events),
+                 EXISTS(SELECT 1 FROM world_events WHERE generation = ?1)",
+            params![generation],
+            |r| Ok((r.get::<_, i64>(0)?, r.get::<_, i64>(1)? != 0)),
+        )?;
         Ok(CursorAnchor { retained, head })
     }
 

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -1222,6 +1222,44 @@ impl WorldStore {
         Ok(out)
     }
 
+    /// **Whether `generation` still names a live event, and where the log ends.**
+    ///
+    /// The anchor a continuation cursor is validated against — see
+    /// `kirra_world_service::cursor`. Both facts come back together because they
+    /// answer one question (*"can this coordinate still be continued from?"*)
+    /// and reading them separately would let a concurrent append land between
+    /// them, making a cursor look past the head that was not.
+    ///
+    /// `retained` is false for a generation compaction has removed AND for one
+    /// that never existed. The distinction is not available here — a deleted row
+    /// and an absent row are the same absence — and it is not needed: both mean
+    /// the cursor cannot be shown to name a real position, and both refuse.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::Sqlite`] on any read failure.
+    pub fn cursor_anchor(&self, generation: i64) -> Result<CursorAnchor, StoreError> {
+        let head: i64 = self
+            .conn
+            .query_row(
+                "SELECT generation FROM world_events ORDER BY generation DESC LIMIT 1",
+                [],
+                |r| r.get(0),
+            )
+            .optional()?
+            .unwrap_or(0);
+        let retained: bool = self
+            .conn
+            .query_row(
+                "SELECT 1 FROM world_events WHERE generation = ?1",
+                params![generation],
+                |_| Ok(true),
+            )
+            .optional()?
+            .unwrap_or(false);
+        Ok(CursorAnchor { retained, head })
+    }
+
     /// The chain digest of the newest event, or [`GENESIS`].
     pub fn head_chain(&self) -> Result<String, StoreError> {
         let head: Option<String> = self
@@ -4479,6 +4517,16 @@ fn rand_component() -> u128 {
     // The top 48 bits are the ULID's timestamp; mask them off so only the
     // 80-bit random field is populated.
     u128::from_be_bytes(buf) & ((1u128 << 80) - 1)
+}
+
+/// **What a continuation cursor's coordinate anchors to** — see
+/// [`WorldStore::cursor_anchor`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CursorAnchor {
+    /// Whether the log still holds an event at that generation.
+    pub retained: bool,
+    /// The highest generation the log holds, or `0` for an empty log.
+    pub head: i64,
 }
 
 /// **One page of a subject's claim history, and how complete the record is.**

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -2066,18 +2066,37 @@ pressure that produced every stale claim this box already documents.
 
 **Cross-cutting, applying to every box above:**
 
-- [ ] Every interactive query bounded (existing rule 2; D-9, ADR-0041 D-12)
-- [ ] Pagination and truncation explicit, and **cursors stable across releases**
-      — an unversioned sort re-executes the answer identically while page 2
-      differs
-- [ ] No dependency path from the query engine to checker or actuation, on the
-      `ci/check_mick_actuation_fence.py` fence pattern — this is what makes
-      ADR-0042 Decision 5's *non-authoritative* mechanical rather than declared
-- [ ] `ChangedSince` takes an **opaque domain cursor**, never the SQLite
-      `generation`. The adapter may encode a generation inside it; a caller that
-      knows this makes the API un-implementable over another backend, against
-      ADR-0040's domain-core/swappable-adapter shape. Same opaque-newtype
-      discipline as `reference.rs`.
+- [x] **Every interactive query bounded** (existing rule 2; D-9, ADR-0041 D-12).
+      ✅ **DONE 2026-08-12**, `ci/check_query_boundedness.py` rules 1–4, and the
+      coverage extends to the typed engine rather than stopping at the
+      pre-engine surface: rule 2 scans the whole boundary crate by glob, so
+      `query.rs` was in scope the moment it existed. Verified by mutation — an
+      unbounded call placed inside the `History` dispatch reds the gate naming
+      `query.rs`.
+- [x] **Pagination and truncation explicit, and cursors stable across releases.**
+      ✅ **DONE 2026-08-15**. Truncation was already explicit (`Continuation`,
+      an enum rather than a bool beside an `Option`). Stability was not: the
+      cursor was a bare `i64` generation. See *"cursors name a contract, not a
+      row"* below.
+- [x] **No dependency path from the query engine to checker or actuation**, on
+      the `ci/check_mick_actuation_fence.py` fence pattern — what makes ADR-0042
+      Decision 5's *non-authoritative* mechanical rather than declared.
+      ✅ Covered since the fence landed, and covered **by construction**: Fence A
+      check 2 walks the dependency closure of every `kirra-world*` package,
+      which includes `kirra-world-service`. Adding the engine needed no fence
+      change, and a new module cannot fall outside it.
+- [x] **Raw store coordinates are not exposed by the typed domain-query API.**
+      ✅ **DONE 2026-08-15**. This item read *"`ChangedSince` takes an opaque
+      domain cursor, never the SQLite `generation`"*, and that named the wrong
+      symbol: `WorldStore::changed_since` takes a transaction-time
+      **millisecond**, not a generation, and there is no `ChangedSince` domain
+      query at the boundary at all. The generation leak was real and it was in
+      the **page cursors** — see below. `changed_since` remains an internal
+      store primitive, classified `unbounded`, which rule 5 bars domain
+      consumers from calling. Any future public *"what changed since"* query is
+      a new bounded family through `QueryEngine` with an opaque cursor from day
+      one; it does not promote the store primitive into the architecture because
+      its name sounds convenient.
 
 **Closing condition.** Tier 3 closes on the contracts plus a representative
 proving set — not on every conceivable query. The minimum set:
@@ -3615,6 +3634,60 @@ dispatch *into the bounded family* read as a call to the unbounded one.
 Renamed `history_whole` — the same correction `resolve_at` →
 `resolve_at_whole_graph` already took in this box. A read that returns
 everything should say so in its name; that is how it gets called by mistake.
+
+### Cursors name a contract, not a row — 2026-08-15
+
+The rule:
+
+> A cursor names a continuation of ONE query contract under ONE semantic-version
+> set, not merely a position in SQLite.
+
+Pagination shipped with the cursor as a bare `i64` generation, handed out by
+`PageBoundary::More { next_after_generation }` and taken back by
+`LineagePage::after_generation`. Every page of every family passed a raw log
+position across the domain boundary.
+
+#### Wrapping the integer would have fixed nothing
+
+The hazard was never that a caller could READ the coordinate. It is that a
+cursor carried no evidence of *what it continued* — so a cursor from another
+family, another rule version, or another store returned a page rather than an
+error. Right shape, right subject, plausible contents, wrong question. The same
+defect class boxes 3d spent two PRs on, one level up.
+
+So `PageCursor` binds three things and validates all three before a page is
+served, each with its own refusal: the query **family**, the **semantic
+versions** in force when it was minted, and a generation this store still
+**retains** — plus `BeyondHead` and `ImpossibleGeneration` for a coordinate that
+cannot have come from this log. The generation is private to the cursor module,
+so the only code that can read it is the code that validates it.
+
+#### The control that took a mutation to get right
+
+The obvious test — mint from each family, swap them — **passes for the wrong
+reason**. `SubjectHistory` and `SubjectLineage` declare different rule sets
+today, so a naive swap is caught by the version check and the family binding is
+never exercised. Deleting the family check entirely still refused the swap, with
+`SemanticsChanged` instead of `WrongFamily`.
+
+The real control re-stamps the cursor with the target family's live semantics
+first: coordinate identical, versions identical and current, family the only
+difference. Each of the three bindings is then independently load-bearing —
+dropping any one reds exactly one test and no others.
+
+> That the two families' version sets differ today is not a defence. It is a
+> coincidence of which rules each depends on, and a future family sharing a rule
+> set would collapse it.
+
+#### Every failure is a refusal
+
+Never a reset to page 1, never a jump to the next surviving generation. Both are
+available, both look like recovery, and both silently answer a different
+question — re-serving rows already seen, or skipping the ones that vanished. A
+caller told *"this cursor no longer names a continuation"* can restart
+deliberately; a caller silently handed page 1 cannot tell it happened. One test
+asserts the absence of a served page specifically, because asserting only on the
+error would let an `Ok(page_one)` fallback through.
 
 #### One deviation from the five
 


### PR DESCRIPTION
Closes the Tier 3 §6 cross-cutting cursor item. The other three cross-cutting items are audited and resolved in the same pass — two closed as stale on evidence, one rewritten because it named the wrong symbol.

Tier 3's eight boxes were green while §6 still carried four unticked items, which is exactly the *"functionally done, document says maybe"* ambiguity this work exists to remove.

## The audit, before any code

**STALE — closed on evidence, not assertion.**

| Item | Why it was already true |
|---|---|
| every interactive query bounded | rule 2 scans the boundary crate by **glob**, so `query.rs` was in scope the moment it existed |
| no dependency path to checker/actuation | Fence A check 2 walks the dependency closure of every `kirra-world*` package, which includes `kirra-world-service` |

Neither was taken on faith. Planting an unbounded call inside the `History` dispatch reds the gate naming `query.rs:243`; the fence covers the engine **by construction**, which is why adding it required no fence change.

**THE REAL LEAK — and the doc pointed at the wrong symbol.**

Item 4 read *"`ChangedSince` takes an opaque domain cursor, never the SQLite `generation`"*. But `WorldStore::changed_since` takes a transaction-time **millisecond**, not a generation, and there is no `ChangedSince` domain query at the boundary at all.

The generation leak was real and it was in the **page cursors**:

```rust
pub enum PageBoundary { More { next_after_generation: i64 } }  // handed out
pub fn after_generation(&self) -> Option<i64>                  // taken back
```

on every page of both paginated families. Building item 4 as written would have fixed nothing and left the actual leak in the cursors `History` and `Lineage` hand out today.

`changed_since` is deliberately untouched: rule 5 already bars domain consumers from it, so it is not part of Tier 3's public contract. A future public *"what changed since"* is a new bounded family with an opaque cursor from day one, not a promotion of the store primitive because its name sounds convenient.

## Wrapping the integer would have fixed nothing

The hazard was never that a caller could **read** the coordinate. It is that a cursor carried no evidence of *what it continued* — so one from another family, another rule version, or another store returned a page rather than an error. Right shape, right subject, plausible contents, wrong question. The 3d defect class, one level up.

`PageCursor` binds three things and validates all three before a page is served:

| Bound | Refusal |
|---|---|
| query **family** | `WrongFamily` |
| **semantic versions** in force when minted | `SemanticsChanged` (carries which rules moved) |
| a generation the store still **retains** | `Unreproducible` |

plus `BeyondHead` and `ImpossibleGeneration` for a coordinate that cannot have come from this log.

The generation is private to the cursor **module**, not merely the crate — the only code that can read it is the code that validates it, so nothing else in the boundary can accidentally pass one on.

## The control took a mutation to get right

The obvious test — mint from each family, swap them — **passes for the wrong reason**. `SubjectHistory` and `SubjectLineage` declare different rule sets today, so a naive swap is caught by the *version* check and the family binding is never exercised. Deleting the family check entirely still refused the swap, with `SemanticsChanged` instead of `WrongFamily`.

The real control re-stamps the cursor with the target family's live semantics first: **coordinate identical, versions identical and current, family the only difference.**

Mutation matrix — each binding is independently necessary, and none masks another:

| Binding dropped | Result |
|---|---|
| family | 1 failed |
| semantics | 1 failed |
| retention anchor | 1 failed |
| none | 7 passed |

> That the two families' version sets differ today is not a defence. It is a coincidence of which rules each depends on, and a future family sharing a rule set would collapse it.

Two doc comments claimed the naive swap was the proof. The mutation falsified that, and the last commit corrects them rather than leaving a claim the code does not support.

## Every failure is a refusal

Never a reset to page 1, never a jump to the next surviving generation. Both are available, both look like recovery, and both silently answer a different question — re-serving rows already seen, or skipping the ones that vanished.

One test asserts the **absence of a served page** specifically, because asserting only on the error would let an `Ok(page_one)` fallback through untouched.

## Also here

- `WorldStore::cursor_anchor` — one bounded primitive returning retention + head together, so a concurrent append cannot land between two separate reads and make a valid cursor look past the head. Classified `bounded` in the gate baseline.
- `AskError::Cursor` and `AskError::PageSpec` as their own channels: a stale cursor is not a storage fault, and *"your cursor is from a previous rule version"* must not read as *"the database is broken"*.
- `LineageRef::continuing_from` for the persisted-cursor case, since `next_page` only covers in-flight continuation.

## Verification

- **40 suites green** across the world crates and the Tier 2.5 differential consumer, including 7 new cursor-contract tests
- `cargo build --workspace`, `cargo fmt --all --check`, `cargo clippy --all-targets` — clean
- all six world CI gates green, including the boundedness gate at zero violations and its 12-check self-test

Tier 3's cross-cutting list is now fully resolved. The formal proving set (eight query cases) follows separately, from `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_