### PR TITLE
Give kirra-explain-types serde, and the neutrality gate the rule it was claiming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2222,6 +2222,10 @@ dependencies = [
 [[package]]
 name = "kirra-explain-types"
 version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "kirra-fabric-types"

--- a/ci/check_explain_artifact_neutral.py
+++ b/ci/check_explain_artifact_neutral.py
@@ -77,13 +77,85 @@ from pathlib import Path
 # same affordance `check_proposal_context_symbolic.py` provides.
 GUARDED_CRATES = ("crates/kirra-explain-types",)
 
-# The crate must have no dependency on Kirra World. Checked HERE, directly,
-# rather than left to Fence B: Fence B would catch a `kirra-world*` dependency
-# added below, but only transitively, through `kirra-sidecars`' CorridorSource
-# impl and the closure walk. That is a chain of other facts continuing to hold.
-# The invariant `KIRRA-WM-EXPLAIN-PLACEMENT-001` actually needs is direct, so it
-# is asserted directly.
-WORLD_PACKAGE_PREFIX = "kirra-world"
+# ---------------------------------------------------------------------------
+# The dependency half of the rule
+# ---------------------------------------------------------------------------
+#
+# The property is NOT "this manifest is empty". It used to be stated that way,
+# and the manifest said so too, which was a stronger sentence than the invariant
+# it was protecting. `serde` had to go in the moment these types became the wire
+# contract (the derive must sit on the type DEFINITION -- a `#[serde(remote)]`
+# mirror in a sibling crate drifts silently, which is the defect class this tier
+# exists to close). A rule that overstates itself is broken the first time it is
+# inconvenient, and then it protects nothing.
+#
+# So the rule is the narrower, checkable one:
+#
+#     These presentation types stay NEUTRAL. They may not acquire a dependency
+#     on Kirra World, on Mick, on the doer (planner/map/perception), on the
+#     checker/governor, or on anything carrying actuation authority.
+#
+# That is strictly stronger than emptiness was in practice, because emptiness
+# was an accident that no check could distinguish from a deliberate boundary.
+#
+# WHY THE FAMILIES ARE IMPORTED, NOT RETYPED
+# ------------------------------------------
+# `check_kirra_world_bidirectional_fence` already classifies the actuation
+# family, and `kirra-explain-types` is already inside its FENCE_A_EXTRA_PACKAGES,
+# so Fence A check 2 walks this crate's CLOSURE against those names -- a
+# strictly stronger check than the direct one below. Retyping the list here
+# would create two statements of one classification, and the one that stops
+# being updated is the one that silently stops matching. That is the same
+# failure mode as the serde mirror, one level up. So they are IMPORTED: a crate
+# added to the fence's actuation set is forbidden here the same day.
+#
+# The direct check is kept anyway, for the reason the World ban was always
+# direct: `KIRRA-WM-EXPLAIN-PLACEMENT-001` is an invariant about THIS manifest,
+# and an invariant that holds only through a chain of other facts is an
+# invariant one refactor away from being false. A direct hit also names the
+# offending line instead of a closure path.
+_CI_DIR = Path(__file__).resolve().parent
+if str(_CI_DIR) not in sys.path:
+    sys.path.insert(0, str(_CI_DIR))
+
+from check_kirra_world_bidirectional_fence import (  # noqa: E402
+    ACTUATION_EXTERNAL,
+    ACTUATION_PACKAGES,
+    WORLD_PACKAGE_EXACT,
+    WORLD_PACKAGE_PREFIX,
+)
+
+# Families the FENCE does not classify, named here because this seam is where
+# they matter. Each entry is the reason the dependency would break the ruling,
+# printed verbatim when the gate fires.
+FORBIDDEN_PACKAGES: dict[str, str] = {
+    "kirra-mick": (
+        "the renderer -- an arrow from the shared contract INTO Mick makes "
+        "kirra-world-service depend on Mick transitively, which is the coupling "
+        "the placement ruling exists to prevent, reversed"
+    ),
+    "kirra-sidecars": (
+        "depends on kirra-mick, so it reconstructs the Mick edge one hop out"
+    ),
+    "kirra-planner": "the doer -- a planner type here would make the artifact plan-shaped",
+    "kirra-map": "doer-side lane graph; carries World-adjacent coordinates",
+    "kirra-taj": "doer-side perception",
+    "kirra-core": "the checker's home (KirraKernelGovernor, the frozen kinematics talisman)",
+    "kirra-trajectory": "the checker (validate_trajectory_slow)",
+    "kirra-safety-authority": "the posture DAG -- safety authority",
+    "kirra-policy-types": "command classification -- authorization, not presentation",
+    "kirra-persistence": "the store; a persistence type on this wire is a coordinate by another name",
+    "kirra-proposal-context": "the SANCTIONED answer boundary -- it depends on kirra-world-service",
+    "kirra-mission-orchestrator": "sits above kirra-proposal-context, same reach",
+}
+
+FORBIDDEN_PREFIXES: tuple[tuple[str, str], ...] = (
+    (
+        WORLD_PACKAGE_PREFIX,
+        "Kirra World itself -- the artifact would carry the store it is meant to "
+        "stand in for",
+    ),
+)
 
 # The integer widths a Kirra World coordinate is. `generation` is `i64` in
 # `world_events` (it is the table's INTEGER PRIMARY KEY), and every bitemporal
@@ -217,18 +289,59 @@ def violations_in(text: str) -> list[str]:
     return found
 
 
-def check_no_world_dependency(root: Path, crate: str) -> list[str]:
-    """The direct half: the guarded crate must not depend on `kirra-world*`."""
+def declared_dependencies(manifest_text: str) -> list[str]:
+    """Every package name declared as a dependency, comments stripped.
+
+    Deliberately not `kirra-`-scoped: an external actuation transport
+    (`r2r`, `serialport`, ...) is exactly as disqualifying as an internal one,
+    and scoping the regex to `kirra-` was how the previous version could only
+    ever have caught half the rule.
+    """
+    text = strip_comments_toml(manifest_text)
+    return sorted(set(re.findall(r"^\s*([A-Za-z][\w-]*)\s*=", text, re.M)))
+
+
+def forbidden_dependencies(manifest_text: str) -> list[str]:
+    """The pure half: which declared dependencies break neutrality, and why.
+
+    Pure and text-level ON PURPOSE. The path-reading wrapper below cannot be
+    handed a crafted manifest, so a self-test written against it could only
+    assert that the real crate passes -- which is true of a function that
+    returns the empty list unconditionally. Taking text means the self-test can
+    feed it a forbidden dependency and assert the gate FLAGS it.
+    """
+    problems: list[str] = []
+    for dep in declared_dependencies(manifest_text):
+        if dep in FORBIDDEN_PACKAGES:
+            problems.append(f"`{dep}` — {FORBIDDEN_PACKAGES[dep]}")
+        elif dep in WORLD_PACKAGE_EXACT:
+            problems.append(f"`{dep}` — Kirra World itself")
+        elif dep in ACTUATION_PACKAGES:
+            problems.append(
+                f"`{dep}` — {ACTUATION_PACKAGES[dep]}; actuation authority never "
+                "rides a presentation type"
+            )
+        elif dep in ACTUATION_EXTERNAL:
+            problems.append(
+                f"`{dep}` — an actuator transport; a renderer inheriting it could "
+                "reach a wheel from an explanation"
+            )
+        else:
+            for prefix, why in FORBIDDEN_PREFIXES:
+                if dep.startswith(prefix):
+                    problems.append(f"`{dep}` — {why}")
+                    break
+    return problems
+
+
+def check_dependency_neutrality(root: Path, crate: str) -> list[str]:
+    """The direct half: the guarded crate's manifest must stay neutral."""
     manifest = root / crate / "Cargo.toml"
     if not manifest.is_file():
         raise GateError(f"guarded crate has no manifest: {crate}")
-    text = strip_comments_toml(manifest.read_text(encoding="utf-8"))
-    hits = sorted(set(re.findall(r"^\s*(kirra-[\w-]+)\s*=", text, re.M)))
     return [
-        f"{crate} depends on `{dep}` — the whole placement ruling rests on this "
-        "crate carrying no Kirra World into Mick"
-        for dep in hits
-        if dep.startswith(WORLD_PACKAGE_PREFIX)
+        f"{crate}/Cargo.toml depends on {p}"
+        for p in forbidden_dependencies(manifest.read_text(encoding="utf-8"))
     ]
 
 
@@ -242,7 +355,7 @@ def main() -> int:
     checked = 0
 
     for crate in GUARDED_CRATES:
-        problems += check_no_world_dependency(root, crate)
+        problems += check_dependency_neutrality(root, crate)
         src_dir = root / crate / "src"
         if not src_dir.is_dir():
             raise GateError(f"guarded crate has no src/: {crate}")
@@ -265,10 +378,16 @@ def main() -> int:
             print(f"  - {p}", file=sys.stderr)
         print(
             "\nAn explanation crosses a process boundary to a renderer that must "
-            "not query\nKirra World. A coordinate here is the argument it would "
-            "need to do so.\nCarry a DisplayLabel or an EvidenceDigest instead, "
-            "or justify the field in\nALLOWLIST if it genuinely cannot address "
-            "the store.",
+            "not query\nKirra World.\n"
+            "\n  A CARRIED FIELD: a coordinate is the argument that query would "
+            "need. Carry a\n  DisplayLabel or an EvidenceDigest instead, or "
+            "justify the field in ALLOWLIST if\n  it genuinely cannot address "
+            "the store.\n"
+            "\n  A DEPENDENCY: these types are shared by both sides, so anything "
+            "they depend on,\n  both sides inherit. Neutrality is the rule — not "
+            "an empty manifest. An\n  authority-free crate (serde and its like) "
+            "is fine; World, Mick, the doer, the\n  checker and actuation are "
+            "not, and no allowlist admits them.",
             file=sys.stderr,
         )
         return 1
@@ -331,11 +450,69 @@ def _self_test() -> int:
                 path.read_text(encoding="utf-8")
             ), f"{path} violates its own gate"
 
