### PR TITLE
Clear RUSTSEC-2026-0258 (h2), and re-audit the paste ignore rather than delete it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1602,9 +1602,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/deny.toml
+++ b/deny.toml
@@ -102,9 +102,38 @@ ignore = [
     { id = "RUSTSEC-2025-0134", reason = "unmaintained; no drop-in upgrade; parses operator-supplied PEM only" },
     # paste is unmaintained (advisory is unmaintained-class only, no known
     # vulnerability). It is a COMPILE-TIME proc-macro (token pasting) with
-    # zero runtime footprint, pinned by the r2r 0.9.5 ROS bindings chain —
-    # surfaced only now that the policy graph covers the ros2 feature tree
-    # (#797 F3). Not bumpable from this repo. Remove when r2r moves off
-    # paste (track r2r releases > 0.9.5).
-    { id = "RUSTSEC-2024-0436", reason = "unmaintained; compile-time-only proc-macro; pinned by r2r 0.9.5; remove on r2r upgrade" },
+    # zero runtime footprint. Not bumpable from this repo.
+    #
+    # RE-AUDITED 2026-08-19 (#1451), and the previous removal condition was
+    # WRONG. It read "remove when r2r moves off paste", which names ONE of the
+    # paths. `cargo tree --workspace --all-features --invert paste` finds FOUR
+    # in the root workspace:
+    #
+    #     paste v1.0.15 (proc-macro)
+    #     ├── mcap        → kirra-collector
+    #     ├── parquet     → kirra-collector
+    #     ├── r2r_rcl     → r2r → kirra-ros2-adapter
+    #     └── token-cell  → zenoh-keyexpr → zenoh
+    #
+    # plus r2r_rcl → r2r → parko-ros2 in the parko workspace. So an r2r upgrade
+    # alone would NOT make this entry dead, and acting on the old condition
+    # would have deleted a suppression three other paths still need. The
+    # correct condition is below, and it is a conjunction.
+    #
+    # REMOVE ONLY WHEN the reverse-tree above is EMPTY in BOTH workspaces —
+    # i.e. mcap, parquet, r2r_rcl and token-cell have all moved off paste.
+    # Re-run that command; do not infer it from any single dependency bump, and
+    # do not infer it from cargo-deny reporting the entry as unused (see below).
+    #
+    # NOTE, unresolved: cargo-deny emits `advisory-not-detected` ("no crate
+    # matched advisory criteria") for this entry even though the paths above are
+    # live, while the rustls-pemfile entry — a DIRECT dependency of
+    # kirra-verifier — is reported as used. cargo audit, which scans the
+    # lockfile flat, still reports paste 1.0.15 against this advisory. The
+    # asymmetry is a cargo-deny graph/severity question, NOT evidence that the
+    # crate left the tree, and it is deliberately not acted on here: the
+    # warning does not fail the gate (main passed with it on 2026-08-17), and
+    # making cargo-deny quiet by deleting a live suppression would be a green
+    # signal for the wrong property.
+    { id = "RUSTSEC-2024-0436", reason = "unmaintained; compile-time-only proc-macro; four live paths (mcap/parquet/r2r_rcl/token-cell) re-verified 2026-08-19; remove only when ALL are off paste" },
 ]

--- a/parko/Cargo.lock
+++ b/parko/Cargo.lock
@@ -744,9 +744,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
Dependency hygiene, split out of #1450 because neither item is a regression from
that branch — both red `main` and every open branch equally. The two items are
kept separate on purpose, because **only one of them is a fix**.

---

## 1. h2 0.4.15 → 0.4.16 — the advisory that actually fails the lanes

```
error[vulnerability]: h2 unbounded empty DATA frames
   ID: RUSTSEC-2026-0258   (published 2026-08-17)
   Solution: Upgrade to >=0.4.16
```

Empty DATA frames are accepted and queued without limit, so an undrained stream
grows memory unboundedly, or panics if the length overflows. Low severity,
patched upstream in 0.4.16. It reaches us transitively through
`hyper → {axum, reqwest, hyper-rustls, hyper-util} → kirra-verifier`.

**This is the failure in both lanes** — `cargo audit` in Static Analysis, and
`error[vulnerability]` in cargo-deny. Item 2 below is *not* what reds them.

**The bump is four lines.** `cargo update -p h2 --precise 0.4.16` was rejected
because it also **downgraded** unrelated packages as re-resolution churn:

| Package | `cargo update` result |
|---|---|
| `windows-sys` | 0.61.2 → 0.52.0 / 0.60.2 |
| `socket2` | 0.6.4 → 0.5.10 |

A security fix should not quietly move the graph underneath itself, so the
version and checksum were applied by hand to the `h2` block in both lockfiles.
Verified rather than assumed:

- `cargo metadata --locked` accepts both lockfiles — which is what would fail if
  0.4.16's dependency set differed from 0.4.15's;
- `cargo build --locked -p kirra-verifier` compiles `h2 v0.4.16`.

## 2. The `paste` ignore stays — and its removal condition was wrong

The instruction was to prove which path still pulls RUSTSEC-2024-0436 before
touching the ignore. It is emphatically live:

```
paste v1.0.15 (proc-macro)
├── mcap v0.9.2        → kirra-collector
├── parquet v59.1.0    → kirra-collector
├── r2r_rcl v0.9.5     → r2r → kirra-ros2-adapter
└── token-cell v2.1.1  → zenoh-keyexpr → zenoh
```

plus `r2r_rcl → r2r → parko-ros2` in the parko workspace.

**The audit found a defect in the entry itself.** Its removal condition read
*"remove when r2r moves off paste"* — naming **one** of four paths. Acting on it
after an r2r upgrade would have deleted a suppression that `mcap`, `parquet` and
`token-cell` still need. Corrected to a conjunction over all four, with the
command to re-verify it recorded next to it.

**The `advisory-not-detected` warning is recorded as an open question, not
diagnosed.** cargo-deny reports this entry as unused while the paths above are
live, and reports the `rustls-pemfile` entry — a *direct* dependency — as used.
I could not settle the cause without running cargo-deny, so it is written down
rather than guessed at. It does not fail the gate: `main` passed with the same
warning on 2026-08-17.

Deleting a live suppression to make cargo-deny quiet would be a **green signal
for the wrong property** — the exact failure this audit exists to avoid.

---

## Three corrections to my own measurements

Worth recording, because each one briefly pointed the opposite way:

1. **`cargo tree` at the repo root** shows only the root package's tree, not the
   workspace's. It reported `paste` as unreachable — which, taken at face value,
   is the evidence that would have justified deleting the ignore. `--workspace`
   reverses it.
2. **A "parko workspace" hypothesis** for the disagreement, disproved by both
   lockfiles containing `paste` and both graphs reaching it.
3. **An "unmaintained advisories are transitive-only" theory**, contradicted by
   `bincode` — unmaintained *and* a direct workspace dependency of
   `kirra-wire-client` and `kirra-governor-service`.

The pattern is the session's: a measurement that scans the wrong scope returns a
confident, clean, wrong answer, and it looks exactly like a real result.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_