### PR TITLE
Tier 4 box 4a — the citation relation as real structure, without its resolution

### DIFF
--- a/ci/store_boundedness_baseline.json
+++ b/ci/store_boundedness_baseline.json
@@ -68,6 +68,10 @@
       "class": "operational",
       "why": "The one-time scan that fills the v6 reverse index on a migrated store. Deliberately a full scan and deliberately NOT on any request path \u2014 an explicit operational call rather than work hidden in `open`, so the cost lands where an operator can see it. This is exactly the trade box 3d is for: one operational scan buys bounded interactive reads."
     },
+    "backfill_provenance_edges": {
+      "class": "operational",
+      "why": "Tier 4 box 4a. The one-time scan that fills the v7 citation index on a migrated store, and drops the coverage floor to 0. A full log scan by design, and deliberately NOT on any request path -- an explicit operational call rather than work hidden in `open`, exactly as `backfill_adjudication_affects`."
+    },
     "candidates": {
       "class": "unbounded",
       "why": "Every candidate claim ever proposed about a subject, no page. The same shape as `history` and unbounded for the same reason -- an LLM proposing repeatedly grows this without limit."
@@ -79,6 +83,10 @@
     "citations": {
       "class": "unbounded",
       "why": "Every compaction citation in the store. Accumulates for the store's life."
+    },
+    "citations_of": {
+      "class": "bounded",
+      "why": "Tier 4 box 4a. Bounded by the ARGUMENT: `limit`, refused above MAX_CITATIONS_PAGE and at 0, applied as SQL LIMIT with one extra probe row so truncation is reported rather than inferred. It is bounded BECAUSE it was made so -- nothing else bounds it. No schema constraint, no domain rule and no other argument limits how many observations one event may cite, so the whole-array read this replaced was structurally unbounded while looking fine at the API: the exact shape of the three defects in the header. Classifying it `unbounded` and leaving 4b to bound it would have been the 'move the unbounded call behind another helper' move 3d ruled out."
     },
     "compact_range": {
       "class": "operational",
@@ -203,6 +211,10 @@
     "projection_state_digest": {
       "class": "operational",
       "why": "Checkpoint metadata."
+    },
+    "provenance_edges_floor": {
+      "class": "bounded",
+      "why": "Tier 4 box 4a. One `world_store_meta` row by primary key. The fail-closed fallback for an absent/unparseable value is `MAX(generation)`, an index max rather than a scan. Constant result size -- one integer."
     },
     "read_at_generation": {
       "class": "unbounded",

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -87,6 +87,7 @@ pub mod compaction;
 pub mod entity_projection;
 pub mod lineage;
 pub mod projection;
+pub mod provenance_edges;
 pub mod retention_driver;
 pub mod retention_sweeper;
 pub mod schema;
@@ -254,6 +255,12 @@ pub enum StoreError {
         /// Which row, and how it disagreed.
         detail: String,
     },
+    /// A citation page was requested with an unusable bound — Tier 4 box 4a.
+    ///
+    /// **Refused, never clamped**, for the reason [`lineage::PageSpecError`]
+    /// gives about lineage pages, and the error type is shared rather than
+    /// duplicated because it is the same decision about the same kind of bound.
+    CitationPageSpec(lineage::PageSpecError),
     /// A [`SubjectRef::Candidate`] was offered as a label.
     ///
     /// Refused by ruling `KIRRA-WM-CANDIDATE-ID-001` (2026-08-08), not by
@@ -381,6 +388,7 @@ impl std::fmt::Display for StoreError {
             Self::CorruptEntityProjectionRow { detail } => {
                 write!(f, "corrupt entities_projection row: {detail}")
             }
+            Self::CitationPageSpec(e) => write!(f, "citation page: {e}"),
             Self::LlmCannotConfirm => write!(
                 f,
                 "writer_class=llm_candidate may not write claim_status=confirmed \
@@ -988,6 +996,7 @@ pub fn schema_digest() -> String {
     effective.push_str(schema::SCHEMA_V4_MIGRATION);
     effective.push_str(schema::SCHEMA_V5_MIGRATION);
     effective.push_str(schema::SCHEMA_V6_MIGRATION);
+    effective.push_str(schema::SCHEMA_V7_MIGRATION);
     sha256_hex(effective.as_bytes())
 }
 
@@ -997,6 +1006,19 @@ pub fn schema_digest() -> String {
 pub fn schema_digest_v1() -> String {
     sha256_hex(schema::SCHEMA_V1.as_bytes())
 }
+
+/// The `world_store_meta` key holding the citation index's coverage floor.
+///
+/// The highest generation the `provenance_edges` index does **not** cover. `0`
+/// means fully covered — a store born at v7, or a migrated one whose backfill
+/// has completed.
+///
+/// It exists because an empty edge set is ambiguous on its own: it is what a
+/// source citing nothing looks like, and equally what an un-backfilled store
+/// makes every source look like. Box 4b consults this before reporting that a
+/// source cited nothing, so a missing backfill is a refusal rather than a
+/// confident wrong answer about provenance.
+pub const PROVENANCE_EDGES_FLOOR_KEY: &str = "provenance_edges_floor";
 
 /// The genesis value the first event chains from.
 ///
@@ -1043,9 +1065,16 @@ impl WorldStore {
             tx.execute_batch(schema::SCHEMA_V4_MIGRATION)?;
             tx.execute_batch(schema::SCHEMA_V5_MIGRATION)?;
             tx.execute_batch(schema::SCHEMA_V6_MIGRATION)?;
+            tx.execute_batch(schema::SCHEMA_V7_MIGRATION)?;
             tx.execute(
                 "INSERT INTO world_store_meta (key, value) VALUES ('schema_version', ?1)",
                 params![SCHEMA_VERSION.to_string()],
+            )?;
+            // A store born at v7 indexes every event as it is appended, so no
+            // generation is outside the citation index and the floor is 0.
+            tx.execute(
+                "INSERT INTO world_store_meta (key, value) VALUES (?1, '0')",
+                params![PROVENANCE_EDGES_FLOOR_KEY],
             )?;
             tx.execute(
                 "INSERT INTO world_store_meta (key, value) VALUES ('chain_algorithm', ?1)",
@@ -1153,6 +1182,41 @@ impl WorldStore {
         // it, not on the path of whoever happens to open the store first.
         if from < 6 {
             tx.execute_batch(schema::SCHEMA_V6_MIGRATION)?;
+        }
+        // v7 is the same shape as v6 — a table and its index, no column change,
+        // no trigger, no existing row touched — and it migrates EMPTY for the
+        // same reason, with `backfill_provenance_edges` as the explicit
+        // operational step.
+        //
+        // But emptiness is NOT harmless here the way it is for
+        // `adjudication_affects`, and the difference is worth the extra row this
+        // writes. A missing affects-row makes a lookup return nothing, which
+        // reads as "no such adjudication" — wrong, but the caller was asking a
+        // question with a negative answer either way. A missing citation edge
+        // makes a source event look like it CITED NOTHING, which is a positive
+        // claim about its provenance, and an unbackfilled store would make it
+        // about every event it holds.
+        //
+        // So the migration records the highest generation the index does not
+        // cover. Above the floor, appends index themselves; at or below it, the
+        // index is not authoritative until `backfill_provenance_edges` has run
+        // and reset it to 0. That is what lets 4b tell "cited nothing" from "not
+        // indexed yet" instead of guessing, and it costs one meta row rather
+        // than a per-append write.
+        if from < 7 {
+            tx.execute_batch(schema::SCHEMA_V7_MIGRATION)?;
+            let head: i64 = tx
+                .query_row(
+                    "SELECT COALESCE(MAX(generation), 0) FROM world_events",
+                    [],
+                    |r| r.get(0),
+                )
+                .unwrap_or(0);
+            tx.execute(
+                "INSERT INTO world_store_meta (key, value) VALUES (?1, ?2)
+                 ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                params![PROVENANCE_EDGES_FLOOR_KEY, head.to_string()],
+            )?;
         }
 
         // Digest before version, inside the transaction. The order no longer
@@ -1394,7 +1458,99 @@ impl WorldStore {
                 e.subject_ref.map(SubjectRef::as_str),
             ],
         )?;
+        self.write_citation_edges(generation, e.provenance)?;
         Ok(generation)
+    }
+
+    /// Index one event's citations — Tier 4 box 4a, the append half.
+    ///
+    /// Derived by [`provenance_edges::citation_edges`], the same function the
+    /// backfill uses, so the two paths agree by construction rather than by
+    /// happening to match. Written from the `&[&str]` the caller passed rather
+    /// than by re-parsing the JSON this row just stored: the array is the
+    /// authoritative statement and it is right here, so a decode step would only
+    /// add a way for the index to disagree with the evidence.
+    ///
+    /// # A SAVEPOINT, not a transaction
+    ///
+    /// The event row and its edges must commit together — an index that could
+    /// lag the log by one crash would under-report the newest event's
+    /// provenance, and silently, since missing edges read as "cited nothing".
+    ///
+    /// It cannot be `BEGIN IMMEDIATE`, because [`Self::append_adjudication`]
+    /// already holds an open transaction across its call to `append`, and SQLite
+    /// refuses a nested `BEGIN` with "cannot start a transaction within a
+    /// transaction". A savepoint composes in both cases: standalone it opens and
+    /// commits its own transaction, and inside one it nests.
+    fn write_citation_edges(&self, generation: i64, cited: &[&str]) -> Result<(), StoreError> {
+        let edges = provenance_edges::citation_edges(cited);
+        if edges.is_empty() {
+            return Ok(());
+        }
+        self.conn.execute_batch("SAVEPOINT kirra_prov_edges")?;
+        for edge in &edges {
+            // Plain INSERT, not INSERT OR IGNORE. The primary key is
+            // (generation, ordinal) and both are freshly minted here, so a
+            // conflict is not a duplicate append — it means this generation was
+            // already indexed, which would mean the log reused a generation.
+            // Failing loudly is the only honest response.
+            if let Err(err) = self.conn.execute(
+                "INSERT INTO provenance_edges
+                     (source_generation, ordinal, cited_observation_id)
+                 VALUES (?1, ?2, ?3)",
+                params![generation, edge.ordinal, edge.cited_observation_id],
+            ) {
+                let _ = self.conn.execute_batch("ROLLBACK TO kirra_prov_edges");
+                let _ = self.conn.execute_batch("RELEASE kirra_prov_edges");
+                return Err(err.into());
+            }
+        }
+        // A failing RELEASE leaves the savepoint on the stack. Same hazard as
+        // the failed-COMMIT case in `append_adjudication`: returning without
+        // unwinding poisons every later write on this connection with a fault
+        // that names the wrong operation.
+        if let Err(err) = self.conn.execute_batch("RELEASE kirra_prov_edges") {
+            let _ = self.conn.execute_batch("ROLLBACK TO kirra_prov_edges");
+            let _ = self.conn.execute_batch("RELEASE kirra_prov_edges");
+            return Err(err.into());
+        }
+        Ok(())
+    }
+
+    /// The highest generation the citation index does **not** cover.
+    ///
+    /// `0` means fully covered. See [`PROVENANCE_EDGES_FLOOR_KEY`] for why a
+    /// reader must consult this before concluding that a source cited nothing.
+    ///
+    /// A store predating the key reports its own head, which is the fail-closed
+    /// reading: nothing is known to be indexed.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::Sqlite`] if the meta table cannot be read.
+    pub fn provenance_edges_floor(&self) -> Result<i64, StoreError> {
+        let stored: Option<String> = self
+            .conn
+            .query_row(
+                "SELECT value FROM world_store_meta WHERE key = ?1",
+                params![PROVENANCE_EDGES_FLOOR_KEY],
+                |r| r.get(0),
+            )
+            .optional()?;
+        match stored.as_deref().and_then(|v| v.parse::<i64>().ok()) {
+            Some(floor) => Ok(floor),
+            // Absent or unparseable. Both mean the same thing operationally —
+            // this store makes no claim about its index's coverage — and the
+            // safe reading of "no claim" is "covers nothing".
+            None => self
+                .conn
+                .query_row(
+                    "SELECT COALESCE(MAX(generation), 0) FROM world_events",
+                    [],
+                    |r| r.get(0),
+                )
+                .map_err(Into::into),
+        }
     }
 
     /// **Record an identity adjudication.** The single door for §14.3's
@@ -1630,6 +1786,173 @@ impl WorldStore {
         }
         tx.commit()?;
         Ok(written)
+    }
+
+    /// **Populate the citation index from the existing log** — Tier 4 box 4a.
+    ///
+    /// A v7 migration installs an EMPTY index and records a coverage floor at
+    /// the log head. This fills the index and drops the floor to 0. Like
+    /// [`Self::backfill_adjudication_affects`] it is an explicit operational
+    /// call rather than work hidden in `open`, because it scans the whole log.
+    ///
+    /// # Why it deletes before it writes
+    ///
+    /// Each source's edges are replaced wholesale rather than merged with
+    /// `INSERT OR IGNORE`, so this is a REBUILD rather than a top-up.
+    ///
+    /// The tempting justification — that a merge could interleave ordinals from
+    /// a half-written earlier attempt — does not actually hold, and is worth
+    /// recording as rejected rather than left as folklore: the log is immutable,
+    /// so a generation's array never changes, and both writers are atomic (a
+    /// savepoint at append, this transaction here), so no half-written state is
+    /// reachable without tampering. A merge would in fact converge.
+    ///
+    /// The real reason is what the method is FOR. Its correctness argument is
+    /// *"rebuilding from retained sources reproduces the index"*, and a merge
+    /// can only claim *"…provided what is already there is a prefix of the
+    /// truth"* — a precondition the caller cannot check and the test cannot
+    /// state. Replacing makes the postcondition depend on the source events
+    /// alone, which is exactly the property that makes this table an index
+    /// rather than evidence.
+    ///
+    /// # It reads the stored JSON, and that is the point
+    ///
+    /// The append path indexes from the caller's slice; this one decodes the
+    /// hash-covered `provenance` column. Two inputs, one derivation
+    /// ([`provenance_edges::citation_edges`]) — which is exactly what makes
+    /// rebuild-equivalence a property of the design rather than of two code
+    /// paths agreeing today.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::CorruptEntityProjectionRow`] if a stored provenance column
+    /// is not a JSON array of strings. Fail-closed: an index built over a
+    /// citation nobody could decode would be an index nobody can trust, and
+    /// silently skipping the row would understate that source's provenance.
+    pub fn backfill_provenance_edges(&mut self) -> Result<usize, StoreError> {
+        let mut rows: Vec<(i64, String)> = Vec::new();
+        {
+            let mut stmt = self.conn.prepare(
+                "SELECT generation, provenance FROM world_events ORDER BY generation ASC",
+            )?;
+            let mapped = stmt.query_map([], |r| Ok((r.get(0)?, r.get(1)?)))?;
+            for row in mapped {
+                rows.push(row?);
+            }
+        }
+
+        // Decode EVERY row before writing anything. A corrupt column halfway
+        // through would otherwise leave the index half-rebuilt and the floor
+        // still claiming the old coverage, which is a worse state than the one
+        // we started in.
+        let mut decoded: Vec<(i64, Vec<provenance_edges::CitationEdge>)> =
+            Vec::with_capacity(rows.len());
+        for (generation, provenance) in rows {
+            let cited: Vec<String> = serde_json::from_str(&provenance).map_err(|e| {
+                StoreError::CorruptEntityProjectionRow {
+                    detail: format!("generation {generation}: provenance is not a JSON array: {e}"),
+                }
+            })?;
+            decoded.push((generation, provenance_edges::citation_edges(&cited)));
+        }
+
+        let mut written = 0usize;
+        let tx = self.conn.unchecked_transaction()?;
+        for (generation, edges) in decoded {
+            tx.execute(
+                "DELETE FROM provenance_edges WHERE source_generation = ?1",
+                params![generation],
+            )?;
+            for edge in edges {
+                written += tx.execute(
+                    "INSERT INTO provenance_edges
+                         (source_generation, ordinal, cited_observation_id)
+                     VALUES (?1, ?2, ?3)",
+                    params![generation, edge.ordinal, edge.cited_observation_id],
+                )?;
+            }
+        }
+        // Floor last, inside the same transaction: it is the CLAIM that the
+        // index is complete, and a crash that committed the claim without the
+        // rows would make an un-indexed store assert full coverage.
+        tx.execute(
+            "INSERT INTO world_store_meta (key, value) VALUES (?1, '0')
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            params![PROVENANCE_EDGES_FLOOR_KEY],
+        )?;
+        tx.commit()?;
+        Ok(written)
+    }
+
+    /// **The citations one source event recorded**, in recorded order.
+    ///
+    /// The structural replacement for decoding `provenance` JSON at the query
+    /// path — box 4b resolves these against the events visible at a pinned
+    /// generation, and this is what it walks.
+    ///
+    /// Returns what the source CLAIMED to cite. Whether any of it resolves, and
+    /// to how many rows, is not asked or answered here.
+    ///
+    /// # An empty result is not by itself "cited nothing"
+    ///
+    /// It is also what an un-backfilled generation looks like. This method
+    /// reports the index as it stands and does not consult
+    /// [`Self::provenance_edges_floor`], because a raw read that silently
+    /// refused would be harder to reason about than one that answers narrowly.
+    /// The floor check belongs to the caller that turns an empty set into the
+    /// CLAIM *"this source cited nothing"* — box 4b — and it must not skip it:
+    /// at or below the floor, the honest answer is a refusal, not an empty
+    /// provenance.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::Sqlite`] if the index cannot be read.
+    pub fn citations_of(
+        &self,
+        source_generation: i64,
+        limit: usize,
+        after_ordinal: Option<i64>,
+    ) -> Result<provenance_edges::CitationPage, StoreError> {
+        if limit == 0 {
+            return Err(StoreError::CitationPageSpec(
+                lineage::PageSpecError::ZeroLimit,
+            ));
+        }
+        if limit > provenance_edges::MAX_CITATIONS_PAGE {
+            return Err(StoreError::CitationPageSpec(
+                lineage::PageSpecError::LimitTooLarge {
+                    requested: limit,
+                    maximum: provenance_edges::MAX_CITATIONS_PAGE,
+                },
+            ));
+        }
+
+        // Fetch one MORE than asked for. That extra row is what makes
+        // `truncated` a fact rather than an inference: `edges.len() == limit` is
+        // ambiguous exactly at the boundary, where a source with precisely
+        // `limit` citations is complete and would be reported cut short.
+        let probe = limit.saturating_add(1);
+        let mut stmt = self.conn.prepare(
+            "SELECT ordinal, cited_observation_id FROM provenance_edges
+             WHERE source_generation = ?1 AND ordinal > ?2
+             ORDER BY ordinal ASC LIMIT ?3",
+        )?;
+        let mapped = stmt.query_map(
+            params![source_generation, after_ordinal.unwrap_or(-1), probe as i64],
+            |r| {
+                Ok(provenance_edges::CitationEdge {
+                    ordinal: r.get(0)?,
+                    cited_observation_id: r.get(1)?,
+                })
+            },
+        )?;
+        let mut edges = Vec::new();
+        for row in mapped {
+            edges.push(row?);
+        }
+        let truncated = edges.len() > limit;
+        edges.truncate(limit);
+        Ok(provenance_edges::CitationPage { edges, truncated })
     }
 
     /// Install the entity projection's DDL, lazily.
@@ -2486,6 +2809,59 @@ impl WorldStore {
     #[cfg(any(test, feature = "test-support"))]
     pub fn query_scalar_for_test(&self, sql: &str) -> Result<i64, StoreError> {
         Ok(self.conn.query_row(sql, [], |r| r.get(0))?)
+    }
+
+    /// Test-only: every citation edge in the store, in a total order.
+    ///
+    /// Gated like its neighbours. Exists for box 4a's rebuild-equivalence proof,
+    /// which has to compare two whole tables rather than one source's edges —
+    /// a per-source comparison would miss an extra row under a generation the
+    /// test never thought to ask about, which is exactly the drift the proof is
+    /// looking for.
+    ///
+    /// # Panics
+    ///
+    /// If the index cannot be read. Test-only, and an unreadable index during a
+    /// rebuild proof is the proof failing.
+    #[cfg(any(test, feature = "test-support"))]
+    #[must_use]
+    pub fn raw_query_edges_for_test(&self) -> Vec<(i64, i64, String)> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT source_generation, ordinal, cited_observation_id
+                 FROM provenance_edges
+                 ORDER BY source_generation ASC, ordinal ASC",
+            )
+            .expect("prepare edge scan");
+        let rows = stmt
+            .query_map([], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)))
+            .expect("scan edges");
+        rows.map(|r| r.expect("edge row")).collect()
+    }
+
+    /// Test-only: how many edges name a source generation the log no longer has.
+    ///
+    /// Must be 0 at all times — see the compaction delete in
+    /// [`Self::compact_range`]. Written as a LEFT JOIN rather than a
+    /// `NOT IN (SELECT …)` because the latter is silently empty-safe in a way
+    /// that would make this count 0 for the wrong reason on an empty log.
+    ///
+    /// # Panics
+    ///
+    /// If the query fails.
+    #[cfg(any(test, feature = "test-support"))]
+    #[must_use]
+    pub fn raw_count_orphan_edges_for_test(&self) -> i64 {
+        self.conn
+            .query_row(
+                "SELECT COUNT(*) FROM provenance_edges e
+                 LEFT JOIN world_events w ON w.generation = e.source_generation
+                 WHERE w.generation IS NULL",
+                [],
+                |r| r.get(0),
+            )
+            .expect("orphan count")
     }
 
     /// Test-only: rewrite one column of one row, bypassing the write path.
@@ -3437,6 +3813,25 @@ impl WorldStore {
         let tx = self.conn.transaction()?;
         tx.execute(
             "DELETE FROM world_events WHERE generation BETWEEN ?1 AND ?2",
+            params![lo, hi],
+        )?;
+        // The citation index goes with its sources, in the SAME transaction.
+        //
+        // This is the one invariant Tier 4 box 4a rests on. `provenance_edges`
+        // is a deterministic index over retained source events, never evidence
+        // of its own — and an edge that outlived its source event would be
+        // exactly that: a citation still readable after the hash-covered
+        // statement it was derived from has been deleted, with nothing left to
+        // check it against.
+        //
+        // Deleting is what makes the branch honest rather than what loses the
+        // information. A compacted source is already `Degraded` through the
+        // citation/summary machinery, and `Degraded` is the true answer —
+        // "the evidence was deleted", not "it cited nothing". Keeping the edges
+        // would let a walk descend confidently into a region whose events no
+        // longer exist.
+        tx.execute(
+            "DELETE FROM provenance_edges WHERE source_generation BETWEEN ?1 AND ?2",
             params![lo, hi],
         )?;
         for s in &summaries {

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -1009,9 +1009,15 @@ pub fn schema_digest_v1() -> String {
 
 /// The `world_store_meta` key holding the citation index's coverage floor.
 ///
-/// The highest generation the `provenance_edges` index does **not** cover. `0`
-/// means fully covered — a store born at v7, or a migrated one whose backfill
-/// has completed.
+/// The rule it exists to state:
+///
+/// > The provenance-edge index is only authoritative over the generation range
+/// > it explicitly covers. **Outside that range, absence of edges is not
+/// > evidence of "no citations."**
+///
+/// The value is the highest generation the index does **not** cover. `0` means
+/// fully covered — a store born at v7, or a migrated one whose backfill has
+/// completed.
 ///
 /// It exists because an empty edge set is ambiguous on its own: it is what a
 /// source citing nothing looks like, and equally what an un-backfilled store

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -385,8 +385,13 @@ impl std::fmt::Display for StoreError {
                 "identity closure reachable from {from} exceeds {limit} entities; \
                  refused rather than truncated"
             ),
+            // Generic, because the variant long outgrew its name: it also
+            // carries corrupt adjudication tokens and, since 4a, undecodable
+            // provenance JSON. A message naming `entities_projection` sends
+            // triage to the wrong table. The variant's own rename is a
+            // pre-existing cleanup, deliberately not smuggled into this PR.
             Self::CorruptEntityProjectionRow { detail } => {
-                write!(f, "corrupt entities_projection row: {detail}")
+                write!(f, "corrupt stored row: {detail}")
             }
             Self::CitationPageSpec(e) => write!(f, "citation page: {e}"),
             Self::LlmCannotConfirm => write!(
@@ -1211,13 +1216,17 @@ impl WorldStore {
         // than a per-append write.
         if from < 7 {
             tx.execute_batch(schema::SCHEMA_V7_MIGRATION)?;
-            let head: i64 = tx
-                .query_row(
-                    "SELECT COALESCE(MAX(generation), 0) FROM world_events",
-                    [],
-                    |r| r.get(0),
-                )
-                .unwrap_or(0);
+            // `?`, never `unwrap_or(0)`. `COALESCE(MAX(...), 0)` already returns
+            // a row for an empty table, so a swallowed error here could only be
+            // a real one — and it would stamp the floor `0`, which reads as
+            // FULLY COVERED. A store that could not read its own head would
+            // claim to have indexed every citation in it. That is precisely the
+            // fail-open this floor exists to deny, so the migration fails.
+            let head: i64 = tx.query_row(
+                "SELECT COALESCE(MAX(generation), 0) FROM world_events",
+                [],
+                |r| r.get(0),
+            )?;
             tx.execute(
                 "INSERT INTO world_store_meta (key, value) VALUES (?1, ?2)
                  ON CONFLICT(key) DO UPDATE SET value = excluded.value",
@@ -1420,8 +1429,22 @@ impl WorldStore {
             sequence_of(generation)?,
         );
 
-        self.conn.execute(
-            "INSERT INTO world_events (
+        // The event row and its citation edges must become durable TOGETHER, so
+        // the savepoint opens here — before the event insert — not inside the
+        // edge write.
+        //
+        // It previously opened inside `write_citation_edges`, which made the
+        // invariant this comment asserts false in the ordinary case: outside an
+        // enclosing transaction SQLite autocommits the event row immediately, so
+        // a crash before the edge write left a durable event with no edges, in a
+        // v7-born store whose floor says `0` — fully covered. Missing edges read
+        // as "cited nothing", so the store would have made a confident, wrong,
+        // positive claim about that event's provenance. Found in review.
+        self.conn.execute_batch("SAVEPOINT kirra_append_event")?;
+        let written = self
+            .conn
+            .execute(
+                "INSERT INTO world_events (
                 generation, event_id, observation_id, txn_time_ms, valid_from_ms,
                 valid_to_ms, source, source_version, writer_class, claim_status,
                 provenance, frame_id, map_id, kind, subject, predicate, object,
@@ -1463,8 +1486,22 @@ impl WorldStore {
                 // recorded and the one property this design exists to deny.
                 e.subject_ref.map(SubjectRef::as_str),
             ],
-        )?;
-        self.write_citation_edges(generation, e.provenance)?;
+            )
+            .map_err(StoreError::from)
+            .and_then(|_| self.write_citation_edges(generation, e.provenance));
+        if let Err(err) = written {
+            let _ = self.conn.execute_batch("ROLLBACK TO kirra_append_event");
+            let _ = self.conn.execute_batch("RELEASE kirra_append_event");
+            return Err(err);
+        }
+        // A failing RELEASE leaves the savepoint on the stack, poisoning every
+        // later write on this connection with a fault naming the wrong
+        // operation. Unwind it explicitly, as `append_adjudication` does.
+        if let Err(err) = self.conn.execute_batch("RELEASE kirra_append_event") {
+            let _ = self.conn.execute_batch("ROLLBACK TO kirra_append_event");
+            let _ = self.conn.execute_batch("RELEASE kirra_append_event");
+            return Err(err.into());
+        }
         Ok(generation)
     }
 
@@ -1477,23 +1514,24 @@ impl WorldStore {
     /// authoritative statement and it is right here, so a decode step would only
     /// add a way for the index to disagree with the evidence.
     ///
-    /// # A SAVEPOINT, not a transaction
+    /// # Atomicity belongs to the caller
     ///
-    /// The event row and its edges must commit together — an index that could
-    /// lag the log by one crash would under-report the newest event's
-    /// provenance, and silently, since missing edges read as "cited nothing".
+    /// This opens no savepoint of its own. [`Self::append`] wraps the event
+    /// insert and this call in ONE savepoint, which is the only placement that
+    /// makes the row and its edges commit together — a savepoint opened here
+    /// would begin after the event row had already autocommitted.
     ///
-    /// It cannot be `BEGIN IMMEDIATE`, because [`Self::append_adjudication`]
-    /// already holds an open transaction across its call to `append`, and SQLite
-    /// refuses a nested `BEGIN` with "cannot start a transaction within a
-    /// transaction". A savepoint composes in both cases: standalone it opens and
-    /// commits its own transaction, and inside one it nests.
+    /// That enclosing scope is a SAVEPOINT rather than `BEGIN IMMEDIATE`
+    /// because [`Self::append_adjudication`] already holds an open transaction
+    /// across its call to `append`, and SQLite refuses a nested `BEGIN` with
+    /// "cannot start a transaction within a transaction". A savepoint composes
+    /// in both cases: standalone it opens and commits its own transaction, and
+    /// inside one it nests.
     fn write_citation_edges(&self, generation: i64, cited: &[&str]) -> Result<(), StoreError> {
         let edges = provenance_edges::citation_edges(cited);
         if edges.is_empty() {
             return Ok(());
         }
-        self.conn.execute_batch("SAVEPOINT kirra_prov_edges")?;
         for edge in &edges {
             // Plain INSERT, not INSERT OR IGNORE. The primary key is
             // (generation, ordinal) and both are freshly minted here, so a
@@ -1506,19 +1544,10 @@ impl WorldStore {
                  VALUES (?1, ?2, ?3)",
                 params![generation, edge.ordinal, edge.cited_observation_id],
             ) {
-                let _ = self.conn.execute_batch("ROLLBACK TO kirra_prov_edges");
-                let _ = self.conn.execute_batch("RELEASE kirra_prov_edges");
+                // The caller's savepoint unwinds this; returning the error is
+                // enough to trigger it.
                 return Err(err.into());
             }
-        }
-        // A failing RELEASE leaves the savepoint on the stack. Same hazard as
-        // the failed-COMMIT case in `append_adjudication`: returning without
-        // unwinding poisons every later write on this connection with a fault
-        // that names the wrong operation.
-        if let Err(err) = self.conn.execute_batch("RELEASE kirra_prov_edges") {
-            let _ = self.conn.execute_batch("ROLLBACK TO kirra_prov_edges");
-            let _ = self.conn.execute_batch("RELEASE kirra_prov_edges");
-            return Err(err.into());
         }
         Ok(())
     }

--- a/crates/kirra-world-store/src/provenance_edges.rs
+++ b/crates/kirra-world-store/src/provenance_edges.rs
@@ -1,0 +1,182 @@
+//! **Citation edges — Tier 4 box 4a, the structural half.**
+//!
+//! `KIRRA-WM-PROVENANCE-GRAPH-001`:
+//!
+//! > Materialize the citation relation at append, but do not materialize its
+//! > resolved target. That distinction is what preserves historical
+//! > correctness.
+//!
+//! This module owns the *derivation*: given what a source event recorded in its
+//! `provenance` array, which edge rows exist. It is deliberately tiny, and
+//! deliberately shared — see below.
+//!
+//! # What an edge is, and the one thing it must not become
+//!
+//! An edge says **"generation G, at position N, cited observation id X"**. It
+//! does not say what X is, whether X exists, or which row X names. Those are
+//! read-time questions with a different answer at every coordinate, and box 4b
+//! answers them against the events visible at the generation being explained.
+//!
+//! The pressure to answer them HERE is real and worth naming, because it will
+//! present itself as an optimisation: resolving at append would let a reader
+//! follow one column instead of joining, and every measurement would say it was
+//! faster. It would also silently fix, at write time, an answer whose whole
+//! purpose is to be different at different coordinates — a citation dangling
+//! when it was written and resolvable a week later must still read as dangling
+//! when a query is pinned to the week before. `world_events.observation_id` is
+//! not unique and nothing requires a cited id to exist, so there is not even a
+//! single target to bake in.
+//!
+//! # Why the derivation is one shared function rather than two call sites
+//!
+//! [`citation_edges`] is used by BOTH the append path and the backfill. That is
+//! the `adjudication_affects` precedent and it is load-bearing for the same
+//! reason: a backfilled store and an append-indexed store then agree **by
+//! construction** rather than by two pieces of code happening to match. The
+//! rebuild-equivalence test proves the property; this function is what makes it
+//! true rather than lucky.
+//!
+//! # Verbatim, including what looks wrong
+//!
+//! The array is indexed exactly as recorded — order kept, duplicates kept, and
+//! an empty or malformed-looking id kept. No validation, for the same reason as
+//! no resolution: the hash-covered `provenance` column is the authoritative
+//! statement, and an index that dropped an element a caller could see in the
+//! evidence would be disagreeing with the thing it indexes. An id that can never
+//! resolve is not a corrupt row, it is a citation that will read as
+//! `Dangling` — which is a fact about the source, and one 4b is required to
+//! report rather than hide.
+
+/// The largest citation page a caller may request.
+///
+/// Rule 2 — *queries are bounded* — reaching the one place 4a could have leaked
+/// it. Nothing bounds how many observations an event may cite: not the schema,
+/// not the caller's argument, not the domain. So a whole-array read is
+/// structurally unbounded, and box 3d's finding was that such a read looks
+/// perfectly bounded at the API while the store method underneath is not.
+///
+/// It matches [`crate::lineage::MAX_LINEAGE_PAGE`] deliberately. A citation page
+/// and a lineage page are both "evidence a caller is walking", and two different
+/// ceilings would be two numbers to keep in step for no stated reason.
+pub const MAX_CITATIONS_PAGE: usize = 256;
+
+/// One page of a source's citations, and whether it is all of them.
+///
+/// `truncated` is carried rather than inferred from `edges.len() == limit`,
+/// which is ambiguous exactly at the boundary: an array of precisely `limit`
+/// citations is complete, and a caller comparing lengths would report it as cut
+/// short. Same reason [`crate::lineage::PageBoundary`] is an enum.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CitationPage {
+    /// The citations, in recorded order.
+    pub edges: Vec<CitationEdge>,
+    /// Whether more citations follow this page.
+    pub truncated: bool,
+}
+
+impl CitationPage {
+    /// The ordinal to continue after, or `None` when the page is complete.
+    ///
+    /// Ordinals are dense from 0, so a continuation is the last ordinal served.
+    #[must_use]
+    pub fn next_after_ordinal(&self) -> Option<i64> {
+        if self.truncated {
+            self.edges.last().map(|e| e.ordinal)
+        } else {
+            None
+        }
+    }
+}
+
+/// One recorded citation, positioned.
+///
+/// `ordinal` is the element's index in the source's `provenance` array, dense
+/// from 0. It is part of the identity of the edge rather than decoration: a
+/// source that cites the same observation twice has two edges, and collapsing
+/// them would report an array the hash does not cover.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct CitationEdge {
+    /// Position in the source's provenance array, dense from 0.
+    pub ordinal: i64,
+    /// The observation id the source claimed to cite, **verbatim**.
+    pub cited_observation_id: String,
+}
+
+/// **The edges a provenance array yields** — the whole derivation, in one place.
+///
+/// Total: every input produces a result, and an empty array produces no edges.
+///
+/// That last case is worth stating because it is indistinguishable, in this
+/// table alone, from a source event whose edges were deleted by compaction. The
+/// two are told apart by whether the SOURCE EVENT is still retained, which is
+/// why compaction removes edges with their event and why 4b checks the source
+/// rather than inferring from an empty edge set.
+#[must_use]
+pub fn citation_edges<S: AsRef<str>>(cited: &[S]) -> Vec<CitationEdge> {
+    cited
+        .iter()
+        .enumerate()
+        .map(|(i, id)| CitationEdge {
+            // `usize` -> `i64`: an array long enough to overflow this cannot fit
+            // in memory, let alone in a JSON column.
+            ordinal: i as i64,
+            cited_observation_id: id.as_ref().to_owned(),
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ids(edges: &[CitationEdge]) -> Vec<(i64, &str)> {
+        edges
+            .iter()
+            .map(|e| (e.ordinal, e.cited_observation_id.as_str()))
+            .collect()
+    }
+
+    #[test]
+    fn an_empty_array_yields_no_edges() {
+        assert!(citation_edges::<&str>(&[]).is_empty());
+    }
+
+    #[test]
+    fn ordinals_are_dense_from_zero_and_follow_the_recorded_order() {
+        let edges = citation_edges(&["obs-c", "obs-a", "obs-b"]);
+        assert_eq!(
+            ids(&edges),
+            vec![(0, "obs-c"), (1, "obs-a"), (2, "obs-b")],
+            "the array's order is the source's statement, not something to sort"
+        );
+    }
+
+    #[test]
+    fn a_repeated_citation_is_two_edges_not_one() {
+        // The reason the primary key is (generation, ordinal) rather than
+        // (generation, cited_observation_id). Deduplicating here would index a
+        // provenance array different from the hash-covered one.
+        let edges = citation_edges(&["obs-a", "obs-a"]);
+        assert_eq!(ids(&edges), vec![(0, "obs-a"), (1, "obs-a")]);
+    }
+
+    #[test]
+    fn an_id_that_could_never_resolve_is_still_indexed_verbatim() {
+        // No validation, deliberately. An empty id is a citation that will read
+        // as Dangling at every coordinate — a fact about the source event, and
+        // one 4b must report. Dropping it here would make the index disagree
+        // with the evidence it indexes.
+        let edges = citation_edges(&["", "   ", "obs-a"]);
+        assert_eq!(ids(&edges), vec![(0, ""), (1, "   "), (2, "obs-a")]);
+    }
+
+    #[test]
+    fn the_derivation_is_the_same_for_borrowed_and_owned_inputs() {
+        // The append path holds `&[&str]`; the backfill holds `Vec<String>`
+        // decoded from JSON. They must be the same derivation, or
+        // rebuild-equivalence would be a coincidence of two code paths.
+        let borrowed = citation_edges(&["obs-a", "obs-b"]);
+        let owned = citation_edges(&["obs-a".to_string(), "obs-b".to_string()]);
+        assert_eq!(borrowed, owned);
+    }
+}

--- a/crates/kirra-world-store/src/schema.rs
+++ b/crates/kirra-world-store/src/schema.rs
@@ -113,7 +113,9 @@ pub const CHAIN_ALGORITHM: &str = "kirra-audit-hash/compute_record_hash_v2";
 /// | 3 | the `subject_kind` discriminant | `KIRRA-WM-CANDIDATE-ID-001` |
 /// | 4 | the `entity_id_mint` ledger | `WM_SCOPE.md` §5 |
 /// | 5 | the object-requires-predicate trigger | `KIRRA-WM-CLAIM-SHAPES-001` |
-pub const SCHEMA_VERSION: i64 = 6;
+/// | 6 | the `adjudication_affects` reverse index | `WM_SCOPE.md` box 3d |
+/// | 7 | the `provenance_edges` citation index | `KIRRA-WM-PROVENANCE-GRAPH-001` |
+pub const SCHEMA_VERSION: i64 = 7;
 
 /// **v2 — the four orthogonal trust axes, added additively.**
 ///
@@ -418,4 +420,80 @@ CREATE TABLE IF NOT EXISTS adjudication_affects (
 );
 CREATE INDEX IF NOT EXISTS adjudication_affects_by_entity
     ON adjudication_affects (entity_id, generation);
+"#;
+
+/// **v7 — the citation edge index.** Tier 4 box 4a.
+///
+/// `KIRRA-WM-PROVENANCE-GRAPH-001`:
+///
+/// > Materialize the citation relation at append, but **do not materialize its
+/// > resolved target.**
+///
+/// `world_events.provenance` is a JSON array of observation ids, and `WM_SCOPE`
+/// §7 makes `Explain` wait on *"derivation edges being real structure rather
+/// than a JSON array of identifiers"*. This is that structure — and the
+/// distinction the ruling draws is the whole design, so it is worth stating as
+/// what this table CANNOT say.
+///
+/// # It records the citation, never its resolution
+///
+/// The real relation is:
+///
+/// ```text
+/// source event  ──cites──▶  observation id X
+/// ```
+///
+/// and deliberately NOT:
+///
+/// ```text
+/// source event  ──cites──▶  target event row Y
+/// ```
+///
+/// because at any given generation *T*, X may resolve to exactly one row, to
+/// several, or to none — `world_events.observation_id` is indexed but **not
+/// unique**, and nothing constrains a cited id to exist at all. A citation that
+/// dangles at *T* may become resolvable later, and Tier 4 must still be able to
+/// say it was dangling THEN. Baking a target generation in here would fix one
+/// answer for all time and destroy exactly that.
+///
+/// So the table has no target column, and there is nowhere to put one without a
+/// migration that a reviewer would have to see. Resolution happens at read, in
+/// box 4b, against the events visible at the pinned coordinate.
+///
+/// # Order and duplicates are preserved
+///
+/// The primary key is `(source_generation, ordinal)` rather than
+/// `(source_generation, cited_observation_id)`. A source citing the same
+/// observation twice is a source that said something twice, and an index that
+/// deduplicated it would be reporting a provenance array the hash does not
+/// cover. `ordinal` is the element's index in the stored array, dense from 0.
+///
+/// # The index is never evidence
+///
+/// Same rule as `adjudication_affects`, and the same structural reason: the
+/// table holds no claim content, so it cannot manufacture one. The authoritative
+/// statement stays the hash-covered `provenance` column on `world_events`, and
+/// this table must remain a pure function of the source events still retained —
+/// which is why compaction deletes an event's edges along with the event. An
+/// edge outliving its source would be the index quietly promoting itself to
+/// evidence, which is the one failure mode this design has.
+///
+/// No foreign key, because `PRAGMA foreign_keys` is off by default and a
+/// constraint that silently does not run is worse than a stated invariant with a
+/// test behind it.
+pub const SCHEMA_V7_MIGRATION: &str = r#"
+CREATE TABLE IF NOT EXISTS provenance_edges (
+    source_generation    INTEGER NOT NULL,
+    ordinal              INTEGER NOT NULL,
+    cited_observation_id TEXT    NOT NULL,
+
+    PRIMARY KEY (source_generation, ordinal),
+    CHECK (ordinal >= 0)
+);
+
+-- The reverse direction: who cited this observation. Not used by 4a, and
+-- installed with the table rather than later because adding an index to a
+-- populated table is a migration, while adding it to an empty one is free.
+CREATE INDEX IF NOT EXISTS provenance_edges_by_cited
+    ON provenance_edges (cited_observation_id, source_generation);
 "#;

--- a/crates/kirra-world-store/tests/citation_edges.rs
+++ b/crates/kirra-world-store/tests/citation_edges.rs
@@ -154,8 +154,12 @@ fn an_edge_is_identical_whether_or_not_its_target_exists() {
         kind: "mission",
         subject: "package_17",
         subject_ref: None,
-        predicate: Some("scanned_by"),
-        object: Some("scanner_1"),
+        // `last_seen_at`, not an invented predicate. These fixtures need a
+        // second EVENT, not a second vocabulary term — and minting one would
+        // force a real freshness ruling (`check_freshness_coverage`) on a
+        // predicate the domain does not actually use. Caught by that gate.
+        predicate: Some("last_seen_at"),
+        object: Some("dock_b"),
         payload: "{}",
         payload_schema: 1,
         retention_class: "raw",
@@ -215,8 +219,8 @@ fn an_edge_is_unchanged_when_its_target_becomes_plural() {
             kind: "mission",
             subject: "package_17",
             subject_ref: None,
-            predicate: Some("scanned_by"),
-            object: Some("scanner_1"),
+            predicate: Some("last_seen_at"),
+            object: Some("dock_b"),
             payload: "{}",
             payload_schema: 1,
             retention_class: "raw",

--- a/crates/kirra-world-store/tests/citation_edges.rs
+++ b/crates/kirra-world-store/tests/citation_edges.rs
@@ -651,3 +651,87 @@ fn a_compacted_source_leaves_no_edge_claiming_to_be_backed() {
     drop(s);
     clean(&path);
 }
+
+// ---------------------------------------------------------------------------
+// 5. The event row and its edges commit together
+// ---------------------------------------------------------------------------
+
+/// **A failed edge write must take the event row with it.**
+///
+/// Found in review, and the failure it describes is the one this whole box is
+/// built to prevent. `write_citation_edges` used to open its own savepoint —
+/// *after* `append` had inserted the event row. Outside an enclosing
+/// transaction SQLite autocommits that insert immediately, so the two writes
+/// were never atomic: a failure (or a crash) between them left a durable event
+/// with no edges, in a store whose floor reads `0` — fully covered.
+///
+/// That is not a missing optimization. Missing edges read as **"cited
+/// nothing"**, so the store would answer a provenance question confidently and
+/// wrongly, which is exactly what `provenance_edges_floor` exists to make
+/// impossible. The savepoint now opens before the event insert.
+///
+/// Forcing the failure rather than simulating a crash: an edge row is planted
+/// at the `(generation, ordinal)` the next append will claim, so its first edge
+/// insert hits the primary key. Same window, deterministically.
+#[test]
+fn a_failed_edge_write_rolls_back_the_event_row() {
+    let path = tmp("atomic");
+    let mut s = WorldStore::open(&path).expect("open");
+
+    append_citing(&mut s, "first", "package_17", T0, &["obs-a"]);
+
+    let next = s
+        .query_scalar_for_test("SELECT COALESCE(MAX(generation), 0) FROM world_events")
+        .expect("head")
+        + 1;
+    s.raw_execute_for_test(&format!(
+        "INSERT INTO provenance_edges (source_generation, ordinal, cited_observation_id)
+         VALUES ({next}, 0, 'squatter')"
+    ))
+    .expect("plant");
+
+    let event_id = EventId::new("ev-doomed").expect("event id");
+    let observation_id = ObservationId::new("obs-doomed").expect("obs id");
+    let err = s.append(&NewEvent {
+        event_id: &event_id,
+        observation_id: &observation_id,
+        txn_time_ms: T0 + 1,
+        valid_from_ms: T0 + 1,
+        valid_to_ms: None,
+        source: "warehouse-scanner",
+        source_version: "1.0.0",
+        writer_class: WriterClass::Sensor,
+        claim_status: ClaimStatus::Confirmed,
+        provenance: &["obs-a"],
+        frame_id: None,
+        map_id: None,
+        kind: "mission",
+        subject: "package_17",
+        subject_ref: None,
+        predicate: Some("last_seen_at"),
+        object: Some("dock_c"),
+        payload: "{}",
+        payload_schema: 1,
+        retention_class: "raw",
+        trust: None,
+    });
+    assert!(
+        err.is_err(),
+        "the conflicting edge insert must fail the append"
+    );
+
+    let survived = s
+        .query_scalar_for_test(&format!(
+            "SELECT COUNT(*) FROM world_events WHERE generation = {next}"
+        ))
+        .expect("count");
+    assert_eq!(
+        survived, 0,
+        "the event row must not outlive its failed edge write — a durable event \
+         with no edges reads as 'cited nothing', which is a positive claim about \
+         its provenance that nothing in the store would contradict"
+    );
+
+    drop(s);
+    clean(&path);
+}

--- a/crates/kirra-world-store/tests/citation_edges.rs
+++ b/crates/kirra-world-store/tests/citation_edges.rs
@@ -1,0 +1,649 @@
+//! **Tier 4 box 4a — the citation relation as real structure.**
+//!
+//! `KIRRA-WM-PROVENANCE-GRAPH-001`:
+//!
+//! > Materialize the citation relation at append, but **do not materialize its
+//! > resolved target.** That distinction is what preserves historical
+//! > correctness.
+//!
+//! `WM_SCOPE.md` §7 made `Explain` wait on *"derivation edges being real
+//! structure rather than a JSON array of identifiers"*. These tests are about
+//! the structure existing **and about what it is forbidden to contain**, which
+//! is the harder half: a table with a resolved target column would pass every
+//! test about the edges being present, and would have destroyed the property
+//! Tier 4 exists to have.
+//!
+//! # The four properties
+//!
+//! 1. **The edge is the citation, not its resolution.** An edge is byte-identical
+//!    whether or not the cited observation exists. This is the 4a-level
+//!    precondition for 4b's historical honesty: if resolution were captured
+//!    here, a query pinned before a target appeared could not report it as
+//!    dangling, because the answer would already have been decided at write.
+//! 2. **The recorded array is reproduced exactly** — order and duplicates.
+//! 3. **Rebuilding from retained sources reproduces the table.** This is what
+//!    makes it a deterministic index rather than evidence.
+//! 4. **An edge never outlives its source event.** Compaction takes both.
+//!
+//! Plus the ambiguity the coverage floor exists to resolve: an empty edge set
+//! means *"cited nothing"* only when the index actually covers that generation.
+
+use kirra_world_store::provenance_edges::{CitationEdge, MAX_CITATIONS_PAGE};
+use kirra_world_store::{
+    ClaimStatus, EventId, NewEvent, ObservationId, WorldStore, WriterClass,
+    PROVENANCE_EDGES_FLOOR_KEY,
+};
+
+const T0: i64 = 1_700_000_000_000;
+
+fn tmp(name: &str) -> std::path::PathBuf {
+    static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let n = NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "kirra-cite-{name}-{}-{n}.sqlite",
+        std::process::id()
+    ));
+    clean(&p);
+    p
+}
+
+fn clean(p: &std::path::Path) {
+    for s in ["", "-wal", "-shm"] {
+        let mut q = p.as_os_str().to_os_string();
+        q.push(s);
+        let _ = std::fs::remove_file(std::path::PathBuf::from(q));
+    }
+}
+
+/// Append one claim about `subject`, citing `cited`, and return its generation.
+fn append_citing(s: &mut WorldStore, tag: &str, subject: &str, at_ms: i64, cited: &[&str]) -> i64 {
+    let event_id = EventId::new(format!("ev-{tag}")).expect("event id");
+    let observation_id = ObservationId::new(format!("obs-{tag}")).expect("obs id");
+    s.append(&NewEvent {
+        event_id: &event_id,
+        observation_id: &observation_id,
+        txn_time_ms: at_ms,
+        valid_from_ms: at_ms,
+        valid_to_ms: None,
+        source: "warehouse-scanner",
+        source_version: "1.0.0",
+        writer_class: WriterClass::Sensor,
+        claim_status: ClaimStatus::Confirmed,
+        provenance: cited,
+        frame_id: None,
+        map_id: None,
+        kind: "mission",
+        subject,
+        subject_ref: None,
+        predicate: Some("last_seen_at"),
+        object: Some("dock_a"),
+        payload: "{}",
+        payload_schema: 1,
+        retention_class: "raw",
+        trust: None,
+    })
+    .expect("append")
+}
+
+fn cited_ids(edges: &[CitationEdge]) -> Vec<(i64, &str)> {
+    edges
+        .iter()
+        .map(|e| (e.ordinal, e.cited_observation_id.as_str()))
+        .collect()
+}
+
+/// A source's citations at the full page size — the shape most tests want.
+fn cites(s: &WorldStore, generation: i64) -> Vec<CitationEdge> {
+    s.citations_of(generation, MAX_CITATIONS_PAGE, None)
+        .expect("citations")
+        .edges
+}
+
+/// Every edge in the store, ordered — the comparison subject for rebuilds.
+fn all_edges(s: &WorldStore) -> Vec<(i64, i64, String)> {
+    s.raw_query_edges_for_test()
+}
+
+// ---------------------------------------------------------------------------
+// 1. The edge is the citation, not its resolution
+// ---------------------------------------------------------------------------
+
+/// **The decisive test: an edge does not change when its target appears.**
+///
+/// The user's ruling in one assertion. A source cites `obs-x` at a time when no
+/// event carries that observation id; later an event carrying `obs-x` is
+/// appended. The recorded edge must be **identical** — because the edge records
+/// what the source claimed to cite, and the source's claim did not change.
+///
+/// If this ever fails, 4a has started storing resolution, and 4b's historical
+/// honesty becomes unimplementable: the answer to *"did this resolve at T?"*
+/// would have been fixed at write time, when the only true answer depends on
+/// the coordinate the question is asked at.
+#[test]
+fn an_edge_is_identical_whether_or_not_its_target_exists() {
+    let path = tmp("cite-not-resolve");
+    let mut s = WorldStore::open(&path).expect("open");
+
+    // T1 — cite an observation nothing carries.
+    let source = append_citing(&mut s, "source", "package_17", T0, &["obs-x"]);
+    let at_t1 = cites(&s, source);
+    assert_eq!(
+        cited_ids(&at_t1),
+        vec![(0, "obs-x")],
+        "the citation is recorded even though obs-x resolves to nothing"
+    );
+
+    // T2 — an event carrying obs-x is appended. The citation now has something
+    // to resolve to. That is a fact about the LOG, not about the source event.
+    let observation_id = ObservationId::new("obs-x").expect("obs id");
+    let event_id = EventId::new("ev-target").expect("event id");
+    s.append(&NewEvent {
+        event_id: &event_id,
+        observation_id: &observation_id,
+        txn_time_ms: T0 + 1,
+        valid_from_ms: T0 + 1,
+        valid_to_ms: None,
+        source: "warehouse-scanner",
+        source_version: "1.0.0",
+        writer_class: WriterClass::Sensor,
+        claim_status: ClaimStatus::Confirmed,
+        provenance: &[],
+        frame_id: None,
+        map_id: None,
+        kind: "mission",
+        subject: "package_17",
+        subject_ref: None,
+        predicate: Some("scanned_by"),
+        object: Some("scanner_1"),
+        payload: "{}",
+        payload_schema: 1,
+        retention_class: "raw",
+        trust: None,
+    })
+    .expect("append target");
+
+    let at_t2 = cites(&s, source);
+    assert_eq!(
+        at_t2, at_t1,
+        "the source's recorded citation must not change because the log later \
+         grew something that resolves it — an edge that moved here would have \
+         decided, at write time, an answer that depends on the query's coordinate"
+    );
+
+    drop(s);
+    clean(&path);
+}
+
+/// **And the same when the target becomes PLURAL.**
+///
+/// `world_events.observation_id` is not unique. A second event carrying the
+/// same id makes the citation resolve to two rows — still without touching the
+/// edge, because plurality is a property of the log at a coordinate.
+#[test]
+fn an_edge_is_unchanged_when_its_target_becomes_plural() {
+    let path = tmp("plural");
+    let mut s = WorldStore::open(&path).expect("open");
+    let source = append_citing(&mut s, "source", "package_17", T0, &["obs-shared"]);
+    let before = cites(&s, source);
+    // Pinned, not assumed. Comparing `before` to `after` proves nothing if both
+    // are empty, and an implementation that indexed only resolvable citations
+    // would make both empty — so this assertion is what stops the comparison
+    // below from passing for the wrong reason. Found by mutating exactly that.
+    assert_eq!(
+        cited_ids(&before),
+        vec![(0, "obs-shared")],
+        "the citation must be recorded before anything resolves it"
+    );
+
+    for (i, tag) in ["first", "second"].iter().enumerate() {
+        let observation_id = ObservationId::new("obs-shared").expect("obs id");
+        let event_id = EventId::new(format!("ev-{tag}")).expect("event id");
+        s.append(&NewEvent {
+            event_id: &event_id,
+            observation_id: &observation_id,
+            txn_time_ms: T0 + 1 + i as i64,
+            valid_from_ms: T0 + 1 + i as i64,
+            valid_to_ms: None,
+            source: "warehouse-scanner",
+            source_version: "1.0.0",
+            writer_class: WriterClass::Sensor,
+            claim_status: ClaimStatus::Confirmed,
+            provenance: &[],
+            frame_id: None,
+            map_id: None,
+            kind: "mission",
+            subject: "package_17",
+            subject_ref: None,
+            predicate: Some("scanned_by"),
+            object: Some("scanner_1"),
+            payload: "{}",
+            payload_schema: 1,
+            retention_class: "raw",
+            trust: None,
+        })
+        .expect("append");
+    }
+
+    assert_eq!(
+        cites(&s, source),
+        before,
+        "two rows now carry obs-shared; the citation that named it is unchanged"
+    );
+
+    drop(s);
+    clean(&path);
+}
+
+// ---------------------------------------------------------------------------
+// 2. The recorded array is reproduced exactly
+// ---------------------------------------------------------------------------
+
+#[test]
+fn order_and_duplicates_survive_into_the_index() {
+    let path = tmp("verbatim");
+    let mut s = WorldStore::open(&path).expect("open");
+    // Deliberately unsorted, and with a repeat: the array is the source's
+    // statement, and an index that tidied it would describe a provenance the
+    // hash does not cover.
+    let g = append_citing(
+        &mut s,
+        "source",
+        "package_17",
+        T0,
+        &["obs-c", "obs-a", "obs-c"],
+    );
+    assert_eq!(
+        cited_ids(&cites(&s, g)),
+        vec![(0, "obs-c"), (1, "obs-a"), (2, "obs-c")]
+    );
+
+    drop(s);
+    clean(&path);
+}
+
+#[test]
+fn an_event_citing_nothing_has_no_edges() {
+    let path = tmp("empty");
+    let mut s = WorldStore::open(&path).expect("open");
+    let g = append_citing(&mut s, "source", "package_17", T0, &[]);
+    assert!(cites(&s, g).is_empty());
+
+    // ...and this store SAYS the index covers that generation, which is what
+    // makes the empty set readable as "cited nothing" rather than "unknown".
+    assert_eq!(
+        s.provenance_edges_floor().expect("floor"),
+        0,
+        "a store born at v7 indexes every append, so nothing is uncovered"
+    );
+
+    drop(s);
+    clean(&path);
+}
+
+/// Adjudications are appended through `append_adjudication`, which holds an open
+/// transaction across its call to `append`. The edge write must nest inside it —
+/// a `BEGIN` there would fail with "cannot start a transaction within a
+/// transaction", which is why the implementation uses a SAVEPOINT.
+#[test]
+fn an_adjudications_justification_is_indexed_through_the_nested_write() {
+    use kirra_world::adjudication::{AssertIdentity, IdentityAdjudication, Justification};
+    use kirra_world::observation::{ClockDomain, DomainInstant};
+    use kirra_world::reference::EntityId;
+    use kirra_world_store::adjudication_record::AdjudicationRow;
+
+    let path = tmp("adjudication");
+    let mut s = WorldStore::open(&path).expect("open");
+
+    let event_id = EventId::new("ev-adj").expect("event id");
+    let observation_id = ObservationId::new("obs-adj").expect("obs id");
+    let justification =
+        Justification::new([ObservationId::new("obs-just").expect("obs")]).expect("justification");
+    let adjudication = IdentityAdjudication::Assert(AssertIdentity::new(
+        EntityId::new("dock_a").expect("entity"),
+        justification,
+        DomainInstant {
+            ms: 1,
+            domain: ClockDomain::System,
+        },
+    ));
+
+    let g = s
+        .append_adjudication(
+            &AdjudicationRow {
+                event_id: &event_id,
+                observation_id: &observation_id,
+                txn_time_ms: T0,
+                valid_from_ms: T0,
+                source: "operator-console",
+                source_version: "1.0.0",
+                writer_class: WriterClass::Operator,
+            },
+            &adjudication,
+        )
+        .expect("append adjudication");
+
+    assert_eq!(
+        cited_ids(&cites(&s, g)),
+        vec![(0, "obs-just")],
+        "the justification IS the adjudication's provenance, and must be indexed \
+         like any other citation"
+    );
+
+    drop(s);
+    clean(&path);
+}
+
+// ---------------------------------------------------------------------------
+// 3. Rebuild equivalence — the index is a function of retained sources
+// ---------------------------------------------------------------------------
+
+/// **The property that makes this an index rather than evidence.**
+///
+/// Drop the whole table, restore the migration's coverage floor, and rebuild
+/// from the stored `provenance` columns. The result must equal what the append
+/// path wrote — which is the v6→v7 migration path exactly, since that is a
+/// store with events and no edges.
+///
+/// The two sides are produced from different INPUTS — the caller's `&[&str]` at
+/// append, the hash-covered JSON at backfill — through the same derivation. If
+/// they ever diverge, the index has stopped being reproducible from the
+/// evidence, and it can no longer be checked against anything.
+#[test]
+fn rebuilding_from_retained_sources_reproduces_the_index() {
+    let path = tmp("rebuild");
+    let mut s = WorldStore::open(&path).expect("open");
+    append_citing(&mut s, "a", "package_17", T0, &["obs-1", "obs-2"]);
+    append_citing(&mut s, "b", "package_17", T0 + 1, &[]);
+    append_citing(
+        &mut s,
+        "c",
+        "package_18",
+        T0 + 2,
+        &["obs-2", "obs-2", "obs-3"],
+    );
+
+    let appended = all_edges(&s);
+    assert!(!appended.is_empty(), "the fixture must index something");
+
+    // Simulate a v6 store migrated to v7: table installed, empty, floor at head.
+    s.raw_execute_for_test("DELETE FROM provenance_edges")
+        .expect("clear");
+    s.raw_execute_for_test(&format!(
+        "INSERT INTO world_store_meta (key, value) VALUES ('{PROVENANCE_EDGES_FLOOR_KEY}', '3')
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value"
+    ))
+    .expect("set floor");
+    assert_eq!(s.provenance_edges_floor().expect("floor"), 3);
+    assert!(all_edges(&s).is_empty(), "the simulated migration is empty");
+
+    let written = s.backfill_provenance_edges().expect("backfill");
+    assert_eq!(written, appended.len(), "every edge is rewritten");
+    assert_eq!(
+        all_edges(&s),
+        appended,
+        "a backfilled store and an append-indexed store must hold the SAME rows"
+    );
+    assert_eq!(
+        s.provenance_edges_floor().expect("floor"),
+        0,
+        "a completed backfill claims full coverage"
+    );
+
+    drop(s);
+    clean(&path);
+}
+
+#[test]
+fn the_backfill_is_idempotent() {
+    let path = tmp("idempotent");
+    let mut s = WorldStore::open(&path).expect("open");
+    append_citing(&mut s, "a", "package_17", T0, &["obs-1", "obs-1"]);
+    let once = {
+        s.backfill_provenance_edges().expect("first");
+        all_edges(&s)
+    };
+    s.backfill_provenance_edges().expect("second");
+    assert_eq!(
+        all_edges(&s),
+        once,
+        "running the backfill over an already-indexed store converges rather \
+         than duplicating or interleaving ordinals"
+    );
+
+    drop(s);
+    clean(&path);
+}
+
+// ---------------------------------------------------------------------------
+// Rule 2 — the citation read is bounded, and says when it stopped
+// ---------------------------------------------------------------------------
+
+/// **Nothing bounds how many observations an event may cite.**
+///
+/// Not the schema, not the domain, not the caller's argument — so a
+/// whole-array read is structurally unbounded, which is exactly the shape box
+/// 3d found looking bounded at the API while the store method underneath was
+/// not. `citations_of` therefore takes a limit and reports truncation.
+#[test]
+fn a_source_citing_more_than_a_page_is_truncated_and_says_so() {
+    let path = tmp("bounded");
+    let mut s = WorldStore::open(&path).expect("open");
+    let many: Vec<String> = (0..MAX_CITATIONS_PAGE + 7)
+        .map(|i| format!("obs-{i}"))
+        .collect();
+    let refs: Vec<&str> = many.iter().map(String::as_str).collect();
+    let g = append_citing(&mut s, "wide", "package_17", T0, &refs);
+
+    let page = s
+        .citations_of(g, MAX_CITATIONS_PAGE, None)
+        .expect("citations");
+    assert_eq!(page.edges.len(), MAX_CITATIONS_PAGE, "the page is bounded");
+    assert!(page.truncated, "and it must SAY it stopped short");
+    assert_eq!(
+        page.next_after_ordinal(),
+        Some((MAX_CITATIONS_PAGE - 1) as i64)
+    );
+
+    // Continuing reaches the tail, and the tail reports itself complete.
+    let rest = s
+        .citations_of(g, MAX_CITATIONS_PAGE, page.next_after_ordinal())
+        .expect("citations");
+    assert_eq!(rest.edges.len(), 7);
+    assert!(!rest.truncated);
+    assert_eq!(rest.next_after_ordinal(), None);
+    assert_eq!(
+        rest.edges[0].cited_observation_id,
+        format!("obs-{MAX_CITATIONS_PAGE}"),
+        "continuation resumes exactly after the served ordinal — no gap, no repeat"
+    );
+
+    drop(s);
+    clean(&path);
+}
+
+/// A source with *precisely* a page of citations is COMPLETE.
+///
+/// The off-by-one the extra probe row exists to get right: inferring truncation
+/// from `edges.len() == limit` would report this one cut short.
+#[test]
+fn a_source_with_exactly_one_page_is_not_reported_truncated() {
+    let path = tmp("exact");
+    let mut s = WorldStore::open(&path).expect("open");
+    let exact: Vec<String> = (0..MAX_CITATIONS_PAGE)
+        .map(|i| format!("obs-{i}"))
+        .collect();
+    let refs: Vec<&str> = exact.iter().map(String::as_str).collect();
+    let g = append_citing(&mut s, "exact", "package_17", T0, &refs);
+
+    let page = s
+        .citations_of(g, MAX_CITATIONS_PAGE, None)
+        .expect("citations");
+    assert_eq!(page.edges.len(), MAX_CITATIONS_PAGE);
+    assert!(
+        !page.truncated,
+        "a full page is not the same as a truncated one"
+    );
+
+    drop(s);
+    clean(&path);
+}
+
+/// Refused, never clamped — the `SelfFilterMask` / `LineagePage` discipline.
+#[test]
+fn an_unusable_page_bound_is_refused() {
+    let path = tmp("refuse");
+    let mut s = WorldStore::open(&path).expect("open");
+    let g = append_citing(&mut s, "a", "package_17", T0, &["obs-1"]);
+
+    assert!(
+        s.citations_of(g, 0, None).is_err(),
+        "a zero limit returns nothing while more remains — an infinite loop \
+         dressed as a paginated read"
+    );
+    assert!(
+        s.citations_of(g, MAX_CITATIONS_PAGE + 1, None).is_err(),
+        "over the ceiling is refused rather than silently clamped, which would \
+         answer a different question and report it as the one asked"
+    );
+
+    drop(s);
+    clean(&path);
+}
+
+// ---------------------------------------------------------------------------
+// The coverage floor — "cited nothing" vs "not indexed yet"
+// ---------------------------------------------------------------------------
+
+/// **An empty edge set is ambiguous, and the floor is what disambiguates it.**
+///
+/// Two stores can hold a source event with zero edges and mean opposite things:
+/// one where that source genuinely cited nothing, and one migrated from v6
+/// whose backfill has not run. Without the floor they are byte-identical, and a
+/// reader would report "cited nothing" for every event in an un-backfilled
+/// store — a positive claim about provenance, made about the whole log, silently.
+///
+/// This is the same absent-because-unknown versus absent-because-empty
+/// distinction Tier 3 spent case 8 on, at the storage layer.
+#[test]
+fn the_floor_separates_cited_nothing_from_not_indexed_yet() {
+    let path = tmp("floor");
+    let mut s = WorldStore::open(&path).expect("open");
+    let genuinely_empty = append_citing(&mut s, "a", "package_17", T0, &[]);
+    let has_citations = append_citing(&mut s, "b", "package_17", T0 + 1, &["obs-1"]);
+
+    // Store A: fully indexed. An empty set here MEANS cited nothing.
+    assert_eq!(s.provenance_edges_floor().expect("floor"), 0);
+    assert!(cites(&s, genuinely_empty).is_empty());
+
+    // Store B: the same rows, index not yet built. Both sources now look empty,
+    // and only the floor tells a reader not to believe it.
+    s.raw_execute_for_test("DELETE FROM provenance_edges")
+        .expect("clear");
+    s.raw_execute_for_test(&format!(
+        "INSERT INTO world_store_meta (key, value) VALUES ('{PROVENANCE_EDGES_FLOOR_KEY}', '2')
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value"
+    ))
+    .expect("set floor");
+
+    assert!(cites(&s, has_citations).is_empty());
+    assert_eq!(
+        s.provenance_edges_floor().expect("floor"),
+        2,
+        "a source with real citations now reads as empty, and ONLY the floor \
+         distinguishes this store from the one above"
+    );
+
+    drop(s);
+    clean(&path);
+}
+
+/// A store predating the key claims no coverage at all, rather than full
+/// coverage by omission. Fail-closed: "no claim" reads as "covers nothing".
+#[test]
+fn a_store_with_no_recorded_floor_claims_no_coverage() {
+    let path = tmp("no-floor");
+    let mut s = WorldStore::open(&path).expect("open");
+    append_citing(&mut s, "a", "package_17", T0, &["obs-1"]);
+    append_citing(&mut s, "b", "package_17", T0 + 1, &["obs-2"]);
+
+    s.raw_execute_for_test(&format!(
+        "DELETE FROM world_store_meta WHERE key = '{PROVENANCE_EDGES_FLOOR_KEY}'"
+    ))
+    .expect("drop the key");
+
+    assert_eq!(
+        s.provenance_edges_floor().expect("floor"),
+        2,
+        "absent means the log head, not 0 — a missing claim must not read as a \
+         claim of completeness"
+    );
+
+    drop(s);
+    clean(&path);
+}
+
+// ---------------------------------------------------------------------------
+// 4. An edge never outlives its source event
+// ---------------------------------------------------------------------------
+
+/// **Compaction takes the edges with the events.**
+///
+/// The invariant the whole "index, never evidence" claim rests on. An edge whose
+/// source row is gone would be a citation still readable after the hash-covered
+/// statement it came from was deleted — with nothing left to check it against,
+/// and no way for a reader to tell it apart from one that is still backed.
+#[test]
+fn compaction_removes_the_edges_of_the_events_it_removes() {
+    let path = tmp("compaction");
+    let mut s = WorldStore::open(&path).expect("open");
+    let doomed = append_citing(&mut s, "a", "package_17", T0, &["obs-1", "obs-2"]);
+    let doomed2 = append_citing(&mut s, "b", "package_17", T0 + 1, &["obs-3"]);
+    let survivor = append_citing(&mut s, "c", "package_17", T0 + 2, &["obs-4"]);
+
+    assert!(!cites(&s, doomed).is_empty());
+
+    s.compact_range(doomed, doomed2, T0 + 9_000)
+        .expect("compact");
+
+    assert!(
+        cites(&s, doomed).is_empty(),
+        "the source event is gone; its citations must go with it"
+    );
+    assert!(
+        cites(&s, doomed2).is_empty(),
+        "every generation in the compacted range, not just the first"
+    );
+    assert_eq!(
+        cited_ids(&cites(&s, survivor)),
+        vec![(0, "obs-4")],
+        "a source outside the compacted range keeps its citations — otherwise \
+         the test above would pass against a compaction that deleted everything"
+    );
+
+    drop(s);
+    clean(&path);
+}
+
+/// The counterpart to the deletion: what a reader is left with is *degraded*,
+/// not a confident empty answer. The distinction is already carried by the
+/// citation/summary machinery; this pins that compaction did not quietly leave
+/// the index looking intact.
+#[test]
+fn a_compacted_source_leaves_no_edge_claiming_to_be_backed() {
+    let path = tmp("no-orphans");
+    let mut s = WorldStore::open(&path).expect("open");
+    append_citing(&mut s, "a", "package_17", T0, &["obs-1"]);
+    append_citing(&mut s, "b", "package_17", T0 + 1, &["obs-2"]);
+    append_citing(&mut s, "c", "package_17", T0 + 2, &["obs-3"]);
+    s.compact_range(1, 2, T0 + 9_000).expect("compact");
+
+    let orphans = s.raw_count_orphan_edges_for_test();
+    assert_eq!(
+        orphans, 0,
+        "no edge may name a source generation the log no longer holds"
+    );
+
+    drop(s);
+    clean(&path);
+}

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -2454,8 +2454,9 @@ carelessly. Neither can be exercised end-to-end, and no test pretends to.
 
 ## 7. Tier 4 — `Explain`, the flagship
 
-- [ ] `Explain(FactHandle) → ProvenanceTree`
-- [ ] Prose rendering through Mick (§16)
+- [ ] **4a — structured citation edges** (in progress)
+- [ ] **4b — historical provenance graph**
+- [ ] **4c — `Explain` / Mick rendering** (§16)
 
 Depends on the provenance model **and** on derivation edges being real structure
 rather than a JSON array of identifiers. This is the capability the whole
@@ -2465,6 +2466,139 @@ between a database and something that can be asked to justify itself.
 Mick's three non-negotiables apply unchanged and are already precedented in
 `robot/mick_chat_contract.py`: **never invent**, **never state stale as
 current**, **never supply geometry**.
+
+### What Tier 3 did and did not take off this tier — audited 2026-08-16
+
+Re-scoped rather than inherited, because box 3f built lineage machinery and the
+question was whether it had already absorbed part of `Explain`.
+
+**It absorbed the retrieval mechanics.** Bounded pagination (`MAX_LINEAGE_PAGE`,
+`Continuation`, the family-bound `PageCursor`), generation pinning, a reproducible
+`LineageRef`, a citable `EvidenceDigest` per entry, and — the one most likely to
+have been rebuilt from scratch here — `LineagePageAnswer::completeness()`, which
+already distinguishes *"the evidence was deleted"* from *"there was none"*. Tier 4
+does not re-derive any of it; 4b pushes the last of these from the PAGE down to
+the BRANCH.
+
+**It did not touch the graph, and said so.** `kirra_world_store::lineage` reports
+`provenance` verbatim and stops:
+
+> It is **not** a traversal of that array. […] Following it would mean inventing
+> the structure whose absence is the reason `Explain` is Tier 4. The stopping
+> point is the tier boundary, not an oversight.
+
+So the answer to *"rendering layer, provenance-graph layer, or both"* is **both,
+with the graph strictly first** — rendering cannot be specified until the tree
+has a type, and the tree cannot have a type until the citation edge has defined
+cardinality and defined failure modes.
+
+### `KIRRA-WM-PROVENANCE-GRAPH-001` — RULED 2026-08-16
+
+> **Materialize the citation relation at append; do not materialize its resolved
+> target.** Tier 4 reports the provenance graph that was resolvable at the
+> answer's historical coordinate, not the graph that happens to be resolvable
+> today.
+
+The real structure is `source event → cites observation id X`, and deliberately
+not `source event → target event row Y`. At generation *T*, X may resolve to
+exactly one row, to several, or to none:
+
+* `world_events.observation_id` is indexed but **not unique** — many-to-many, not
+  a parent pointer;
+* nothing requires a cited id to exist at all, in the log or anywhere;
+* a citation dangling at *T* may become resolvable later, and Tier 4 must still
+  report it as dangling *then*.
+
+Baking a target in at append would fix, at write time, an answer whose only
+correct value depends on the coordinate the question is asked at. This is §7's
+own warning — *"2d's trap re-appearing one tier up, and it will look like reuse
+when it arrives"* — and the ruling is what forecloses it structurally rather than
+by discipline.
+
+#### 4a — structured citation edges
+
+Normalize the hash-covered provenance array into a deterministic edge table at
+append: `(source_generation, ordinal) → cited_observation_id`. Invariants:
+
+* one stored edge per array element, **order and duplicates preserved**;
+* no target generation, and no resolution performed at append;
+* rebuilding from retained source events reproduces the table exactly;
+* raw JSON traversal is not part of the Tier 4 query path.
+
+**A deterministic index, never independent evidence.** The authoritative
+statement stays the hash-covered `provenance` column. Two consequences that are
+not optional:
+
+1. **Compaction deletes an event's edges with the event.** An edge outliving its
+   source would be the index promoting itself to evidence — a citation still
+   readable after the statement it came from was deleted, with nothing left to
+   check it against. The affected branch reads `Degraded`, which is the true
+   answer; the edges are not what carries it.
+2. **An empty edge set is ambiguous, so coverage is recorded.** It is what a
+   source citing nothing looks like, and equally what an un-backfilled store
+   makes *every* source look like — a positive claim about provenance, made
+   about the whole log, silently. A `provenance_edges_floor` meta row records the
+   highest generation the index does not cover, so 4b refuses rather than
+   reporting a confident empty provenance. (This is Tier 3 case 8's
+   absent-because-unknown / absent-because-empty distinction, at the storage
+   layer; it was found by checking a migration comment that claimed the two were
+   already distinguishable, and they were not.)
+
+#### 4b — historical provenance graph
+
+Where resolution happens. At pinned generation *G*, each edge resolves against
+the events visible at *G* into one of three **first-class** outcomes:
+
+| Outcome | Meaning |
+|---|---|
+| `Resolved(target)` | exactly one visible event carries the cited id |
+| `Plural(targets…)` | several do |
+| `Dangling(cited_id)` | none do |
+
+Plural must not become "pick the newest", and dangling must not become an empty
+child list. Both are the same collapse Tier 3 case 8 ruled out, one tier up.
+
+`ProvenanceTree` / `ProvenanceGraphPage` carries: the generation pin, the
+semantic-version set, max depth, max nodes, a continuation cursor, visible
+truncation, per-branch completeness/degradation, and explicit plural/dangling
+nodes.
+
+**Cycles are not truncation.** Once provenance is a real graph, a cycle is
+possible unless admission proves otherwise, and a depth limit alone would make a
+malformed cycle look like an ordinary bound being reached. Two distinct
+outcomes, because they mean different things in an explanation:
+
+```text
+Truncated      // a legitimate bound was reached
+CycleDetected  // malformed / recursive provenance
+```
+
+The load-bearing test — if it ever returns the T2 node, Tier 4 has become
+historically dishonest:
+
+```text
+T1: A cites observation X; nothing carries X   → Dangling(X)
+T2: an event carrying observation_id X appended → a current query resolves X
+    query pinned to T1                          → MUST still say Dangling(X)
+```
+
+and its plural counterpart: a query before the second row resolves one; after it,
+reports plural.
+
+#### 4c — `Explain` / Mick rendering
+
+Only once 4b's type exists. Mick receives typed lineage and turns it into
+language; **Mick does not discover provenance, and does not repair it.**
+
+```text
+AnswerRef → Tier 3 reproducible answer → Tier 4 provenance graph → Mick rendering
+```
+
+Rendering must preserve historical tense, degradation, dangling evidence,
+plural/ambiguous citations, truncation, and freshness/validity where relevant.
+So it may say *"at that time, this claim cited observation X, but Kirra could not
+resolve X to a recorded event"* — and must not rewrite that into *"this came from
+camera observation X"* because X became resolvable later.
 
 ---
 

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -2534,7 +2534,13 @@ not optional:
    readable after the statement it came from was deleted, with nothing left to
    check it against. The affected branch reads `Degraded`, which is the true
    answer; the edges are not what carries it.
-2. **An empty edge set is ambiguous, so coverage is recorded.** It is what a
+2. **An empty edge set is ambiguous, so coverage is recorded.**
+
+   > The provenance-edge index is only authoritative over the generation range
+   > it explicitly covers. **Outside that range, absence of edges is not
+   > evidence of "no citations."**
+
+   An empty set is what a
    source citing nothing looks like, and equally what an un-backfilled store
    makes *every* source look like — a positive claim about provenance, made
    about the whole log, silently. A `provenance_edges_floor` meta row records the


### PR DESCRIPTION
`WM_SCOPE.md` §7 made `Explain` wait on *"derivation edges being real structure rather than a JSON array of identifiers"*. This is that structure — and the ruling it lands under is mostly about what it is **forbidden to contain**.

## `KIRRA-WM-PROVENANCE-GRAPH-001`

> Materialize the citation relation at append; **do not materialize its resolved target.**

The real edge is `source event → cites observation id X`, never `source event → target event row Y`. At generation *T*, X may resolve to exactly one row, several, or none:

- `world_events.observation_id` is indexed but **not unique** — many-to-many, not a parent pointer;
- nothing requires a cited id to exist at all;
- a citation dangling at *T* may become resolvable later, and Tier 4 must still report it as dangling **then**.

Baking a target in here would fix, at write time, an answer whose only correct value depends on the coordinate the question is asked at. That is §7's own warning — *"2d's trap re-appearing one tier up, and it will look like reuse when it arrives"* — foreclosed structurally rather than by discipline: `provenance_edges` is keyed `(source_generation, ordinal) → cited_observation_id`, with no target column and nowhere to put one without a migration a reviewer would see.

Order and duplicates are preserved. A source citing the same observation twice said so twice, and deduplicating would index a provenance array the hash does not cover.

## A deterministic index, never independent evidence

Two consequences that are not optional:

**Compaction deletes an event's edges with the event**, in the same transaction. An edge outliving its source would be the index promoting itself to evidence — a citation still readable after the hash-covered statement it came from was deleted, with nothing left to check it against. The branch reads `Degraded`, which is the true answer; the edges are not what carries it.

**An empty edge set is ambiguous, so coverage is recorded.** It is what a source citing nothing looks like, *and* what an un-backfilled store makes every source look like — a positive claim about provenance, made about the whole log, silently. A `provenance_edges_floor` meta row records the highest generation the index does not cover.

This one was found by checking a migration comment I had just written, which claimed the two cases were already distinguishable by whether the source event was retained. They are not: an un-backfilled store has a **retained** source with zero edges. It is Tier 3 case 8's absent-because-unknown / absent-because-empty distinction, at the storage layer.

## Boundedness — the gate earned its keep

Nothing bounds how many observations an event may cite: not the schema, not the domain, not any argument. So the whole-array read was structurally unbounded *while looking fine at the API* — the exact shape of the three defects box 3d exists for. The gate caught it as an unclassified public method rather than as a review comment.

Classifying it `unbounded` and leaving 4b to bound it would have been the "move the unbounded call behind another helper" move ruled out in 3d. Instead `citations_of` takes a limit, refuses `0` and over-ceiling rather than clamping, and reports truncation from a probe row rather than inferring it from `len() == limit` — which is ambiguous exactly at the boundary, where a source with precisely `limit` citations is complete.

## Mutations

Each isolates cleanly:

| Mutation | Reds |
|---|---|
| drop the compaction edge delete | 2 — both compaction tests |
| `BEGIN`/`COMMIT` instead of `SAVEPOINT` | 1 — the nested adjudication write |
| index only citations that resolve today | 6 — including the decisive one |
| absent floor reads as full coverage | 1 — the fail-closed default |

The third also exposed a vacuous assertion of my own: the plural test compared `before` to `after` without pinning that `before` was non-empty, so under that mutation `[] == []` passed. Fixed, and re-verified that it now bites.

## Two things recorded as rejected rather than left as folklore

- The backfill **replaces** rather than merges — but not for the reason that first suggested itself. A merge cannot in fact interleave ordinals from a half-written attempt: the log is immutable and both writers are atomic. It replaces because its postcondition must depend on the source events **alone**, which is what makes the table an index rather than evidence.
- The edge write uses a `SAVEPOINT`, not `BEGIN`: `append_adjudication` already holds a transaction across its call to `append`, and SQLite refuses a nested `BEGIN`. One test covers exactly that, and exactly that test reds when the primitive is swapped.

## Scope also recorded

§7 now carries the 4a/4b/4c split, the audit of what 3f did and did not take off this tier, the three first-class resolution outcomes (`Resolved` / `Plural` / `Dangling`), **cycles as an outcome distinct from truncation**, and the T1/T2 historical-honesty test 4b must satisfy.

## Verification

- 14 new tests in `citation_edges.rs`; **39 suites green** across the world crates
- `cargo test --workspace` green; `cargo fmt --all --check` and `cargo clippy --all-targets` clean
- all six world CI gates green, including the boundedness gate at zero violations

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_