### PR TITLE
Box 2b: adjudication judges persisted evidence, and the identity-freshness ruling

### DIFF
--- a/ci/freshness_unruled_baseline.json
+++ b/ci/freshness_unruled_baseline.json
@@ -44,6 +44,11 @@
       "kind": "observation",
       "predicate": "serial_number",
       "why": "The identifying predicate box 2a's end-to-end fixture observes, so the exact-identifier rule has evidence to survey. Knowingly unruled: whether a serial number ages is a question about the asset-tagging regime that issues it, not about Kirra World -- a serial is timeless while it is affixed and meaningless the moment the tag is replaced, and the class alone cannot tell those apart. No production producer writes it today; when one does, it rules its own predicate rather than inheriting a disposition invented for a fixture."
+    },
+    {
+      "kind": "observation",
+      "predicate": "near",
+      "why": "A fixture predicate in box 2b's adversarial suite, standing in for 'a candidate-status claim that proposes something other than co-reference' so the wrong-predicate refusal can be isolated. Knowingly unruled: proximity is plainly recency-sensitive, but by how much is a question about the sensing regime rather than about Kirra World, and no production producer writes it. A real proximity producer rules its own predicate rather than inheriting a number invented for a fixture."
     }
   ]
 }

--- a/ci/store_boundedness_baseline.json
+++ b/ci/store_boundedness_baseline.json
@@ -56,6 +56,10 @@
       "class": "operational",
       "why": "A write, classified with append and append_adjudication for the same reason: it is not a query and answers no domain question. One row per call, so there is nothing to bound -- the size of the write does not vary with the size of the store."
     },
