### PR TITLE
Orphan-gate consumer-attribution audit — the fallout report (measurement only, no gate change)

### DIFF
--- a/ci/audit_orphan_gate.py
+++ b/ci/audit_orphan_gate.py
@@ -57,7 +57,7 @@ def crate_manifests() -> dict[str, Path]:
             + list(REPO.glob("crates/*/Cargo.toml")) + list(REPO.glob("parko/crates/*/Cargo.toml")) \
             + list(REPO.glob("parko/Cargo.toml")):
         try:
-            data = tomllib.loads(man.read_text())
+            data = tomllib.loads(man.read_text(encoding="utf-8"))
         except Exception:
             continue
         name = data.get("package", {}).get("name")
@@ -70,7 +70,7 @@ def dep_edges(crate_dir: Path) -> set[str]:
     """Direct dependency lib-idents declared by this crate (all tables)."""
     man = crate_dir / "Cargo.toml"
     try:
-        data = tomllib.loads(man.read_text())
+        data = tomllib.loads(man.read_text(encoding="utf-8"))
     except Exception:
         return set()
     names: set[str] = set()
@@ -231,7 +231,7 @@ def main() -> int:
             "evidence": hits[:12],
         })
     out = Path(os.environ.get("ORPHAN_AUDIT_OUT", "/tmp/orphan_audit.json"))
-    out.write_text(json.dumps(report, indent=1))
+    out.write_text(json.dumps(report, indent=1), encoding="utf-8")
 
     total = len(report)
     consumed = [r for r in report if r["consumed_by_gate"]]