+    # --- the dependency half -------------------------------------------------
+    #
+    # These are the non-vacuity controls for the rule that changed. Each one
+    # feeds a CRAFTED manifest and asserts the gate FLAGS it. The distinction
+    # matters: a test that only ran the real manifest through and found nothing
+    # would pass identically against a function that returns [] unconditionally,
+    # which is how a widened rule can be shipped without ever being exercised.
+
+    def t_a_world_dependency_is_flagged():
+        src = '[dependencies]\nkirra-world-store = { path = "../kirra-world-store" }\n'
+        assert forbidden_dependencies(src), "a kirra-world* dependency was admitted"
+
+    def t_a_mick_dependency_is_flagged():
+        src = '[dependencies]\nkirra-mick = { path = "../kirra-mick" }\n'
+        assert forbidden_dependencies(src), "the renderer edge was admitted"
+
+    def t_a_checker_dependency_is_flagged():
+        src = '[dependencies]\nkirra-core = { path = "../kirra-core" }\n'
+        assert forbidden_dependencies(src), "a checker dependency was admitted"
+
+    def t_a_doer_dependency_is_flagged():
+        src = '[dependencies]\nkirra-planner = { path = "../kirra-planner" }\n'
+        assert forbidden_dependencies(src), "a planner dependency was admitted"
+
+    def t_an_actuation_dependency_is_flagged():
+        # Imported from the fence, so this also proves the import is live: if
+        # the constant were renamed away, this case fails rather than the gate
+        # silently checking an empty set.
+        src = '[dependencies]\nkirra-release-token = { path = "../kirra-release-token" }\n'
+        assert forbidden_dependencies(src), "an actuation dependency was admitted"
+
+    def t_an_external_actuator_transport_is_flagged():
+        # The old regex was scoped to `kirra-`, so this whole family was
+        # invisible to it -- a serial port is not a kirra crate.
+        src = '[dependencies]\nserialport = "4"\n'
+        assert forbidden_dependencies(src), "an external actuator transport was admitted"
+
+    def t_serde_is_admitted():
+        # The rule is neutrality, not emptiness. If this ever fails, the gate
+        # has drifted back to counting entries.
+        src = '[dependencies]\nserde = { version = "1", features = ["derive"] }\n'
+        assert not forbidden_dependencies(src), "serde was rejected by a neutrality rule"
+
+    def t_a_commented_out_dependency_is_not_a_violation():
+        src = '[dependencies]\n# kirra-mick = { path = "../kirra-mick" }\nserde = "1"\n'
+        assert not forbidden_dependencies(src), "a commented-out dep was read as real"
+
+    def t_the_real_manifest_is_neutral():
+        root = Path(__file__).resolve().parent.parent
+        text = (root / GUARDED_CRATES[0] / "Cargo.toml").read_text(encoding="utf-8")
+        assert not forbidden_dependencies(text), "the guarded crate breaks its own rule"
+        # ...and non-vacuously: it must actually be declaring something, or the
+        # case above passes because the parser found nothing at all.
+        assert "serde" in declared_dependencies(text), (
+            "no serde in the guarded manifest — either the parser is broken or "
+            "the wire contract lost its derive"
+        )
+
     cases = [(n, f) for n, f in sorted(locals().items()) if n.startswith("t_") and callable(f)]
     for name, fn in cases:
         case(name, fn)
 