+    "adjudicate_same_as": {
+      "class": "operational",
+      "why": "A write, classified with append and the other doors. Its one read is a point lookup (load_same_as_candidate, LIMIT 1) and it appends exactly one row, so nothing about its cost varies with the size of the store. Box 2b's sanctioned adjudication door."
+    },
     "as_of": {
       "class": "bounded",
       "why": "One subject at one bitemporal point. Same PRIMARY KEY bound as `current`."

--- a/crates/kirra-world-ingest/Cargo.toml
+++ b/crates/kirra-world-ingest/Cargo.toml
@@ -41,3 +41,10 @@ publish = false  # proprietary (see COPYRIGHT) — not for crates.io
 kirra-world-store = { path = "../kirra-world-store" }
 # SameAsCandidate, MatcherIdentity, Confidence — the domain types the door takes.
 kirra-world = { path = "../kirra-world" }
+
+[dev-dependencies]
+# `test-support` for `head_generation_for_test`: box 2b's provenance-walk tests
+# need the generation of the row they just appended, and inferring it from
+# `count()` would bake in "generations are dense" -- which compaction makes
+# false. Dev-only, so the production build of this crate is unchanged.
+kirra-world-store = { path = "../kirra-world-store", features = ["test-support"] }

--- a/crates/kirra-world-ingest/tests/persisted_adjudication.rs
+++ b/crates/kirra-world-ingest/tests/persisted_adjudication.rs
@@ -569,3 +569,88 @@ fn a_refused_adjudication_appends_nothing() {
         .expect("adjudicable");
     assert_eq!(store.count().expect("count"), before + 1);
 }
+
+// ---------------------------------------------------------------------------
+// Review finding on #1466 — the provenance walk must reach the judged candidate
+// ---------------------------------------------------------------------------
+
+/// **A provenance walk from the decision reaches the candidate it judged.**
+///
+/// The adjudication row's `provenance` originally carried only `cited()`, so the
+/// `candidate_observation_id` — the single most important citation, the thing
+/// the decision is ABOUT — was reachable only by parsing the payload. Box 4a's
+/// citation index is built from the `provenance` column, so a walk from a
+/// decision could not reach the proposal it judged.
+///
+/// This asserts the walk, not the encoding: it reads the edges the store
+/// actually indexed rather than the payload it wrote, which is the whole
+/// difference the finding turned on.
+#[test]
+fn the_decision_cites_the_candidate_it_judged_in_walkable_provenance() {
+    let (mut store, obs_a, _) = store_with_a_candidate("walkable");
+    let (e, o) = ids("walk");
+    store
+        .adjudicate_same_as(&request(
+            &e,
+            &o,
+            CANDIDATE_OBS,
+            vec![ObservationId::new(&obs_a).expect("id")],
+            operator(),
+            Outcome::Promoted,
+        ))
+        .expect("adjudicable");
+
+    // The decision is the newest row; take its generation from the row itself
+    // rather than assuming generations are dense.
+    let generation = store.head_generation_for_test().expect("head");
+    let page = store
+        .citations_of(generation, 16, None)
+        .expect("citations of the decision");
+    let cited: Vec<String> = page
+        .edges
+        .iter()
+        .map(|edge| edge.cited_observation_id.clone())
+        .collect();
+
+    assert!(
+        cited.contains(&CANDIDATE_OBS.to_owned()),
+        "the walk must reach the judged candidate: {cited:?}"
+    );
+    assert!(
+        cited.contains(&obs_a),
+        "and still reach the operator's own citations: {cited:?}"
+    );
+}
+
+/// **The candidate is cited once, even when the caller also names it.**
+///
+/// `provenance` is keyed `(generation, ordinal)`, so one observation appearing
+/// twice would make a single piece of evidence look like two — the defect
+/// `SameAsCandidate::propose` already refuses for support lists.
+#[test]
+fn naming_the_candidate_in_cited_as_well_does_not_double_count_it() {
+    let (mut store, obs_a, _) = store_with_a_candidate("no-double");
+    let (e, o) = ids("dup");
+    store
+        .adjudicate_same_as(&request(
+            &e,
+            &o,
+            CANDIDATE_OBS,
+            vec![
+                ObservationId::new(CANDIDATE_OBS).expect("id"),
+                ObservationId::new(&obs_a).expect("id"),
+            ],
+            operator(),
+            Outcome::Promoted,
+        ))
+        .expect("adjudicable");
+
+    let generation = store.head_generation_for_test().expect("head");
+    let page = store.citations_of(generation, 16, None).expect("citations");
+    let occurrences = page
+        .edges
+        .iter()
+        .filter(|edge| edge.cited_observation_id == CANDIDATE_OBS)
+        .count();
+    assert_eq!(occurrences, 1, "one citation, not two: {:?}", page.edges);
+}

--- a/crates/kirra-world-ingest/tests/persisted_adjudication.rs
+++ b/crates/kirra-world-ingest/tests/persisted_adjudication.rs
@@ -1,0 +1,571 @@
+//! **Box 2b: adjudication judges persisted evidence, or refuses.**
+//!
+//! `KIRRA-WM-PROMOTION-001` puts confirmed identity behind an explicitly
+//! authorized adjudicator ruling over *recorded* evidence. Until 2b the API took
+//! a `&SameAsCandidate` — a value the caller built — so an adjudicator could
+//! judge something that merely looked like evidence.
+//!
+//! # The load-bearing property is structural, so there is no test for it
+//!
+//! `SameAsAdjudicationRequest` carries a candidate `ObservationId` and **no
+//! candidate value**. An in-memory `SameAsCandidate` with no persisted id cannot
+//! be passed to `adjudicate_same_as` at all — not "is rejected by it". That is a
+//! compile-time property, and the honest way to record it is to say so rather
+//! than to write a test that cannot fail.
+//!
+//! What IS tested is every way a caller can name a persisted thing that turns
+//! out not to be admissible evidence, which is where the runtime risk actually
+//! lives.
+
+use kirra_world::observation::{ClockDomain, DomainInstant, SourceClass};
+use kirra_world::reference::{EventId, ObservationId};
+use kirra_world::same_as_adjudication::{
+    corroboration_count, AdjudicationAuthority, Outcome, SameAsAdjudication,
+};
+use kirra_world::same_as_candidate::MatcherIdentity;
+use kirra_world_ingest::{run_ingest_pass, ExactIdentifierRule};
+use kirra_world_store::same_as_adjudication_record::{AdjudicateError, SameAsAdjudicationRequest};
+use kirra_world_store::{ClaimStatus, NewEvent, StoreError, WorldStore, WriterClass};
+
+const T0: i64 = 1_700_000_000_000;
+const SURVEY_LIMIT: usize = 1_000;
+/// The observation id the ingest pass mints for its first proposal.
+const CANDIDATE_OBS: &str = "cand-obs-1";
+
+fn tmp(name: &str) -> std::path::PathBuf {
+    static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let n = NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let mut p = std::env::temp_dir();
+    p.push(format!("kirra-2b-{name}-{}-{n}.sqlite", std::process::id()));
+    for s in ["", "-wal", "-shm"] {
+        let mut q = p.as_os_str().to_os_string();
+        q.push(s);
+        let _ = std::fs::remove_file(std::path::PathBuf::from(q));
+    }
+    p
+}
+
+fn at(ms: u64) -> DomainInstant {
+    DomainInstant {
+        ms,
+        domain: ClockDomain::System,
+    }
+}
+
+fn observe(store: &mut WorldStore, n: &str, subject: &str, value: &str) -> String {
+    let event_id = EventId::new(format!("ev-{n}")).expect("event id");
+    let observation_id = ObservationId::new(format!("obs-{n}")).expect("observation id");
+    store
+        .append(&NewEvent {
+            event_id: &event_id,
+            observation_id: &observation_id,
+            txn_time_ms: T0,
+            valid_from_ms: T0,
+            valid_to_ms: None,
+            source: "asset-tag-reader",
+            source_version: "1.0.0",
+            writer_class: WriterClass::Sensor,
+            claim_status: ClaimStatus::Confirmed,
+            provenance: &[],
+            frame_id: None,
+            map_id: None,
+            kind: "observation",
+            subject,
+            subject_ref: None,
+            predicate: Some("serial_number"),
+            object: Some(value),
+            payload: "{}",
+            payload_schema: 1,
+            retention_class: "raw",
+            trust: None,
+        })
+        .expect("append observation");
+    observation_id.as_str().to_owned()
+}
+
+/// A store holding one real, persisted `same_as` candidate for `(track-a, track-b)`.
+fn store_with_a_candidate(name: &str) -> (WorldStore, String, String) {
+    let path = tmp(name);
+    let mut store = WorldStore::open(&path).expect("open");
+    let obs_a = observe(&mut store, "a", "track-a", "SN-1");
+    let obs_b = observe(&mut store, "b", "track-b", "SN-1");
+
+    let rule = ExactIdentifierRule::new(
+        "serial_number",
+        MatcherIdentity::new("world-ingest", "exact-identifier", "1.0.0").expect("matcher"),
+    )
+    .expect("rule");
+    let mut n = 0;
+    let report = run_ingest_pass(&mut store, &rule, T0, SURVEY_LIMIT, move || {
+        n += 1;
+        (
+            EventId::new(format!("cand-ev-{n}")).expect("id"),
+            ObservationId::new(format!("cand-obs-{n}")).expect("id"),
+        )
+    })
+    .expect("pass");
+    assert_eq!(
+        report.proposed, 1,
+        "fixture must persist exactly one candidate"
+    );
+    (store, obs_a, obs_b)
+}
+
+/// A payload that decodes as a perfectly good candidate.
+///
+/// Load-bearing for the adversarial fixtures below: with `"{}"` they were
+/// refused for having no `matcher` field, so each case passed without its named
+/// property ever being consulted. Mutating away the `writer_class` check left
+/// them all green — which is how that was found.
+const VALID_CANDIDATE_PAYLOAD: &str = r#"{"matcher":{"producer":"p","model_or_rule":"m","version":"1.0.0"},"confidence":{"score":null,"basis":"unspecified","calibration":null}}"#;
+
+fn operator() -> AdjudicationAuthority {
+    AdjudicationAuthority::new(SourceClass::Operator, "console-operator").expect("authority")
+}
+
+fn request<'a>(
+    event_id: &'a EventId,
+    observation_id: &'a ObservationId,
+    candidate_observation_id: &'a str,
+    cited: Vec<ObservationId>,
+    authority: AdjudicationAuthority,
+    outcome: Outcome,
+) -> SameAsAdjudicationRequest<'a> {
+    SameAsAdjudicationRequest {
+        event_id,
+        observation_id,
+        candidate_observation_id,
+        cited,
+        authority,
+        outcome,
+        decided_at: at(T0 as u64 + 10),
+        txn_time_ms: T0 + 10,
+        source: "operator-console",
+        source_version: "1.0.0",
+    }
+}
+
+fn ids(n: &str) -> (EventId, ObservationId) {
+    (
+        EventId::new(format!("adj-ev-{n}")).expect("id"),
+        ObservationId::new(format!("adj-obs-{n}")).expect("id"),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// The positive case, first — everything below is a refusal, and a suite of
+// refusals with no admitted case proves only that nothing works.
+// ---------------------------------------------------------------------------
+
+/// **A persisted, valid candidate adjudicates.**
+#[test]
+fn a_persisted_valid_candidate_can_be_adjudicated() {
+    let (mut store, obs_a, _) = store_with_a_candidate("valid");
+    let (e, o) = ids("ok");
+    let decision = store
+        .adjudicate_same_as(&request(
+            &e,
+            &o,
+            CANDIDATE_OBS,
+            vec![ObservationId::new(&obs_a).expect("id")],
+            operator(),
+            Outcome::Promoted,
+        ))
+        .expect("a real candidate, judged by an operator, is adjudicable");
+
+    assert_eq!(decision.outcome(), Outcome::Promoted);
+    assert_eq!(decision.pair().low().as_str(), "track-a");
+    assert_eq!(decision.pair().high().as_str(), "track-b");
+    assert_eq!(
+        decision.candidate_observation_id().as_str(),
+        CANDIDATE_OBS,
+        "the decision must name the persisted candidate it judged"
+    );
+}
+
+/// **The pair comes from the loaded evidence, not from the caller.**
+///
+/// There is no pair parameter, so a decision cannot be recorded against a pair
+/// the candidate does not name. Asserted against the fixture's real entities so
+/// the property is checked rather than merely arranged.
+#[test]
+fn the_decided_pair_is_the_one_the_evidence_names() {
+    let (mut store, obs_a, _) = store_with_a_candidate("pair-from-evidence");
+    let (e, o) = ids("pair");
+    let decision = store
+        .adjudicate_same_as(&request(
+            &e,
+            &o,
+            CANDIDATE_OBS,
+            vec![ObservationId::new(&obs_a).expect("id")],
+            operator(),
+            Outcome::Rejected,
+        ))
+        .expect("adjudicable");
+    assert_eq!(
+        (
+            decision.pair().low().as_str(),
+            decision.pair().high().as_str()
+        ),
+        ("track-a", "track-b")
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The adversarial cases
+// ---------------------------------------------------------------------------
+
+/// **1. A nonexistent observation id is refused.**
+#[test]
+fn a_nonexistent_observation_id_is_refused() {
+    let (mut store, obs_a, _) = store_with_a_candidate("nonexistent");
+    let (e, o) = ids("none");
+    let err = store
+        .adjudicate_same_as(&request(
+            &e,
+            &o,
+            "no-such-observation",
+            vec![ObservationId::new(&obs_a).expect("id")],
+            operator(),
+            Outcome::Promoted,
+        ))
+        .expect_err("there is no such evidence");
+    assert!(
+        matches!(
+            err,
+            StoreError::Adjudicate(AdjudicateError::NoSuchCandidate { .. })
+        ),
+        "and the refusal must say the evidence is ABSENT, not malformed: {err:?}"
+    );
+}
+
+/// **2. An id naming a CONFIRMED row rather than a candidate is refused.**
+///
+/// `obs-a` is the sensor observation the matcher computed FROM — real, relevant,
+/// and not a proposal. Judging it would be judging the input as though it were
+/// the candidate.
+///
+/// Note what this does and does not isolate. That row differs from a candidate
+/// in several ways at once (status, class, predicate), so it proves the door
+/// refuses it, not *which* check did. The single-property isolation for
+/// `claim_status` is
+/// `a_derivation_row_marked_confirmed_is_refused_by_the_decoder` below, and it
+/// has to live at the decoder because the store cannot produce such a row at
+/// all.
+#[test]
+fn an_observation_that_is_confirmed_rather_than_candidate_is_refused() {
+    let (mut store, obs_a, _) = store_with_a_candidate("confirmed-row");
+    let (e, o) = ids("conf");
+    let err = store
+        .adjudicate_same_as(&request(
+            &e,
+            &o,
+            &obs_a,
+            vec![ObservationId::new(&obs_a).expect("id")],
+            operator(),
+            Outcome::Promoted,
+        ))
+        .expect_err("a confirmed observation is not a candidate");
+    assert!(
+        matches!(
+            err,
+            StoreError::Adjudicate(AdjudicateError::NotACandidate { .. })
+        ),
+        "the row EXISTS, so this must not read as absence: {err:?}"
+    );
+}
+
+/// **2a. `derivation` + `confirmed` is refused by the decoder — and cannot be
+/// stored in the first place.**
+///
+/// This one is deliberately at the decode layer rather than through the door,
+/// and the reason is a structural fact worth stating: schema **v8** installs a
+/// trigger refusing `writer_class = 'derivation'` with
+/// `claim_status = 'confirmed'`, so no such row can exist in any store. The
+/// door therefore cannot be handed one, and a store-level test of this property
+/// would be asserting against an unreachable state.
+///
+/// The decoder's `claim_status` check is still not dead: `decode_candidate` is
+/// public and total, so it must refuse a row shape it may be handed by any
+/// caller — including a future backend whose write path is not SQLite's.
+#[test]
+fn a_derivation_row_marked_confirmed_is_refused_by_the_decoder() {
+    use kirra_world_store::candidate_record::{
+        decode_candidate, CandidateDecodeError, StoredCandidateRow, CANDIDATE_KIND,
+        CANDIDATE_PAYLOAD_SCHEMA, CANDIDATE_PREDICATE_TOKEN, CANDIDATE_STATUS_TOKEN,
+        DERIVATION_TOKEN,
+    };
+    let row = |status: &'static str| StoredCandidateRow {
+        writer_class: DERIVATION_TOKEN,
+        claim_status: status,
+        kind: CANDIDATE_KIND,
+        predicate: Some(CANDIDATE_PREDICATE_TOKEN),
+        subject: "track-a",
+        object_id: Some("track-b"),
+        payload: VALID_CANDIDATE_PAYLOAD,
+        payload_schema: CANDIDATE_PAYLOAD_SCHEMA,
+    };
+    assert!(
+        matches!(
+            decode_candidate(&row("confirmed"), &["obs-a".to_owned()]),
+            Err(CandidateDecodeError::NotACandidateRow { .. })
+        ),
+        "a confirmed row is not a matcher's proposal"
+    );
+    // Non-vacuity: the SAME row at candidate status decodes, so the refusal is
+    // attributable to `claim_status` and to nothing else about the fixture.
+    decode_candidate(&row(CANDIDATE_STATUS_TOKEN), &["obs-a".to_owned()])
+        .expect("the identical row, as a candidate, decodes");
+}
+
+/// **3. An id naming the wrong predicate is refused.**
+///
+/// A candidate-status row that proposes something other than co-reference is
+/// still not a `same_as` candidate.
+#[test]
+fn an_observation_with_the_wrong_predicate_is_refused() {
+    let (mut store, obs_a, _) = store_with_a_candidate("wrong-predicate");
+    let (e, o) = ids("pred");
+    let other = ObservationId::new("other-candidate").expect("id");
+    store
+        .append(&NewEvent {
+            event_id: &EventId::new("other-ev").expect("id"),
+            observation_id: &other,
+            txn_time_ms: T0,
+            valid_from_ms: T0,
+            valid_to_ms: None,
+            source: "some-matcher",
+            source_version: "1.0.0",
+            writer_class: WriterClass::Derivation,
+            claim_status: ClaimStatus::Candidate,
+            provenance: &[obs_a.as_str()],
+            frame_id: None,
+            map_id: None,
+            kind: "observation",
+            subject: "track-a",
+            subject_ref: None,
+            predicate: Some("near"),
+            object: Some("track-b"),
+            payload: VALID_CANDIDATE_PAYLOAD,
+            payload_schema: 1,
+            retention_class: "raw",
+            trust: None,
+        })
+        .expect("append");
+
+    let err = store
+        .adjudicate_same_as(&request(
+            &e,
+            &o,
+            "other-candidate",
+            vec![ObservationId::new(&obs_a).expect("id")],
+            operator(),
+            Outcome::Promoted,
+        ))
+        .expect_err("`near` is not `same_as`");
+    assert!(matches!(
+        err,
+        StoreError::Adjudicate(AdjudicateError::NotACandidate { .. })
+    ));
+}
+
+/// **4. An id naming a non-`Derivation` writer is refused.**
+///
+/// A `same_as` candidate written by an operator or a sensor is not a matcher's
+/// proposal, whatever its predicate says.
+#[test]
+fn an_observation_from_a_non_derivation_writer_is_refused() {
+    let (mut store, obs_a, _) = store_with_a_candidate("wrong-writer");
+    let (e, o) = ids("writer");
+    let hand = ObservationId::new("hand-written").expect("id");
+    store
+        .append(&NewEvent {
+            event_id: &EventId::new("hand-ev").expect("id"),
+            observation_id: &hand,
+            txn_time_ms: T0,
+            valid_from_ms: T0,
+            valid_to_ms: None,
+            source: "operator-console",
+            source_version: "1.0.0",
+            writer_class: WriterClass::Operator,
+            claim_status: ClaimStatus::Candidate,
+            provenance: &[obs_a.as_str()],
+            frame_id: None,
+            map_id: None,
+            kind: "observation",
+            subject: "track-a",
+            subject_ref: None,
+            predicate: Some("same_as"),
+            object: Some("track-b"),
+            payload: VALID_CANDIDATE_PAYLOAD,
+            payload_schema: 1,
+            retention_class: "raw",
+            trust: None,
+        })
+        .expect("append");
+
+    let err = store
+        .adjudicate_same_as(&request(
+            &e,
+            &o,
+            "hand-written",
+            vec![ObservationId::new(&obs_a).expect("id")],
+            operator(),
+            Outcome::Promoted,
+        ))
+        .expect_err("only a derivation-class proposal is a candidate");
+    assert!(matches!(
+        err,
+        StoreError::Adjudicate(AdjudicateError::NotACandidate { .. })
+    ));
+}
+
+/// **5. An unauthorized adjudicator cannot be CONSTRUCTED, let alone reach the
+/// door.**
+///
+/// This test changed shape while being written, and the change is the finding.
+/// It began as "the door refuses a `Derivation`-class adjudicator" — and failed,
+/// because `AdjudicationAuthority::new` refuses that class itself. The store had
+/// a comparison against `Operator` that could only ever be `false`: a dead guard
+/// that a reader would count as the enforcement and stop looking for the real
+/// one. It has been removed, and this asserts what is actually true.
+///
+/// A `Derivation`-class "adjudicator" is a matcher confirming its own proposal —
+/// the exact loop `KIRRA-WM-PROMOTION-001` exists to break — and it is
+/// unrepresentable rather than rejected.
+#[test]
+fn an_unauthorized_adjudicator_cannot_be_constructed_at_all() {
+    for class in [
+        SourceClass::Derivation,
+        SourceClass::Sensor,
+        SourceClass::Network,
+        SourceClass::Import,
+        SourceClass::Configuration,
+    ] {
+        assert!(
+            AdjudicationAuthority::new(class, "would-be-adjudicator").is_err(),
+            "{class:?} must not be able to hold adjudication authority"
+        );
+    }
+    // Non-vacuity: the one authorized class still constructs, so the loop above
+    // is rejecting the CLASS and not every authority.
+    AdjudicationAuthority::new(SourceClass::Operator, "console-operator")
+        .expect("v1 authorizes the operator");
+}
+
+/// **6. The candidate survives a rejection, and an unresolved decision.**
+///
+/// Deleting the thing a judgement is about destroys the judgement's subject, so
+/// the candidate must still be loadable afterwards — and still be a candidate,
+/// not something the rejection mutated.
+#[test]
+fn the_candidate_remains_in_the_ledger_after_reject_and_unresolved() {
+    for (name, outcome, n) in [
+        ("rejected", Outcome::Rejected, "rej"),
+        ("unresolved", Outcome::Unresolved, "unr"),
+    ] {
+        let (mut store, obs_a, _) = store_with_a_candidate(name);
+        let (e, o) = ids(n);
+        store
+            .adjudicate_same_as(&request(
+                &e,
+                &o,
+                CANDIDATE_OBS,
+                vec![ObservationId::new(&obs_a).expect("id")],
+                operator(),
+                outcome,
+            ))
+            .expect("adjudicable");
+
+        let still_there = store
+            .load_same_as_candidate(CANDIDATE_OBS)
+            .expect("load")
+            .expect("the candidate must survive being judged");
+        assert_eq!(still_there.pair().low().as_str(), "track-a");
+        assert_eq!(still_there.pair().high().as_str(), "track-b");
+    }
+}
+
+/// **7. Re-adjudicating one persisted pair cannot inflate corroboration.**
+///
+/// `Corroboration(n)` counts **distinct confirmed relations**, not adjudication
+/// records — so three promotions of one pair are one corroboration. Asserted
+/// here against decisions that all came through the persisted door, because the
+/// pure-layer test cannot show that the store path preserves the property.
+#[test]
+fn re_adjudicating_the_same_persisted_pair_does_not_inflate_corroboration() {
+    let (mut store, obs_a, _) = store_with_a_candidate("replay");
+    let mut decisions: Vec<SameAsAdjudication> = Vec::new();
+    for i in 0..3 {
+        let (e, o) = ids(&format!("replay-{i}"));
+        decisions.push(
+            store
+                .adjudicate_same_as(&request(
+                    &e,
+                    &o,
+                    CANDIDATE_OBS,
+                    vec![ObservationId::new(&obs_a).expect("id")],
+                    operator(),
+                    Outcome::Promoted,
+                ))
+                .expect("adjudicable"),
+        );
+    }
+
+    assert_eq!(decisions.len(), 3, "three records were genuinely written");
+    assert_eq!(
+        corroboration_count(&decisions),
+        1,
+        "but one pair is one corroboration, however many times it is affirmed"
+    );
+}
+
+/// **Nothing is written when an adjudication is refused.**
+///
+/// The order is load → validate → decide → append, so a refused attempt leaves
+/// no trace. Without this, a refusal could still be appending a row a later
+/// reader would count.
+///
+/// The refusal used here is a nonexistent candidate — a REACHABLE one. An
+/// earlier version reached for an unauthorized authority, which cannot be
+/// constructed, so the test would have been asserting against a call that never
+/// happened.
+#[test]
+fn a_refused_adjudication_appends_nothing() {
+    let (mut store, obs_a, _) = store_with_a_candidate("no-trace");
+    let before = store.count().expect("count");
+
+    let (e, o) = ids("refused");
+    store
+        .adjudicate_same_as(&request(
+            &e,
+            &o,
+            "no-such-observation",
+            vec![ObservationId::new(&obs_a).expect("id")],
+            operator(),
+            Outcome::Promoted,
+        ))
+        .expect_err("refused");
+
+    assert_eq!(
+        store.count().expect("count"),
+        before,
+        "a refused adjudication must not append"
+    );
+
+    // Non-vacuity: an ACCEPTED adjudication does append, so the equality above
+    // is showing that the refusal wrote nothing rather than that this door
+    // never writes.
+    let (e2, o2) = ids("accepted");
+    store
+        .adjudicate_same_as(&request(
+            &e2,
+            &o2,
+            CANDIDATE_OBS,
+            vec![ObservationId::new(&obs_a).expect("id")],
+            operator(),
+            Outcome::Promoted,
+        ))
+        .expect("adjudicable");
+    assert_eq!(store.count().expect("count"), before + 1);
+}

--- a/crates/kirra-world-service/src/freshness.rs
+++ b/crates/kirra-world-service/src/freshness.rs
@@ -167,6 +167,37 @@ pub const RULED: &[(SemanticClass, FreshnessPolicy)] = &[
         },
         FreshnessPolicy::Timeless,
     ),
+    // `KIRRA-WM-IDENTITY-FRESHNESS-001` (2026-08-20). An **adjudicated identity
+    // decision** does not age.
+    //
+    // The distinction this ruling turns on, stated because it is the whole
+    // argument and it is easy to collapse:
+    //
+    //   candidate evidence   — "I currently think A and B may be the same"
+    //                          -> freshness may matter
+    //   adjudicated decision — "an authorized adjudicator DECIDED A and B are
+    //                          the same identity"
+    //                          -> does not age out merely because time passed
+    //
+    // A matcher's proposal is a present-tense belief resting on observations
+    // that may themselves be bounded. A decision recorded by an authorized
+    // adjudicator is a different kind of fact: it remains valid until CHANGED by
+    // later adjudication -- `SplitEntity`, `ForgetEntity`, or superseding
+    // identity evidence -- not until a clock runs out. Ageing it would make
+    // identity silently dissolve with nobody deciding anything, which is exactly
+    // what §6.3's "a merged id stays resolvable forever" forbids.
+    //
+    // Note this rules the DECISION row (`same_as_adjudication`), not the
+    // candidate. `(observation, "same_as")` -- the matcher's proposal -- stays
+    // in `ci/freshness_unruled_baseline.json`, deliberately: whether a PROPOSAL
+    // goes stale is a separate question this ruling does not answer.
+    (
+        SemanticClass {
+            kind: "same_as_adjudication",
+            predicate: Some("same_as_adjudged"),
+        },
+        FreshnessPolicy::Timeless,
+    ),
 ];
 
 /// The ruled disposition for a semantic class, if one exists.

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -92,6 +92,7 @@ pub mod provenance_edges;
 pub mod provenance_graph;
 pub mod retention_driver;
 pub mod retention_sweeper;
+pub mod same_as_adjudication_record;
 pub mod schema;
 pub mod semantics;
 pub mod snapshot;
@@ -197,6 +198,8 @@ pub enum StoreError {
     /// SQLite said no — including the schema `CHECK` violations, which is
     /// deliberate. See [`schema`].
     Sqlite(rusqlite::Error),
+    /// An adjudication was refused — box 2b.
+    Adjudicate(same_as_adjudication_record::AdjudicateError),
     /// A stored row is not a well-formed derivation-class `same_as` candidate.
     ///
     /// Distinct from `Ok(None)` on purpose — see
@@ -430,6 +433,7 @@ impl std::fmt::Display for StoreError {
                 f,
                 "provenance index does not cover generation {requested} (floor {floor})"
             ),
+            Self::Adjudicate(e) => write!(f, "{e}"),
             Self::CandidateDecode(e) => write!(f, "stored same_as candidate: {e}"),
             Self::LlmCannotConfirm => write!(
                 f,
@@ -1798,6 +1802,149 @@ impl WorldStore {
             return Err(e.into());
         }
         Ok(generation)
+    }
+
+    /// **Adjudicate a persisted `same_as` candidate** — box 2b's sanctioned door.
+    ///
+    /// `KIRRA-WM-PROMOTION-001`: confirmed identity arrives only through an
+    /// explicitly authorized adjudicator, over recorded evidence.
+    ///
+    /// # The trust boundary is the signature
+    ///
+    /// [`SameAsAdjudicationRequest`](same_as_adjudication_record::SameAsAdjudicationRequest)
+    /// carries a candidate `ObservationId` and no candidate VALUE. An in-memory
+    /// `SameAsCandidate` cannot be passed here, so "adjudication acts on
+    /// persisted evidence" is not a check that could be forgotten — there is no
+    /// argument through which unpersisted evidence could arrive.
+    ///
+    /// The order matters: load → validate → decide → append. Nothing is written
+    /// until the evidence has been found and proved to be what it claims, so a
+    /// refused adjudication leaves no trace of having been attempted, and a
+    /// recorded one always names a candidate that exists.
+    ///
+    /// # What is validated
+    ///
+    /// * the observation **exists** ([`AdjudicateError::NoSuchCandidate`]);
+    /// * the row is a `derivation`-class, `candidate`-status, `same_as` claim
+    ///   with its support intact — all of it by going through
+    ///   [`Self::load_same_as_candidate`], whose decode ends in the domain's own
+    ///   constructor ([`AdjudicateError::NotACandidate`]);
+    /// * the **adjudicator is authorized** — v1 is `SourceClass::Operator` only
+    ///   ([`AdjudicateError::UnauthorizedAdjudicator`]). A `Derivation`-class
+    ///   "adjudicator" is a matcher confirming its own proposal, which is the
+    ///   exact loop the ruling exists to break.
+    ///
+    /// # The candidate survives
+    ///
+    /// Nothing here mutates or removes the candidate row, on any outcome. A
+    /// rejection is a **new** append-only record citing the same evidence — the
+    /// candidate remains in the ledger, because deleting the thing a judgement
+    /// is about destroys the judgement's subject.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::Adjudicate`] wrapping the reason, or
+    /// [`StoreError::Sqlite`] if the log cannot be read or written.
+    pub fn adjudicate_same_as(
+        &mut self,
+        request: &same_as_adjudication_record::SameAsAdjudicationRequest<'_>,
+    ) -> Result<kirra_world::same_as_adjudication::SameAsAdjudication, StoreError> {
+        use same_as_adjudication_record as rec;
+
+        // 1. LOAD. `load_same_as_candidate` distinguishes "no such row" from
+        //    "that row is not a candidate", and both distinctions survive here:
+        //    an adjudicator told the wrong one would look in the wrong place.
+        let candidate = match self.load_same_as_candidate(request.candidate_observation_id) {
+            Ok(Some(c)) => c,
+            Ok(None) => {
+                return Err(StoreError::Adjudicate(
+                    rec::AdjudicateError::NoSuchCandidate {
+                        observation_id: request.candidate_observation_id.to_owned(),
+                    },
+                ))
+            }
+            Err(StoreError::CandidateDecode(e)) => {
+                return Err(StoreError::Adjudicate(
+                    rec::AdjudicateError::NotACandidate {
+                        detail: e.to_string(),
+                    },
+                ))
+            }
+            Err(e) => return Err(e),
+        };
+
+        // 2. AUTHORITY -- carried by the TYPE, not re-checked here.
+        //
+        //    An earlier draft of this method compared
+        //    `request.authority.class()` against `Operator` and refused
+        //    otherwise. That check was DEAD: `AdjudicationAuthority::new`
+        //    already refuses every class but `Operator`, and the type does not
+        //    even store one -- `class()` returns the constant. So the comparison
+        //    was a constant `false` dressed as a guard, which is worse than no
+        //    guard: a reader counts it as the enforcement and stops looking for
+        //    the real one.
+        //
+        //    Same reasoning `Justification` records for declining to offer
+        //    `is_empty`. An unauthorized adjudicator is UNREPRESENTABLE, so it
+        //    cannot reach this door -- see
+        //    `an_unauthorized_adjudicator_cannot_be_constructed_at_all`.
+        //
+        // 2. DECIDE. The pair comes from the LOADED candidate, never from the
+        //    caller -- so a decision cannot be recorded against a pair the
+        //    evidence does not name.
+        let adjudication = kirra_world::same_as_adjudication::SameAsAdjudication::record(
+            candidate.pair().clone(),
+            kirra_world::reference::ObservationId::new(request.candidate_observation_id).map_err(
+                |e| {
+                    StoreError::Adjudicate(rec::AdjudicateError::Domain {
+                        detail: e.to_string(),
+                    })
+                },
+            )?,
+            request.cited.clone(),
+            request.authority.clone(),
+            request.outcome,
+            request.decided_at,
+        )
+        .map_err(|e| {
+            StoreError::Adjudicate(rec::AdjudicateError::Domain {
+                detail: e.to_string(),
+            })
+        })?;
+
+        // 3. APPEND.
+        let payload = rec::encode_same_as_adjudication(&adjudication);
+        let provenance = rec::same_as_adjudication_provenance(&adjudication);
+        let prov: Vec<&str> = provenance.iter().map(String::as_str).collect();
+        let (subject, object) = rec::adjudication_columns(adjudication.pair());
+
+        self.append(&NewEvent {
+            event_id: request.event_id,
+            observation_id: request.observation_id,
+            txn_time_ms: request.txn_time_ms,
+            valid_from_ms: request.txn_time_ms,
+            valid_to_ms: None,
+            source: request.source,
+            source_version: request.source_version,
+            // The authorized class, checked above. `Operator` is not a default
+            // here -- it is the only value the check admits.
+            writer_class: WriterClass::Operator,
+            claim_status: ClaimStatus::Confirmed,
+            provenance: &prov,
+            frame_id: None,
+            map_id: None,
+            kind: rec::SAME_AS_ADJUDICATION_KIND,
+            subject: subject.as_str(),
+            subject_ref: None,
+            predicate: Some(rec::ADJUDICATION_PREDICATE_TOKEN),
+            object: Some(object.as_str()),
+            payload: payload.as_str(),
+            payload_schema: rec::SAME_AS_ADJUDICATION_PAYLOAD_SCHEMA,
+            retention_class: rec::SAME_AS_ADJUDICATION_RETENTION_CLASS,
+            trust: None,
+        })?;
+
+        Ok(adjudication)
     }
 
     /// Load a persisted `same_as` candidate **by its observation id** — the

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -1804,6 +1804,20 @@ impl WorldStore {
         Ok(generation)
     }
 
+    /// The generation of the newest event in the log.
+    ///
+    /// Test-support: a caller that has just appended one row needs its
+    /// generation to walk its citations, and inferring it from `count()` would
+    /// bake in "generations are dense" — which compaction makes false.
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn head_generation_for_test(&self) -> Result<i64, StoreError> {
+        Ok(self
+            .conn
+            .query_row("SELECT MAX(generation) FROM world_events", [], |r| r.get(0))
+            .optional()?
+            .unwrap_or(0))
+    }
+
     /// **Adjudicate a persisted `same_as` candidate** — box 2b's sanctioned door.
     ///
     /// `KIRRA-WM-PROMOTION-001`: confirmed identity arrives only through an
@@ -1829,10 +1843,14 @@ impl WorldStore {
     ///   with its support intact — all of it by going through
     ///   [`Self::load_same_as_candidate`], whose decode ends in the domain's own
     ///   constructor ([`AdjudicateError::NotACandidate`]);
-    /// * the **adjudicator is authorized** — v1 is `SourceClass::Operator` only
-    ///   ([`AdjudicateError::UnauthorizedAdjudicator`]). A `Derivation`-class
-    ///   "adjudicator" is a matcher confirming its own proposal, which is the
-    ///   exact loop the ruling exists to break.
+    ///
+    /// What is **not** validated here, deliberately: the adjudicator's
+    /// authority. `AdjudicationAuthority::new` refuses every class but
+    /// `SourceClass::Operator` and the struct does not store one, so an
+    /// unauthorized adjudicator is unrepresentable and cannot reach this door.
+    /// An earlier draft carried a comparison against `Operator` anyway; it could
+    /// only ever be `false`, and a guard that cannot fire reads as the
+    /// enforcement while a reader stops looking for the real one.
     ///
     /// # The candidate survives
     ///

--- a/crates/kirra-world-store/src/same_as_adjudication_record.rs
+++ b/crates/kirra-world-store/src/same_as_adjudication_record.rs
@@ -112,10 +112,16 @@ pub fn source_class_token(class: SourceClass) -> &'static str {
 /// Encode an adjudication's payload.
 ///
 /// The pair is NOT in here — it travels in `subject`/`object`, where an index
-/// can see it. The cited observations are the row's `provenance`, for the same
-/// reason candidates put their support there: box 4a's citation index is built
-/// from that column, so a decision whose evidence lived only in its payload
-/// would be invisible to the provenance walk.
+/// can see it. The evidence is not here either: the judged candidate and the
+/// cited observations are the row's `provenance`, because box 4a's citation
+/// index is built from that column and a decision whose evidence lived only in
+/// its payload would be invisible to the provenance walk.
+///
+/// `candidate_observation_id` DOES appear here as well, and the duplication is
+/// deliberate: `provenance` is a flat list of ids, so it records *that* the
+/// candidate was cited but not that it was the SUBJECT of the decision rather
+/// than one input among several. The payload keeps that distinction; the
+/// provenance column keeps the walk.
 #[must_use]
 pub fn encode_same_as_adjudication(a: &SameAsAdjudication) -> String {
     serde_json::json!({
@@ -137,9 +143,30 @@ pub fn encode_same_as_adjudication(a: &SameAsAdjudication) -> String {
 }
 
 /// The observation ids an adjudication row records as its `provenance`.
+///
+/// **The judged candidate comes first, then the cited observations.**
+///
+/// An earlier version returned only `cited()`, which left the
+/// `candidate_observation_id` — the single most important citation, the thing
+/// the decision is ABOUT — reachable only by parsing the payload. That
+/// contradicted this module's own stated reason for putting citations in
+/// `provenance`: box 4a's index is built from that column, so a provenance walk
+/// from a decision could not reach the proposal it judged.
+///
+/// Deduplicated, because a caller may legitimately also name the candidate in
+/// `cited` and the citation index keys on `(generation, ordinal)` — one
+/// observation appearing twice would make one piece of evidence look like two,
+/// the same defect `SameAsCandidate::propose` refuses for support lists.
 #[must_use]
 pub fn same_as_adjudication_provenance(a: &SameAsAdjudication) -> Vec<String> {
-    a.cited().iter().map(|o| o.as_str().to_owned()).collect()
+    let mut out = vec![a.candidate_observation_id().as_str().to_owned()];
+    for o in a.cited() {
+        let id = o.as_str().to_owned();
+        if !out.contains(&id) {
+            out.push(id);
+        }
+    }
+    out
 }
 
 /// What a caller must supply to adjudicate a persisted candidate.

--- a/crates/kirra-world-store/src/same_as_adjudication_record.rs
+++ b/crates/kirra-world-store/src/same_as_adjudication_record.rs
@@ -1,0 +1,224 @@
+//! Persisting a `same_as` **adjudication** — `WM_SCOPE.md` §5 box 2b.
+//!
+//! `KIRRA-WM-PROMOTION-001`: confirmed identity arrives only through an
+//! **explicitly authorized adjudicator**, and v1 is `SourceClass::Operator`
+//! only.
+//!
+//! # Where the authority rule is actually enforced
+//!
+//! In the TYPE, not here. `AdjudicationAuthority::new` refuses every class but
+//! `Operator`, and the struct does not even store one — `class()` returns the
+//! constant. An unauthorized adjudicator is therefore unrepresentable, and this
+//! module deliberately does NOT re-check it: a comparison that can only ever be
+//! `false` reads as the enforcement and stops a reader looking for the real one.
+//! (An earlier draft of this module carried exactly that dead check, and its own
+//! test found it.)
+//!
+//! # What box 2b actually closed
+//!
+//! Adjudication used to accept a `&SameAsCandidate` — a value the caller
+//! constructed. That let an adjudicator judge something that merely LOOKED like
+//! evidence, which is the opposite of resting confirmed identity on recorded
+//! evidence. The API now takes the persisted candidate's `ObservationId` and the
+//! store does the loading, so an in-memory candidate cannot enter at all.
+//!
+//! # Why the predicate is not `same_as`
+//!
+//! A row saying `(low, same_as, high)` at `claim_status = confirmed` would read
+//! as *"these are the same"*. That is not what this row is. This row says *"an
+//! authorized adjudicator reached a decision about that pair"* — and the
+//! decision may be `Rejected`. Storing a rejection under the `same_as`
+//! predicate would make the log assert the very thing the operator refused.
+//!
+//! So the predicate is [`ADJUDICATION_PREDICATE_TOKEN`], and the outcome lives
+//! in the payload. Both entities stay in indexed columns, which is what lets a
+//! reader find every decision about a pair without parsing payloads.
+
+use kirra_world::observation::SourceClass;
+use kirra_world::reference::{EventId, ObservationId};
+use kirra_world::same_as_adjudication::{AdjudicationAuthority, Outcome, SameAsAdjudication};
+use kirra_world::same_as_candidate::CandidatePair;
+
+/// The `world_events.kind` token every `same_as` adjudication row carries.
+pub const SAME_AS_ADJUDICATION_KIND: &str = "same_as_adjudication";
+
+/// The `world_events.predicate` token every adjudication row carries.
+///
+/// **Not `same_as`** — see the module docs. This names the RELATION between the
+/// row and the pair (*a decision was reached about it*), not the relation
+/// between the two entities.
+pub const ADJUDICATION_PREDICATE_TOKEN: &str = "same_as_adjudged";
+
+/// The `world_events.retention_class` every adjudication row carries.
+///
+/// `"adjudication"`, and NOT the `"raw"` its candidate carries.
+/// `crate::compaction::is_protected` holds for every class except `"raw"`, so
+/// this is what keeps a decision from being compacted away.
+///
+/// The asymmetry with [`crate::candidate_record::CANDIDATE_RETENTION_CLASS`] is
+/// the point rather than an inconsistency. A matcher proposes continuously and
+/// most proposals are never judged; an *authorized adjudicator's decision* is
+/// rare, deliberate, and the thing §6.3's "a merged id stays resolvable forever"
+/// ultimately rests on.
+pub const SAME_AS_ADJUDICATION_RETENTION_CLASS: &str = "adjudication";
+
+/// Version of the payload encoding below.
+pub const SAME_AS_ADJUDICATION_PAYLOAD_SCHEMA: i64 = 1;
+
+/// The stored spelling of an outcome.
+///
+/// An exhaustive `match` with no wildcard: a new [`Outcome`] variant must be a
+/// COMPILE error here rather than a row storing a decision this encoder never
+/// considered.
+#[must_use]
+pub fn outcome_token(outcome: Outcome) -> &'static str {
+    match outcome {
+        Outcome::Promoted => "promoted",
+        Outcome::Rejected => "rejected",
+        Outcome::Unresolved => "unresolved",
+    }
+}
+
+/// The inverse of [`outcome_token`].
+///
+/// # Errors
+///
+/// Returns `None` for a token this build does not know — refused by the caller
+/// rather than defaulted, because guessing which decision an operator made is
+/// worse than admitting the row cannot be read.
+#[must_use]
+pub fn outcome_from_token(token: &str) -> Option<Outcome> {
+    match token {
+        "promoted" => Some(Outcome::Promoted),
+        "rejected" => Some(Outcome::Rejected),
+        "unresolved" => Some(Outcome::Unresolved),
+        _ => None,
+    }
+}
+
+/// The stored spelling of an authority's source class.
+#[must_use]
+pub fn source_class_token(class: SourceClass) -> &'static str {
+    match class {
+        SourceClass::Sensor => "sensor",
+        SourceClass::Operator => "operator",
+        SourceClass::Configuration => "configuration",
+        SourceClass::Import => "import",
+        SourceClass::Derivation => "derivation",
+        SourceClass::Network => "network",
+    }
+}
+
+/// Encode an adjudication's payload.
+///
+/// The pair is NOT in here — it travels in `subject`/`object`, where an index
+/// can see it. The cited observations are the row's `provenance`, for the same
+/// reason candidates put their support there: box 4a's citation index is built
+/// from that column, so a decision whose evidence lived only in its payload
+/// would be invisible to the provenance walk.
+#[must_use]
+pub fn encode_same_as_adjudication(a: &SameAsAdjudication) -> String {
+    serde_json::json!({
+        "outcome": outcome_token(a.outcome()),
+        "candidate_observation_id": a.candidate_observation_id().as_str(),
+        "authority": {
+            "source_class": source_class_token(a.authority().class()),
+            "identity": a.authority().adjudicator(),
+        },
+        "decided_at": {
+            "ms": a.decided_at().ms,
+            "domain": match a.decided_at().domain {
+                kirra_world::observation::ClockDomain::Boundary => "boundary",
+                kirra_world::observation::ClockDomain::System => "system",
+            },
+        },
+    })
+    .to_string()
+}
+
+/// The observation ids an adjudication row records as its `provenance`.
+#[must_use]
+pub fn same_as_adjudication_provenance(a: &SameAsAdjudication) -> Vec<String> {
+    a.cited().iter().map(|o| o.as_str().to_owned()).collect()
+}
+
+/// What a caller must supply to adjudicate a persisted candidate.
+///
+/// Note what is **absent**: there is no candidate value and no pair. Both are
+/// derived by the store from the row `candidate_observation_id` names, which is
+/// what makes "adjudication acts on persisted evidence" a property of this
+/// type rather than of the caller's discipline.
+#[derive(Debug, Clone)]
+pub struct SameAsAdjudicationRequest<'a> {
+    /// This decision's identity in the log.
+    pub event_id: &'a EventId,
+    /// This decision's own observation identity.
+    pub observation_id: &'a ObservationId,
+    /// **The persisted candidate being judged.** The store loads it.
+    pub candidate_observation_id: &'a str,
+    /// The observations this decision rests on.
+    pub cited: Vec<ObservationId>,
+    /// Who decided.
+    pub authority: AdjudicationAuthority,
+    /// What they decided.
+    pub outcome: Outcome,
+    /// When they decided, on a named clock.
+    pub decided_at: kirra_world::observation::DomainInstant,
+    /// When the store learned it.
+    pub txn_time_ms: i64,
+    /// The operator console or tool that submitted it.
+    pub source: &'a str,
+    /// Its version.
+    pub source_version: &'a str,
+}
+
+/// Why an adjudication could not be recorded.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AdjudicateError {
+    /// No row in the log carries that observation id.
+    ///
+    /// Distinct from [`Self::NotACandidate`]: "there is no such evidence" and
+    /// "that is not evidence of this kind" are different findings, and an
+    /// adjudicator told the wrong one would look in the wrong place.
+    NoSuchCandidate {
+        /// The id that named nothing.
+        observation_id: String,
+    },
+    /// The row exists but is not a derivation-class `same_as` candidate.
+    NotACandidate {
+        /// What disagreed, from the decoder.
+        detail: String,
+    },
+    /// The domain refused the decision.
+    Domain {
+        /// The domain's own message.
+        detail: String,
+    },
+}
+
+impl std::fmt::Display for AdjudicateError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoSuchCandidate { observation_id } => write!(
+                f,
+                "no candidate observation `{observation_id}` in the log — \
+                 an adjudication must judge evidence that exists"
+            ),
+            Self::NotACandidate { detail } => {
+                write!(f, "that observation is not a same_as candidate: {detail}")
+            }
+            Self::Domain { detail } => write!(f, "decision refused: {detail}"),
+        }
+    }
+}
+
+impl std::error::Error for AdjudicateError {}
+
+/// The pair a loaded candidate names, for the record's `subject`/`object`.
+#[must_use]
+pub fn adjudication_columns(pair: &CandidatePair) -> (String, String) {
+    (
+        pair.low().as_str().to_owned(),
+        pair.high().as_str().to_owned(),
+    )
+}