--- a/ci/audit_orphan_gate.py
+++ b/ci/audit_orphan_gate.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""MEASUREMENT ONLY — the orphan gate's consumer-attribution blind spot.
+
+    NOT A GATE. Nothing invokes this from CI, and it changes nothing about what
+    CI rejects. It exists so the fallout of a STRONGER consumer test can be read
+    off the tree before that test is written, per the tier-order rule: measure
+    and disposition first, tighten second, so `main` never meets a red wall
+    nobody has classified.
+
+    Run: python3 ci/audit_orphan_gate.py
+    Report: docs/design/ORPHAN_GATE_FALLOUT.md
+
+
+Changes NOTHING about what CI rejects. It replicates `check_orphan_cores.is_consumed`
+exactly, but RECORDS the evidence instead of short-circuiting on the first hit, then
+asks one question the gate never asks:
+
+    could the crediting file possibly name this module at all?
+
+A reference in crate B can only consume crate A's module if B depends on A (or B IS A).
+Where no such dependency edge exists, the credit is PROVABLY FALSE — not a judgement
+call, a fact about the Cargo graph.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import tomllib
+from collections import defaultdict
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+CI = Path(__file__).resolve().parent
+sys.path.insert(0, str(CI))
+import check_orphan_cores as G  # noqa: E402
+
+REPO = G.REPO
+
+
+# ---------------------------------------------------------------------------
+# The Cargo graph: which crates can name which
+# ---------------------------------------------------------------------------
+def crate_manifests() -> dict[str, Path]:
+    """package-ident -> crate directory, for EVERY crate, lib or bin-only.
+
+    Keying off `lib.rs` was wrong and the audit caught itself doing it:
+    `kirra-wcet-bench` is bin-only, so its files fell through longest-prefix
+    matching to the repo-root crate and its perfectly ordinary
+    `kirra_timing::evt::estimate_pwcet(..)` call was reported as unattributable.
+    A measurement instrument that mis-attributes is worth less than no
+    instrument, so ownership is read from manifests, not from lib targets.
+    """
+    out: dict[str, Path] = {}
+    for man in list(REPO.glob("Cargo.toml")) + list(REPO.glob("*/Cargo.toml")) \
+            + list(REPO.glob("crates/*/Cargo.toml")) + list(REPO.glob("parko/crates/*/Cargo.toml")) \
+            + list(REPO.glob("parko/Cargo.toml")):
+        try:
+            data = tomllib.loads(man.read_text())
+        except Exception:
+            continue
+        name = data.get("package", {}).get("name")
+        if name:
+            out[name.replace("-", "_")] = man.parent
+    return out
+
+
+def dep_edges(crate_dir: Path) -> set[str]:
+    """Direct dependency lib-idents declared by this crate (all tables)."""
+    man = crate_dir / "Cargo.toml"
+    try:
+        data = tomllib.loads(man.read_text())
+    except Exception:
+        return set()
+    names: set[str] = set()
+    tables = ["dependencies", "dev-dependencies", "build-dependencies"]
+    for t in tables:
+        names |= set(data.get(t, {}).keys())
+    for target in data.get("target", {}).values():
+        for t in tables:
+            names |= set(target.get(t, {}).keys())
+    return {n.replace("-", "_") for n in names}
+
+
+def reachable(crates: dict[str, Path]) -> dict[str, set[str]]:
+    """crate -> every crate it can name (transitive closure, incl. itself)."""
+    direct = {c: dep_edges(d) & set(crates) for c, d in crates.items()}
+    out: dict[str, set[str]] = {}
+    for c in crates:
+        seen, stack = {c}, [c]
+        while stack:
+            cur = stack.pop()
+            for nxt in direct.get(cur, set()):
+                if nxt not in seen:
+                    seen.add(nxt)
+                    stack.append(nxt)
+        out[c] = seen
+    return out
+
+
+def owning_crate(path: Path, crates: dict[str, Path]) -> str | None:
+    """Which crate a consumer file belongs to (longest matching dir)."""
+    best, best_len = None, -1
+    for name, d in crates.items():
+        s = str(d.resolve())
+        if str(path).startswith(s + "/") and len(s) > best_len:
+            best, best_len = name, len(s)
+    return best
+
+
+# ---------------------------------------------------------------------------
+# Evidence collection — the gate's own rules, recorded rather than short-circuited
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# Multi-line `pub use` blocks — the continuation lines the gate's skip misses
+# ---------------------------------------------------------------------------
+_USE_START = re.compile(r"^\s*(pub\s+)?use\b")
+
+
+def statement_spans(lines: list[str]) -> dict[int, str]:
+    """1-indexed line -> "pub-use" | "use", for lines INSIDE a use statement.
+
+    `REEXPORT_RE` is line-anchored, so it skips `pub use backend_selector::{`
+    and then credits the item names rustfmt wrapped onto the next two lines.
+    A re-export is a re-export however it is formatted, so the whole statement
+    has to be attributed, not just its first line.
+
+    A plain `use` continuation is kept distinct: importing IS consumption, and
+    only the `pub` form is the shelf.
+    """
+    spans: dict[int, str] = {}
+    i, n = 0, len(lines)
+    while i < n:
+        m = _USE_START.match(lines[i])
+        if not m:
+            i += 1
+            continue
+        kind = "pub-use" if m.group(1) else "use"
+        depth = 0
+        j = i
+        while j < n:
+            depth += lines[j].count("{") - lines[j].count("}")
+            spans[j + 1] = kind
+            if ";" in lines[j] and depth <= 0:
+                break
+            j += 1
+        i = j + 1
+    return spans
+
+
+def evidence_for(crate, mod_name, lib_rs, files, ambiguous):
+    own = {p.resolve() for p in G.module_own_paths(lib_rs, mod_name)}
+    use_re = re.compile(rf"^\s*(?:pub\s+)?use\s+[\w:{{}}, ]*\b{mod_name}\b")
+    path_re = re.compile(rf"\b{mod_name}::")
+    qualified_re = re.compile(rf"\b{crate}::{mod_name}\b")
+    items = G.module_pub_items(lib_rs, mod_name) - (ambiguous or set())
+    item_re = G.code_reference_re(items)
+    hits = []
+    for f in files:
+        if f in own:
+            continue
+        flines = G.stripped_lines(f)
+        spans = statement_spans(flines)
+        for n, line in enumerate(flines, start=1):
+            if G.REEXPORT_RE.match(line):
+                continue
+            rule = None
+            if qualified_re.search(line):
+                rule = "qualified"          # crate::mod — unambiguous
+            elif path_re.search(line):
+                rule = "path"              # bare mod:: — NOT crate-scoped
+            elif use_re.match(line):
+                rule = "use"
+            elif item_re:
+                for m in item_re.finditer(line):
+                    if G.is_code_shaped(line, m.start(1), m.end(1)):
+                        rule = "item"
+                        break
+            if rule:
+                hits.append({"file": str(f.relative_to(REPO)), "line": n,
+                             "rule": rule, "text": line.strip()[:160],
+                             "in_stmt": spans.get(n, "")})
+    return hits
+
+
+def main() -> int:
+    mods = G.declared_pub_mods()
+    files = G.consumer_files()
+    ambiguous = G.ambiguous_item_names(mods)
+    crates = crate_manifests()
+    reach = reachable(crates)
+
+    report = []
+    for crate, mod_name, lib_rs in mods:
+        hits = evidence_for(crate, mod_name, lib_rs, files, ambiguous)
+        for h in hits:
+            consumer = owning_crate((REPO / h["file"]).resolve(), crates)
+            h["consumer_crate"] = consumer
+            if consumer == crate:
+                h["attribution"] = "same-crate"
+            elif consumer is None:
+                h["attribution"] = "unknown-crate"
+            elif crate in reach.get(consumer, set()):
+                h["attribution"] = "cross-crate-with-dep"
+            else:
+                h["attribution"] = "PROVABLY-FALSE"
+        attribs = {h["attribution"] for h in hits}
+        # Computed over the FULL hit list, never the capped sample written to
+        # JSON. A first pass recomputed these from `evidence[:12]` and reported
+        # 9 exposures where there are 3 — a module with 200 hits whose first 12
+        # happen to be refuted looks exposed while hits 13+ are fine. Recorded
+        # because it is the same defect class this audit exists to find: a
+        # measurement that reads a truncated sample as the whole population.
+        real = [h for h in hits
+                if h["in_stmt"] != "pub-use" and h["attribution"] != "PROVABLY-FALSE"]
+        real_a = [h for h in hits if h["attribution"] != "PROVABLY-FALSE"]
+        real_b = [h for h in hits if h["in_stmt"] != "pub-use"]
+        report.append({
+            "module": f"{crate}::{mod_name}",
+            "crate": crate,
+            "consumed_by_gate": bool(hits),
+            "n_evidence": len(hits),
+            "attributions": sorted(attribs),
+            "only_false": bool(hits) and attribs == {"PROVABLY-FALSE"},
+            "n_real": len(real),
+            "hidden_orphan": bool(hits) and not real,
+            "exposed_by_rule_a_only": bool(hits) and not real_a,
+            "exposed_by_rule_b_only": bool(hits) and not real_b,
+            "evidence": hits[:12],
+        })
+    out = Path(os.environ.get("ORPHAN_AUDIT_OUT", "/tmp/orphan_audit.json"))
+    out.write_text(json.dumps(report, indent=1))
+
+    total = len(report)
+    consumed = [r for r in report if r["consumed_by_gate"]]
+    orphans = [r for r in report if not r["consumed_by_gate"]]
+    only_false = [r for r in consumed if r["only_false"]]
+    print(f"modules scanned            {total}")
+    print(f"  credited as consumed     {len(consumed)}")
+    print(f"  reported orphan today    {len(orphans)}")
+    hidden = [r for r in consumed if r["hidden_orphan"]]
+    print(f"  credited ONLY by evidence the Cargo graph refutes: {len(only_false)}")
+    for r in only_false:
+        print(f"    - {r['module']}  ({r['n_evidence']} hits)")
+    print(f"\n  HIDDEN ORPHANS — no surviving evidence once refuted credit and")
+    print(f"  `pub use` continuation lines are removed:            {len(hidden)}")
+    for r in hidden:
+        why = sorted({h["in_stmt"] or h["attribution"] for h in r["evidence"]})
+        print(f"    - {r['module']:48} {r['n_evidence']:3} hits  {why}")
+    by_rule = defaultdict(int)
+    by_attr = defaultdict(int)
+    for r in consumed:
+        for h in r["evidence"]:
+            by_rule[h["rule"]] += 1
+            by_attr[h["attribution"]] += 1
+    a_only = [r["module"] for r in consumed if r["exposed_by_rule_a_only"]]
+    b_only = [r["module"] for r in consumed if r["exposed_by_rule_b_only"]]
+    print(f"\n  rule A alone (crate attribution) exposes {len(a_only)}: {a_only}")
+    print(f"  rule B alone (whole `pub use` stmt) exposes {len(b_only)}: {b_only}")
+    print("\nevidence by rule (first 12/module):", dict(by_rule))
+    print("evidence by attribution:          ", dict(by_attr))
+    print(f"\nfull report: {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/design/ORPHAN_GATE_FALLOUT.md
+++ b/docs/design/ORPHAN_GATE_FALLOUT.md
@@ -1,0 +1,175 @@
+# Orphan-gate consumer-attribution audit — the fallout report
+
+**Status: MEASUREMENT ONLY. No gate behaviour changes in this document or the
+commit that adds it.**
+
+`ci/check_orphan_cores.py` is the wire-or-delete guard: a `pub mod` at a crate
+root must gain a non-test consumer, or be listed in
+`ci/orphan_cores_baseline.json` with a justification. It decides *consumed* by
+matching identifiers in consumer sources.
+
+Tier 4 produced a concrete instance of that detector crediting a module on
+evidence that does not establish a consumer path. This audit measures how far
+that reaches **before** anything about CI changes, per the tier-order rule the
+boundedness gate established: measure, classify, disposition — then tighten.
+
+Instrument: `ci/audit_orphan_gate.py` (not run by CI, changes no verdict). It
+replays `is_consumed`'s own rules but records every hit instead of
+short-circuiting on the first, then asks a question the gate never asks.
+
+---
+
+## The question the gate never asks
+
+> Could the crediting file **possibly name this module at all?**
+
+A reference in crate B can only consume crate A's module if B depends on A, or B
+*is* A. The gate's `path` rule is `\b{mod_name}::` — not scoped to a crate — so
+`state::foo` anywhere in the workspace credits every root module named `state`.
+Where no dependency edge exists, the credit is not a judgement call. It is
+refuted by the Cargo graph.
+
+## Counts
+
+| | |
+|---|---|
+| root `pub mod`s scanned | **258** |
+| credited as consumed today | 239 |
+| reported orphan today (all baselined; gate is green) | 19 |
+| **hidden orphans — credited, but no evidence survives attribution** | **3** |
+| modules retaining valid evidence after both candidate rules | 236 |
+
+Evidence lines by attribution: `same-crate` 1184 · `cross-crate-with-dep` 814 ·
+**`PROVABLY-FALSE` 159**. The 159 refuted lines are concentrated: most modules
+carrying some refuted credit also carry valid credit, so only 3 modules rest on
+refuted evidence alone.
+
+**The fallout is 3 modules. There is no red wall.**
+
+---
+
+## Three blind-spot classes, one representative case each
+
+### A — the `path` and `item` rules are not crate-scoped
+
+**`parko_ros2::pointcloud2_shim`** — 680 lines, a ROS `PointCloud2` decoder. Its
+only reference outside its own file is `pub mod pointcloud2_shim;` in `lib.rs`.
+It is credited because it exports a constant `INT8`, and `parko-core` writes
+`PrecisionMode::INT8` — a variant of an unrelated enum, in a crate that does not
+depend on `parko-ros2` at all.
+
+The existing `ambiguous_item_names` guard cannot see this: it discounts names
+exported by two *scanned modules*, and `PrecisionMode::INT8` is an enum variant,
+not a root-module free item. This is the same shape as the
+`entity_projection`/`fold_all` bug already recorded in the gate's docstring —
+the guard was not weak in general, only blind to a name it could not attribute.
+
+**`kirra_planner::lanemap`** — same class, different collision. Two crates own a
+module called `lanemap`; `kirra-map`'s own `use crate::lanemap::{…}` credits
+`kirra-planner`'s.
+
+### B — a single-line re-export skip does not skip a wrapped re-export
+
+**`parko_core::backend_selector`** — credited by exactly two lines, both inside
+its own crate's `lib.rs`:
+
+```rust
+pub use backend_selector::{
+    backend_permitted, current_platform, descriptor_from_env_str, register_backend_factory,
+    BackendFactory, BackendSelector, TargetPlatform, KIRRA_BACKEND_ENV,
+};
+```
+
+`REEXPORT_RE` is line-anchored. It skips line 1 and then credits the item names
+`rustfmt` wrapped onto lines 2–3. A re-export is a re-export however it is
+formatted — this is precisely the "shelf with a label" the gate says it
+excludes, admitted through its own front door.
+
+Confirmed unwired: zero non-comment references to any of its eight exported
+items anywhere in the repository.
+
+### C — textual reachability is not integration (observed, not yet measured)
+
+During Tier 4 box 3b, replacing `render_explanation(explanation)` with a
+hardcoded string left the orphan gate **green**: the `use crate::explain_render::{
+render_explanation, Narration};` line still referenced the module, and `Narration`
+was still genuinely used. The module was consumed; its *core* was dead.
+
+This axis is **not measured here** and the report does not claim otherwise.
+Measuring it needs per-ITEM liveness, not per-module — a materially bigger
+instrument, and arguably a different gate. Recorded so it is not mistaken for
+something this audit covered.
+
+---
+
+## Disposition of every exposed candidate
+
+| Module | Bucket | Disposition |
+|---|---|---|
+| `parko_ros2::pointcloud2_shim` | **genuinely orphaned** | Baseline it. Its three siblings — `image_shim`, `odometry_shim`, `radar_shim` — are *already* baselined with the identical justification (awaiting the sensor integration, external track MGA G-4). It escaped only via the `INT8` collision. |
+| `parko_core::backend_selector` | **genuinely orphaned** | Baseline it. The backend registry awaits a backend crate calling `register_backend_factory`; none does. Same family as the already-baselined `parko_core::detector`. Heals when a backend registers. |
+| `kirra_planner::lanemap` | **intentionally standalone** | A 6-line back-compat re-export shim (`pub use kirra_map::lanemap::*;`, de-monolith Stage 6b). Author's call: baseline as an intentional shim, or delete. Note its stated purpose — keeping `crate::lanemap::*` paths working inside `kirra-planner` — is not currently exercised by any file. |
+| — | **false positive** | None. No currently-credited module was found to be wrongly *reported*; the errors all run the other way, toward hiding orphans. |
+| — | **consumed, detected only textually** | Not measurable by this instrument — see class C. |
+
+The 19 modules the gate reports as orphans today are all baselined with
+justifications and were re-confirmed to carry zero evidence. No change.
+
+### A cross-gate scope gap, noticed in passing
+
+`ci/check_reexport_shims.py` enforces `max_shims: 0` — zero tolerance for
+`pub use <crate>::…` re-export shim modules — but `SRC_ROOT` is the **root
+crate's `src/` only**. `kirra_planner::lanemap` is exactly such a shim, living in
+`crates/`, and is invisible to it. Recorded, not acted on: widening that gate is
+its own measurement.
+
+---
+
+## What the stronger test should be, derived from the cases
+
+Let the measured cases decide, and they point at two changes that are cheap,
+mechanical, and jointly expose 3 modules:
+
+**Rule A — attribute every reference to a crate.** A hit counts only if the
+crediting file's crate can name the module's crate: same crate, or a Cargo
+dependency path to it. Exposes 2. This subsumes the `ambiguous_item_names`
+patch-by-patch approach with a structural fact instead of a name heuristic.
+
+**Rule B — skip the whole `use` statement, not its first line.** Attribute
+continuation lines to the statement that opened them, and keep `pub use`
+(a shelf) distinct from plain `use` (an import, which *is* consumption).
+Exposes 1.
+
+Both move the gate from *"the identifier appears somewhere"* toward
+*"a consumer that could name this module referenced it in code shape"* — which
+is what the existing `is_code_shaped` was already reaching for, one level up.
+
+## Sequencing
+
+1. **This report.** No gate change. ← you are here
+2. Land the disposition: baseline the two genuinely-orphaned modules with
+   justifications, decide `lanemap`.
+3. Only then implement rules A and B, with the self-tests carrying the three
+   measured cases as fixtures, so the gate's non-vacuity is anchored on real
+   defects rather than invented ones.
+
+---
+
+## Two self-corrections in the instrument, kept
+
+Both were caught by checking the instrument's own output against the source
+rather than trusting it, and both would have put false findings in this report.
+
+**Crate ownership read from `lib.rs`.** `kirra-wcet-bench` is bin-only, so its
+files fell through longest-prefix matching to the repo-root crate, and its
+perfectly ordinary `kirra_timing::evt::estimate_pwcet(..)` call was reported as
+unattributable. Ownership is now read from manifests. Removed one false finding.
+
+**Per-rule fallout recomputed from a truncated sample.** The JSON caps evidence
+at 12 lines per module; a first pass recomputed the per-rule exposure counts
+from that cap and reported **9** exposures where there are **2** — a module with
+200 hits whose first 12 happen to be refuted reads as exposed while hits 13+ are
+fine. Now computed over the full hit list.
+
+The second is the same defect class this audit exists to find: a measurement
+reading a truncated sample as the whole population. Worth the paragraph.


### PR DESCRIPTION
Step 1 of the orphan-gate sequence: **measure and classify, change nothing.** `check_orphan_cores.py` is byte-identical, still green, and the new instrument is invoked by no workflow. Two files added, nothing else touched.

Tier 4 produced a concrete case of the wire-or-delete gate crediting a module on evidence that does not establish a consumer path. This measures how far that reaches, before the detector is touched — the same order the boundedness gate used, so `main` never meets a red wall nobody has classified.

## The question the gate never asks

> Could the crediting file **possibly name this module at all?**

A reference in crate B can only consume crate A's module if B depends on A, or B *is* A. The `path` rule is `\b{mod_name}::` — unscoped — so a reference anywhere credits every root module of that name. Where no dependency edge exists, the credit isn't a judgement call; the Cargo graph refutes it.

## Fallout: 3 modules of 258. No red wall.

| | |
|---|---|
| root `pub mod`s scanned | **258** |
| credited as consumed today | 239 |
| reported orphan today (all baselined, gate green) | 19 |
| **hidden orphans — credited, no evidence survives attribution** | **3** |
| retaining valid evidence after both candidate rules | 236 |

159 individual evidence lines are refuted, but they're concentrated — most modules carrying refuted credit also carry valid credit.

## Three classes, one representative case each

**A — `path`/`item` are not crate-scoped.** `parko_ros2::pointcloud2_shim`, 680 lines, no reference outside its own `pub mod` line. Credited because it exports `INT8` and `parko-core` writes `PrecisionMode::INT8` — an unrelated enum variant, in a crate that doesn't depend on `parko-ros2`. `ambiguous_item_names` can't see it: that guard discounts names owned by two scanned *modules*, and this collision is with an enum variant. Same shape as the `entity_projection`/`fold_all` bug already in the gate's own docstring.

**B — a line-anchored re-export skip doesn't skip a wrapped re-export.** `parko_core::backend_selector`, credited by exactly two lines, both inside its own crate's `lib.rs`:

```rust
pub use backend_selector::{
    backend_permitted, current_platform, descriptor_from_env_str, register_backend_factory,
    BackendFactory, BackendSelector, TargetPlatform, KIRRA_BACKEND_ENV,
};
```

`REEXPORT_RE` skips line 1 and credits the item names `rustfmt` wrapped onto lines 2–3. The "shelf with a label" the gate explicitly excludes, admitted through its own front door. Zero non-comment references to any of its eight items repo-wide.

**C — textual reachability is not integration.** Observed in 3b, **not measured here**: replacing `render_explanation(..)` with a constant left the gate green, because the `use` line still named the module and a sibling type was genuinely used. The module was consumed; its *core* was dead. Measuring that needs per-item liveness — a materially bigger instrument, arguably a different gate. Said plainly so the number isn't mistaken for complete coverage.

## Disposition — every candidate, four buckets

| Module | Bucket | Disposition |
|---|---|---|
| `parko_ros2::pointcloud2_shim` | **genuinely orphaned** | Baseline. Its three siblings (`image_shim`, `odometry_shim`, `radar_shim`) are *already* baselined with the identical justification; it escaped only via the `INT8` collision. |
| `parko_core::backend_selector` | **genuinely orphaned** | Baseline. Awaits a backend crate calling `register_backend_factory`; none does. Same family as the baselined `parko_core::detector`. |
| `kirra_planner::lanemap` | **intentionally standalone** | A 6-line back-compat re-export shim. **Author's call**: baseline as intentional, or delete — its stated purpose (keeping `crate::lanemap::*` working inside `kirra-planner`) isn't currently exercised by any file. |
| — | **false positive** | **None.** The errors run only toward hiding orphans, never toward reporting one that isn't. |

Noticed in passing: `check_reexport_shims` enforces `max_shims: 0` but scans only the **root crate's** `src/`, so the `lanemap` shim in `crates/` is invisible to it. Recorded, not acted on — widening that gate is its own measurement.

## The stronger test the cases point at

**Rule A — attribute every reference to a crate** (same crate, or a Cargo dependency path to it). Exposes 2. Replaces name-heuristic patching with a structural fact.
**Rule B — skip the whole `use` statement, not its first line**, keeping `pub use` (a shelf) distinct from plain `use` (an import, which *is* consumption). Exposes 1.

Disjoint, jointly 3. Both move the gate from *"the identifier appears somewhere"* toward *"a consumer that could name this module referenced it in code shape"* — where `is_code_shaped` was already heading, one level up.

## Two self-corrections kept in the write-up

Both would have put false findings in this report, and both were caught by checking the instrument against the source rather than trusting its output.

- Reading crate ownership from `lib.rs` mis-attributed bin-only `kirra-wcet-bench` and invented a third "unattributable" case.
- Recomputing per-rule fallout from the JSON's 12-lines-per-module cap reported **9** exposures where there are **2**.

The second is the same defect class this audit exists to find — a measurement reading a truncated sample as the whole population — so it's written down rather than quietly fixed.

## Sequencing

1. **This report.** No gate change. ← here
2. Land the dispositions (baseline the two, decide `lanemap`).
3. Only then implement A and B, with these three measured cases as the self-test fixtures, so the tightened gate's non-vacuity rests on real defects rather than invented ones.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_