-    expected = 10
+    expected = 19
     if len(cases) != expected:
         print(
             f"SELF-TEST HARNESS: discovered {len(cases)} cases, expected {expected}.",

--- a/ci/check_explain_artifact_neutral.py
+++ b/ci/check_explain_artifact_neutral.py
@@ -70,6 +70,7 @@ from __future__ import annotations
 
 import re
 import sys
+import tomllib
 from pathlib import Path
 
 # The crate this gate guards. A list, so a second neutral artifact crate
@@ -289,16 +290,70 @@ def violations_in(text: str) -> list[str]:
     return found
 
 
-def declared_dependencies(manifest_text: str) -> list[str]:
-    """Every package name declared as a dependency, comments stripped.
+# The manifest tables Cargo resolves dependencies from. `build-dependencies`
+# is here even though this crate has no build script: the rule is about what
+# the crate may pull in, and a build script pulling in an actuation transport
+# is not less of a breach for running at build time.
+DEPENDENCY_TABLES = ("dependencies", "dev-dependencies", "build-dependencies")
 
-    Deliberately not `kirra-`-scoped: an external actuation transport
-    (`r2r`, `serialport`, ...) is exactly as disqualifying as an internal one,
-    and scoping the regex to `kirra-` was how the previous version could only
-    ever have caught half the rule.
+
+def declared_dependencies(manifest_text: str) -> list[str]:
+    """Every package name declared as a dependency, in any Cargo spelling.
+
+    PARSED, not pattern-matched. The first version of this used a line regex,
+    and a line regex is wrong in both directions at once:
+
+      MISSES  `kirra-mick.path = "../kirra-mick"` (dotted key -- the name and
+              the `=` are not adjacent) and `[dependencies.kirra-mick]`
+              (sub-table -- the name is in the header, and no line under it
+              names the package at all). Both are ordinary Cargo, and either
+              one walks a forbidden dependency straight past the gate.
+
+      INVENTS a violation for `[features]\nkirra-mick = []`, because a line
+              regex cannot see which table it is standing in. A feature named
+              after a crate is not a dependency on it.
+
+    A gate that can be both bypassed and wrong is worse than a strict one: the
+    bypass is the hole, and the false positive is what teaches a reader to stop
+    believing the failures. `tomllib` knows the grammar; this function should
+    not be re-deriving it.
+
+    Renamed dependencies (`foo = { package = "kirra-mick" }`) are resolved to
+    the REAL package, because the alias is the caller's choice of local name and
+    the fence is about what actually gets linked.
     """
-    text = strip_comments_toml(manifest_text)
-    return sorted(set(re.findall(r"^\s*([A-Za-z][\w-]*)\s*=", text, re.M)))
+    try:
+        manifest = tomllib.loads(manifest_text)
+    except tomllib.TOMLDecodeError as exc:
+        # Fail closed: an unparseable manifest is not a neutral one.
+        raise GateError(f"guarded manifest is not valid TOML: {exc}") from exc
+
+    found: set[str] = set()
+
+    def harvest(table: object) -> None:
+        if not isinstance(table, dict):
+            return
+        for name, spec in table.items():
+            # `pkg = { package = "real-name" }` renames; the fence follows the
+            # real package, never the local alias.
+            if isinstance(spec, dict) and isinstance(spec.get("package"), str):
+                found.add(spec["package"])
+            else:
+                found.add(name)
+
+    for key in DEPENDENCY_TABLES:
+        harvest(manifest.get(key))
+
+    # `[target."cfg(unix)".dependencies]` and friends. Platform-conditional is
+    # still a dependency: "only on Linux" is not a neutrality exemption.
+    targets = manifest.get("target")
+    if isinstance(targets, dict):
+        for cfg in targets.values():
+            if isinstance(cfg, dict):
+                for key in DEPENDENCY_TABLES:
+                    harvest(cfg.get(key))
+
+    return sorted(found)
 
 
 def forbidden_dependencies(manifest_text: str) -> list[str]:
@@ -487,6 +542,60 @@ def _self_test() -> int:
         src = '[dependencies]\nserialport = "4"\n'
         assert forbidden_dependencies(src), "an external actuator transport was admitted"
 
+    def t_a_dotted_key_dependency_is_flagged():
+        # `kirra-mick.path = ...` -- the package name and the `=` are not
+        # adjacent, so the line regex this replaced saw nothing at all.
+        src = '[dependencies]\nkirra-mick.path = "../kirra-mick"\n'
+        assert forbidden_dependencies(src), "a dotted-key dependency was admitted"
+
+    def t_a_sub_table_dependency_is_flagged():
+        # `[dependencies.kirra-mick]` -- the name is in the HEADER, and no line
+        # inside the table mentions the package.
+        src = '[dependencies.kirra-mick]\npath = "../kirra-mick"\n'
+        assert forbidden_dependencies(src), "a sub-table dependency was admitted"
+
+    def t_a_dotted_external_transport_is_flagged():
+        src = '[dependencies]\nserialport.version = "4"\n'
+        assert forbidden_dependencies(src), "a dotted external transport was admitted"
+
+    def t_a_forbidden_dev_dependency_is_flagged():
+        # Dev-only still ships the edge to anyone building the tests, and the
+        # rule is about what this crate may pull in.
+        src = '[dev-dependencies]\nkirra-taj.path = "../kirra-taj"\n'
+        assert forbidden_dependencies(src), "a forbidden dev-dependency was admitted"
+
+    def t_a_forbidden_build_dependency_is_flagged():
+        src = '[build-dependencies]\nkirra-ros2-adapter = "0.1"\n'
+        assert forbidden_dependencies(src), "a forbidden build-dependency was admitted"
+
+    def t_a_platform_conditional_dependency_is_flagged():
+        # "only on Linux" is not a neutrality exemption.
+        src = '[target."cfg(unix)".dependencies]\nkirra-r2cp = { path = "../kirra-r2cp" }\n'
+        assert forbidden_dependencies(src), "a target-specific dependency was admitted"
+
+    def t_a_renamed_dependency_is_flagged_by_its_real_package():
+        # The alias is the caller's choice of local name; the fence follows what
+        # actually gets linked. Renaming must not be a way through.
+        src = '[dependencies]\nhelper = { package = "kirra-mick", path = "../kirra-mick" }\n'
+        assert forbidden_dependencies(src), "a renamed forbidden dependency was admitted"
+
+    def t_a_feature_named_after_a_crate_is_not_a_dependency():
+        # The other direction. A gate that invents violations teaches readers to
+        # stop believing its failures, which costs it the real ones too.
+        src = '[dependencies]\nserde = "1"\n\n[features]\nkirra-mick = []\n'
+        assert not forbidden_dependencies(src), "a feature name was read as a dependency"
+
+    def t_a_package_name_is_not_a_dependency():
+        src = '[package]\nname = "kirra-explain-types"\nversion = "0.1.0"\n'
+        assert not forbidden_dependencies(src), "[package] keys were read as dependencies"
+
+    def t_an_unparseable_manifest_fails_closed():
+        try:
+            forbidden_dependencies("[dependencies\nkirra-mick = 1\n")
+        except GateError:
+            return
+        raise AssertionError("a malformed manifest was treated as neutral")
+
     def t_serde_is_admitted():
         # The rule is neutrality, not emptiness. If this ever fails, the gate
         # has drifted back to counting entries.
@@ -512,7 +621,7 @@ def _self_test() -> int:
     for name, fn in cases:
         case(name, fn)
 
-    expected = 19
+    expected = 29
     if len(cases) != expected:
         print(
             f"SELF-TEST HARNESS: discovered {len(cases)} cases, expected {expected}.",

--- a/crates/kirra-explain-types/Cargo.toml
+++ b/crates/kirra-explain-types/Cargo.toml
@@ -3,11 +3,20 @@
 # Tier 4 box 4c (KIRRA-WM-EXPLAIN-PLACEMENT-001): the neutral type contract
 # across the explanation process boundary.
 #
-# THE EMPTY DEPENDENCY LIST IS THE POINT, and it is stated as a rule rather than
-# left to inspection: this crate has NO dependencies at all, and in particular no
-# `kirra-world*` package. That is what lets both sides depend on it —
-# `kirra-world-service` projects INTO these types, `kirra-mick` renders FROM
-# them — while there is no Cargo arrow between Mick and Kirra World.
+# NEUTRALITY IS THE POINT, and it is stated as a rule rather than left to
+# inspection: this crate may not depend on Kirra World, on Mick, on the planner
+# or map, on the checker/governor, or on anything carrying actuation authority.
+# That is what lets both sides depend on it — `kirra-world-service` projects
+# INTO these types, `kirra-mick` renders FROM them — while there is no Cargo
+# arrow between Mick and Kirra World.
+#
+# The rule used to read "NO dependencies at all". That was a stronger sentence
+# than the property it was protecting, and a rule that overstates itself gets
+# quietly broken the first time it is inconvenient. What actually matters is
+# that these types cannot acquire AUTHORITY, not that the list is empty; an
+# empty list was the accident, neutrality is the invariant. The narrower rule is
+# also the mechanically checkable one — see `ci/check_explain_artifact_neutral.py`,
+# which enforces the families above rather than counting entries.
 #
 # The precedent is `kirra-proposal-context` (KIRRA-WM-CONSUMER-PLACEMENT-001) and
 # so is the technique: a seam is made safe by having nowhere to put the dangerous
@@ -24,6 +33,23 @@ repository = "https://github.com/kirra-systems/kirra-runtime-sdk"
 license-file = "../../COPYRIGHT"
 publish = false  # proprietary (see COPYRIGHT) — not for crates.io
 
-# Deliberately empty. A dependency added here is a dependency Mick inherits, and
-# the first `kirra-world*` one reconstructs the path Fence B exists to refuse.
+# A dependency added here is a dependency Mick inherits, and the first
+# `kirra-world*` one reconstructs the path Fence B exists to refuse. Every entry
+# must be authority-free.
+#
+# `serde` is here because these types are the WIRE CONTRACT for the explanation
+# transport, and the derive has to sit on the type DEFINITION. A sibling wire
+# crate would have kept this manifest empty, at the cost of `#[serde(remote)]`
+# mirrors or a duplicate DTO — and a mirror that drifts from the real type
+# drifts SILENTLY, which is the defect class this tier exists to close. Serde on
+# the definition cannot drift. The precedent is `kirra-capture-schema`, a
+# neutral schema crate whose stated boundary is likewise "serde only".
 [dependencies]
+serde = { version = "1", features = ["derive"] }
+
+# Dev-only, so it never reaches Mick. Present so the round-trip proof below can
+# run through a REAL codec rather than asserting the derive expanded: a type
+# that compiles with `#[derive(Serialize)]` has not thereby been shown to
+# survive a wire.
+[dev-dependencies]
+serde_json = "1"

--- a/crates/kirra-explain-types/src/lib.rs
+++ b/crates/kirra-explain-types/src/lib.rs
@@ -86,7 +86,9 @@ pub const EXPLANATION_ARTIFACT_VERSION: u32 = 1;
 /// it. That is what keeps the semantics on the World side of the boundary — a
 /// label that Mick took apart and reinterpreted would be Mick resolving
 /// provenance, which is exactly what the placement ruling forbids.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
+)]
 pub struct DisplayLabel(String);
 
 impl DisplayLabel {
@@ -116,7 +118,9 @@ impl std::fmt::Display for DisplayLabel {
 /// matches. Mick cannot: a digest is not an argument to any query this system
 /// offers, which is precisely why it is admissible here where a generation is
 /// not.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
+)]
 pub struct EvidenceDigest(String);
 
 impl std::fmt::Display for EvidenceDigest {
@@ -146,7 +150,7 @@ impl EvidenceDigest {
 /// current one, and a renderer with no tense marker will narrate it in the
 /// present. A historical answer says what was knowable **then**, and the tense
 /// is not decoration on that — it is the claim.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum Tense {
     /// Pinned to a past coordinate. `pinned_at` is a rendered instant, not the
     /// coordinate itself: the projection converts, and that conversion is the
@@ -165,7 +169,7 @@ pub enum Tense {
 /// carried across the boundary WITHOUT their coordinates. `Plural` keeps its
 /// cardinality because that is the fact — *"several, and Kirra cannot say
 /// which"* — and loses the generations because those are query handles.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum BranchState {
     /// Exactly one recorded event carried the cited evidence.
     Resolved {
@@ -201,7 +205,7 @@ pub enum BranchState {
 /// *Never recorded* and *deleted* are different facts about the world, and a
 /// renderer that collapses them tells an investigator nothing was there when the
 /// truth may be that it was removed.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum DanglingReason {
     /// No compacted window could have held it.
     NeverRecorded,
@@ -211,7 +215,7 @@ pub enum DanglingReason {
 }
 
 /// Whether an explanation continues below a branch, and if not, why.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum BranchContinuation {
     /// The cited evidence's own provenance is in this artifact.
     Expanded {
@@ -230,7 +234,7 @@ pub enum BranchContinuation {
 /// are the ones the ruling names as never interchangeable: a bound being reached
 /// invites *"there is more"*, and a cycle must not, because raising a limit
 /// cannot help circular evidence.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum StopReason {
     /// The citation dangles — there is nothing below it.
     NothingToFollow,
@@ -245,7 +249,7 @@ pub enum StopReason {
 }
 
 /// One recorded citation, as presented.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct ExplanationBranch {
     /// What it resolved to.
     pub state: BranchState,
@@ -254,7 +258,7 @@ pub struct ExplanationBranch {
 }
 
 /// What is known about one claim's own citations.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum NodeEvidence {
     /// The claim is recorded and its citations are known.
     Recorded {
@@ -274,7 +278,7 @@ pub enum NodeEvidence {
 }
 
 /// One claim in the explanation.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct ExplanationNode {
     /// Distance from the root, which is 0. Indentation, not a coordinate.
     pub depth: u16,
@@ -291,7 +295,7 @@ pub struct ExplanationNode {
 /// Independent flags rather than one enum, mirroring the tree they come from: an
 /// explanation can be truncated AND circular AND degraded at once, and a shape
 /// that forces a precedence hides whichever loses.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
 pub struct Completeness {
     /// A legitimate bound was reached; more evidence exists.
     pub truncated: bool,
@@ -326,7 +330,7 @@ impl Completeness {
 ///
 /// Immutable and self-contained: everything a renderer needs is here, and
 /// nothing here can be used to ask for more.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct ExplanationArtifact {
     /// The contract version this artifact was built to.
     pub version: u32,
@@ -386,6 +390,96 @@ mod tests {
             cited: DisplayLabel::new("an unrecorded scan"),
             reason: DanglingReason::PossiblyDeleted,
         };
+    }
+
+    /// Every semantic this artifact distinguishes survives a real codec.
+    ///
+    /// SCOPE, stated so it is not mistaken for more than it is: this proves
+    /// SERIALIZATION. It does not prove the World-side producer and the
+    /// Mick-side renderer are connected — a hand-built value round-tripping
+    /// would stay green with either endpoint deleted. That control belongs to
+    /// the transport box, and runs the real projection through the wire into
+    /// the real renderer.
+    ///
+    /// What it does buy is that the transport box never has to wonder whether a
+    /// missing caveat came from the wire: the states that oblige a caveat are
+    /// checked here, at the type, where the failure would be cheapest to find.
+    #[test]
+    fn every_distinguishable_state_survives_a_round_trip() {
+        let artifact = ExplanationArtifact {
+            version: EXPLANATION_ARTIFACT_VERSION,
+            tense: Tense::Historical {
+                pinned_at: DisplayLabel::new("last Tuesday"),
+            },
+            nodes: vec![
+                ExplanationNode {
+                    depth: 0,
+                    parent: None,
+                    claim: DisplayLabel::new("package 17 was last seen at dock A"),
+                    evidence: NodeEvidence::Recorded {
+                        branches: vec![
+                            ExplanationBranch {
+                                state: BranchState::Resolved {
+                                    evidence: DisplayLabel::new("a dock-A scan"),
+                                    digest: EvidenceDigest::new("9f86d081"),
+                                },
+                                continuation: BranchContinuation::Expanded { node: 1 },
+                            },
+                            ExplanationBranch {
+                                state: BranchState::Plural {
+                                    cited: DisplayLabel::new("a dock-A scan"),
+                                    carriers: 3,
+                                    more_than_counted: true,
+                                },
+                                continuation: BranchContinuation::Stopped(StopReason::Ambiguous),
+                            },
+                            ExplanationBranch {
+                                state: BranchState::Dangling {
+                                    cited: DisplayLabel::new("an unrecorded scan"),
+                                    reason: DanglingReason::PossiblyDeleted,
+                                },
+                                continuation: BranchContinuation::Stopped(StopReason::Cycle),
+                            },
+                        ],
+                        more_citations: true,
+                    },
+                },
+                ExplanationNode {
+                    depth: 1,
+                    parent: Some(0),
+                    claim: DisplayLabel::new("the scan was recorded by the dock reader"),
+                    evidence: NodeEvidence::DeletedByCompaction,
+                },
+                ExplanationNode {
+                    depth: 1,
+                    parent: Some(0),
+                    claim: DisplayLabel::new("the reader was calibrated"),
+                    evidence: NodeEvidence::NotIndexed,
+                },
+            ],
+            completeness: Completeness {
+                truncated: true,
+                cycle_detected: true,
+                degraded: true,
+                coverage_limited: true,
+            },
+        };
+
+        // Non-vacuity: a fixture that had quietly lost its distinguishing
+        // states would round-trip perfectly and prove nothing.
+        assert!(matches!(artifact.tense, Tense::Historical { .. }));
+        assert!(artifact.completeness.requires_disclosure());
+        assert_eq!(artifact.nodes.len(), 3);
+
+        let wire = serde_json::to_string(&artifact).expect("artifact must serialize");
+        let back: ExplanationArtifact =
+            serde_json::from_str(&wire).expect("artifact must deserialize");
+
+        assert_eq!(
+            back, artifact,
+            "a semantic changed across the wire — the renderer would narrate a \
+             different answer from the one Kirra World projected"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Step 2 of the explanation-transport sequence scoped in #1453. Prepares the presentation types to be the wire contract. No transport yet — that is step 3.

## The small half: serde

These types become the wire contract, so the derive has to sit on the type **definition**. The tidier-looking alternative — a sibling wire crate keeping this manifest empty — costs `#[serde(remote)]` mirrors or a duplicate DTO, and a mirror that drifts from the real type drifts *silently*. That is the defect class this tier exists to close, so it is not the shape to adopt at the seam that closes it.

## The larger half: the gate was claiming a rule it could not enforce

`check_no_world_dependency` matched `^kirra-…=` and flagged only `kirra-world*`. It could see roughly a third of its own sentence: not a Mick edge, not a checker edge, and — because the regex was scoped to `kirra-` — not `serialport` either.

Adding serde also falsified the manifest's stated rule, *"NO dependencies at all"*. That was a stronger sentence than the property it protected, and a rule that overstates itself gets quietly broken the first time it is inconvenient, after which it protects nothing. The rule is now the property actually being defended:

> These presentation types stay **neutral**: no World, Mick, doer, checker or actuation-authority dependencies.

Narrower than "none", and stronger in practice — emptiness was an accident that no check could distinguish from a deliberate boundary.

## The classification is imported, not retyped

`kirra-explain-types` is already in the bidirectional fence's `FENCE_A_EXTRA_PACKAGES`, so Fence A check 2 already walks its **closure** against the actuation names — a stronger check than anything local. So the gate now imports `ACTUATION_PACKAGES`, `ACTUATION_EXTERNAL`, `WORLD_PACKAGE_EXACT` and `WORLD_PACKAGE_PREFIX` from the fence rather than copying them.

Two hand-maintained copies of one classification is the serde-mirror failure one level up: the copy that stops being updated is the one that silently stops matching. A crate added to the fence's actuation set is forbidden here the same day.

The direct check is kept anyway, for the reason the World ban was always direct: `KIRRA-WM-EXPLAIN-PLACEMENT-001` is an invariant about *this manifest*, and an invariant that holds only through a chain of other facts is one refactor from being false. A direct hit also names the offending line instead of a closure path.

## Review found a hole in the first version of this, and it was wider than reported

The first commit enumerated dependencies with a line regex. Review pointed out that dotted keys bypass it. Reproducing before fixing showed **four of six spellings walked straight through**:

```
FLAGGED  kirra-mick = { path = ... }        the one spelling I had tested
MISSED   kirra-mick.path = "..."            dotted key
MISSED   serialport.version = "4"           dotted key, external
MISSED   [dependencies.kirra-mick]          sub-table — name is in the HEADER
MISSED   [dev-dependencies] dotted
FLAGGED  [target."cfg(unix)".dependencies]  by accident — see below
```

The sub-table form was not in the report and is the worst of them: the package name appears only in the table header, so no line inside the table names it at all.

The regex was wrong in the **other** direction too, which is what made the target-specific case appear to pass. It scanned every table in the file, so `[features]\nkirra-mick = []` was reported as a forbidden dependency. That case passed not because the gate understood target tables but because it did not understand tables at all.

That combination is worse than either fault alone: the bypass is the hole, and the false positive is what teaches a reader to stop believing the gate's failures, which costs it the real ones too.

`declared_dependencies` now **parses** with `tomllib` and walks `dependencies`, `dev-dependencies`, `build-dependencies` and every `[target.*]` variant. tomllib knows the grammar; this gate should not be re-deriving it. Two cases beyond the report: a renamed dependency (`helper = { package = "kirra-mick" }`) resolves to the real package, since the alias is the caller's choice of local name and otherwise renaming is a way through; and an unparseable manifest raises rather than returning `[]`.

## Non-vacuity

The old function read a path, so nothing could hand it a crafted manifest — a self-test written against it could only assert that the real crate passes, which is equally true of a function returning `[]` unconditionally. Split into a pure `forbidden_dependencies(manifest_text)` plus a thin wrapper, following the shape the existing `violations_in(src)` self-tests already use.

**10 → 29 self-test cases.** Nineteen new: one per forbidden family, one per dependency spelling, and four asserting the opposite direction — serde, a commented-out dependency, a feature named after a crate, and a `[package]` key must all be **admitted** — so the rule cannot drift back into counting entries and cannot start inventing violations.

## Verified by mutation, each checked twice

Once that the edit landed, once that a *named* control observed it:

| Mutation | Landed | Observed by |
|---|---|---|
| `forbidden_dependencies` returns `[]` unconditionally | 1 marker | 6 self-tests fail |
| real manifest gains `kirra-mick` | 1 line | the gate itself fails, naming the line |
| imported actuation sets go empty (simulated fence drift) | 2 markers | 2 self-tests fail — the import is load-bearing |
| `Completeness.degraded` gets `#[serde(skip)]` | 1 marker | the round-trip proof fails |
| `declared_dependencies` reverts to the line regex | 1 marker | 7 self-tests fail, including both false-direction controls |
| real manifest gains `[dependencies.kirra-mick]` (the spelling that bypassed) | 1 table | the gate fails, naming the package |

## The round-trip proof, and what it does not prove

Carries every state the artifact distinguishes — historical tense, resolved/plural/dangling, cycle, compaction, all four caveat flags — through real `serde_json` (a dev-dependency, so Mick never inherits it), asserting equality. Up-front assertions check the fixture still holds those states, so a hollowed-out fixture cannot pass trivially.

Its docstring states the limit explicitly: **this proves serialization, not connection.** A hand-built value round-tripping would stay green with either endpoint deleted. The producer→renderer control belongs to step 3, where removing either side must break it.

## Also

The failure epilogue gave coordinate advice ("carry a `DisplayLabel` instead") for dependency violations, which was wrong guidance for half the rule. It now answers whichever half fired.

## Verification

`cargo test -p kirra-explain-types` (5 passed) · gate self-test (29 cases) · the neutrality gate · `check_kirra_world_bidirectional_fence` (INTACT) · `check_mick_actuation_fence` (INTACT) · `check_world_semantics` · `cargo fmt --check` · all 36 CI checks green. `Cargo.lock` moves 3 lines; serde was already in the graph.