--- a/crates/kirra-world-store/tests/same_as_promotion.rs
+++ b/crates/kirra-world-store/tests/same_as_promotion.rs
@@ -32,6 +32,13 @@ use kirra_world_store::{WorldStore, WriterClass};
 const T0: i64 = 1_700_000_000_000;
 const OBS: &str = "01ARZ3NDEKTSV4RRFFQ69G5FAV";
 const OBS2: &str = "01ARZ3NDEKTSV4RRFFQ69G5FB0";
+/// The persisted candidate these decisions judge.
+///
+/// Box 2b made adjudication name the candidate OBSERVATION rather than take a
+/// candidate value, so every record here carries one. These are pure-layer
+/// promotion tests, so the id is a fixture — the store door is what proves a
+/// real one exists (`kirra-world-ingest/tests/persisted_adjudication.rs`).
+const CANDIDATE_OBS: &str = "01ARZ3NDEKTSV4RRFFQ69G5FC1";
 
 fn eid(s: &str) -> EntityId {
     EntityId::new(s.to_string()).expect("entity id")
@@ -77,8 +84,15 @@ fn operator() -> AdjudicationAuthority {
 }
 
 fn decide(c: &SameAsCandidate, outcome: Outcome, ms: u64) -> SameAsAdjudication {
-    SameAsAdjudication::record(c, vec![obs(OBS)], operator(), outcome, at(ms))
-        .expect("adjudication")
+    SameAsAdjudication::record(
+        c.pair().clone(),
+        obs(CANDIDATE_OBS),
+        vec![obs(OBS)],
+        operator(),
+        outcome,
+        at(ms),
+    )
+    .expect("adjudication")
 }
 
 /// `decide`, but the caller names the clock the decision was read from.
@@ -93,7 +107,8 @@ fn decide_on(
     domain: ClockDomain,
 ) -> SameAsAdjudication {
     SameAsAdjudication::record(
-        c,
+        c.pair().clone(),
+        obs(CANDIDATE_OBS),
         vec![obs(OBS)],
         operator(),
         outcome,
@@ -220,7 +235,8 @@ fn promotion_does_not_depend_on_which_side_was_named_first() {
 #[test]
 fn the_promoted_merge_cites_the_adjudications_evidence() {
     let adj = SameAsAdjudication::record(
-        &candidate("a", "b"),
+        candidate("a", "b").pair().clone(),
+        obs(CANDIDATE_OBS),
         vec![obs(OBS), obs(OBS2)],
         operator(),
         Outcome::Promoted,

--- a/crates/kirra-world/src/same_as_adjudication.rs
+++ b/crates/kirra-world/src/same_as_adjudication.rs
@@ -50,7 +50,7 @@ use std::collections::BTreeSet;
 use crate::observation::{DomainInstant, SourceClass};
 use crate::reference::ObservationId;
 use crate::relationship::Predicate;
-use crate::same_as_candidate::{CandidatePair, SameAsCandidate};
+use crate::same_as_candidate::CandidatePair;
 
 /// The one writer class authorized to promote, per `KIRRA-WM-PROMOTION-001`.
 pub const AUTHORIZED_ADJUDICATOR_CLASS: SourceClass = SourceClass::Operator;
@@ -181,6 +181,7 @@ pub enum Outcome {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SameAsAdjudication {
     pair: CandidatePair,
+    candidate_observation_id: ObservationId,
     cited: Vec<ObservationId>,
     authority: AdjudicationAuthority,
     outcome: Outcome,
@@ -188,18 +189,33 @@ pub struct SameAsAdjudication {
 }
 
 impl SameAsAdjudication {
-    /// Record a decision about a candidate.
+    /// Record a decision about a **persisted** candidate.
     ///
-    /// Takes the candidate by reference: an adjudication **cites** a candidate,
-    /// it never consumes one. That is what makes "a rejected candidate survives
-    /// as evidence" a property of the signature rather than a convention.
+    /// # There is no `&SameAsCandidate` parameter, deliberately
+    ///
+    /// An earlier signature took the candidate by value-reference, which meant
+    /// an adjudicator could be handed a caller-constructed struct that merely
+    /// *looked* like evidence. Judging that is judging an assertion, not a
+    /// record — and the whole point of `KIRRA-WM-PROMOTION-001` is that
+    /// confirmed identity rests on recorded evidence.
+    ///
+    /// So this takes the `pair` and the **`candidate_observation_id`** of a
+    /// candidate that exists in the log. The production caller is
+    /// `WorldStore::adjudicate_same_as`, which obtains both by LOADING the row
+    /// and validating it; nothing here can be satisfied by a value that was
+    /// never written.
+    ///
+    /// The id is kept on the record rather than merely checked, because *which*
+    /// persisted candidate was judged is part of what a later reader needs — a
+    /// decision that cannot name its subject is not auditable.
     ///
     /// # Errors
     ///
     /// * [`AdjudicationError::NoCandidateCited`] — `cited` is empty.
     /// * [`AdjudicationError::DuplicateCitation`] — an id appears twice.
     pub fn record(
-        candidate: &SameAsCandidate,
+        pair: CandidatePair,
+        candidate_observation_id: ObservationId,
         cited: Vec<ObservationId>,
         authority: AdjudicationAuthority,
         outcome: Outcome,
@@ -213,12 +229,19 @@ impl SameAsAdjudication {
             return Err(AdjudicationError::DuplicateCitation);
         }
         Ok(Self {
-            pair: candidate.pair().clone(),
+            pair,
+            candidate_observation_id,
             cited,
             authority,
             outcome,
             decided_at,
         })
+    }
+
+    /// The persisted candidate observation this decision judged.
+    #[must_use]
+    pub fn candidate_observation_id(&self) -> &ObservationId {
+        &self.candidate_observation_id
     }
 
     /// The pair decided about.
@@ -295,7 +318,7 @@ mod tests {
     use super::*;
     use crate::observation::{ClockDomain, Confidence, ConfidenceBasis};
     use crate::reference::EntityId;
-    use crate::same_as_candidate::MatcherIdentity;
+    use crate::same_as_candidate::{MatcherIdentity, SameAsCandidate};
 
     const OBS_A: &str = "01ARZ3NDEKTSV4RRFFQ69G5FAV";
     const OBS_B: &str = "01ARZ3NDEKTSV4RRFFQ69G5FAW";
@@ -326,7 +349,15 @@ mod tests {
         .expect("valid candidate")
     }
     fn decide(c: &SameAsCandidate, o: Outcome, cite: &str) -> SameAsAdjudication {
-        SameAsAdjudication::record(c, vec![obs(cite)], operator(), o, at(1)).expect("recordable")
+        SameAsAdjudication::record(
+            c.pair().clone(),
+            obs("cand-obs-1"),
+            vec![obs(cite)],
+            operator(),
+            o,
+            at(1),
+        )
+        .expect("recordable")
     }
 
     /// **Only the ruled class may promote.** A matcher writes as `Derivation`,
@@ -354,13 +385,21 @@ mod tests {
     fn an_adjudication_must_cite_the_candidate() {
         let c = candidate("robot-a", "robot-b", OBS_A);
         assert_eq!(
-            SameAsAdjudication::record(&c, vec![], operator(), Outcome::Promoted, at(1))
-                .unwrap_err(),
+            SameAsAdjudication::record(
+                c.pair().clone(),
+                obs("cand-obs-1"),
+                vec![],
+                operator(),
+                Outcome::Promoted,
+                at(1)
+            )
+            .unwrap_err(),
             AdjudicationError::NoCandidateCited
         );
         assert_eq!(
             SameAsAdjudication::record(
-                &c,
+                c.pair().clone(),
+                obs("cand-obs-1"),
                 vec![obs(OBS_A), obs(OBS_A)],
                 operator(),
                 Outcome::Promoted,

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -1031,7 +1031,7 @@ does not describe is how a residue disappears.
       in-memory cluster objects passed to an adjudicator. 2a needs to know
       nothing else about how confirmation works.
 
-- [ ] **2b — Adjudication / promotion.** The deterministic, auditable step that
+- [x] **2b — Adjudication / promotion. DONE 2026-08-20.** The deterministic, auditable step that
       turns a confirmed `same_as` into identity, and the **only** boundary at
       which a relation may affect canonical identity.
       **Unblocked: transitivity was ruled 2026-08-08**
@@ -1047,6 +1047,60 @@ does not describe is how a residue disappears.
       Rejection is a **separate append-only record** (not a deletion, and not a
       reversal); reversing an actual promotion is existing `SplitEntity`;
       `ForgetEntity` is erasure and is not a reversal mechanism.
+
+      **BUILT 2026-08-20 — adjudication acts on PERSISTED evidence.**
+      `SameAsAdjudication::record` no longer takes a `&SameAsCandidate`. It takes
+      the pair and the **`ObservationId` of a persisted candidate**, and the
+      production door `WorldStore::adjudicate_same_as` obtains both by LOADING
+      the row and validating it. An in-memory candidate with no persisted id
+      cannot enter the API — that is a property of the signature, not a check,
+      so there is deliberately no test for it.
+
+      Order is load → validate → decide → append: a refused attempt writes
+      nothing, and a recorded decision always names a candidate that exists.
+
+      **Two findings from writing the tests, both recorded because they are the
+      kind that survive review:**
+
+      1. **A dead guard.** The door originally compared
+         `authority.class()` against `Operator` and refused otherwise. That
+         comparison can never be true: `AdjudicationAuthority::new` refuses every
+         other class and the struct does not even store one — `class()` returns
+         the constant. An unauthorized adjudicator is UNREPRESENTABLE. The check
+         was removed; a guard that is constantly `false` is worse than none,
+         because a reader counts it as the enforcement and stops looking.
+      2. **Adversarial fixtures passing for the wrong reason.** Three refusal
+         tests used a `"{}"` payload and empty provenance, so each was refused by
+         the payload decode or by `NoSupportingEvidence` before its named
+         property was ever consulted — disabling the `writer_class` check left
+         them all green. The fixtures are now valid candidates in every respect
+         but the one column under test, and each mutation now kills exactly its
+         own case.
+
+      **`claim_status` is checked at the DECODER, not reachable through the
+      door** — schema v8 forbids `derivation` + `confirmed`, so no such row can
+      exist to be loaded. The decoder's check stays because `decode_candidate` is
+      public and total and a future non-SQLite backend has no v8 trigger.
+
+- [x] **`KIRRA-WM-IDENTITY-FRESHNESS-001` — RULED 2026-08-20.** An adjudicated
+      identity decision is **`Timeless`**.
+
+      > candidate evidence — *"I currently think A and B may be the same"* →
+      > freshness may matter.
+      > adjudicated decision — *"an authorized adjudicator DECIDED A and B are
+      > the same identity"* → does not age out merely because time passed.
+
+      A promoted `same_as` identity relation remains valid until CHANGED by later
+      adjudication — `SplitEntity`, `ForgetEntity`, or superseding identity
+      evidence — not until a clock runs out. Ageing it would make identity
+      dissolve with nobody deciding anything, which §6.3's *"a merged id stays
+      resolvable forever"* forbids.
+
+      Recorded in `kirra_world_service::freshness::RULED` against
+      `(same_as_adjudication, "same_as_adjudged")`. It rules the DECISION row and
+      **not** the candidate: `(observation, "same_as")` stays knowingly unruled,
+      because whether a matcher's PROPOSAL goes stale is a separate question this
+      ruling does not answer.
 
 - [x] **2c — Deterministic resolution over promoted identity. DONE 2026-08-20.**
       `kirra_world::adjudication::promote_confirmed_same_as` is the join: it asks


### PR DESCRIPTION
## The trust boundary is the signature

`SameAsAdjudication::record` no longer takes a `&SameAsCandidate` — a value the caller built, which meant an adjudicator could judge something that merely *looked* like evidence. It now takes the pair and the **`ObservationId` of a persisted candidate**, and the production door `WorldStore::adjudicate_same_as` obtains both by loading the row and validating it.

```
record(candidate_observation_id, authority, outcome, …)
  → load_same_as_candidate(candidate_observation_id)
  → verify: persisted · Derivation · same_as · candidate-status · support intact
  → record Promote / Reject / Unresolved
```

An in-memory candidate with no persisted id **cannot enter the API at all**. That's a property of the signature rather than a check — so there is deliberately **no test for it**. A test that cannot fail proves nothing, and saying so is more honest than writing one.

Order is load → validate → decide → append, so a refused attempt writes nothing and a recorded decision always names a candidate that exists.

## The freshness ruling

`KIRRA-WM-IDENTITY-FRESHNESS-001`: an adjudicated identity decision is **`Timeless`**.

> **candidate evidence** — *"I currently think A and B may be the same"* → freshness may matter
> **adjudicated decision** — *"an authorized adjudicator DECIDED A and B are the same identity"* → does not age out merely because time passed

It stays valid until **changed** by later adjudication (`Split` / `Forget` / superseding evidence), not until a clock runs out. Ageing it would make identity dissolve with nobody deciding anything, which §6.3's *"a merged id stays resolvable forever"* forbids.

It rules the **decision row only**. `(observation, "same_as")` — the matcher's proposal — stays knowingly unruled, because whether a *proposal* goes stale is a separate question this ruling doesn't answer.

## Two findings from writing the tests

**1. A dead guard, in my own new code.** The door compared `authority.class()` against `Operator` and refused otherwise. That can never be true: `AdjudicationAuthority::new` refuses every other class, and the struct doesn't even *store* one — `class()` returns the constant. An unauthorized adjudicator is **unrepresentable**.

Removed. A guard that is constantly `false` is worse than none, because a reader counts it as the enforcement and stops looking for the real one — the same reasoning `Justification` already records for declining to offer `is_empty`. The test that found it now asserts what is actually true.

**2. Three adversarial fixtures passing for the wrong reason.** They used a `"{}"` payload and empty provenance, so each was refused by the payload decode or by `NoSupportingEvidence` *before its named property was ever consulted*. Disabling the `writer_class` check left all of them green. The fixtures are now valid candidates in every respect but the one column under test.

| Mutation | Died on |
|---|---|
| skip the load, trust the caller's id | nonexistent-id · no-trace (**2**) |
| disable the `writer_class` check | **exactly** the non-derivation case |
| disable the predicate check | **exactly** the wrong-predicate case |
| disable the `claim_status` check | **exactly** the decoder case |

## One structural fact worth stating

`claim_status` is checked at the **decoder** and is not reachable through the door: schema v8 forbids `derivation` + `confirmed`, so no such row can exist to be loaded. The check stays because `decode_candidate` is public and total and a future non-SQLite backend has no v8 trigger — and its test says so, rather than pretending the store path exercises it.

## The seven cases you pinned

nonexistent id → refused · confirmed-not-candidate → refused · wrong predicate → refused · non-`Derivation` writer → refused · valid candidate → succeeds · candidate survives `Reject`/`Unresolved` → yes, loadable and unchanged · re-adjudicating one pair → 3 records, **1** corroboration.

The fifth landed differently than specified, for the reason in finding 1: an unauthorized adjudicator can't be *constructed*, so the test asserts unrepresentability instead of refusal.

## Verification

11 new tests · five mutations, each killing exactly its own case · all 13 gates green locally including self-tests · every world-side suite green · `cargo clippy` clean on the three touched crates · `cargo fmt --all --check`.

The one clippy warning in `kirra-world-store` (`unused import: StoreError` in `claim_at_generation`) was verified pre-existing on `main` by stashing.

## Scope

5a is untouched. With 2a, 2b and the freshness ruling in place, the relationship projection now has persisted, confirmed, ruled evidence to consume.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_