### PR TITLE
Add claim_at_generation: the evidence lookup 4c needs to tell absent from deleted

### DIFF
--- a/ci/store_boundedness_baseline.json
+++ b/ci/store_boundedness_baseline.json
@@ -1,356 +1,360 @@
 {
- "_comment": [
-  "Tier 3 box 3d \u2014 the boundedness classification of the store's read surface.",
-  "",
-  "KIRRA-WM-ANSWER-IDENTITY-001 clause 2 is 'queries are bounded'. Three defects",
-  "in three consecutive PRs showed that per-query vigilance does not enforce it:",
-  "",
-  "  #1440  lineage      per-page query over a whole-history fetch   (review)",
-  "  #1441  subject_summary  per-subject query over a store scan     (review)",
-  "  #1441  history      no bound at all, in the same PR that wrote up the first two",
-  "",
-  "Each looked bounded at the API and called an unbounded store method underneath.",
-  "So boundedness is an ENGINE-level invariant, not per-query hygiene, and this",
-  "file is what makes it mechanical.",
-  "",
-  "WHY A CLASSIFICATION AND NOT A DENYLIST OF UNBOUNDED METHODS",
-  "",
-  "A denylist fails the way the three defects failed: a new store method simply",
-  "is not on it, and nothing notices. This is FAIL-CLOSED instead, on 3e's",
-  "pattern -- every public read method must appear here, and an unclassified one",
-  "REDS THE GATE. Adding a store method without deciding its boundedness becomes",
-  "a red build naming the rule.",
-  "",
-  "THE CATEGORIES",
-  "",
-  "  bounded      Result size is bounded by the ARGUMENTS. An interactive query",
-  "               may call this.",
-  "  unbounded    Result grows with store size or with a subject's accumulated",
-  "               history. An interactive query may NOT call this. Legitimate for",
-  "               operators, rebuilds and analysis -- none of which sit on a",
-  "               request path.",
-  "  operational  Not a domain read: mutations, folds, schema, diagnostics,",
-  "               counts. WM_SCOPE names these as legitimate readers below the",
-  "               engine, and a rule forbidding them 'would be false on the day",
-  "               it was written'.",
-  "",
-  "'Bounded' means bounded by the arguments, not small. `current` returns one row",
-  "per predicate for one subject -- bounded by the PRIMARY KEY, which is a",
-  "STRUCTURAL bound rather than a page. That counts, and is asserted rather than",
-  "assumed (see the structural-bound tests).",
-  "",
-  "Methods ending `_for_test` are classified automatically and are not listed:",
-  "they are compiled out of the production path, and listing them would be a",
-  "second thing to maintain for no coverage."
- ],
- "world_store": {
-  "append": {
-   "class": "operational",
-   "why": "Write path."
-  },
-  "append_adjudication": {
-   "class": "operational",
-   "why": "Write path."
-  },
-  "as_of": {
-   "class": "bounded",
-   "why": "One subject at one bitemporal point. Same PRIMARY KEY bound as `current`."
-  },
-  "as_of_composed": {
-   "class": "unbounded",
-   "why": "Composes `as_of` (bounded) with `identity_view_at` (the whole graph). The claims half is bounded and the identity half is not, so the composition is not \u2014 a bounded half does not bound a composition."
-  },
-  "as_of_composed_bounded": {
-   "class": "bounded",
-   "why": "Box 3d. Both halves bounded inside ONE transaction: `as_of` was already subject-keyed, and the identity half now folds only the adjudications bearing on the objects those claims name, discovered through the affected-entity reverse index. Deliberately one primitive rather than two bounded calls \u2014 two would satisfy boundedness while reintroducing the cross-read incoherence box 3h closed."
-  },
-  "backfill_adjudication_affects": {
-   "class": "operational",
-   "why": "The one-time scan that fills the v6 reverse index on a migrated store. Deliberately a full scan and deliberately NOT on any request path \u2014 an explicit operational call rather than work hidden in `open`, so the cost lands where an operator can see it. This is exactly the trade box 3d is for: one operational scan buys bounded interactive reads."
-  },
-  "backfill_provenance_edges": {
-   "class": "operational",
-   "why": "Tier 4 box 4a. The one-time scan that fills the v7 citation index on a migrated store, and drops the coverage floor to 0. A full log scan by design, and deliberately NOT on any request path -- an explicit operational call rather than work hidden in `open`, exactly as `backfill_adjudication_affects`."
-  },
-  "candidates": {
-   "class": "unbounded",
-   "why": "Every candidate claim ever proposed about a subject, no page. The same shape as `history` and unbounded for the same reason -- an LLM proposing repeatedly grows this without limit."
-  },
-  "changed_since": {
-   "class": "unbounded",
-   "why": "Every change after a timestamp. The result grows with how long ago the caller asks about."
-  },
-  "citations": {
-   "class": "unbounded",
-   "why": "Every compaction citation in the store. Accumulates for the store's life."
-  },
-  "citations_of": {
-   "class": "bounded",
-   "why": "Tier 4 box 4a. Bounded by the ARGUMENT: `limit`, refused above MAX_CITATIONS_PAGE and at 0, applied as SQL LIMIT with one extra probe row so truncation is reported rather than inferred. It is bounded BECAUSE it was made so -- nothing else bounds it. No schema constraint, no domain rule and no other argument limits how many observations one event may cite, so the whole-array read this replaced was structurally unbounded while looking fine at the API: the exact shape of the three defects in the header. Classifying it `unbounded` and leaving 4b to bound it would have been the 'move the unbounded call behind another helper' move 3d ruled out."
-  },
-  "compact_range": {
-   "class": "operational",
-   "why": "Retention mutation."
-  },
-  "count": {
-   "class": "operational",
-   "why": "A scalar row count."
-  },
-  "current": {
-   "class": "bounded",
-   "why": "STRUCTURAL bound: `world_current` is keyed by (subject, predicate_key), so one subject yields at most one row per predicate. Not a page, and does not need one -- a subject's predicate set does not grow without limit the way its event history does."
-  },
-  "current_all": {
-   "class": "unbounded",
-   "why": "The whole claims projection. Grows with the number of subjects."
-  },
-  "cursor_anchor": {
-   "class": "bounded",
-   "why": "Two point reads: one row by primary key, and the log head via ORDER BY generation DESC LIMIT 1. Structurally bounded \u2014 the result is two scalars regardless of log size. It exists so a continuation cursor can be REFUSED rather than silently continued from a coordinate the log no longer holds."
-  },
-  "entity_projection_generation": {
-   "class": "operational",
-   "why": "Checkpoint metadata."
-  },
-  "entity_projection_state_digest": {
-   "class": "operational",
-   "why": "Checkpoint metadata."
-  },
-  "fold": {
-   "class": "operational",
-   "why": "Projection fold."
-  },
-  "fold_entity_projection": {
-   "class": "operational",
-   "why": "Projection fold."
-  },
-  "fold_subject_summary": {
-   "class": "operational",
-   "why": "Projection fold."
-  },
-  "has_citations": {
-   "class": "operational",
-   "why": "Existence probe."
-  },
-  "has_entity_projection": {
-   "class": "operational",
-   "why": "Existence probe."
-  },
-  "has_projections": {
-   "class": "operational",
-   "why": "Existence probe."
-  },
-  "has_subject_summary": {
-   "class": "operational",
-   "why": "Existence probe."
-  },
-  "has_summaries": {
-   "class": "operational",
-   "why": "Existence probe."
-  },
-  "head_chain": {
-   "class": "bounded",
-   "why": "One row: the log head."
-  },
-  "history_page": {
-   "class": "bounded",
-   "why": "Box 3d's bounded replacement for `history`. Narrows in SQL with `generation > cursor` and `LIMIT limit + 1` rather than fetching the record and truncating \u2014 #1440's lesson, since truncating after the fetch bounds the ANSWER while leaving the WORK unbounded, which is what made all three defects invisible. The boundary decision is `lineage::boundary_for`, shared with the lineage family so the off-by-one has one implementation."
-  },
-  "history_whole": {
-   "class": "unbounded",
-   "why": "EVERY confirmed claim ever recorded about a subject, no page and no cursor. The third instance of the defect class this gate exists for, and the one that proves per-query vigilance does not work: it was written in the PR that documented the other two. Its bounded replacement is the paginated form. RENAMED from `history` in the 3d dispatch slice: `WorldView::history` is the BOUNDED family of the same name, and the collision made the gate read the engine's dispatch into the bounded family as a call to this one. The same correction `resolve_at` -> `resolve_at_whole_graph` already took \u2014 a name that does not say `whole` is how a whole-record read gets called by mistake."
-  },
-  "identity_view": {
-   "class": "unbounded",
-   "why": "The whole entity equivalence graph."
-  },
-  "identity_view_at": {
-   "class": "unbounded",
-   "why": "The whole entity graph as it stood at a cut. Pinning the coordinate bounds WHEN, not HOW MUCH."
-  },
-  "invalid_shape_rows": {
-   "class": "operational",
-   "why": "A schema-diagnostic sweep, not a domain question."
-  },
-  "largest_compactable_prefix": {
-   "class": "operational",
-   "why": "The compaction planner's own query. WM_SCOPE names the planner as a legitimate reader below the engine."
-  },
-  "lineage_at_generation": {
-   "class": "bounded",
-   "why": "Takes a validated `LineagePage`, and #1440 made the fetch itself narrow to limit+1 rather than fetching the history and truncating."
-  },
-  "load_entity_projection": {
-   "class": "operational",
-   "why": "The fold's own loader."
-  },
-  "mint_entity_id": {
-   "class": "operational",
-   "why": "Id minting."
-  },
-  "minted_entity_id_count": {
-   "class": "operational",
-   "why": "A scalar count."
-  },
-  "open": {
-   "class": "operational",
-   "why": "Constructor."
-  },
-  "projected_row_count": {
-   "class": "operational",
-   "why": "A scalar count."
-  },
-  "projection_coordinate": {
-   "class": "operational",
-   "why": "Checkpoint metadata."
-  },
-  "projection_generation": {
-   "class": "operational",
-   "why": "Checkpoint metadata."
-  },
-  "projection_state_digest": {
-   "class": "operational",
-   "why": "Checkpoint metadata."
-  },
-  "provenance_edges_floor": {
-   "class": "bounded",
-   "why": "Tier 4 box 4a. One `world_store_meta` row by primary key. The fail-closed fallback for an absent/unparseable value is `MAX(generation)`, an index max rather than a scan. Constant result size -- one integer."
-  },
-  "provenance_tree": {
-   "class": "bounded",
-   "why": "Tier 4 box 4b. Every dimension of the WALK has a validated ceiling: at most `GraphSpec::max_nodes` nodes (<= MAX_PROVENANCE_NODES), each reading one citation page (<= MAX_CITATIONS_PAGE, probe-truncated) and resolving each citation against at most MAX_CARRIERS carriers by the observation_id index. Stated rather than waved at, because the product is the honest part: 256 nodes x 256 citations is ~65k index lookups in the theoretical worst case, and a caller wanting an interactive answer passes a smaller GraphSpec rather than relying on real provenance being shallow. Two independent budgets is deliberate -- a depth bound alone leaves width open, since one event may cite any number of observations. The compaction-span enumeration WAS the exception and is no longer one (#1449): `compacted_spans(at_generation)` is a single `WHERE lo_generation <= ?1 ORDER BY lo_generation ASC LIMIT ?2` read once per walk, so the last dimension that grew with the store -- its compaction history -- is now bounded by MAX_COMPACTED_SPANS. Only the ENUMERATION is capped: the NeverVisible vs PossiblyCompacted qualification needs mere existence, so a cap can only shorten an already non-empty list and can never flip the qualification, and `DanglingReason::PossiblyCompacted.truncated` says when it did. Enforced structurally by rule 6 of ci/check_query_boundedness.py (a MAX_* ceiling applied over a LIMIT-less SELECT reds), because the truncated-in-Rust version returns a byte-identical answer and no behavioural test can tell the two apart."
-  },
-  "read_at_generation": {
-   "class": "unbounded",
-   "why": "The whole claims projection reconstructed at a generation. Pinning the coordinate bounds WHEN, not HOW MUCH -- the same trap as `identity_view_at`."
-  },
-  "read_composed_at_generation": {
-   "class": "unbounded",
-   "why": "Both projections at a generation. Unbounded for the same reason as `read_at_generation`."
+  "_comment": [
+    "Tier 3 box 3d \u2014 the boundedness classification of the store's read surface.",
+    "",
+    "KIRRA-WM-ANSWER-IDENTITY-001 clause 2 is 'queries are bounded'. Three defects",
+    "in three consecutive PRs showed that per-query vigilance does not enforce it:",
+    "",
+    "  #1440  lineage      per-page query over a whole-history fetch   (review)",
+    "  #1441  subject_summary  per-subject query over a store scan     (review)",
+    "  #1441  history      no bound at all, in the same PR that wrote up the first two",
+    "",
+    "Each looked bounded at the API and called an unbounded store method underneath.",
+    "So boundedness is an ENGINE-level invariant, not per-query hygiene, and this",
+    "file is what makes it mechanical.",
+    "",
+    "WHY A CLASSIFICATION AND NOT A DENYLIST OF UNBOUNDED METHODS",
+    "",
+    "A denylist fails the way the three defects failed: a new store method simply",
+    "is not on it, and nothing notices. This is FAIL-CLOSED instead, on 3e's",
+    "pattern -- every public read method must appear here, and an unclassified one",
+    "REDS THE GATE. Adding a store method without deciding its boundedness becomes",
+    "a red build naming the rule.",
+    "",
+    "THE CATEGORIES",
+    "",
+    "  bounded      Result size is bounded by the ARGUMENTS. An interactive query",
+    "               may call this.",
+    "  unbounded    Result grows with store size or with a subject's accumulated",
+    "               history. An interactive query may NOT call this. Legitimate for",
+    "               operators, rebuilds and analysis -- none of which sit on a",
+    "               request path.",
+    "  operational  Not a domain read: mutations, folds, schema, diagnostics,",
+    "               counts. WM_SCOPE names these as legitimate readers below the",
+    "               engine, and a rule forbidding them 'would be false on the day",
+    "               it was written'.",
+    "",
+    "'Bounded' means bounded by the arguments, not small. `current` returns one row",
+    "per predicate for one subject -- bounded by the PRIMARY KEY, which is a",
+    "STRUCTURAL bound rather than a page. That counts, and is asserted rather than",
+    "assumed (see the structural-bound tests).",
+    "",
+    "Methods ending `_for_test` are classified automatically and are not listed:",
+    "they are compiled out of the production path, and listing them would be a",
+    "second thing to maintain for no coverage."
+  ],
+  "world_store": {
+    "append": {
+      "class": "operational",
+      "why": "Write path."
+    },
+    "append_adjudication": {
+      "class": "operational",
+      "why": "Write path."
+    },
+    "as_of": {
+      "class": "bounded",
+      "why": "One subject at one bitemporal point. Same PRIMARY KEY bound as `current`."
+    },
+    "as_of_composed": {
+      "class": "unbounded",
+      "why": "Composes `as_of` (bounded) with `identity_view_at` (the whole graph). The claims half is bounded and the identity half is not, so the composition is not \u2014 a bounded half does not bound a composition."
+    },
+    "as_of_composed_bounded": {
+      "class": "bounded",
+      "why": "Box 3d. Both halves bounded inside ONE transaction: `as_of` was already subject-keyed, and the identity half now folds only the adjudications bearing on the objects those claims name, discovered through the affected-entity reverse index. Deliberately one primitive rather than two bounded calls \u2014 two would satisfy boundedness while reintroducing the cross-read incoherence box 3h closed."
+    },
+    "backfill_adjudication_affects": {
+      "class": "operational",
+      "why": "The one-time scan that fills the v6 reverse index on a migrated store. Deliberately a full scan and deliberately NOT on any request path \u2014 an explicit operational call rather than work hidden in `open`, so the cost lands where an operator can see it. This is exactly the trade box 3d is for: one operational scan buys bounded interactive reads."
+    },
+    "backfill_provenance_edges": {
+      "class": "operational",
+      "why": "Tier 4 box 4a. The one-time scan that fills the v7 citation index on a migrated store, and drops the coverage floor to 0. A full log scan by design, and deliberately NOT on any request path -- an explicit operational call rather than work hidden in `open`, exactly as `backfill_adjudication_affects`."
+    },
+    "candidates": {
+      "class": "unbounded",
+      "why": "Every candidate claim ever proposed about a subject, no page. The same shape as `history` and unbounded for the same reason -- an LLM proposing repeatedly grows this without limit."
+    },
+    "changed_since": {
+      "class": "unbounded",
+      "why": "Every change after a timestamp. The result grows with how long ago the caller asks about."
+    },
+    "citations": {
+      "class": "unbounded",
+      "why": "Every compaction citation in the store. Accumulates for the store's life."
+    },
+    "citations_of": {
+      "class": "bounded",
+      "why": "Tier 4 box 4a. Bounded by the ARGUMENT: `limit`, refused above MAX_CITATIONS_PAGE and at 0, applied as SQL LIMIT with one extra probe row so truncation is reported rather than inferred. It is bounded BECAUSE it was made so -- nothing else bounds it. No schema constraint, no domain rule and no other argument limits how many observations one event may cite, so the whole-array read this replaced was structurally unbounded while looking fine at the API: the exact shape of the three defects in the header. Classifying it `unbounded` and leaving 4b to bound it would have been the 'move the unbounded call behind another helper' move 3d ruled out."
+    },
+    "compact_range": {
+      "class": "operational",
+      "why": "Retention mutation."
+    },
+    "count": {
+      "class": "operational",
+      "why": "A scalar row count."
+    },
+    "current": {
+      "class": "bounded",
+      "why": "STRUCTURAL bound: `world_current` is keyed by (subject, predicate_key), so one subject yields at most one row per predicate. Not a page, and does not need one -- a subject's predicate set does not grow without limit the way its event history does."
+    },
+    "current_all": {
+      "class": "unbounded",
+      "why": "The whole claims projection. Grows with the number of subjects."
+    },
+    "cursor_anchor": {
+      "class": "bounded",
+      "why": "Two point reads: one row by primary key, and the log head via ORDER BY generation DESC LIMIT 1. Structurally bounded \u2014 the result is two scalars regardless of log size. It exists so a continuation cursor can be REFUSED rather than silently continued from a coordinate the log no longer holds."
+    },
+    "claim_at_generation": {
+      "class": "bounded",
+      "why": "Tier 4 box 4c. A POINT READ by primary key: `WHERE generation = ?1` on `world_events`, whose PRIMARY KEY is `generation`, so the result is at most one row regardless of log size. Structurally bounded in the same sense as `cursor_anchor` -- there is no page, no cursor and no ordering because there is nothing to order. It is an EVIDENCE LOOKUP PRIMITIVE, not a query family, and the distinction is what keeps it off the Tier 3 bypass road: it takes a coordinate the caller ALREADY HOLDS (from a provenance node) and returns the row at it. There is no subject argument, no predicate, no time and no ordering, so it cannot be used to ASK anything -- a consumer cannot reach a generation with it that it did not already have. A consumer wanting to know something about a subject still goes through QueryEngine. It exists because `explain::ClaimLabels` is generation-addressed and nothing public could implement it: a subject-scoped substitute would return None for cross-subject provenance nodes, and `project_explanation` DEFINES None as 'the event is gone', so the artifact would have stated that retained evidence was deleted."
+    },
+    "entity_projection_generation": {
+      "class": "operational",
+      "why": "Checkpoint metadata."
+    },
+    "entity_projection_state_digest": {
+      "class": "operational",
+      "why": "Checkpoint metadata."
+    },
+    "fold": {
+      "class": "operational",
+      "why": "Projection fold."
+    },
+    "fold_entity_projection": {
+      "class": "operational",
+      "why": "Projection fold."
+    },
+    "fold_subject_summary": {
+      "class": "operational",
+      "why": "Projection fold."
+    },
+    "has_citations": {
+      "class": "operational",
+      "why": "Existence probe."
+    },
+    "has_entity_projection": {
+      "class": "operational",
+      "why": "Existence probe."
+    },
+    "has_projections": {
+      "class": "operational",
+      "why": "Existence probe."
+    },
+    "has_subject_summary": {
+      "class": "operational",
+      "why": "Existence probe."
+    },
+    "has_summaries": {
+      "class": "operational",
+      "why": "Existence probe."
+    },
+    "head_chain": {
+      "class": "bounded",
+      "why": "One row: the log head."
+    },
+    "history_page": {
+      "class": "bounded",
+      "why": "Box 3d's bounded replacement for `history`. Narrows in SQL with `generation > cursor` and `LIMIT limit + 1` rather than fetching the record and truncating \u2014 #1440's lesson, since truncating after the fetch bounds the ANSWER while leaving the WORK unbounded, which is what made all three defects invisible. The boundary decision is `lineage::boundary_for`, shared with the lineage family so the off-by-one has one implementation."
+    },
+    "history_whole": {
+      "class": "unbounded",
+      "why": "EVERY confirmed claim ever recorded about a subject, no page and no cursor. The third instance of the defect class this gate exists for, and the one that proves per-query vigilance does not work: it was written in the PR that documented the other two. Its bounded replacement is the paginated form. RENAMED from `history` in the 3d dispatch slice: `WorldView::history` is the BOUNDED family of the same name, and the collision made the gate read the engine's dispatch into the bounded family as a call to this one. The same correction `resolve_at` -> `resolve_at_whole_graph` already took \u2014 a name that does not say `whole` is how a whole-record read gets called by mistake."
+    },
+    "identity_view": {
+      "class": "unbounded",
+      "why": "The whole entity equivalence graph."
+    },
+    "identity_view_at": {
+      "class": "unbounded",
+      "why": "The whole entity graph as it stood at a cut. Pinning the coordinate bounds WHEN, not HOW MUCH."
+    },
+    "invalid_shape_rows": {
+      "class": "operational",
+      "why": "A schema-diagnostic sweep, not a domain question."
+    },
+    "largest_compactable_prefix": {
+      "class": "operational",
+      "why": "The compaction planner's own query. WM_SCOPE names the planner as a legitimate reader below the engine."
+    },
+    "lineage_at_generation": {
+      "class": "bounded",
+      "why": "Takes a validated `LineagePage`, and #1440 made the fetch itself narrow to limit+1 rather than fetching the history and truncating."
+    },
+    "load_entity_projection": {
+      "class": "operational",
+      "why": "The fold's own loader."
+    },
+    "mint_entity_id": {
+      "class": "operational",
+      "why": "Id minting."
+    },
+    "minted_entity_id_count": {
+      "class": "operational",
+      "why": "A scalar count."
+    },
+    "open": {
+      "class": "operational",
+      "why": "Constructor."
+    },
+    "projected_row_count": {
+      "class": "operational",
+      "why": "A scalar count."
+    },
+    "projection_coordinate": {
+      "class": "operational",
+      "why": "Checkpoint metadata."
+    },
+    "projection_generation": {
+      "class": "operational",
+      "why": "Checkpoint metadata."
+    },
+    "projection_state_digest": {
+      "class": "operational",
+      "why": "Checkpoint metadata."
+    },
+    "provenance_edges_floor": {
+      "class": "bounded",
+      "why": "Tier 4 box 4a. One `world_store_meta` row by primary key. The fail-closed fallback for an absent/unparseable value is `MAX(generation)`, an index max rather than a scan. Constant result size -- one integer."
+    },
+    "provenance_tree": {
+      "class": "bounded",
+      "why": "Tier 4 box 4b. Every dimension of the WALK has a validated ceiling: at most `GraphSpec::max_nodes` nodes (<= MAX_PROVENANCE_NODES), each reading one citation page (<= MAX_CITATIONS_PAGE, probe-truncated) and resolving each citation against at most MAX_CARRIERS carriers by the observation_id index. Stated rather than waved at, because the product is the honest part: 256 nodes x 256 citations is ~65k index lookups in the theoretical worst case, and a caller wanting an interactive answer passes a smaller GraphSpec rather than relying on real provenance being shallow. Two independent budgets is deliberate -- a depth bound alone leaves width open, since one event may cite any number of observations. The compaction-span enumeration WAS the exception and is no longer one (#1449): `compacted_spans(at_generation)` is a single `WHERE lo_generation <= ?1 ORDER BY lo_generation ASC LIMIT ?2` read once per walk, so the last dimension that grew with the store -- its compaction history -- is now bounded by MAX_COMPACTED_SPANS. Only the ENUMERATION is capped: the NeverVisible vs PossiblyCompacted qualification needs mere existence, so a cap can only shorten an already non-empty list and can never flip the qualification, and `DanglingReason::PossiblyCompacted.truncated` says when it did. Enforced structurally by rule 6 of ci/check_query_boundedness.py (a MAX_* ceiling applied over a LIMIT-less SELECT reds), because the truncated-in-Rust version returns a byte-identical answer and no behavioural test can tell the two apart."
+    },
+    "read_at_generation": {
+      "class": "unbounded",
+      "why": "The whole claims projection reconstructed at a generation. Pinning the coordinate bounds WHEN, not HOW MUCH -- the same trap as `identity_view_at`."
+    },
+    "read_composed_at_generation": {
+      "class": "unbounded",
+      "why": "Both projections at a generation. Unbounded for the same reason as `read_at_generation`."
+    },
+    "read_snapshot": {
+      "class": "operational",
+      "why": "Returns a HANDLE, reading nothing. The rows come from `ReadSnapshot`'s own methods, which are classified separately below -- a snapshot must not become a way to reach an unbounded read without being seen."
+    },
+    "rebuild_entity_projection": {
+      "class": "operational",
+      "why": "Projection rebuild."
+    },
+    "rebuild_projections": {
+      "class": "operational",
+      "why": "Projection rebuild."
+    },
+    "rebuild_subject_summary": {
+      "class": "operational",
+      "why": "Projection rebuild."
+    },
+    "resolve_at_whole_graph": {
+      "class": "unbounded",
+      "why": "RENAMED from `resolve_at` on box 3d. Its body is `self.identity_view_at(cut)?.resolve_at(id)` \u2014 it materialises the WHOLE equivalence graph and then indexes it, so the old name read as a point lookup and was classified `bounded` from its signature on the first pass. The name now says what it does. Renaming also removes a real ambiguity in the gate's name-based scan: `HistoricalIdentityView::resolve_at` is a pure in-memory call on an already-loaded view, and sharing a name with an unbounded store method made every use of it look like a violation. `resolve_bounded_at` is the bounded form."
+    },
+    "resolve_bounded": {
+      "class": "bounded",
+      "why": "Box 3d's identity primitive. Loads only the entities within MAX_REDIRECT_EDGES hops of the queried id and resolves over that subset, so the work is bounded by the traversal budget the resolver already enforces rather than by graph size. The resolution RULE is unchanged \u2014 the same `resolve` over a smaller view \u2014 which is what lets `bounded_resolution_agrees_with_whole_graph_resolution` assert the two are identical. Classified `bounded` and MEANT: the transitive check reads its body, so it stays honest."
+    },
+    "resolve_bounded_at": {
+      "class": "bounded",
+      "why": "Box 3d's bounded historical identity read. Discovers the adjudications affecting the queried id through the affected-entity reverse index, expands newly-named entities, and stops at the resolver's own MAX_REDIRECT_EDGES budget \u2014 so it folds the records bearing on one entity's identity rather than every adjudication in the log. The index supplies GENERATIONS only; every record is read from world_events and folded by the unchanged fold_adjudication, so the log remains the sole evidence."
+    },
+    "resolved_entities": {
+      "class": "unbounded",
+      "why": "Every summarised entity in the store."
+    },
+    "schema_version": {
+      "class": "operational",
+      "why": "PRAGMA read."
+    },
+    "subject_summaries": {
+      "class": "unbounded",
+      "why": "Every retained summary row."
+    },
+    "subject_summaries_for": {
+      "class": "bounded",
+      "why": "One subject's summaries across kinds -- SQL-narrowed, at most one row per kind."
+    },
+    "subject_summaries_with_coverage": {
+      "class": "unbounded",
+      "why": "Every summary AND every citation, grouped once. A deliberate BULK api, optimised as one -- which is precisely why #1441's per-subject query standing on it was a defect rather than a slow path."
+    },
+    "subject_summary": {
+      "class": "bounded",
+      "why": "One (kind, subject) row."
+    },
+    "subject_summary_generation": {
+      "class": "operational",
+      "why": "Checkpoint metadata."
+    },
+    "subject_summary_state_digest": {
+      "class": "operational",
+      "why": "Checkpoint metadata."
+    },
+    "subject_summary_with_coverage": {
+      "class": "bounded",
+      "why": "One subject, both sources SQL-narrowed. The bounded replacement #1441's review produced."
+    },
+    "summaries": {
+      "class": "unbounded",
+      "why": "Every degraded-summary citation in the store."
+    },
+    "verify_chain": {
+      "class": "operational",
+      "why": "The audit walk. WM_SCOPE names it explicitly as a legitimate reader below the engine."
+    }
   },
   "read_snapshot": {
-   "class": "operational",
-   "why": "Returns a HANDLE, reading nothing. The rows come from `ReadSnapshot`'s own methods, which are classified separately below -- a snapshot must not become a way to reach an unbounded read without being seen."
+    "current": {
+      "class": "bounded",
+      "why": "The snapshot-scoped `current`; same PRIMARY KEY bound."
+    },
+    "coordinate": {
+      "class": "operational",
+      "why": "Checkpoint metadata."
+    },
+    "identity_is_current": {
+      "class": "operational",
+      "why": "A boolean freshness probe."
+    },
+    "identity_view": {
+      "class": "unbounded",
+      "why": "The whole entity graph, snapshot-scoped. A snapshot bounds COHERENCE, not size."
+    },
+    "lineage_at_generation": {
+      "class": "bounded",
+      "why": "Takes a validated `LineagePage`; narrows to limit+1 in SQL."
+    },
+    "read_at_generation": {
+      "class": "unbounded",
+      "why": "The whole claims projection at a generation."
+    },
+    "read_composed_at_generation": {
+      "class": "unbounded",
+      "why": "Both projections at a generation."
+    },
+    "identity_view_for": {
+      "class": "bounded",
+      "why": "Box 3d. Loads only the entities reachable from the seed ids within MAX_REDIRECT_EDGES hops, so `ask` pays O(predicates x budget) instead of O(entities) to resolve the objects its own claims name. Snapshot-scoped so the identity half of a composed answer is observed at the same point as the claims half \u2014 a WorldStore-level bounded resolve would be a second connection and would reintroduce the between-walks incoherence 3c closed."
+    },
+    "read_composed_subject_at_generation": {
+      "class": "bounded",
+      "why": "Box 3d. Re-executes a recorded reference with the identity half bounded to the adjudications bearing on the objects that subject's claims name, cut at the pinned GENERATION rather than a transaction time. Still ONE composed read taken from this snapshot's transaction: splitting it into a bounded claims read plus a bounded identity read would bound the work and reintroduce the cross-read incoherence box 3h closed. The reproducibility refusal is delegated to read_at_generation, so one refusal still covers both halves."
+    }
   },
-  "rebuild_entity_projection": {
-   "class": "operational",
-   "why": "Projection rebuild."
-  },
-  "rebuild_projections": {
-   "class": "operational",
-   "why": "Projection rebuild."
-  },
-  "rebuild_subject_summary": {
-   "class": "operational",
-   "why": "Projection rebuild."
-  },
-  "resolve_at_whole_graph": {
-   "class": "unbounded",
-   "why": "RENAMED from `resolve_at` on box 3d. Its body is `self.identity_view_at(cut)?.resolve_at(id)` \u2014 it materialises the WHOLE equivalence graph and then indexes it, so the old name read as a point lookup and was classified `bounded` from its signature on the first pass. The name now says what it does. Renaming also removes a real ambiguity in the gate's name-based scan: `HistoricalIdentityView::resolve_at` is a pure in-memory call on an already-loaded view, and sharing a name with an unbounded store method made every use of it look like a violation. `resolve_bounded_at` is the bounded form."
-  },
-  "resolve_bounded": {
-   "class": "bounded",
-   "why": "Box 3d's identity primitive. Loads only the entities within MAX_REDIRECT_EDGES hops of the queried id and resolves over that subset, so the work is bounded by the traversal budget the resolver already enforces rather than by graph size. The resolution RULE is unchanged \u2014 the same `resolve` over a smaller view \u2014 which is what lets `bounded_resolution_agrees_with_whole_graph_resolution` assert the two are identical. Classified `bounded` and MEANT: the transitive check reads its body, so it stays honest."
-  },
-  "resolve_bounded_at": {
-   "class": "bounded",
-   "why": "Box 3d's bounded historical identity read. Discovers the adjudications affecting the queried id through the affected-entity reverse index, expands newly-named entities, and stops at the resolver's own MAX_REDIRECT_EDGES budget \u2014 so it folds the records bearing on one entity's identity rather than every adjudication in the log. The index supplies GENERATIONS only; every record is read from world_events and folded by the unchanged fold_adjudication, so the log remains the sole evidence."
-  },
-  "resolved_entities": {
-   "class": "unbounded",
-   "why": "Every summarised entity in the store."
-  },
-  "schema_version": {
-   "class": "operational",
-   "why": "PRAGMA read."
-  },
-  "subject_summaries": {
-   "class": "unbounded",
-   "why": "Every retained summary row."
-  },
-  "subject_summaries_for": {
-   "class": "bounded",
-   "why": "One subject's summaries across kinds -- SQL-narrowed, at most one row per kind."
-  },
-  "subject_summaries_with_coverage": {
-   "class": "unbounded",
-   "why": "Every summary AND every citation, grouped once. A deliberate BULK api, optimised as one -- which is precisely why #1441's per-subject query standing on it was a defect rather than a slow path."
-  },
-  "subject_summary": {
-   "class": "bounded",
-   "why": "One (kind, subject) row."
-  },
-  "subject_summary_generation": {
-   "class": "operational",
-   "why": "Checkpoint metadata."
-  },
-  "subject_summary_state_digest": {
-   "class": "operational",
-   "why": "Checkpoint metadata."
-  },
-  "subject_summary_with_coverage": {
-   "class": "bounded",
-   "why": "One subject, both sources SQL-narrowed. The bounded replacement #1441's review produced."
-  },
-  "summaries": {
-   "class": "unbounded",
-   "why": "Every degraded-summary citation in the store."
-  },
-  "verify_chain": {
-   "class": "operational",
-   "why": "The audit walk. WM_SCOPE names it explicitly as a legitimate reader below the engine."
+  "interactive_paths": {
+    "_comment": [
+      "Files whose functions are INTERACTIVE query paths -- reached by a caller",
+      "asking a domain question, so subject to the bounded-only rule.",
+      "",
+      "Everything else in the boundary crate is free to call unbounded methods:",
+      "a test, a rebuild helper or an operator tool legitimately reads the store",
+      "whole. The rule is about what sits on a request path."
+    ],
+    "crates/kirra-world-service/src/read_view.rs": "WorldView -- the four non-lineage query families",
+    "crates/kirra-world-service/src/lineage.rs": "LineageRef::resolve -- the lineage family",
+    "crates/kirra-world-service/src/answer_ref.rs": "AnswerRef::resolve -- re-execution of a recorded reference",
+    "crates/kirra-world-service/src/query.rs": "QueryEngine + the typed requests -- the ONE sanctioned entry point. Every request dispatches into the family implementations below it and adds no query logic of its own, so this file is on the request path by definition."
   }
- },
- "read_snapshot": {
-  "current": {
-   "class": "bounded",
-   "why": "The snapshot-scoped `current`; same PRIMARY KEY bound."
-  },
-  "coordinate": {
-   "class": "operational",
-   "why": "Checkpoint metadata."
-  },
-  "identity_is_current": {
-   "class": "operational",
-   "why": "A boolean freshness probe."
-  },
-  "identity_view": {
-   "class": "unbounded",
-   "why": "The whole entity graph, snapshot-scoped. A snapshot bounds COHERENCE, not size."
-  },
-  "lineage_at_generation": {
-   "class": "bounded",
-   "why": "Takes a validated `LineagePage`; narrows to limit+1 in SQL."
-  },
-  "read_at_generation": {
-   "class": "unbounded",
-   "why": "The whole claims projection at a generation."
-  },
-  "read_composed_at_generation": {
-   "class": "unbounded",
-   "why": "Both projections at a generation."
-  },
-  "identity_view_for": {
-   "class": "bounded",
-   "why": "Box 3d. Loads only the entities reachable from the seed ids within MAX_REDIRECT_EDGES hops, so `ask` pays O(predicates x budget) instead of O(entities) to resolve the objects its own claims name. Snapshot-scoped so the identity half of a composed answer is observed at the same point as the claims half \u2014 a WorldStore-level bounded resolve would be a second connection and would reintroduce the between-walks incoherence 3c closed."
-  },
-  "read_composed_subject_at_generation": {
-   "class": "bounded",
-   "why": "Box 3d. Re-executes a recorded reference with the identity half bounded to the adjudications bearing on the objects that subject's claims name, cut at the pinned GENERATION rather than a transaction time. Still ONE composed read taken from this snapshot's transaction: splitting it into a bounded claims read plus a bounded identity read would bound the work and reintroduce the cross-read incoherence box 3h closed. The reproducibility refusal is delegated to read_at_generation, so one refusal still covers both halves."
-  }
- },
- "interactive_paths": {
-  "_comment": [
-   "Files whose functions are INTERACTIVE query paths -- reached by a caller",
-   "asking a domain question, so subject to the bounded-only rule.",
-   "",
-   "Everything else in the boundary crate is free to call unbounded methods:",
-   "a test, a rebuild helper or an operator tool legitimately reads the store",
-   "whole. The rule is about what sits on a request path."
-  ],
-  "crates/kirra-world-service/src/read_view.rs": "WorldView -- the four non-lineage query families",
-  "crates/kirra-world-service/src/lineage.rs": "LineageRef::resolve -- the lineage family",
-  "crates/kirra-world-service/src/answer_ref.rs": "AnswerRef::resolve -- re-execution of a recorded reference",
-  "crates/kirra-world-service/src/query.rs": "QueryEngine + the typed requests -- the ONE sanctioned entry point. Every request dispatches into the family implementations below it and adds no query logic of its own, so this file is on the request path by definition."
- }
 }

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -2043,6 +2043,86 @@ impl WorldStore {
     /// Bounded in three dimensions — depth, node count, and citations per node —
     /// which is why `spec` is a validated type rather than a pair of numbers.
     ///
+    /// **The retained event at exactly `generation`, decoded — an EVIDENCE
+    /// lookup primitive, not a query family.**
+    ///
+    /// Tier 4 box 4c. `explain::ClaimLabels` is generation-addressed
+    /// (`claim_label(generation)`, `evidence(generation)`), and until this
+    /// existed there was nothing public to implement it against: every route to
+    /// a [`ProjectedClaim`] is subject-scoped ([`Self::current`],
+    /// [`Self::candidates`]) or whole-world-current ([`Self::current_all`]), and
+    /// [`Self::read_at_generation`] hands back a projection whose rows are
+    /// private and reachable only per-subject.
+    ///
+    /// # Why the missing primitive was a TRUTH problem, not an ergonomics one
+    ///
+    /// A provenance walk follows citations into whatever events carry the cited
+    /// observations, and those routinely belong to OTHER subjects. So a
+    /// `ClaimLabels` built on a subject-scoped map would return `None` for every
+    /// cross-subject node — and `explain::project_explanation` DEFINES `None` as
+    /// *"the event is gone"*, rendering `DELETED_CLAIM_LABEL`. The artifact would
+    /// have stated that evidence was deleted when it was sitting in the log,
+    /// and every gate would still have been green, because nothing checks
+    /// whether a label is true. This method exists so `None` can mean what the
+    /// projection already says it means.
+    ///
+    /// # The contract, stated precisely because the three cases differ
+    ///
+    /// - `Some(claim)` — an event IS retained at exactly this generation and
+    ///   decoded successfully.
+    /// - `None` — that generation is genuinely absent from retained evidence:
+    ///   never written, or compacted away. There is **no fallback** to current
+    ///   state, no nearest-neighbour, and no inference beyond the exact
+    ///   coordinate. An absent generation is absent.
+    /// - `Err` — a row is there and cannot be trusted. A corrupt trust axis
+    ///   fails closed via [`claim_axes_from_row`] rather than degrading to an
+    ///   unlabelled claim, for the same reason it does on every other read path:
+    ///   dropping it would turn *"something is wrong"* into *"no trust
+    ///   recorded"*.
+    ///
+    /// # NOT a domain query
+    ///
+    /// No subject filter, no predicate, no time argument, no ordering, no page.
+    /// It takes a coordinate the caller already holds — from a provenance node —
+    /// and hands back the one row at it. It cannot be used to ASK anything: you
+    /// cannot reach a generation with it that you did not already have. That is
+    /// deliberate, so it does not become a way around the typed engine and the
+    /// Tier 3 answer boundary; a consumer wanting to know something about a
+    /// subject still goes through `QueryEngine`.
+    ///
+    /// # Known gap, recorded rather than hidden
+    ///
+    /// `claim_status` is deliberately NOT filtered, so a retained CANDIDATE
+    /// event (ADR-0040: what an LLM may write) is returned like any other. That
+    /// is the honest choice — filtering to `confirmed` would make a retained
+    /// candidate indistinguishable from a deleted one, reintroducing the exact
+    /// lie this method exists to prevent. But [`ProjectedClaim`] carries no
+    /// status field, so a caller that must distinguish proposed evidence from
+    /// confirmed evidence cannot do it from this return value alone. A renderer
+    /// that would present the two differently must establish the difference
+    /// another way.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::Sqlite`] if the store cannot be read, or a conversion
+    /// failure if the retained row does not decode.
+    pub fn claim_at_generation(
+        &self,
+        generation: i64,
+    ) -> Result<Option<ProjectedClaim>, StoreError> {
+        let mut stmt = self.conn.prepare(&format!(
+            "SELECT {CLAIM_COLUMNS} FROM world_events WHERE generation = ?1"
+        ))?;
+        // `query_row` + QueryReturnedNoRows is the point-read idiom here: the
+        // generation is the PRIMARY KEY, so there is at most one row and no
+        // ordering to state.
+        match stmt.query_row(params![generation], claim_from_row) {
+            Ok(claim) => Ok(Some(claim)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
     /// # Errors
     ///
     /// [`StoreError::ProvenanceIndexIncomplete`] when the root is at or below
@@ -3015,6 +3095,9 @@ impl WorldStore {
             // without it must break the chain, which is what proves the column
             // cannot be stored-but-unhashed.
             "subject_kind",
+            // 4c. So the axis CHECK's refusal of a PARTIAL set is asserted at
+            // the storage layer, not the allowlist. tests/claim_at_generation.rs.
+            "origin",
         ];
         if !TAMPERABLE.contains(&column) {
             return Err(StoreError::CorruptRow {

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -2031,18 +2031,6 @@ impl WorldStore {
         Ok(provenance_edges::CitationPage { edges, truncated })
     }
 
-    /// **Explain one event's provenance at a historical coordinate** — Tier 4
-    /// box 4b.
-    ///
-    /// Walks the citation index from `root_generation`, resolving each cited
-    /// observation id against the events visible **at `at_generation`** into
-    /// [`provenance_graph::CitationResolution`]. Two pins over the same root are
-    /// two different and equally correct trees; that is the property the whole
-    /// box exists to have, and the reason resolution is not a stored column.
-    ///
-    /// Bounded in three dimensions — depth, node count, and citations per node —
-    /// which is why `spec` is a validated type rather than a pair of numbers.
-    ///
     /// **The retained event at exactly `generation`, decoded — an EVIDENCE
     /// lookup primitive, not a query family.**
     ///
@@ -2075,7 +2063,7 @@ impl WorldStore {
     ///   state, no nearest-neighbour, and no inference beyond the exact
     ///   coordinate. An absent generation is absent.
     /// - `Err` — a row is there and cannot be trusted. A corrupt trust axis
-    ///   fails closed via [`claim_axes_from_row`] rather than degrading to an
+    ///   fails closed in the shared claim decoder rather than degrading to an
     ///   unlabelled claim, for the same reason it does on every other read path:
     ///   dropping it would turn *"something is wrong"* into *"no trust
     ///   recorded"*.
@@ -2123,6 +2111,18 @@ impl WorldStore {
         }
     }
 
+    /// **Explain one event's provenance at a historical coordinate** — Tier 4
+    /// box 4b.
+    ///
+    /// Walks the citation index from `root_generation`, resolving each cited
+    /// observation id against the events visible **at `at_generation`** into
+    /// [`provenance_graph::CitationResolution`]. Two pins over the same root are
+    /// two different and equally correct trees; that is the property the whole
+    /// box exists to have, and the reason resolution is not a stored column.
+    ///
+    /// Bounded in three dimensions — depth, node count, and citations per node —
+    /// which is why `spec` is a validated type rather than a pair of numbers.
+    ///
     /// # Errors
     ///
     /// [`StoreError::ProvenanceIndexIncomplete`] when the root is at or below

--- a/crates/kirra-world-store/tests/claim_at_generation.rs
+++ b/crates/kirra-world-store/tests/claim_at_generation.rs
@@ -1,0 +1,312 @@
+//! **Tier 4 box 4c — the generation-addressed evidence lookup.**
+//!
+//! `explain::ClaimLabels` is generation-addressed, and nothing public could
+//! implement it: every route to a `ProjectedClaim` is subject-scoped or
+//! whole-world-current, and `read_at_generation` returns a projection whose
+//! rows are private and reachable only per-subject.
+//!
+//! # The missing primitive was a TRUTH problem
+//!
+//! A provenance walk follows citations into whatever events carry the cited
+//! observations, and those routinely belong to OTHER subjects. A `ClaimLabels`
+//! built on a subject-scoped map would return `None` for every cross-subject
+//! node — and `project_explanation` DEFINES `None` as *"the event is gone"*,
+//! rendering `DELETED_CLAIM_LABEL`. The artifact would have said evidence was
+//! deleted while it sat in the log, and every gate would have stayed green,
+//! because nothing checks whether a label is true.
+//!
+//! So the suite is organised around the three cases being genuinely distinct:
+//!
+//! | Case | Must be | Must never be |
+//! |---|---|---|
+//! | retained at that generation | `Some(claim)` | — |
+//! | genuinely absent | `None` | the current claim, or a neighbour |
+//! | present but undecodable | `Err` | `None` |
+//!
+//! The middle row is why there is a no-fallback test, and the bottom row is why
+//! `origin` was added to the tamper allowlist: without it, *"a malformed row
+//! errors rather than reading as absent"* was a claim with no test behind it.
+
+use kirra_world_store::{
+    provenance_graph::GraphSpec, ClaimStatus, EventId, NewEvent, ObservationId, StoreError,
+    WorldStore, WriterClass,
+};
+
+const T0: i64 = 1_700_000_000_000;
+
+fn tmp(name: &str) -> std::path::PathBuf {
+    static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let n = NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "kirra-claimgen-{name}-{}-{n}.sqlite",
+        std::process::id()
+    ));
+    clean(&p);
+    p
+}
+
+fn clean(p: &std::path::Path) {
+    for s in ["", "-wal", "-shm"] {
+        let mut q = p.as_os_str().to_os_string();
+        q.push(s);
+        let _ = std::fs::remove_file(std::path::PathBuf::from(q));
+    }
+}
+
+fn store(name: &str) -> (WorldStore, std::path::PathBuf) {
+    let p = tmp(name);
+    let s = WorldStore::open(&p).expect("open");
+    (s, p)
+}
+
+/// Append one claim about `subject`, citing `cited`.
+fn append_ev(s: &mut WorldStore, tag: &str, obs: &str, subject: &str, cited: &[&str]) -> i64 {
+    let event_id = EventId::new(format!("ev-{tag}")).expect("event id");
+    let observation_id = ObservationId::new(obs.to_string()).expect("obs id");
+    s.append(&NewEvent {
+        event_id: &event_id,
+        observation_id: &observation_id,
+        txn_time_ms: T0,
+        valid_from_ms: T0,
+        valid_to_ms: None,
+        source: "warehouse-scanner",
+        source_version: "1.0.0",
+        writer_class: WriterClass::Sensor,
+        claim_status: ClaimStatus::Confirmed,
+        provenance: cited,
+        frame_id: None,
+        map_id: None,
+        kind: "mission",
+        subject,
+        subject_ref: None,
+        predicate: Some("last_seen_at"),
+        object: Some("dock_a"),
+        payload: "{}",
+        payload_schema: 1,
+        retention_class: "raw",
+        trust: None,
+    })
+    .expect("append")
+}
+
+// ===========================================================================
+// The three cases, kept apart
+// ===========================================================================
+
+#[test]
+fn a_retained_generation_returns_that_exact_claim() {
+    let (mut s, p) = store("retained");
+    let g = append_ev(&mut s, "a", "obs-a", "package_17", &[]);
+
+    let got = s
+        .claim_at_generation(g)
+        .expect("read")
+        .expect("the event is retained, so this must be Some");
+
+    // The EXACT event, not merely something about the subject.
+    assert_eq!(got.generation, g);
+    assert_eq!(got.event_id, "ev-a");
+    assert_eq!(got.subject, "package_17");
+    assert_eq!(got.predicate.as_deref(), Some("last_seen_at"));
+    assert_eq!(got.object.as_deref(), Some("dock_a"));
+    assert_eq!(got.txn_time_ms, T0);
+    assert!(
+        !got.chain_digest.is_empty(),
+        "the provenance handle must survive the read — an evidence lookup that \
+         drops the citable digest cannot support an auditable explanation"
+    );
+    clean(&p);
+}
+
+#[test]
+fn a_generation_that_was_never_written_is_none() {
+    let (mut s, p) = store("never-written");
+    let g = append_ev(&mut s, "a", "obs-a", "package_17", &[]);
+
+    assert!(
+        s.claim_at_generation(g + 1).expect("read").is_none(),
+        "a generation past the head is absent, not an error and not a neighbour"
+    );
+    assert!(
+        s.claim_at_generation(9_999_999).expect("read").is_none(),
+        "a far-future generation is absent"
+    );
+    assert!(
+        s.claim_at_generation(0).expect("read").is_none(),
+        "generation 0 is not an event — the log is 1-based"
+    );
+    clean(&p);
+}
+
+#[test]
+fn another_subjects_generation_still_resolves() {
+    // The case that motivates the whole primitive: a subject-scoped map would
+    // return None here and the artifact would call this evidence deleted.
+    let (mut s, p) = store("cross-subject");
+    let a = append_ev(&mut s, "a", "obs-a", "package_17", &[]);
+    let b = append_ev(&mut s, "b", "obs-b", "dock_a", &[]);
+    let c = append_ev(&mut s, "c", "obs-c", "scanner_3", &[]);
+
+    for (g, subject) in [(a, "package_17"), (b, "dock_a"), (c, "scanner_3")] {
+        let got = s
+            .claim_at_generation(g)
+            .expect("read")
+            .unwrap_or_else(|| panic!("generation {g} is retained and must resolve"));
+        assert_eq!(
+            got.subject, subject,
+            "the lookup must not be scoped to any one subject"
+        );
+    }
+    clean(&p);
+}
+
+// ===========================================================================
+// No fallback — the property that separates "absent" from "answered anyway"
+// ===========================================================================
+
+#[test]
+fn a_compacted_generation_is_none_and_does_not_fall_back_to_a_neighbour() {
+    let (mut s, p) = store("compacted-no-fallback");
+    // THREE claims about the same subject, and the MIDDLE one is compacted.
+    //
+    // The middle matters. A two-event fixture with the OLDEST compacted cannot
+    // catch a `WHERE generation <= ?1 ORDER BY generation DESC LIMIT 1`
+    // fallback, because there is nothing below the hole for it to find — the
+    // test would pass against a mutant that silently answers with a neighbour.
+    // With a retained event on BOTH sides, every fallback direction has
+    // something plausible to return, so `None` is the only correct answer.
+    let older = append_ev(&mut s, "older", "obs-older", "package_17", &[]);
+    let gone = append_ev(&mut s, "gone", "obs-gone", "package_17", &[]);
+    let newer = append_ev(&mut s, "newer", "obs-newer", "package_17", &[]);
+
+    assert!(
+        s.claim_at_generation(gone).expect("read").is_some(),
+        "precondition: the middle generation is retained before compaction"
+    );
+
+    s.compact_range(gone, gone, T0 + 1).expect("compact");
+
+    let got = s.claim_at_generation(gone).expect("read");
+    assert!(
+        got.is_none(),
+        "a compacted generation must read as absent — got {got:?}, which means          the lookup answered with a neighbour or with current state"
+    );
+
+    // Both neighbours are untouched, which is what proves the None above is
+    // about that COORDINATE rather than about the subject.
+    for (g, tag) in [(older, "ev-older"), (newer, "ev-newer")] {
+        let still = s
+            .claim_at_generation(g)
+            .expect("read")
+            .unwrap_or_else(|| panic!("{tag} is retained and must still resolve"));
+        assert_eq!(still.event_id, tag);
+    }
+    clean(&p);
+}
+
+// ===========================================================================
+// Present but undecodable — Err, never None
+// ===========================================================================
+
+#[test]
+fn the_schema_refuses_to_create_the_corrupt_shape_at_all() {
+    // This test began as "a malformed row errors rather than reading as
+    // absent", because Err and None converging would turn *"something is
+    // wrong"* into *"this evidence was deleted"*. Trying to build such a row
+    // established something better: it cannot be built.
+    //
+    // The axis CHECK enforces that the three stored axes travel together
+    // (`(adjudication IS NULL) = (origin IS NULL)`), so a partial set is
+    // refused even by `tamper_for_test`, which bypasses the WRITE path but not
+    // the storage constraints. Enumerating the rest closes the case: every
+    // tamperable column the decoder reads is either NOT NULL — so it cannot be
+    // cleared — or already `Option`, so a NULL decodes cleanly to `None`.
+    //
+    // So `claim_at_generation` has no reachable Err-on-decode path through the
+    // supported surface, and the decoder's refusal arms are defence in depth
+    // against a row edited outside SQLite. That is worth PINNING rather than
+    // leaving as an assumption: if a later migration relaxes the CHECK, this
+    // test fails and says so, instead of the Err arm quietly becoming
+    // reachable with nothing exercising it.
+    let (mut s, p) = store("schema-refuses");
+    let g = append_ev(&mut s, "a", "obs-a", "package_17", &[]);
+
+    // `observed` is a VALID origin token — the schema's vocabulary CHECK admits
+    // it — so what is being refused here is the COMBINATION, not the value.
+    let refused = s.tamper_for_test(g, "origin", Some("observed"));
+    let err = refused.expect_err(
+        "a partial axis set was accepted — the axes no longer travel together,          and claim_at_generation's Err-on-decode arm is now reachable with no          test exercising it",
+    );
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("CHECK constraint failed"),
+        "the refusal must come from the SCHEMA, not from the tamper allowlist          or the writer — those would be weaker guarantees. Got: {msg}"
+    );
+
+    // And the row is untouched, so the lookup still reads it: a refused edit
+    // must not leave the evidence half-written.
+    let still = s
+        .claim_at_generation(g)
+        .expect("read")
+        .expect("the event is still retained after the refused tamper");
+    assert_eq!(still.event_id, "ev-a");
+    assert!(
+        still.trust.is_none(),
+        "the refused edit must not have landed a partial axis set"
+    );
+    clean(&p);
+}
+
+// ===========================================================================
+// The 3a fit: every node of a real cross-subject provenance tree resolves
+// ===========================================================================
+
+#[test]
+fn every_node_of_a_cross_subject_provenance_tree_resolves() {
+    // This is the test that says the primitive is the right SHAPE, not merely
+    // that it works: it walks a real tree and demands the lookup answer for
+    // every node the walk produced. A primitive that answered for the root's
+    // subject only would pass all the tests above and fail this one.
+    let (mut s, p) = store("tree-fit");
+    let leaf = append_ev(&mut s, "leaf", "obs-leaf", "scanner_3", &[]);
+    let mid = append_ev(&mut s, "mid", "obs-mid", "dock_a", &["obs-leaf"]);
+    let root = append_ev(&mut s, "root", "obs-root", "package_17", &["obs-mid"]);
+
+    let tree = s
+        .provenance_tree(root, root, GraphSpec::widest())
+        .expect("provenance tree");
+
+    assert!(
+        tree.nodes.len() >= 3,
+        "fixture must actually produce a multi-node tree, got {} node(s) — a \
+         one-node tree would make the assertion below vacuous",
+        tree.nodes.len()
+    );
+
+    let subjects: std::collections::BTreeSet<String> = tree
+        .nodes
+        .iter()
+        .map(|n| {
+            s.claim_at_generation(n.generation)
+                .expect("read")
+                .unwrap_or_else(|| {
+                    panic!(
+                        "node at generation {} did not resolve — project_explanation \
+                         would render this as DELETED_CLAIM_LABEL",
+                        n.generation
+                    )
+                })
+                .subject
+        })
+        .collect();
+
+    assert!(
+        subjects.len() >= 2,
+        "the tree must span more than one subject or it does not exercise the \
+         cross-subject case at all; spanned {subjects:?}"
+    );
+    assert_eq!(leaf, tree.nodes.iter().map(|n| n.generation).min().unwrap());
+    assert!(mid > leaf && root > mid);
+    clean(&p);
+}


### PR DESCRIPTION
Prerequisite for Tier 4 box 3a (the store-backed `ClaimLabels`), split out because it is a **store** change and 3a is an explanation change — one trust boundary per diff.

## The gap was a truth problem, not an ergonomic one

`explain::ClaimLabels` is generation-addressed — `claim_label(generation)`, `evidence(generation)` — and nothing public could implement it. Every route to a `ProjectedClaim` is subject-scoped (`current`, `candidates`) or whole-world-current (`current_all`), and `read_at_generation` returns a projection whose `rows` are private and reachable only per-subject.

A provenance walk follows citations into whatever events carry the cited observations, and **those routinely belong to other subjects.** So a `ClaimLabels` built on a subject-scoped map would return `None` for every cross-subject node — and `project_explanation` defines `None` as *"the event is gone"*:

```rust
None => DisplayLabel::new(match node.citations {
    NodeCitations::BelowCoverageFloor => UNINDEXED_CLAIM_LABEL,
    _ => DELETED_CLAIM_LABEL,
}),
```

The artifact would have stated that evidence was deleted while it sat in the log — and every gate would have stayed green, because nothing checks whether a label is true. This method exists so `None` can mean what the projection already says it means.

## The contract

| Case | Result |
|---|---|
| an event is retained at exactly this generation and decodes | `Some(claim)` |
| the generation is genuinely absent — never written, or compacted | `None`, with **no** fallback to current state, no nearest neighbour, no inference beyond the coordinate |
| a row is there and cannot be trusted | `Err` |

**An evidence lookup primitive, not a query family.** No subject, predicate, time, ordering or page. It takes a coordinate the caller already holds from a provenance node and returns the row at it, so it cannot be used to *ask* anything — you cannot reach a generation you did not already have. Classified `bounded` in `store_boundedness_baseline.json` (point read on the PRIMARY KEY) with that reasoning recorded, so it does not become a route around the typed engine.

`claim_status` is deliberately **not** filtered: filtering to `confirmed` would make a retained candidate (ADR-0040) indistinguishable from a deleted one, reintroducing the exact lie. `ProjectedClaim` carries no status field, so that limitation is recorded in the doc rather than hidden.

## Two findings worth the review

**The "malformed row errors rather than reading as absent" case is unreachable, and the attempt is what established that.** The axis CHECK enforces `(adjudication IS NULL) = (origin IS NULL)`, so `tamper_for_test` — which bypasses the write path but not storage constraints — cannot build a partial axis set. Enumerating the rest closes it: every tamperable column the decoder reads is either `NOT NULL` (cannot be cleared) or already `Option` (a NULL decodes cleanly).

So the test now pins the guarantee that **does** exist — the schema refuses the corrupt shape — and records why the decoder's `Err` arms are defence in depth. If a migration relaxes that CHECK, this test fails and says so, rather than the `Err` arm quietly becoming reachable with nothing exercising it. `origin` joins the tamper allowlist so the refusal is asserted at the *storage* layer; off the allowlist the attempt fails on the allowlist and proves nothing about the schema.

**The compaction fixture I first wrote could not catch a fallback.** It compacted the oldest of two events — so a `WHERE generation <= ?1 ORDER BY generation DESC LIMIT 1` mutant finds nothing below the hole and returns `None` anyway. Rebuilt with three events and the hole in the **middle**, so every fallback direction has something plausible to return and `None` is the only correct answer.

## Mutation-verified, each checked twice

Once that the edit landed, once that a *named* control observed it:

| Mutation | Observed by |
|---|---|
| nearest-neighbour fallback (`generation <= ?1 ORDER BY … DESC`) | 2 tests fail |
| lookup scoped to one subject | the 2 cross-subject tests fail |
| **fallback mutant + the original weak fixture** | **survives** — the evidence that the fixture change was load-bearing, not cosmetic |

## Tests

`existing generation → exact claim` · `never-written / far-future / zero → None` · `another subject's generation still resolves` · `compacted middle → None, neighbours untouched` · `schema refuses the corrupt shape` · `every node of a real cross-subject provenance tree resolves` (with a guard that the fixture actually spans ≥2 subjects, so the assertion cannot go vacuous).

## Verification

26 `kirra-world-store` suites green · `check_query_boundedness` (which caught the unclassified method unprompted) · `check_world_answer_boundary` · `check_world_domain_logic_gate` · `check_world_semantics` · `check_kirra_world_bidirectional_fence` · `check_explain_artifact_neutral` · `cargo fmt --check`.

One incidental: `sd1_valid_to_ms_is_set_at_insert_or_never` caught the allowlist comment pushing the test-only `cfg` gate 42 lines from its `UPDATE`, over the 40-line bound. Comment trimmed rather than the bound touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_