### PR TITLE
Schema v8: a derivation-class writer may not confirm its own claim

### DIFF
--- a/ci/freshness_unruled_baseline.json
+++ b/ci/freshness_unruled_baseline.json
@@ -34,6 +34,11 @@
       "kind": "spatial",
       "predicate": "located_in",
       "why": "A containment relation from the SD-4 frame fixtures. Whether containment ages depends on whether the container moves, which the class alone does not say."
+    },
+    {
+      "kind": "observation",
+      "predicate": "same_as",
+      "why": "The co-reference claim shape KIRRA-WM-CLUSTERING-001 rules in, appearing here as the fixture the schema-v8 promotion guard is tested against. Knowingly unruled, and deliberately not ruled by this PR: whether a same_as claim ages is a question about how long two references stay co-referent, which is Tier 2's (2a/2b) to answer alongside the matcher and the adjudicator. Ruling it inside a schema-guard change would be exactly the smuggled semantics that tier keeps out. Unruled means queries for it REFUSE, which is the safe direction while the ruling is open. Moves into RULED when 2a/2b land."
     }
   ]
 }

--- a/ci/store_boundedness_baseline.json
+++ b/ci/store_boundedness_baseline.json
@@ -1,6 +1,6 @@
 {
   "_comment": [
-    "Tier 3 box 3d \u2014 the boundedness classification of the store's read surface.",
+    "Tier 3 box 3d — the boundedness classification of the store's read surface.",
     "",
     "KIRRA-WM-ANSWER-IDENTITY-001 clause 2 is 'queries are bounded'. Three defects",
     "in three consecutive PRs showed that per-query vigilance does not enforce it:",
@@ -58,15 +58,15 @@
     },
     "as_of_composed": {
       "class": "unbounded",
-      "why": "Composes `as_of` (bounded) with `identity_view_at` (the whole graph). The claims half is bounded and the identity half is not, so the composition is not \u2014 a bounded half does not bound a composition."
+      "why": "Composes `as_of` (bounded) with `identity_view_at` (the whole graph). The claims half is bounded and the identity half is not, so the composition is not — a bounded half does not bound a composition."
     },
     "as_of_composed_bounded": {
       "class": "bounded",
-      "why": "Box 3d. Both halves bounded inside ONE transaction: `as_of` was already subject-keyed, and the identity half now folds only the adjudications bearing on the objects those claims name, discovered through the affected-entity reverse index. Deliberately one primitive rather than two bounded calls \u2014 two would satisfy boundedness while reintroducing the cross-read incoherence box 3h closed."
+      "why": "Box 3d. Both halves bounded inside ONE transaction: `as_of` was already subject-keyed, and the identity half now folds only the adjudications bearing on the objects those claims name, discovered through the affected-entity reverse index. Deliberately one primitive rather than two bounded calls — two would satisfy boundedness while reintroducing the cross-read incoherence box 3h closed."
     },
     "backfill_adjudication_affects": {
       "class": "operational",
-      "why": "The one-time scan that fills the v6 reverse index on a migrated store. Deliberately a full scan and deliberately NOT on any request path \u2014 an explicit operational call rather than work hidden in `open`, so the cost lands where an operator can see it. This is exactly the trade box 3d is for: one operational scan buys bounded interactive reads."
+      "why": "The one-time scan that fills the v6 reverse index on a migrated store. Deliberately a full scan and deliberately NOT on any request path — an explicit operational call rather than work hidden in `open`, so the cost lands where an operator can see it. This is exactly the trade box 3d is for: one operational scan buys bounded interactive reads."
     },
     "backfill_provenance_edges": {
       "class": "operational",
@@ -106,7 +106,7 @@
     },
     "cursor_anchor": {
       "class": "bounded",
-      "why": "Two point reads: one row by primary key, and the log head via ORDER BY generation DESC LIMIT 1. Structurally bounded \u2014 the result is two scalars regardless of log size. It exists so a continuation cursor can be REFUSED rather than silently continued from a coordinate the log no longer holds."
+      "why": "Two point reads: one row by primary key, and the log head via ORDER BY generation DESC LIMIT 1. Structurally bounded — the result is two scalars regardless of log size. It exists so a continuation cursor can be REFUSED rather than silently continued from a coordinate the log no longer holds."
     },
     "claim_at_generation": {
       "class": "bounded",
@@ -158,11 +158,11 @@
     },
     "history_page": {
       "class": "bounded",
-      "why": "Box 3d's bounded replacement for `history`. Narrows in SQL with `generation > cursor` and `LIMIT limit + 1` rather than fetching the record and truncating \u2014 #1440's lesson, since truncating after the fetch bounds the ANSWER while leaving the WORK unbounded, which is what made all three defects invisible. The boundary decision is `lineage::boundary_for`, shared with the lineage family so the off-by-one has one implementation."
+      "why": "Box 3d's bounded replacement for `history`. Narrows in SQL with `generation > cursor` and `LIMIT limit + 1` rather than fetching the record and truncating — #1440's lesson, since truncating after the fetch bounds the ANSWER while leaving the WORK unbounded, which is what made all three defects invisible. The boundary decision is `lineage::boundary_for`, shared with the lineage family so the off-by-one has one implementation."
     },
     "history_whole": {
       "class": "unbounded",
-      "why": "EVERY confirmed claim ever recorded about a subject, no page and no cursor. The third instance of the defect class this gate exists for, and the one that proves per-query vigilance does not work: it was written in the PR that documented the other two. Its bounded replacement is the paginated form. RENAMED from `history` in the 3d dispatch slice: `WorldView::history` is the BOUNDED family of the same name, and the collision made the gate read the engine's dispatch into the bounded family as a call to this one. The same correction `resolve_at` -> `resolve_at_whole_graph` already took \u2014 a name that does not say `whole` is how a whole-record read gets called by mistake."
+      "why": "EVERY confirmed claim ever recorded about a subject, no page and no cursor. The third instance of the defect class this gate exists for, and the one that proves per-query vigilance does not work: it was written in the PR that documented the other two. Its bounded replacement is the paginated form. RENAMED from `history` in the 3d dispatch slice: `WorldView::history` is the BOUNDED family of the same name, and the collision made the gate read the engine's dispatch into the bounded family as a call to this one. The same correction `resolve_at` -> `resolve_at_whole_graph` already took — a name that does not say `whole` is how a whole-record read gets called by mistake."
     },
     "identity_view": {
       "class": "unbounded",
@@ -175,6 +175,10 @@
     "invalid_shape_rows": {
       "class": "operational",
       "why": "A schema-diagnostic sweep, not a domain question."
+    },
+    "unauthorized_confirmation_rows": {
+      "class": "operational",
+      "why": "The KIRRA-WM-PROMOTION-001 sibling of invalid_shape_rows, and classified with it for the same reason: a schema-diagnostic sweep an operator runs against a migrated store, not a domain question any interactive path asks. Unbounded by nature -- it must report EVERY inherited derivation-confirmed row or it would understate the finding, and a paged diagnostic that silently stopped at a limit would be the worse failure here."
     },
     "largest_compactable_prefix": {
       "class": "operational",
@@ -250,15 +254,15 @@
     },
     "resolve_at_whole_graph": {
       "class": "unbounded",
-      "why": "RENAMED from `resolve_at` on box 3d. Its body is `self.identity_view_at(cut)?.resolve_at(id)` \u2014 it materialises the WHOLE equivalence graph and then indexes it, so the old name read as a point lookup and was classified `bounded` from its signature on the first pass. The name now says what it does. Renaming also removes a real ambiguity in the gate's name-based scan: `HistoricalIdentityView::resolve_at` is a pure in-memory call on an already-loaded view, and sharing a name with an unbounded store method made every use of it look like a violation. `resolve_bounded_at` is the bounded form."
+      "why": "RENAMED from `resolve_at` on box 3d. Its body is `self.identity_view_at(cut)?.resolve_at(id)` — it materialises the WHOLE equivalence graph and then indexes it, so the old name read as a point lookup and was classified `bounded` from its signature on the first pass. The name now says what it does. Renaming also removes a real ambiguity in the gate's name-based scan: `HistoricalIdentityView::resolve_at` is a pure in-memory call on an already-loaded view, and sharing a name with an unbounded store method made every use of it look like a violation. `resolve_bounded_at` is the bounded form."
     },
     "resolve_bounded": {
       "class": "bounded",
-      "why": "Box 3d's identity primitive. Loads only the entities within MAX_REDIRECT_EDGES hops of the queried id and resolves over that subset, so the work is bounded by the traversal budget the resolver already enforces rather than by graph size. The resolution RULE is unchanged \u2014 the same `resolve` over a smaller view \u2014 which is what lets `bounded_resolution_agrees_with_whole_graph_resolution` assert the two are identical. Classified `bounded` and MEANT: the transitive check reads its body, so it stays honest."
+      "why": "Box 3d's identity primitive. Loads only the entities within MAX_REDIRECT_EDGES hops of the queried id and resolves over that subset, so the work is bounded by the traversal budget the resolver already enforces rather than by graph size. The resolution RULE is unchanged — the same `resolve` over a smaller view — which is what lets `bounded_resolution_agrees_with_whole_graph_resolution` assert the two are identical. Classified `bounded` and MEANT: the transitive check reads its body, so it stays honest."
     },
     "resolve_bounded_at": {
       "class": "bounded",
-      "why": "Box 3d's bounded historical identity read. Discovers the adjudications affecting the queried id through the affected-entity reverse index, expands newly-named entities, and stops at the resolver's own MAX_REDIRECT_EDGES budget \u2014 so it folds the records bearing on one entity's identity rather than every adjudication in the log. The index supplies GENERATIONS only; every record is read from world_events and folded by the unchanged fold_adjudication, so the log remains the sole evidence."
+      "why": "Box 3d's bounded historical identity read. Discovers the adjudications affecting the queried id through the affected-entity reverse index, expands newly-named entities, and stops at the resolver's own MAX_REDIRECT_EDGES budget — so it folds the records bearing on one entity's identity rather than every adjudication in the log. The index supplies GENERATIONS only; every record is read from world_events and folded by the unchanged fold_adjudication, so the log remains the sole evidence."
     },
     "resolved_entities": {
       "class": "unbounded",
@@ -336,7 +340,7 @@
     },
     "identity_view_for": {
       "class": "bounded",
-      "why": "Box 3d. Loads only the entities reachable from the seed ids within MAX_REDIRECT_EDGES hops, so `ask` pays O(predicates x budget) instead of O(entities) to resolve the objects its own claims name. Snapshot-scoped so the identity half of a composed answer is observed at the same point as the claims half \u2014 a WorldStore-level bounded resolve would be a second connection and would reintroduce the between-walks incoherence 3c closed."
+      "why": "Box 3d. Loads only the entities reachable from the seed ids within MAX_REDIRECT_EDGES hops, so `ask` pays O(predicates x budget) instead of O(entities) to resolve the objects its own claims name. Snapshot-scoped so the identity half of a composed answer is observed at the same point as the claims half — a WorldStore-level bounded resolve would be a second connection and would reintroduce the between-walks incoherence 3c closed."
     },
     "read_composed_subject_at_generation": {
       "class": "bounded",

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -199,6 +199,16 @@ pub enum StoreError {
     /// SD-2, refused before the statement is built so the message names the
     /// rule rather than a constraint index.
     LlmCannotConfirm,
+    /// `KIRRA-WM-PROMOTION-001` — a `derivation`-class writer (a similarity
+    /// matcher, a rule engine) may PROPOSE co-reference but may never CONFIRM
+    /// it. Confirmed identity arrives only through explicit adjudication.
+    ///
+    /// The sibling of [`Self::LlmCannotConfirm`], and refused at the same point
+    /// for the same reason. The two differ only in which enforcement backs them
+    /// at the SQL layer: SD-2's `CHECK` has covered `llm_candidate` since v1,
+    /// while `derivation` is held by the v8 trigger, because SQLite cannot
+    /// widen a `CHECK` without rewriting the append-only log.
+    DerivationCannotConfirm,
     /// SD-4, refused early for the same reason.
     SpatialClaimNeedsFrame,
     /// `KIRRA-WM-CLAIM-SHAPES-001` — an object-bearing claim requires a
@@ -418,6 +428,11 @@ impl std::fmt::Display for StoreError {
                 f,
                 "writer_class=llm_candidate may not write claim_status=confirmed \
                  (ADR-0040; KIRRA-WM2-SCHEMA-001 SD-2)"
+            ),
+            Self::DerivationCannotConfirm => write!(
+                f,
+                "writer_class=derivation may not write claim_status=confirmed \
+                 (KIRRA-WM-PROMOTION-001: clustering proposes, adjudication confirms)"
             ),
             Self::SpatialClaimNeedsFrame => write!(
                 f,
@@ -1022,6 +1037,7 @@ pub fn schema_digest() -> String {
     effective.push_str(schema::SCHEMA_V5_MIGRATION);
     effective.push_str(schema::SCHEMA_V6_MIGRATION);
     effective.push_str(schema::SCHEMA_V7_MIGRATION);
+    effective.push_str(schema::SCHEMA_V8_MIGRATION);
     sha256_hex(effective.as_bytes())
 }
 
@@ -1097,11 +1113,12 @@ impl WorldStore {
             tx.execute_batch(schema::SCHEMA_V5_MIGRATION)?;
             tx.execute_batch(schema::SCHEMA_V6_MIGRATION)?;
             tx.execute_batch(schema::SCHEMA_V7_MIGRATION)?;
+            tx.execute_batch(schema::SCHEMA_V8_MIGRATION)?;
             tx.execute(
                 "INSERT INTO world_store_meta (key, value) VALUES ('schema_version', ?1)",
                 params![SCHEMA_VERSION.to_string()],
             )?;
-            // A store born at v7 indexes every event as it is appended, so no
+            // A store born at v8 indexes every event as it is appended, so no
             // generation is outside the citation index and the floor is 0.
             tx.execute(
                 "INSERT INTO world_store_meta (key, value) VALUES (?1, '0')",
@@ -1253,6 +1270,19 @@ impl WorldStore {
                 params![PROVENANCE_EDGES_FLOOR_KEY, head.to_string()],
             )?;
         }
+        // v8 installs the KIRRA-WM-PROMOTION-001 trigger. Same shape as v5 and
+        // the same consequence: it constrains future inserts and touches no
+        // existing row, so a store already carrying a `derivation`-confirmed row
+        // migrates cleanly and KEEPS it -- visible via
+        // `unauthorized_confirmation_rows`, never silently coerced or deleted.
+        //
+        // Migrating such a store is deliberately not an error. Refusing to open
+        // it would strand the operator with a database they can neither read nor
+        // repair, and the rows are already written: the honest outcome is a store
+        // that stops the next one and can name the ones it inherited.
+        if from < 8 {
+            tx.execute_batch(schema::SCHEMA_V8_MIGRATION)?;
+        }
 
         // Digest before version, inside the transaction. The order no longer
         // guards a crash window — the transaction does — but it still reads in
@@ -1311,6 +1341,46 @@ impl WorldStore {
         let mut stmt = self.conn.prepare(
             "SELECT generation, subject FROM world_events
              WHERE object IS NOT NULL AND predicate IS NULL
+             ORDER BY generation",
+        )?;
+        let rows = stmt.query_map([], |r| Ok((r.get(0)?, r.get(1)?)))?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row?);
+        }
+        Ok(out)
+    }
+
+    /// Events a `derivation`-class writer self-confirmed — `KIRRA-WM-PROMOTION-001`
+    /// — as `(generation, subject)`.
+    ///
+    /// **Reports; never repairs.** The v8 trigger stops new ones, but a store
+    /// written before it existed may already contain some, and coercing them
+    /// would mean rewriting a hash-chained append-only log. So they survive, and
+    /// this method is what makes them a *finding* rather than a silence — the
+    /// same contract as [`Self::invalid_shape_rows`].
+    ///
+    /// An operator seeing a non-empty result should know what it implies: each
+    /// such row asserts a CONFIRMED claim on a matcher's authority alone, which
+    /// is precisely what promotion exists to prevent. Such a row folds into the
+    /// confirmed-only projection and is indistinguishable there from an
+    /// adjudicated one.
+    ///
+    /// # Why `llm_candidate` is not in the query
+    ///
+    /// Not an omission. SD-2's `CHECK` has refused that pairing since v1, so no
+    /// store of any vintage can hold one — including it would add a branch that
+    /// is unreachable by construction and read as though it might fire.
+    ///
+    /// Empty on any store created at v8 or later, which the trigger guarantees.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::Sqlite`] if the event log cannot be read.
+    pub fn unauthorized_confirmation_rows(&self) -> Result<Vec<(i64, String)>, StoreError> {
+        let mut stmt = self.conn.prepare(
+            "SELECT generation, subject FROM world_events
+             WHERE writer_class = 'derivation' AND claim_status = 'confirmed'
              ORDER BY generation",
         )?;
         let rows = stmt.query_map([], |r| Ok((r.get(0)?, r.get(1)?)))?;
@@ -1401,6 +1471,13 @@ impl WorldStore {
     pub fn append(&mut self, e: &NewEvent<'_>) -> Result<i64, StoreError> {
         if e.writer_class == WriterClass::LlmCandidate && e.claim_status == ClaimStatus::Confirmed {
             return Err(StoreError::LlmCannotConfirm);
+        }
+        // `KIRRA-WM-PROMOTION-001`. Refused here so the error names the RULE,
+        // and again by the v8 trigger so raw SQL cannot route around it -- the
+        // same two-layer shape as the claim-shapes check below. Neither layer
+        // is redundant: this one is the message, that one is the guarantee.
+        if e.writer_class == WriterClass::Derivation && e.claim_status == ClaimStatus::Confirmed {
+            return Err(StoreError::DerivationCannotConfirm);
         }
         if e.kind == "spatial" && e.frame_id.is_none() {
             return Err(StoreError::SpatialClaimNeedsFrame);

--- a/crates/kirra-world-store/src/schema.rs
+++ b/crates/kirra-world-store/src/schema.rs
@@ -115,7 +115,7 @@ pub const CHAIN_ALGORITHM: &str = "kirra-audit-hash/compute_record_hash_v2";
 /// | 5 | the object-requires-predicate trigger | `KIRRA-WM-CLAIM-SHAPES-001` |
 /// | 6 | the `adjudication_affects` reverse index | `WM_SCOPE.md` box 3d |
 /// | 7 | the `provenance_edges` citation index | `KIRRA-WM-PROVENANCE-GRAPH-001` |
-pub const SCHEMA_VERSION: i64 = 7;
+pub const SCHEMA_VERSION: i64 = 8;
 
 /// **v2 — the four orthogonal trust axes, added additively.**
 ///
@@ -496,4 +496,68 @@ CREATE TABLE IF NOT EXISTS provenance_edges (
 -- populated table is a migration, while adding it to an empty one is free.
 CREATE INDEX IF NOT EXISTS provenance_edges_by_cited
     ON provenance_edges (cited_observation_id, source_generation);
+"#;
+
+/// **v8 — a `derivation`-class writer may not confirm its own claim.**
+///
+/// `KIRRA-WM-PROMOTION-001` (adopted 2026-08-08): *clustering may PROPOSE
+/// co-reference; it may never CONFIRM identity.* A heuristic or learned matcher
+/// is authorized as a candidate producer; confirmed identity arrives only
+/// through explicit adjudication by an authorized adjudicator.
+///
+/// # This closed a real hole, not a theoretical one
+///
+/// [`SCHEMA_V1`]'s D-2 `CHECK` is `writer_class <> 'llm_candidate' OR
+/// claim_status = 'candidate'`. It names **one** class. `WM_SCOPE.md` §2a had
+/// already flagged that `derivation` + `confirmed` was consequently accepted,
+/// and recorded that an earlier draft of that same section wrongly claimed the
+/// boundary had been "extended to `derivation`" — so the state of the store was
+/// established by probing it rather than by reading either text:
+///
+/// ```text
+/// PROBE deriv-conf: Ok("ACCEPTED")
+/// PROBE llm-conf:   Err("LlmCannotConfirm")
+/// ```
+///
+/// Until this migration the rule held only because no `derivation`-class
+/// producer existed yet. Tier 2 box 2a is exactly such a producer, so the guard
+/// lands **first**: shipping the producer into a store that cannot refuse it
+/// would make the bypass reachable in the window between the two.
+///
+/// # Why a TRIGGER and not an extended `CHECK`
+///
+/// The same reason as [`SCHEMA_V5_MIGRATION`], and it applies with more force
+/// here. SQLite's `ALTER TABLE` cannot modify a constraint on existing columns;
+/// widening D-2's `CHECK` would require the 12-step table rebuild — create,
+/// copy every row, drop, rename — on the hash-chained append-only log, which is
+/// the one table whose whole value is that it is never rewritten. A rebuild to
+/// install an integrity guard would destroy a stronger integrity property to do
+/// it.
+///
+/// A `BEFORE INSERT` trigger enforces the rule at the SQL layer, so **raw SQL
+/// cannot route around it**, while remaining additive.
+///
+/// # Why this covers `derivation` only
+///
+/// `llm_candidate` is already refused by D-2's `CHECK`, from v1, on every store
+/// ever created. Repeating it here would give one rule two enforcement sites
+/// with two different error texts and no added strength. The two mechanisms are
+/// complementary halves of `KIRRA-WM-PROMOTION-001`, and
+/// `neither_unauthorized_class_can_self_confirm_through_raw_sql` asserts the
+/// **combination** is complete rather than trusting either half alone.
+///
+/// # Historical rows are left alone, deliberately
+///
+/// A trigger constrains future inserts and touches nothing already written —
+/// the v5 precedent, for the v5 reason: repairing a hash-chained log is a much
+/// larger decision than a migration is entitled to make.
+/// [`super::WorldStore::unauthorized_confirmation_rows`] makes any such row a
+/// finding rather than a silence.
+pub const SCHEMA_V8_MIGRATION: &str = r#"
+CREATE TRIGGER IF NOT EXISTS world_events_derivation_cannot_confirm
+BEFORE INSERT ON world_events
+WHEN NEW.writer_class = 'derivation' AND NEW.claim_status = 'confirmed'
+BEGIN
+    SELECT RAISE(ABORT, 'KIRRA-WM-PROMOTION-001: writer_class=derivation may not write claim_status=confirmed');
+END;
 "#;

--- a/crates/kirra-world-store/tests/promotion_authority_guard.rs
+++ b/crates/kirra-world-store/tests/promotion_authority_guard.rs
@@ -1,0 +1,344 @@
+//! **`KIRRA-WM-PROMOTION-001` at the write door** — a matcher may propose, never confirm.
+//!
+//! > *Clustering may PROPOSE co-reference; it may never CONFIRM identity.*
+//! > A heuristic or learned matcher is authorized as a candidate producer;
+//! > confirmed identity still arrives only through explicit adjudication over
+//! > recorded evidence.
+//!
+//! Until schema v8 that rule was **policy, not enforcement**. SD-2's `CHECK`
+//! names `llm_candidate` and only `llm_candidate`, so `derivation` +
+//! `confirmed` was accepted by the store. `WM_SCOPE.md` §2a had flagged it, and
+//! also recorded that an earlier draft of that same section wrongly claimed the
+//! boundary was already "extended to `derivation`" — which is why the hole was
+//! established by probing the store rather than by reading either text.
+//!
+//! The rule held only because no `derivation`-class producer existed yet. Box
+//! 2a is exactly such a producer, so the guard lands before it.
+//!
+//! # What these tests are careful about
+//!
+//! The rule now has **two** enforcement sites for **two** writer classes: a v1
+//! `CHECK` for `llm_candidate`, a v8 trigger for `derivation`. A test that only
+//! went through `append` would prove the Rust early-refusals fire and say
+//! nothing about whether the store itself is safe — and the store is what a
+//! future producer written by someone else will meet. So the load-bearing test
+//! goes around Rust entirely, in raw SQL, and asserts the COMBINATION is
+//! complete rather than trusting either half.
+
+use kirra_world::reference::{EventId, ObservationId};
+use kirra_world_store::{ClaimStatus, NewEvent, StoreError, WorldStore, WriterClass};
+
+const T0: i64 = 1_700_000_000_000;
+
+fn tmp(name: &str) -> std::path::PathBuf {
+    static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let n = NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "kirra-promo-guard-{name}-{}-{n}.sqlite",
+        std::process::id()
+    ));
+    for s in ["", "-wal", "-shm"] {
+        let mut q = p.as_os_str().to_os_string();
+        q.push(s);
+        let _ = std::fs::remove_file(std::path::PathBuf::from(q));
+    }
+    p
+}
+
+/// One `same_as` claim — the exact shape box 2a's matcher will emit.
+fn claim<'a>(
+    event_id: &'a EventId,
+    observation_id: &'a ObservationId,
+    writer_class: WriterClass,
+    claim_status: ClaimStatus,
+) -> NewEvent<'a> {
+    NewEvent {
+        event_id,
+        observation_id,
+        txn_time_ms: T0,
+        valid_from_ms: T0,
+        valid_to_ms: None,
+        source: "track-matcher",
+        source_version: "2.3.1",
+        writer_class,
+        claim_status,
+        provenance: &[],
+        frame_id: None,
+        map_id: None,
+        kind: "observation",
+        subject: "track-a",
+        subject_ref: None,
+        predicate: Some("same_as"),
+        object: Some("track-b"),
+        payload: "{}",
+        payload_schema: 1,
+        retention_class: "raw",
+        trust: None,
+    }
+}
+
+fn ids(n: &str) -> (EventId, ObservationId) {
+    (
+        EventId::new(format!("ev-{n}")).expect("event id"),
+        ObservationId::new(format!("obs-{n}")).expect("observation id"),
+    )
+}
+
+/// A raw `INSERT` naming every `NOT NULL` column, going around `append` and
+/// every Rust-side refusal with it.
+///
+/// Built here rather than as a new `*_for_test` seam on the store: the existing
+/// [`WorldStore::raw_execute_for_test`] is precisely the "arbitrary SQL, so a
+/// test can attempt what the writer refuses" hatch, and adding a second one
+/// would widen the test surface to say something it can already say.
+fn raw_insert(
+    store: &WorldStore,
+    n: &str,
+    writer_class: &str,
+    claim_status: &str,
+) -> Result<(), StoreError> {
+    store.raw_execute_for_test(&format!(
+        "INSERT INTO world_events (
+             event_id, observation_id, txn_time_ms, valid_from_ms,
+             source, source_version, writer_class, claim_status, provenance,
+             kind, subject, predicate, object,
+             payload, payload_schema, payload_digest,
+             retention_class, chain_digest
+         ) VALUES (
+             'ev-{n}-{writer_class}', 'obs-{n}-{writer_class}', {T0}, {T0},
+             'track-matcher', '2.3.1', '{writer_class}', '{claim_status}', '[]',
+             'observation', 'track-a', 'same_as', 'track-b',
+             '{{}}', 1, 'digest',
+             'raw', 'chain'
+         )"
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// The load-bearing test: the STORE refuses, not merely the Rust wrapper
+// ---------------------------------------------------------------------------
+
+/// **Neither unauthorized class can self-confirm, even bypassing `append`.**
+///
+/// Raw `INSERT`s, going around every Rust-side refusal. This is the test that
+/// speaks to the threat the rule actually names — a producer written later, by
+/// someone else, against the same store — because a policy enforced only in a
+/// function is enforced only for callers of that function.
+///
+/// Asserting BOTH classes in one test is the point: the rule is split across a
+/// `CHECK` and a trigger, and checking only the new half would leave "one rule,
+/// two mechanisms, one of them silently dropped" undetectable.
+#[test]
+fn neither_unauthorized_class_can_self_confirm_through_raw_sql() {
+    let path = tmp("raw-sql");
+    let store = WorldStore::open(&path).expect("open");
+
+    for class in ["derivation", "llm_candidate"] {
+        let err = raw_insert(&store, "conf", class, "confirmed")
+            .expect_err(&format!("{class} + confirmed must be refused by the store"));
+        assert!(
+            format!("{err:?}").contains("Sqlite"),
+            "{class} must be refused at the SQL layer, not by a Rust guard: {err:?}"
+        );
+    }
+}
+
+/// **The proposing shape those same classes exist for is still admitted.**
+///
+/// The non-vacuity control for the test above. Without it, a guard that refused
+/// every `derivation` write — or every write at all — would look identical.
+/// A matcher must remain able to do its job.
+#[test]
+fn the_same_classes_may_still_propose_candidates() {
+    let path = tmp("propose");
+    let store = WorldStore::open(&path).expect("open");
+
+    for class in ["derivation", "llm_candidate"] {
+        raw_insert(&store, "cand", class, "candidate")
+            .unwrap_or_else(|e| panic!("{class} must still be able to propose: {e:?}"));
+    }
+}
+
+/// **An authorized class is untouched.** The guard is about WHO confirms, not
+/// about confirmation. A `sensor` and an `operator` still write confirmed
+/// claims — the second being the adjudicator `KIRRA-WM-PROMOTION-001` names as
+/// the v1 promotion authority, so refusing it would break the rule it enforces.
+#[test]
+fn authorized_classes_still_confirm() {
+    let path = tmp("authorized");
+    let store = WorldStore::open(&path).expect("open");
+
+    for class in ["sensor", "operator"] {
+        raw_insert(&store, "auth", class, "confirmed")
+            .unwrap_or_else(|e| panic!("{class} must still be able to confirm: {e:?}"));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The Rust half: the caller gets a message naming the rule
+// ---------------------------------------------------------------------------
+
+/// `append` refuses before building the statement, so the error names the RULE
+/// rather than surfacing a constraint index — the shape `LlmCannotConfirm`
+/// already had, now with the sibling it was always missing.
+#[test]
+fn append_names_the_rule_rather_than_the_constraint() {
+    let path = tmp("named");
+    let mut s = WorldStore::open(&path).expect("open");
+
+    let (e, o) = ids("deriv");
+    assert!(
+        matches!(
+            s.append(&claim(
+                &e,
+                &o,
+                WriterClass::Derivation,
+                ClaimStatus::Confirmed
+            )),
+            Err(StoreError::DerivationCannotConfirm)
+        ),
+        "derivation + confirmed must be refused by name"
+    );
+
+    let (e2, o2) = ids("llm");
+    assert!(
+        matches!(
+            s.append(&claim(
+                &e2,
+                &o2,
+                WriterClass::LlmCandidate,
+                ClaimStatus::Confirmed
+            )),
+            Err(StoreError::LlmCannotConfirm)
+        ),
+        "the sibling refusal must be unchanged"
+    );
+
+    // Non-vacuity: the very same claim, proposed rather than confirmed, lands.
+    let (e3, o3) = ids("candidate");
+    s.append(&claim(
+        &e3,
+        &o3,
+        WriterClass::Derivation,
+        ClaimStatus::Candidate,
+    ))
+    .expect("a derivation-class CANDIDATE is exactly what 2a will write");
+}
+
+/// The message a reader gets must name the ruling, not a SQLite constraint
+/// index. `KIRRA-WM-PROMOTION-001` is the searchable token that leads to the
+/// rationale, so the test pins it rather than the prose around it.
+#[test]
+fn the_message_carries_the_ruling_id() {
+    let text = format!("{}", StoreError::DerivationCannotConfirm);
+    assert!(
+        text.contains("KIRRA-WM-PROMOTION-001"),
+        "the refusal must name the ruling that motivates it: {text}"
+    );
+    assert!(
+        text.contains("derivation") && text.contains("confirmed"),
+        "and the pairing it refused: {text}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Migration: inherited rows survive and are nameable
+// ---------------------------------------------------------------------------
+
+/// **A fresh store has nothing to report.** The floor for the test below: if
+/// `unauthorized_confirmation_rows` returned rows on a clean store, its
+/// non-empty result would mean nothing.
+#[test]
+fn a_clean_store_reports_no_unauthorized_confirmations() {
+    let path = tmp("clean");
+    let mut s = WorldStore::open(&path).expect("open");
+    let (e, o) = ids("ok");
+    s.append(&claim(&e, &o, WriterClass::Sensor, ClaimStatus::Confirmed))
+        .expect("append");
+    assert!(
+        s.unauthorized_confirmation_rows()
+            .expect("query")
+            .is_empty(),
+        "a store created at v8 cannot hold one"
+    );
+}
+
+/// **The store stamps v8**, so a reader can tell a guarded store from an
+/// unguarded one without probing its behaviour.
+#[test]
+fn the_schema_stamps_the_guarded_version() {
+    let path = tmp("version");
+    let s = WorldStore::open(&path).expect("open");
+    assert_eq!(s.schema_version().expect("version"), 8);
+}
+
+/// Return a store to its pre-guard state: drop the v8 trigger and roll the
+/// stamp back to 7, so the next `open` takes the migration path a real v7
+/// store would.
+fn unguard(store: &WorldStore) {
+    store
+        .raw_execute_for_test("DROP TRIGGER world_events_derivation_cannot_confirm")
+        .expect("drop trigger");
+    store
+        .raw_execute_for_test(
+            "UPDATE world_store_meta SET value = '7' WHERE key = 'schema_version'",
+        )
+        .expect("roll back the stamp");
+}
+
+/// **A store migrated from v7 ends up as guarded as one born at v8.**
+///
+/// This test exists because the bug it describes was made and caught here.
+/// `open` has TWO paths — an explicit enumeration for a new store and
+/// `migrate` for an existing one — and a migration added to only one of them
+/// produces a store **stamped v8 with no v8 trigger**. That store passes a
+/// version check and fails the rule.
+///
+/// Which is the wider point: `the_schema_stamps_the_guarded_version` passed
+/// throughout that bug. A version stamp records what someone said the schema
+/// was. Only behaviour records what it is, so this asserts behaviour.
+#[test]
+fn a_store_migrated_from_v7_gains_the_guard() {
+    let path = tmp("migrated");
+    {
+        let store = WorldStore::open(&path).expect("open");
+        unguard(&store);
+        // Non-vacuity: while unguarded, the write the guard forbids succeeds.
+        // Without this the test could not tell "migration installed the guard"
+        // from "the guard was never actually removed".
+        raw_insert(&store, "pre", "derivation", "confirmed")
+            .expect("an unguarded store is exactly what v8 exists to end");
+    }
+
+    let store = WorldStore::open(&path).expect("reopen runs the migration");
+    assert_eq!(store.schema_version().expect("version"), 8);
+    raw_insert(&store, "post", "derivation", "confirmed")
+        .expect_err("after migrating, the store must refuse it");
+}
+
+/// **A row inherited from before the guard survives, and can be named.**
+///
+/// The migration's stated contract: it constrains future inserts and touches
+/// nothing already written, because repairing a hash-chained append-only log is
+/// a much larger decision than a migration is entitled to make. So the honest
+/// outcome is a store that stops the next one and can report the ones it
+/// inherited — which is what makes them a finding rather than a silence.
+#[test]
+fn rows_inherited_from_before_the_guard_survive_and_are_nameable() {
+    let path = tmp("inherited");
+    {
+        let store = WorldStore::open(&path).expect("open");
+        unguard(&store);
+        raw_insert(&store, "legacy", "derivation", "confirmed").expect("pre-guard write");
+    }
+
+    let store = WorldStore::open(&path).expect("reopen runs the migration");
+    let found = store.unauthorized_confirmation_rows().expect("query");
+    assert_eq!(
+        found.len(),
+        1,
+        "the inherited row must SURVIVE migration, not be coerced or dropped: {found:?}"
+    );
+    assert_eq!(found[0].1, "track-a", "and be named by subject: {found:?}");
+}

--- a/crates/kirra-world-store/tests/promotion_authority_guard.rs
+++ b/crates/kirra-world-store/tests/promotion_authority_guard.rs
@@ -138,7 +138,7 @@ fn neither_unauthorized_class_can_self_confirm_through_raw_sql() {
         let err = raw_insert(&store, "conf", class, "confirmed")
             .expect_err(&format!("{class} + confirmed must be refused by the store"));
         assert!(
-            format!("{err:?}").contains("Sqlite"),
+            matches!(err, StoreError::Sqlite(_)),
             "{class} must be refused at the SQL layer, not by a Rust guard: {err:?}"
         );
     }

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -920,14 +920,40 @@ does not describe is how a residue disappears.
       confidence provenance. It writes through the same door as every other
       producer (§4.2) and is visible as inferred.
       **It may not write `claim_status = confirmed`, and may not touch
-      `Corroboration(n)`.** ⚠️ **This is a POLICY REQUIREMENT, not an enforced
-      boundary — and the difference was found by review, not by the schema.**
-      SD-2's `CHECK` refuses `llm_candidate` + `confirmed` and *only* that:
-      `world_events` has `CHECK (writer_class <> 'llm_candidate' OR claim_status
-      = 'candidate')`, so **`derivation` + `confirmed` is currently accepted by
-      the store.** An earlier draft here said the boundary was "extended to
-      `derivation`". It is not, and describing an unenforced policy as an
-      existing guard is how a reader stops looking for the guard.
+      `Corroboration(n)`.** ✅ **ENFORCED as of schema v8** (2026-08-20).
+      History worth keeping, because it is how the gap was found: this was a
+      POLICY REQUIREMENT with no guard behind it, and the difference was found
+      by review rather than by the schema. SD-2's `CHECK` refuses
+      `llm_candidate` + `confirmed` and *only* that, so `derivation` +
+      `confirmed` was accepted by the store. An earlier draft of this bullet
+      said the boundary had been "extended to `derivation`". It had not — and
+      because this section had already been wrong about it once, the state was
+      re-established by PROBING the store rather than by re-reading either text:
+
+      ```text
+      PROBE deriv-conf: Ok("ACCEPTED")
+      PROBE llm-conf:   Err("LlmCannotConfirm")
+      ```
+
+      `SCHEMA_V8_MIGRATION` closes it with a `BEFORE INSERT` trigger — not a
+      widened `CHECK`, because SQLite cannot alter a constraint without the
+      12-step table rebuild, and rebuilding the hash-chained append-only log to
+      install an integrity guard would destroy a stronger integrity property to
+      do it. The v5 claim-shapes trigger is the precedent.
+
+      The rule now has two enforcement sites for two classes — the v1 `CHECK`
+      for `llm_candidate`, the v8 trigger for `derivation` — so
+      `neither_unauthorized_class_can_self_confirm_through_raw_sql` asserts the
+      **combination** in raw SQL, going around every Rust-side refusal, because
+      a policy enforced only in a function is enforced only for callers of that
+      function. `StoreError::DerivationCannotConfirm` is the sibling of
+      `LlmCannotConfirm`: it names the rule for the caller, and is not the
+      guarantee.
+
+      Rows written before the guard are **not** coerced — the migration
+      constrains future inserts and touches nothing already written.
+      `WorldStore::unauthorized_confirmation_rows` makes any inherited row a
+      finding rather than a silence.
 
       In 2a the constraint holds because the *type* cannot express a confirmed
       candidate — `SameAsCandidate` has no claim-status field and pins its class
@@ -935,11 +961,11 @@ does not describe is how a residue disappears.
       producer-side guarantee, and it says nothing about a producer written
       later, by someone else, against the same store.
 
-      **OPEN — closing it is a schema change, not a doc change:** extend the
-      `CHECK` to `writer_class NOT IN ('llm_candidate','derivation') OR
-      claim_status = 'candidate'`, with a migration. Until then the write door
-      admits what `KIRRA-WM-PROMOTION-001` forbids, and only convention stops
-      it.
+      **CLOSED 2026-08-20 (schema v8).** It was closed as a schema change, as
+      that note required, and deliberately BEFORE 2a rather than with it: the
+      rule held only because no `derivation`-class producer existed yet, so
+      shipping the producer first would have made the bypass reachable in the
+      window between them.
 
       **`Corroboration(n)` is NOT 2a's to drive.** The axis folds *confirmed*
       `same_as`, so its first driver is promotion (2b) or an operator-declared


### PR DESCRIPTION
The first missing edge from the producer→projection chain trace. Closes the `derivation` + `confirmed` hole that `WM_SCOPE.md` §2a had flagged as **OPEN**, as a schema change with a migration, as that note required.

## The rule, and why it had no guard

`KIRRA-WM-PROMOTION-001`: *clustering may PROPOSE co-reference; it may never CONFIRM identity.* A matcher is authorized as a candidate producer; confirmed identity arrives only through explicit adjudication.

SD-2's `CHECK` is `writer_class <> 'llm_candidate' OR claim_status = 'candidate'` — it names **one** class. §2a had flagged the consequence, and had *also* once claimed the boundary was already "extended to `derivation`". Because that section had been wrong about this exact point before, the state was established by probing the store rather than by re-reading either text:

```text
PROBE deriv-conf: Ok("ACCEPTED")
PROBE llm-conf:   Err("LlmCannotConfirm")
```

## Why now, before 2a

The rule held only because no `derivation`-class producer exists yet. Box 2a **is** such a producer. Shipping it into a store that cannot refuse it would make the bypass reachable in the window between the two, so the guard lands first.

## A trigger, not a widened `CHECK`

The v5 claim-shapes precedent, for a reason that applies with more force here. SQLite's `ALTER TABLE` cannot modify a constraint on existing columns; widening D-2's `CHECK` needs the 12-step rebuild — create, copy every row, drop, rename — on the hash-chained append-only log, **the one table whose whole value is that it is never rewritten**. A rebuild to install an integrity guard would destroy a stronger integrity property to do it.

## What the tests are careful about

The rule now has **two** enforcement sites for **two** classes: a v1 `CHECK` for `llm_candidate`, a v8 trigger for `derivation`. A test going through `append` would prove the Rust refusals fire and say nothing about the store — and the store is what a producer written later, by someone else, will meet. So the load-bearing test goes around Rust entirely in raw SQL and asserts the **combination** is complete. `DerivationCannotConfirm` names the rule for the caller; it is not the guarantee.

| Mutation | Died on |
|---|---|
| v8 dropped from the fresh-store path | raw-SQL · migrated · inherited-rows (**3**) |
| v8 dropped from `migrate` only | **exactly** the migrated-store control |
| Rust early refusal removed | **exactly** the named-error control — raw-SQL survives |
| trigger's `WHEN` neutered | raw-SQL · migrated — the named-error control survives |

The Rust half and the SQL half are separately observable, and so are the two creation paths.

## A bug found in the writing, and what it says about version stamps

`open` has **two** paths — an explicit enumeration for a new store, `migrate` for an existing one. I added v8 to only the second, producing a store **stamped v8 with no v8 trigger**: it passes a version check and fails the rule. The raw-SQL test caught it.

`the_schema_stamps_the_guarded_version` passed throughout that bug. A version number records what someone said the schema was; only behaviour records what it is. `a_store_migrated_from_v7_gains_the_guard` is the control, and records the point.

## Inherited rows are not coerced

The migration constrains future inserts and touches nothing already written — repairing a hash-chained log is a much larger decision than a migration is entitled to make. Migrating such a store is deliberately **not** an error either: refusing to open it would strand an operator with a database they can neither read nor repair, and the rows are already written. The honest outcome is a store that stops the next one and can name the ones it inherited, via `unauthorized_confirmation_rows` — the `invalid_shape_rows` contract, applied to this rule.

## Scope

This does **not** build 2a, and the chain trace's larger finding stands unaddressed: Kirra World still has no production writer of any kind — two binaries, one read-only, one delete-only. This closes the guard that must exist before a producer does.

## Verification

9 new tests · four mutations, each dying on its own controls · `check_query_boundedness` (it caught the new public method as unclassified — classified `operational` alongside its sibling, with reasoning) · `check_orphan_cores` · `check_world_semantics` · `check_world_answer_boundary` · `check_kirra_world_bidirectional_fence` · `check_reexport_shims` · `kirra-world-store` / `kirra-world` / `kirra-world-service` / `kirra-proposal-context` suites green (50 result lines, 0 failures) · WM-2 schema-growth lane run locally (30 tests + clippy `-D warnings`) since it depends on the store and this is a schema change · `cargo fmt --all --check`.

The one clippy warning in the crate (`unused import: StoreError` in `claim_at_generation`) was verified pre-existing on `main` by stashing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_