### PR TITLE
Box 5a: the relationship projection, over the real production chain

### DIFF
--- a/ci/store_boundedness_baseline.json
+++ b/ci/store_boundedness_baseline.json
@@ -136,6 +136,10 @@
       "class": "operational",
       "why": "Projection fold."
     },
+    "fold_relationship_projection": {
+      "class": "operational",
+      "why": "Projection fold."
+    },
     "fold_subject_summary": {
       "class": "operational",
       "why": "Projection fold."
@@ -149,6 +153,10 @@
       "why": "Existence probe."
     },
     "has_projections": {
+      "class": "operational",
+      "why": "Existence probe."
+    },
+    "has_relationship_projection": {
       "class": "operational",
       "why": "Existence probe."
     },
@@ -172,9 +180,33 @@
       "class": "operational",
       "why": "Box 2a's producer-side EVIDENCE SURVEY, not a domain question -- classified with fold and the backfills rather than with the query families, because no caller is asking Kirra World what is true; a matcher is reading the log it will propose from. Bounded regardless: the caller's limit is pushed into the statement as LIMIT ?2, so the ceiling is SQLite's and a full page means truncation, never completeness."
     },
+    "load_relationship_projection": {
+      "class": "operational",
+      "why": "The fold's own loader. Whole-table by construction -- `fold_relationship_range` seeds its accumulator from it, and a paged seed would fold against a partial prior state. Not a consumer road: the one-pair question has its own point read, `relationship`, because answering it from here was the #1441 shape and this gate is what found it."
+    },
     "load_same_as_candidate": {
       "class": "bounded",
       "why": "A point read keyed on observation_id with LIMIT 1 in the statement -- at most one row by construction, not a set trimmed after fetching. Bounded rather than operational because it answers a question ABOUT a claim (is this observation a derivation-class same_as candidate, and what does it propose), which is what box 2b's adjudicator will ask before it may judge."
+    },
+    "rebuild_relationship_projection": {
+      "class": "operational",
+      "why": "Projection rebuild."
+    },
+    "relationship": {
+      "class": "bounded",
+      "why": "Tier 5 box 5a. A POINT READ by primary key: `WHERE low = ?1 AND high = ?2` on `relationships_projection`, whose PRIMARY KEY is `(low, high)`, so the result is at most one row regardless of how many relationships the fleet has accumulated. STRUCTURALLY bounded in the same sense as `current` -- there is no page and no cursor because there is no growth dimension. It takes a canonical pair the caller already holds and returns the row at it."
+    },
+    "relationship_projection_generation": {
+      "class": "operational",
+      "why": "Checkpoint metadata."
+    },
+    "relationship_projection_state_digest": {
+      "class": "operational",
+      "why": "Checkpoint metadata."
+    },
+    "relationship_provenance": {
+      "class": "bounded",
+      "why": "Tier 5 box 5a. Three bounded steps and no scan: the point read above, then `carriers` (capped at MAX_CARRIERS + a truncation flag) and `compacted_spans` (capped at MAX_COMPACTED_SPANS), both of which box 4b already bounds and classifies. Answers whether ONE relationship's cited candidate is still visible; it cannot be used to enumerate anything."
     },
     "same_as_candidate_exists": {
       "class": "operational",

--- a/ci/world_semantics_baseline.json
+++ b/ci/world_semantics_baseline.json
@@ -59,7 +59,7 @@
     "relationship_fold": [
       {
         "version": 1,
-        "corpus_digest": "0cc3e211f39f90c9e0243525d1e5a5d83449ed930fc72e50f474c60eb7797986",
+        "corpus_digest": "db4975d3adc118885e0c180c58ac45311272df617e0b9f00333571b14cff3b95",
         "source_pin": "e82c8a546104d622f71bb2c12e63670ad4c8a0733ac02eb88e2c7138b991b6b8"
       }
     ]

--- a/ci/world_semantics_baseline.json
+++ b/ci/world_semantics_baseline.json
@@ -55,6 +55,13 @@
         "corpus_digest": "d74f62272fc120646d699e587bfd181e55aa00b00e57b7e23542245fb6f65b4a",
         "source_pin": "07e6d2b8b7d86207a61231c7dfa1e4df46be0240632bba3d15e171e42a5d7b4b"
       }
+    ],
+    "relationship_fold": [
+      {
+        "version": 1,
+        "corpus_digest": "0cc3e211f39f90c9e0243525d1e5a5d83449ed930fc72e50f474c60eb7797986",
+        "source_pin": "e82c8a546104d622f71bb2c12e63670ad4c8a0733ac02eb88e2c7138b991b6b8"
+      }
     ]
   }
 }

--- a/crates/kirra-world-ingest/tests/relationship_projection.rs
+++ b/crates/kirra-world-ingest/tests/relationship_projection.rs
@@ -1,0 +1,869 @@
+//! **Box 5a: the relationship projection, over the whole production chain.**
+//!
+//! These tests live in the INGEST crate, not the store crate, and that is the
+//! point of the box. The chain the audit before 5a traced —
+//!
+//! > real producer → sanctioned candidate write → persisted candidate →
+//! > authorized adjudication → confirmed event → projection
+//!
+//! — is exercised end to end here: every relationship these tests assert about
+//! was proposed by `run_ingest_pass` from real observations and promoted by an
+//! `AdjudicationAuthority`. Nothing is hand-appended into `world_events` except
+//! where a test is deliberately forging a row the production doors refuse to
+//! write, and each of those says so.
+//!
+//! # The scope this suite is testing against
+//!
+//! > The relationship projection is authoritative over promoted identity
+//! > decisions, not over continued retention of the candidate evidence that
+//! > motivated them. If cited candidate evidence is compacted, the relationship
+//! > remains valid as adjudicated, while its explanatory provenance may degrade.
+//!
+//! `a_promoted_relationship_survives_compaction_of_its_candidate` is that
+//! sentence as a test.
+//!
+//! # Operator-authored promotions are the only production input today
+//!
+//! Every promotion below goes through `AdjudicationAuthority::new`, which
+//! refuses every class but `Operator`. There is no automated adjudicator to
+//! test because `KIRRA-WM-PROMOTION-001` v1 does not authorize one.
+
+use kirra_world::observation::{ClockDomain, DomainInstant, SourceClass};
+use kirra_world::reference::{EntityId, EventId, ObservationId};
+use kirra_world::same_as_adjudication::{AdjudicationAuthority, Outcome};
+use kirra_world::same_as_candidate::{CandidatePair, MatcherIdentity};
+use kirra_world_ingest::{run_ingest_pass, ExactIdentifierRule};
+use kirra_world_store::provenance_graph::{CitationResolution, DanglingReason};
+use kirra_world_store::same_as_adjudication_record::SameAsAdjudicationRequest;
+use kirra_world_store::{ClaimStatus, NewEvent, StoreError, WorldStore, WriterClass};
+
+const T0: i64 = 1_700_000_000_000;
+const SURVEY_LIMIT: usize = 1_000;
+
+fn tmp(name: &str) -> std::path::PathBuf {
+    static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let n = NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let mut p = std::env::temp_dir();
+    p.push(format!("kirra-5a-{name}-{}-{n}.sqlite", std::process::id()));
+    for s in ["", "-wal", "-shm"] {
+        let mut q = p.as_os_str().to_os_string();
+        q.push(s);
+        let _ = std::fs::remove_file(std::path::PathBuf::from(q));
+    }
+    p
+}
+
+fn at(ms: u64) -> DomainInstant {
+    DomainInstant {
+        ms,
+        domain: ClockDomain::System,
+    }
+}
+
+fn pair(a: &str, b: &str) -> CandidatePair {
+    CandidatePair::new(
+        EntityId::new(a).expect("entity"),
+        EntityId::new(b).expect("entity"),
+    )
+    .expect("pair")
+}
+
+/// One real sensor observation of an identifier.
+fn observe(store: &mut WorldStore, n: &str, subject: &str, value: &str) {
+    let event_id = EventId::new(format!("ev-{n}")).expect("event id");
+    let observation_id = ObservationId::new(format!("obs-{n}")).expect("observation id");
+    store
+        .append(&NewEvent {
+            event_id: &event_id,
+            observation_id: &observation_id,
+            txn_time_ms: T0,
+            valid_from_ms: T0,
+            valid_to_ms: None,
+            source: "asset-tag-reader",
+            source_version: "1.0.0",
+            writer_class: WriterClass::Sensor,
+            claim_status: ClaimStatus::Confirmed,
+            provenance: &[],
+            frame_id: None,
+            map_id: None,
+            kind: "observation",
+            subject,
+            subject_ref: None,
+            predicate: Some("serial_number"),
+            object: Some(value),
+            payload: "{}",
+            payload_schema: 1,
+            retention_class: "raw",
+            trust: None,
+        })
+        .expect("append observation");
+}
+
+/// Run the real matcher over whatever the store has observed.
+fn propose(store: &mut WorldStore) -> usize {
+    let rule = ExactIdentifierRule::new(
+        "serial_number",
+        MatcherIdentity::new("world-ingest", "exact-identifier", "1.0.0").expect("matcher"),
+    )
+    .expect("rule");
+    let mut n = 0;
+    run_ingest_pass(store, &rule, T0, SURVEY_LIMIT, move || {
+        n += 1;
+        (
+            EventId::new(format!("cand-ev-{n}")).expect("id"),
+            ObservationId::new(format!("cand-obs-{n}")).expect("id"),
+        )
+    })
+    .expect("ingest pass")
+    .proposed
+}
+
+fn operator() -> AdjudicationAuthority {
+    AdjudicationAuthority::new(SourceClass::Operator, "console-operator").expect("authority")
+}
+
+/// Record one authorized decision about a persisted candidate.
+fn decide(
+    store: &mut WorldStore,
+    tag: &str,
+    candidate_observation_id: &str,
+    outcome: Outcome,
+    decided_ms: u64,
+) {
+    let event_id = EventId::new(format!("adj-ev-{tag}")).expect("id");
+    let observation_id = ObservationId::new(format!("adj-obs-{tag}")).expect("id");
+    store
+        .adjudicate_same_as(&SameAsAdjudicationRequest {
+            event_id: &event_id,
+            observation_id: &observation_id,
+            candidate_observation_id,
+            cited: vec![ObservationId::new(candidate_observation_id).expect("id")],
+            authority: operator(),
+            outcome,
+            decided_at: at(decided_ms),
+            txn_time_ms: T0 + 10,
+            source: "operator-console",
+            source_version: "1.0.0",
+        })
+        .expect("an operator judging a persisted candidate");
+}
+
+/// Two tracks agreeing on one serial, and the candidate that agreement produced.
+fn two_tracks_and_a_candidate(name: &str) -> WorldStore {
+    let mut store = WorldStore::open(&tmp(name)).expect("open");
+    observe(&mut store, "a", "track-a", "SN-1");
+    observe(&mut store, "b", "track-b", "SN-1");
+    assert_eq!(
+        propose(&mut store),
+        1,
+        "the fixture must persist exactly one candidate"
+    );
+    store
+}
+
+// ---------------------------------------------------------------------------
+// The positive case first. A suite of absences with nothing admitted proves
+// only that the fold never writes anything.
+// ---------------------------------------------------------------------------
+
+/// **The whole chain, end to end.**
+///
+/// Observations a sensor wrote → a candidate the real matcher proposed → an
+/// operator's promotion → a row in `relationships_projection`. No step is
+/// simulated, and the pair on the row is the pair the evidence named.
+#[test]
+fn a_promoted_candidate_becomes_a_relationship() {
+    let mut store = two_tracks_and_a_candidate("promote");
+    decide(
+        &mut store,
+        "1",
+        "cand-obs-1",
+        Outcome::Promoted,
+        T0 as u64 + 10,
+    );
+    store.fold_relationship_projection().expect("fold");
+
+    let rows = store.load_relationship_projection().expect("load");
+    assert_eq!(rows.len(), 1, "one promotion, one relationship");
+    let r = rows
+        .get(&("track-a".to_owned(), "track-b".to_owned()))
+        .expect("the promoted pair, canonically keyed");
+    assert_eq!(r.pair.low().as_str(), "track-a");
+    assert_eq!(r.pair.high().as_str(), "track-b");
+    assert_eq!(
+        r.candidate_observation_id, "cand-obs-1",
+        "the row cites the persisted candidate the operator judged"
+    );
+    assert_eq!(r.adjudicator, "console-operator");
+    assert_eq!(r.decided_at, at(T0 as u64 + 10));
+}
+
+/// **The row names a real, confirmed adjudication event.**
+///
+/// `decided_generation` is not decoration: it is what an operator follows from
+/// "these two are the same" back to the decision that said so. This resolves it
+/// against the log and checks the row it lands on is the adjudication —
+/// confirmed, operator-written, and about this pair.
+#[test]
+fn a_relationship_traces_back_to_its_confirmed_adjudication_event() {
+    let mut store = two_tracks_and_a_candidate("trace");
+    decide(
+        &mut store,
+        "1",
+        "cand-obs-1",
+        Outcome::Promoted,
+        T0 as u64 + 10,
+    );
+    store.fold_relationship_projection().expect("fold");
+
+    let rows = store.load_relationship_projection().expect("load");
+    let r = rows
+        .get(&("track-a".to_owned(), "track-b".to_owned()))
+        .expect("the relationship");
+    let event = store
+        .claim_at_generation(r.decided_generation)
+        .expect("read the log")
+        .expect("decided_generation must name a retained event");
+    assert_eq!(event.kind, "same_as_adjudication");
+    assert_eq!(event.subject, "track-a");
+    assert_eq!(event.object.as_deref(), Some("track-b"));
+    assert_eq!(event.predicate.as_deref(), Some("same_as_adjudged"));
+    // `ProjectedClaim` carries no writer class or claim status -- deliberately,
+    // per `claim_at_generation`'s own docs -- so those two are asserted against
+    // the row directly. They are the load-bearing half: a projection fed by an
+    // unconfirmed row, or one written under an unauthorized class, would be
+    // KIRRA-WM-PROMOTION-001 bypassed.
+    let authorized = store
+        .query_scalar_for_test(&format!(
+            "SELECT COUNT(*) FROM world_events WHERE generation = {} \
+             AND claim_status = 'confirmed' AND writer_class = 'operator'",
+            r.decided_generation
+        ))
+        .expect("count");
+    assert_eq!(
+        authorized, 1,
+        "the deciding event must be a CONFIRMED, operator-written row"
+    );
+}
+
+/// **A proposal is not a relationship.**
+///
+/// The non-vacuity control for everything above: the same fixture, the same
+/// fold, no adjudication — and no row. Without this, a fold that wrote a row
+/// for every candidate would pass the positive test.
+#[test]
+fn an_unadjudicated_candidate_is_not_a_relationship() {
+    let mut store = two_tracks_and_a_candidate("unjudged");
+    store.fold_relationship_projection().expect("fold");
+    assert!(
+        store
+            .load_relationship_projection()
+            .expect("load")
+            .is_empty(),
+        "clustering proposes and never confirms (KIRRA-WM-CLUSTERING-001)"
+    );
+}
+
+/// **A rejection creates nothing.**
+#[test]
+fn a_rejected_candidate_is_not_a_relationship() {
+    let mut store = two_tracks_and_a_candidate("reject");
+    decide(
+        &mut store,
+        "1",
+        "cand-obs-1",
+        Outcome::Rejected,
+        T0 as u64 + 10,
+    );
+    store.fold_relationship_projection().expect("fold");
+    assert!(
+        store
+            .load_relationship_projection()
+            .expect("load")
+            .is_empty(),
+        "an operator's refusal must not read as an identity"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Supersession — KIRRA-WM-IDENTITY-FRESHNESS-001's "until changed by later
+// adjudication".
+// ---------------------------------------------------------------------------
+
+/// **A later rejection withdraws a standing promotion.**
+#[test]
+fn a_later_rejection_withdraws_a_standing_promotion() {
+    let mut store = two_tracks_and_a_candidate("withdraw-reject");
+    decide(
+        &mut store,
+        "1",
+        "cand-obs-1",
+        Outcome::Promoted,
+        T0 as u64 + 10,
+    );
+    store.fold_relationship_projection().expect("fold");
+    assert_eq!(store.load_relationship_projection().expect("load").len(), 1);
+
+    decide(
+        &mut store,
+        "2",
+        "cand-obs-1",
+        Outcome::Rejected,
+        T0 as u64 + 20,
+    );
+    store.fold_relationship_projection().expect("fold again");
+    assert!(
+        store
+            .load_relationship_projection()
+            .expect("load")
+            .is_empty(),
+        "the newest authorized decision governs, and the table must stop \
+         asserting an identity it revoked"
+    );
+}
+
+/// **A later `Unresolved` withdraws too** — the choice box 5a made, pinned.
+///
+/// The alternative (abstain: leave the promotion standing) is defensible and
+/// was not taken, because the log does not record which the operator meant and
+/// abstaining errs toward continuing to assert an identity the most recent
+/// authorized decision declined to affirm. This test is what makes changing
+/// that a visible decision rather than a quiet edit.
+#[test]
+fn a_later_unresolved_withdraws_a_standing_promotion() {
+    let mut store = two_tracks_and_a_candidate("withdraw-unresolved");
+    decide(
+        &mut store,
+        "1",
+        "cand-obs-1",
+        Outcome::Promoted,
+        T0 as u64 + 10,
+    );
+    store.fold_relationship_projection().expect("fold");
+    assert_eq!(store.load_relationship_projection().expect("load").len(), 1);
+
+    decide(
+        &mut store,
+        "2",
+        "cand-obs-1",
+        Outcome::Unresolved,
+        T0 as u64 + 20,
+    );
+    store.fold_relationship_projection().expect("fold again");
+    assert!(
+        store
+            .load_relationship_projection()
+            .expect("load")
+            .is_empty(),
+        "an unresolved re-decision withdraws rather than abstains"
+    );
+}
+
+/// **A re-promotion after a withdrawal restores the relationship**, and the row
+/// names the NEW decision.
+///
+/// Without this the withdrawal tests are satisfied by a fold that removes and
+/// never re-admits — a projection that decays in one direction only.
+#[test]
+fn a_re_promotion_restores_the_relationship_under_the_new_decision() {
+    let mut store = two_tracks_and_a_candidate("re-promote");
+    decide(
+        &mut store,
+        "1",
+        "cand-obs-1",
+        Outcome::Promoted,
+        T0 as u64 + 10,
+    );
+    decide(
+        &mut store,
+        "2",
+        "cand-obs-1",
+        Outcome::Rejected,
+        T0 as u64 + 20,
+    );
+    store.fold_relationship_projection().expect("fold");
+    assert!(store
+        .load_relationship_projection()
+        .expect("load")
+        .is_empty());
+
+    decide(
+        &mut store,
+        "3",
+        "cand-obs-1",
+        Outcome::Promoted,
+        T0 as u64 + 30,
+    );
+    store.fold_relationship_projection().expect("fold again");
+    let rows = store.load_relationship_projection().expect("load");
+    let r = rows
+        .get(&("track-a".to_owned(), "track-b".to_owned()))
+        .expect("restored");
+    assert_eq!(
+        r.decided_at,
+        at(T0 as u64 + 30),
+        "the row must name the decision that currently holds, not the first one"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// KIRRA-WM-TRANSITIVITY-001
+// ---------------------------------------------------------------------------
+
+/// **Promotion never synthesises a transitive relation.**
+///
+/// `track-a = track-b` and `track-b = track-c` are each promoted from their own
+/// evidence. `(track-a, track-c)` is never proposed and never promoted, and the
+/// projection must not invent it. Resolution (box 2c) may traverse merges;
+/// this layer may not emit the traversal as a recorded relationship.
+#[test]
+fn promotion_never_synthesises_a_transitive_relation() {
+    let mut store = WorldStore::open(&tmp("transitive")).expect("open");
+    observe(&mut store, "a", "track-a", "SN-1");
+    observe(&mut store, "b1", "track-b", "SN-1");
+    observe(&mut store, "b2", "track-b", "SN-2");
+    observe(&mut store, "c", "track-c", "SN-2");
+    // Two agreements, two pairs: (a,b) on SN-1 and (b,c) on SN-2. Nothing
+    // observed a and c agreeing on anything.
+    assert_eq!(propose(&mut store), 2);
+
+    decide(
+        &mut store,
+        "1",
+        "cand-obs-1",
+        Outcome::Promoted,
+        T0 as u64 + 10,
+    );
+    decide(
+        &mut store,
+        "2",
+        "cand-obs-2",
+        Outcome::Promoted,
+        T0 as u64 + 11,
+    );
+    store.fold_relationship_projection().expect("fold");
+
+    let rows = store.load_relationship_projection().expect("load");
+    assert_eq!(
+        rows.len(),
+        2,
+        "two promotions must yield exactly two relationships, not three"
+    );
+    assert!(rows.contains_key(&("track-a".to_owned(), "track-b".to_owned())));
+    assert!(rows.contains_key(&("track-b".to_owned(), "track-c".to_owned())));
+    assert!(
+        !rows.contains_key(&("track-a".to_owned(), "track-c".to_owned())),
+        "KIRRA-WM-TRANSITIVITY-001: the traversed relation is not evidence"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Determinism — ADR-0041's rebuild-equals-incremental.
+// ---------------------------------------------------------------------------
+
+/// **Folding in stages equals rebuilding from generation 0.**
+///
+/// The withdrawal falls ACROSS the checkpoint deliberately: an incremental fold
+/// that seeded its accumulator from empty would not find the promotion it has
+/// to remove, so the two would diverge exactly where a naive implementation is
+/// wrong. Compared by digest, which covers `decided_generation` and the cited
+/// candidate as well as membership.
+#[test]
+fn incremental_folding_equals_rebuild_from_zero() {
+    let mut store = WorldStore::open(&tmp("determinism")).expect("open");
+    observe(&mut store, "a", "track-a", "SN-1");
+    observe(&mut store, "b1", "track-b", "SN-1");
+    observe(&mut store, "b2", "track-b", "SN-2");
+    observe(&mut store, "c", "track-c", "SN-2");
+    assert_eq!(propose(&mut store), 2);
+
+    decide(
+        &mut store,
+        "1",
+        "cand-obs-1",
+        Outcome::Promoted,
+        T0 as u64 + 10,
+    );
+    decide(
+        &mut store,
+        "2",
+        "cand-obs-2",
+        Outcome::Promoted,
+        T0 as u64 + 11,
+    );
+    // Checkpoint here, mid-history.
+    store.fold_relationship_projection().expect("first fold");
+    let mid = store
+        .relationship_projection_generation()
+        .expect("generation");
+    assert!(mid > 0, "the first fold must have consumed something");
+
+    // The tail: one withdrawal and one re-promotion, both after the checkpoint.
+    decide(
+        &mut store,
+        "3",
+        "cand-obs-1",
+        Outcome::Rejected,
+        T0 as u64 + 20,
+    );
+    decide(
+        &mut store,
+        "4",
+        "cand-obs-2",
+        Outcome::Promoted,
+        T0 as u64 + 21,
+    );
+    store.fold_relationship_projection().expect("second fold");
+
+    let incremental = store
+        .relationship_projection_state_digest()
+        .expect("digest");
+    let incremental_rows = store.load_relationship_projection().expect("load");
+
+    store.rebuild_relationship_projection().expect("rebuild");
+    let rebuilt = store
+        .relationship_projection_state_digest()
+        .expect("digest");
+
+    assert_eq!(
+        incremental, rebuilt,
+        "an incremental fold across a withdrawal must equal a rebuild from zero"
+    );
+    // Non-vacuous: the state being compared is not empty, and it is not
+    // everything either — one pair was withdrawn.
+    assert_eq!(incremental_rows.len(), 1);
+    assert!(incremental_rows.contains_key(&("track-b".to_owned(), "track-c".to_owned())));
+}
+
+/// **A rebuild does not inherit a row the log does not justify.**
+///
+/// The negative control for the `DELETE FROM relationships_projection` in
+/// `rebuild_relationship_projection`, which — unlike the entity rebuild's — is
+/// load-bearing. A row forged directly into the projection table must be gone
+/// after a rebuild, because a rebuildable view is a function of the log alone.
+#[test]
+fn a_rebuild_does_not_inherit_a_row_the_log_does_not_justify() {
+    let mut store = two_tracks_and_a_candidate("rebuild-forged");
+    decide(
+        &mut store,
+        "1",
+        "cand-obs-1",
+        Outcome::Promoted,
+        T0 as u64 + 10,
+    );
+    store.fold_relationship_projection().expect("fold");
+
+    // Forged: no adjudication in the log says anything about this pair. Written
+    // with raw SQL precisely because no production door will write it.
+    store
+        .raw_execute_for_test(
+            "INSERT INTO relationships_projection
+                 (low, high, decided_generation, candidate_observation_id,
+                  adjudicator, decided_at_ms, decided_at_domain)
+             VALUES ('track-x', 'track-y', 1, 'cand-obs-1', 'nobody', 1, 'system')",
+        )
+        .expect("forge");
+    assert_eq!(
+        store.load_relationship_projection().expect("load").len(),
+        2,
+        "the forgery must actually be present, or this test proves nothing"
+    );
+
+    store.rebuild_relationship_projection().expect("rebuild");
+    let rows = store.load_relationship_projection().expect("load");
+    assert_eq!(rows.len(), 1);
+    assert!(
+        !rows.contains_key(&("track-x".to_owned(), "track-y".to_owned())),
+        "a rebuild answers from the log, not from what the table already held"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The scope statement, as a test.
+// ---------------------------------------------------------------------------
+
+/// **A promoted relationship survives compaction of the candidate it cites,
+/// and its provenance degrades rather than disappearing or reading as full.**
+///
+/// This is the sentence box 5a was scoped by. Three things are asserted and all
+/// three matter:
+///
+/// 1. Before compaction the citation resolves — otherwise "it degraded" would
+///    be indistinguishable from "it never resolved".
+/// 2. After compaction the relationship is still there, unchanged. Identity is
+///    adjudicated, and `KIRRA-WM-IDENTITY-FRESHNESS-001` makes a promoted
+///    `same_as` `Timeless`; making retention of the proposal a precondition for
+///    the identity holding would contradict that ruling.
+/// 3. The citation now reads `Dangling { PossiblyCompacted }` — not `Resolved`,
+///    and not `NeverVisible`. The last distinction is the one §11.3 forbids
+///    collapsing: *nothing was ever recorded* and *what was recorded was
+///    deleted* are different findings.
+#[test]
+fn a_promoted_relationship_survives_compaction_of_its_candidate() {
+    let mut store = two_tracks_and_a_candidate("compaction");
+    decide(
+        &mut store,
+        "1",
+        "cand-obs-1",
+        Outcome::Promoted,
+        T0 as u64 + 10,
+    );
+    store.fold_relationship_projection().expect("fold");
+
+    let key = pair("track-a", "track-b");
+    // (1) Before: the cited candidate is in the log and resolves to one carrier.
+    let before = store
+        .relationship_provenance(&key)
+        .expect("provenance")
+        .expect("the relationship holds");
+    let candidate_generation = match before {
+        CitationResolution::Resolved { target_generation } => target_generation,
+        other => panic!("the candidate must resolve before it is compacted: {other:?}"),
+    };
+
+    // Compact exactly the candidate's own generation. The adjudication cannot
+    // be compacted with it -- `retention_class = "adjudication"` is protected --
+    // which is what makes this scenario the realistic one rather than contrived.
+    let outcome = store
+        .compact_range(candidate_generation, candidate_generation, T0 + 100)
+        .expect("compacting a raw candidate is permitted");
+    assert!(
+        outcome.removed > 0,
+        "the compaction must actually have removed the candidate"
+    );
+
+    // (2) The relationship is untouched, including after a full rebuild -- so
+    // this is not merely a stale row that a recomputation would drop.
+    store.rebuild_relationship_projection().expect("rebuild");
+    let rows = store.load_relationship_projection().expect("load");
+    let r = rows
+        .get(&("track-a".to_owned(), "track-b".to_owned()))
+        .expect("the relationship remains valid as adjudicated");
+    assert_eq!(r.candidate_observation_id, "cand-obs-1");
+
+    // (3) The provenance degrades, and says which kind of nothing it is.
+    match store
+        .relationship_provenance(&key)
+        .expect("provenance")
+        .expect("the relationship still holds")
+    {
+        CitationResolution::Dangling {
+            reason: DanglingReason::PossiblyCompacted { spans, truncated },
+        } => {
+            assert!(!truncated);
+            assert!(
+                spans.contains(&candidate_generation),
+                "the answer must name the compaction citation to go and read"
+            );
+        }
+        other => panic!(
+            "compacted evidence must degrade to PossiblyCompacted, never to \
+             Resolved and never to NeverVisible: {other:?}"
+        ),
+    }
+}
+
+/// **`relationship_provenance` distinguishes "no such relationship" from
+/// "dangling evidence".**
+///
+/// `Ok(None)` and `Ok(Some(Dangling))` are different findings and a caller told
+/// the wrong one looks in the wrong place — the same distinction
+/// `AdjudicateError` draws between `NoSuchCandidate` and `NotACandidate`.
+#[test]
+fn provenance_of_a_pair_that_was_never_promoted_is_none() {
+    let mut store = two_tracks_and_a_candidate("no-such");
+    store.fold_relationship_projection().expect("fold");
+    assert!(store
+        .relationship_provenance(&pair("track-a", "track-b"))
+        .expect("provenance")
+        .is_none());
+}
+
+// ---------------------------------------------------------------------------
+// Fail-closed reads.
+// ---------------------------------------------------------------------------
+
+/// **A projection row stored the wrong way round is refused, not repaired.**
+///
+/// `CandidatePair::new` canonicalises, so a loader that simply reconstructed
+/// the pair would return a correct-looking relationship and hide that the row
+/// disagrees with the fold's own convention — and the repaired and unrepaired
+/// rows would then collide on one key while claiming different provenance.
+#[test]
+fn a_non_canonical_projection_row_is_refused() {
+    let mut store = two_tracks_and_a_candidate("non-canonical");
+    decide(
+        &mut store,
+        "1",
+        "cand-obs-1",
+        Outcome::Promoted,
+        T0 as u64 + 10,
+    );
+    store.fold_relationship_projection().expect("fold");
+
+    store
+        .raw_execute_for_test(
+            "UPDATE relationships_projection SET low = 'track-b', high = 'track-a'",
+        )
+        .expect("swap");
+
+    match store.load_relationship_projection() {
+        Err(StoreError::CorruptRelationshipProjectionRow { detail }) => {
+            assert!(
+                detail.contains("canonical"),
+                "the refusal must name what disagreed: {detail}"
+            );
+        }
+        other => panic!("a non-canonical row must be refused: {other:?}"),
+    }
+}
+
+/// **A relationship promoted below the checkpoint survives a later, unrelated
+/// fold.**
+///
+/// This test exists because it was MISSING and the gap was found by mutation,
+/// not by review. Seeding `fold_relationship_range`'s accumulator from empty
+/// instead of from the stored rows left all thirteen other tests green: every
+/// pair in `incremental_folding_equals_rebuild_from_zero` is touched by the
+/// tail, so an accumulator that had forgotten the earlier state still ended up
+/// agreeing with one that had not.
+///
+/// Here `(track-a, track-b)` is promoted, folded, and then never mentioned
+/// again while a different pair is decided. An unseeded fold does not merely
+/// leave it stale — it DELETES it, because the withdrawal sweep sees a stored
+/// key the accumulator no longer holds and reads that as a withdrawal.
+#[test]
+fn a_relationship_promoted_below_the_checkpoint_survives_a_later_unrelated_fold() {
+    let mut store = WorldStore::open(&tmp("below-checkpoint")).expect("open");
+    observe(&mut store, "a", "track-a", "SN-1");
+    observe(&mut store, "b1", "track-b", "SN-1");
+    observe(&mut store, "b2", "track-b", "SN-2");
+    observe(&mut store, "c", "track-c", "SN-2");
+    assert_eq!(propose(&mut store), 2);
+
+    decide(
+        &mut store,
+        "1",
+        "cand-obs-1",
+        Outcome::Promoted,
+        T0 as u64 + 10,
+    );
+    store.fold_relationship_projection().expect("first fold");
+    assert_eq!(store.load_relationship_projection().expect("load").len(), 1);
+
+    // A decision about a DIFFERENT pair, after the checkpoint. Nothing here
+    // says anything about (track-a, track-b).
+    decide(
+        &mut store,
+        "2",
+        "cand-obs-2",
+        Outcome::Promoted,
+        T0 as u64 + 20,
+    );
+    store.fold_relationship_projection().expect("second fold");
+
+    let rows = store.load_relationship_projection().expect("load");
+    assert!(
+        rows.contains_key(&("track-a".to_owned(), "track-b".to_owned())),
+        "a relationship the tail never mentions must not be withdrawn by a fold"
+    );
+    assert!(rows.contains_key(&("track-b".to_owned(), "track-c".to_owned())));
+
+    // And the checkpoint digest must describe that state, not the tail alone --
+    // a fold that dropped the earlier pair from its accumulator would also
+    // stamp a digest that omitted it, so the two would agree with each other
+    // while both being wrong.
+    let incremental = store
+        .relationship_projection_state_digest()
+        .expect("digest");
+    store.rebuild_relationship_projection().expect("rebuild");
+    assert_eq!(
+        incremental,
+        store
+            .relationship_projection_state_digest()
+            .expect("digest"),
+        "incremental must equal rebuild across an untouched pair too"
+    );
+}
+
+/// **The provenance pin is the DECIDING generation, and a later carrier of the
+/// same observation id does not resurrect compacted evidence.**
+///
+/// `relationship_provenance` resolves at `decided_generation` rather than at
+/// the head of the log, and this is the case that makes the difference visible.
+/// After the judged candidate is compacted, a *different* event carrying the
+/// same observation id is appended. Resolving at the head would find it and
+/// report `Resolved`, quietly substituting an event the operator never saw for
+/// the one their decision rested on. Pinned at the decision, it is still
+/// `Dangling`.
+///
+/// Written after the pin's justification was already in a code comment — an
+/// asserted reason with no control is the defect this box already hit once.
+#[test]
+fn a_later_carrier_of_the_same_id_does_not_resurrect_compacted_evidence() {
+    let mut store = two_tracks_and_a_candidate("impostor");
+    decide(
+        &mut store,
+        "1",
+        "cand-obs-1",
+        Outcome::Promoted,
+        T0 as u64 + 10,
+    );
+    store.fold_relationship_projection().expect("fold");
+
+    let key = pair("track-a", "track-b");
+    let candidate_generation = match store
+        .relationship_provenance(&key)
+        .expect("provenance")
+        .expect("holds")
+    {
+        CitationResolution::Resolved { target_generation } => target_generation,
+        other => panic!("must resolve before compaction: {other:?}"),
+    };
+    store
+        .compact_range(candidate_generation, candidate_generation, T0 + 100)
+        .expect("compact the raw candidate");
+
+    // A LATER event reusing the compacted observation's id. Not a forgery of
+    // the projection -- an ordinary append, which is why the pin has to do the
+    // work rather than the log preventing it.
+    let event_id = EventId::new("impostor-ev").expect("id");
+    let observation_id = ObservationId::new("cand-obs-1").expect("id");
+    store
+        .append(&NewEvent {
+            event_id: &event_id,
+            observation_id: &observation_id,
+            txn_time_ms: T0 + 200,
+            valid_from_ms: T0 + 200,
+            valid_to_ms: None,
+            source: "asset-tag-reader",
+            source_version: "1.0.0",
+            writer_class: WriterClass::Sensor,
+            claim_status: ClaimStatus::Confirmed,
+            provenance: &[],
+            frame_id: None,
+            map_id: None,
+            kind: "observation",
+            subject: "track-a",
+            subject_ref: None,
+            predicate: Some("serial_number"),
+            object: Some("SN-1"),
+            payload: "{}",
+            payload_schema: 1,
+            retention_class: "raw",
+            trust: None,
+        })
+        .expect("append a later carrier of the same observation id");
+
+    match store
+        .relationship_provenance(&key)
+        .expect("provenance")
+        .expect("holds")
+    {
+        CitationResolution::Dangling { .. } => {}
+        other => panic!(
+            "an event appended after the decision must not stand in for the \
+             evidence the decision rested on: {other:?}"
+        ),
+    }
+}

--- a/crates/kirra-world-ingest/tests/relationship_projection.rs
+++ b/crates/kirra-world-ingest/tests/relationship_projection.rs
@@ -867,3 +867,76 @@ fn a_later_carrier_of_the_same_id_does_not_resurrect_compacted_evidence() {
         ),
     }
 }
+
+/// **A projection row whose citation is not an admissible `ObservationId` is
+/// refused.**
+///
+/// Raised by review on #1467. The mechanism the comment predicted — an error
+/// downstream — is not what happens, and that is precisely why this matters:
+/// `carriers` on a garbage id simply matches nothing, so
+/// `relationship_provenance` would answer `Dangling`, which an operator reads
+/// as *"the evidence was compacted"* when the truth is *"this row was edited"*.
+/// A wrong answer, delivered confidently, is worse than an error.
+#[test]
+fn a_projection_row_with_an_inadmissible_citation_is_refused() {
+    let mut store = two_tracks_and_a_candidate("bad-citation");
+    decide(
+        &mut store,
+        "1",
+        "cand-obs-1",
+        Outcome::Promoted,
+        T0 as u64 + 10,
+    );
+    store.fold_relationship_projection().expect("fold");
+
+    store
+        .raw_execute_for_test("UPDATE relationships_projection SET candidate_observation_id = ''")
+        .expect("blank the citation");
+
+    match store.load_relationship_projection() {
+        Err(StoreError::CorruptRelationshipProjectionRow { detail }) => assert!(
+            detail.contains("candidate_observation_id"),
+            "the refusal must name the field: {detail}"
+        ),
+        other => panic!("an inadmissible citation must be refused: {other:?}"),
+    }
+    // And through the point read too, not only the whole-table load -- the two
+    // share `relationship_from_row` precisely so they cannot come to disagree
+    // about what a stored row means, and this is what holds them to it.
+    assert!(matches!(
+        store.relationship(&pair("track-a", "track-b")),
+        Err(StoreError::CorruptRelationshipProjectionRow { .. })
+    ));
+}
+
+/// **A projection row signed by nobody is refused.**
+///
+/// `AdjudicationAuthority::new` refuses an empty adjudicator at write time
+/// under `KIRRA-WM-PROMOTION-001`; a read path that admitted one would let a
+/// confirmed identity exist with no one accountable for it. The check goes
+/// through that same domain constructor rather than an `is_empty` at the
+/// decoder, so the two cannot drift.
+#[test]
+fn a_projection_row_signed_by_nobody_is_refused() {
+    let mut store = two_tracks_and_a_candidate("no-adjudicator");
+    decide(
+        &mut store,
+        "1",
+        "cand-obs-1",
+        Outcome::Promoted,
+        T0 as u64 + 10,
+    );
+    store.fold_relationship_projection().expect("fold");
+
+    store
+        .raw_execute_for_test("UPDATE relationships_projection SET adjudicator = '   '")
+        .expect("blank the adjudicator");
+
+    match store.load_relationship_projection() {
+        Err(StoreError::CorruptRelationshipProjectionRow { detail }) => assert!(
+            detail.contains("adjudicator"),
+            "the refusal must name the field: {detail}"
+        ),
+        other => panic!("an unsigned decision must be refused: {other:?}"),
+    }
+}

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -4103,6 +4103,32 @@ fn relationship_from_row(
             detail: format!("stored pair ({low}, {high}) is not in canonical order"),
         });
     }
+    // The citation, through the same constructor the WRITE side parses it with
+    // (`decode_same_as_adjudication`). Checked rather than copied out: this
+    // string is the handle a reader follows back to the judged proposal, and an
+    // inadmissible one does NOT error downstream -- `carriers` simply matches
+    // nothing and the answer degrades to `Dangling`, which reads as "the
+    // evidence was compacted" when the truth is "this row was edited". That is
+    // the silent rewrite this decoder claims not to do.
+    //
+    // `ObservationId::new` does not normalize (`reference::admit`, and its
+    // `surrounding_whitespace_is_preserved_not_trimmed` test), so unlike the
+    // pair there is no repaired-vs-stored comparison to make.
+    kirra_world::reference::ObservationId::new(candidate_observation_id.as_str()).map_err(|e| {
+        StoreError::CorruptRelationshipProjectionRow {
+            detail: format!("candidate_observation_id `{candidate_observation_id}`: {e}"),
+        }
+    })?;
+    // And the adjudicator, through the DOMAIN constructor rather than an
+    // `is_empty` here, so "a decision nobody signed" has one definition and this
+    // path cannot drift from the one the write side enforces.
+    kirra_world::same_as_adjudication::AdjudicationAuthority::new(
+        kirra_world::same_as_adjudication::AUTHORIZED_ADJUDICATOR_CLASS,
+        adjudicator.clone(),
+    )
+    .map_err(|e| StoreError::CorruptRelationshipProjectionRow {
+        detail: format!("adjudicator: {e}"),
+    })?;
     // The inverse of the fold's write-side refusal. A negative stored value is
     // not a reading on any clock; the fold cannot write one.
     let decided_ms =

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -90,6 +90,7 @@ pub mod lineage;
 pub mod projection;
 pub mod provenance_edges;
 pub mod provenance_graph;
+pub mod relationship_projection;
 pub mod retention_driver;
 pub mod retention_sweeper;
 pub mod same_as_adjudication_record;
@@ -275,6 +276,18 @@ pub enum StoreError {
         /// Which row, and how it disagreed.
         detail: String,
     },
+    /// A stored relationship-projection row could not be read back faithfully.
+    ///
+    /// **Refused, never repaired**, for
+    /// [`Self::CorruptEntityProjectionRow`]'s reason: the columns are written
+    /// only by the fold, so a row that disagrees with itself means the file was
+    /// edited underneath the store — and the recovery for a rebuildable view is
+    /// `rebuild_relationship_projection`, not a guess at what an operator
+    /// decided.
+    CorruptRelationshipProjectionRow {
+        /// Which row, and how it disagreed.
+        detail: String,
+    },
     /// A citation page was requested with an unusable bound — Tier 4 box 4a.
     ///
     /// **Refused, never clamped**, for the reason [`lineage::PageSpecError`]
@@ -427,6 +440,9 @@ impl std::fmt::Display for StoreError {
             // pre-existing cleanup, deliberately not smuggled into this PR.
             Self::CorruptEntityProjectionRow { detail } => {
                 write!(f, "corrupt stored row: {detail}")
+            }
+            Self::CorruptRelationshipProjectionRow { detail } => {
+                write!(f, "corrupt stored relationship row: {detail}")
             }
             Self::CitationPageSpec(e) => write!(f, "citation page: {e}"),
             Self::ProvenanceIndexIncomplete { requested, floor } => write!(
@@ -2888,6 +2904,371 @@ impl WorldStore {
         Ok(head)
     }
 
+    // -- The relationship projection (Tier 5 box 5a) --------------------
+    //
+    // Deliberately the same SHAPE as the entity projection above -- lazy DDL,
+    // seed-from-stored, fold-forward, rebuild-from-zero, a digest written with
+    // the checkpoint. That is not copy-paste convenience: `WM_SCOPE` §0a's
+    // rebuild-equals-incremental invariant is a property of that shape, and a
+    // projection built a different way would need its own argument for it.
+
+    /// Install the relationship projection's DDL, lazily.
+    ///
+    /// **First fold, never `open`** — [`WorldStore::ensure_entity_projection`]'s
+    /// reason, which applies unchanged: ADR-0041 D-20's `log_only_bytes` must
+    /// stay the size of a store holding only the log.
+    fn ensure_relationship_projection(&self) -> Result<(), StoreError> {
+        self.conn
+            .execute_batch(relationship_projection::RELATIONSHIP_PROJECTION_V1)?;
+        self.conn
+            .execute_batch(projection::PROJECTION_CHECKPOINT_V1)?;
+        Ok(())
+    }
+
+    /// Whether the relationship projection has ever been folded.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::Sqlite`] if the catalogue cannot be read.
+    pub fn has_relationship_projection(&self) -> Result<bool, StoreError> {
+        let n: Option<i64> = self
+            .conn
+            .query_row(
+                "SELECT 1 FROM sqlite_master WHERE type='table' \
+                 AND name='relationships_projection'",
+                [],
+                |r| r.get(0),
+            )
+            .optional()?;
+        Ok(n.is_some())
+    }
+
+    /// How far the relationship fold has consumed.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::Sqlite`] if the checkpoint cannot be read.
+    pub fn relationship_projection_generation(&self) -> Result<i64, StoreError> {
+        if !self.has_relationship_projection()? {
+            return Ok(0);
+        }
+        let g: Option<i64> = self
+            .conn
+            .query_row(
+                "SELECT generation FROM projection_checkpoint WHERE name = ?1",
+                params![relationship_projection::RELATIONSHIP_PROJECTION],
+                |r| r.get(0),
+            )
+            .optional()?;
+        Ok(g.unwrap_or(0))
+    }
+
+    /// Fold new confirmed `same_as` decisions into the relationship projection.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::Sqlite`] on storage failure, or
+    /// [`StoreError::CorruptRelationshipProjectionRow`] if a stored row or a
+    /// log row cannot be read back faithfully. **Fail-closed**: a fold that
+    /// cannot read its own prior state does not start over from empty, because
+    /// that would silently drop every relationship below the checkpoint.
+    pub fn fold_relationship_projection(&mut self) -> Result<i64, StoreError> {
+        self.ensure_relationship_projection()?;
+        let from = self.relationship_projection_generation()?;
+        self.fold_relationship_range(from)
+    }
+
+    /// Discard the relationship projection and rebuild it from generation 0.
+    ///
+    /// The result must equal an incremental fold — ADR-0041's stated purity
+    /// property, checked by
+    /// [`WorldStore::relationship_projection_state_digest`] rather than assumed.
+    ///
+    /// # Errors
+    ///
+    /// As [`WorldStore::fold_relationship_projection`].
+    pub fn rebuild_relationship_projection(&mut self) -> Result<i64, StoreError> {
+        self.ensure_relationship_projection()?;
+        // Unlike the entity rebuild's, this DELETE **is** load-bearing, and the
+        // difference is worth stating because the two methods otherwise read
+        // identically. This fold WITHDRAWS: a pair whose newest decision is not
+        // `Promoted` is removed from the accumulator. `fold_relationship_range`
+        // then upserts the accumulator and deletes the keys it no longer holds,
+        // so leaving stale rows here would be corrected -- but only for pairs
+        // the accumulator SEEDED from those same rows. Clearing first makes the
+        // rebuild depend on the log alone, which is what "rebuildable view"
+        // means. The negative control is
+        // `a_rebuild_does_not_inherit_a_row_the_log_does_not_justify`.
+        self.conn
+            .execute("DELETE FROM relationships_projection", [])?;
+        self.conn.execute(
+            "DELETE FROM projection_checkpoint WHERE name = ?1",
+            params![relationship_projection::RELATIONSHIP_PROJECTION],
+        )?;
+        self.fold_relationship_range(0)
+    }
+
+    fn fold_relationship_range(&mut self, from_generation: i64) -> Result<i64, StoreError> {
+        // Seeded from the STORED rows. The reason is NOT the entity fold's --
+        // that one needs the prior lifecycle to tell a legal transition from a
+        // contradiction, and this reducer needs no prior state at all, since
+        // each decision overwrites its own pair outright.
+        //
+        // What the seed is actually for is the WITHDRAWAL SWEEP below, which
+        // reads "a stored key the accumulator no longer holds" as a
+        // withdrawal. An accumulator seeded from empty holds only the pairs the
+        // tail mentioned, so every relationship promoted below the checkpoint
+        // and untouched since would be swept as though an operator had revoked
+        // it -- silent data loss on an ordinary incremental fold, in the
+        // opposite direction from the stale row one might expect.
+        //
+        // That is a MEASURED claim, not a plausible one: the first draft of
+        // this comment asserted the stale-row failure, the mutation left every
+        // test green, and the test that now names it
+        // (`a_relationship_promoted_below_the_checkpoint_survives_a_later_unrelated_fold`)
+        // was written because of it.
+        let mut acc = self.load_relationship_projection()?;
+        let seeded: Vec<relationship_projection::PairKey> = acc.keys().cloned().collect();
+
+        let tx = self.conn.transaction()?;
+        let mut head = from_generation;
+        {
+            let mut stmt = tx.prepare(
+                "SELECT generation, writer_class, claim_status, kind, predicate,
+                        subject, object, payload, payload_schema
+                 FROM world_events
+                 WHERE generation > ?1 AND claim_status = 'confirmed' AND kind = ?2
+                 ORDER BY generation ASC",
+            )?;
+            let mut rows = stmt.query(params![
+                from_generation,
+                same_as_adjudication_record::SAME_AS_ADJUDICATION_KIND
+            ])?;
+            while let Some(r) = rows.next()? {
+                let generation: i64 = r.get(0)?;
+                let writer_class: String = r.get(1)?;
+                let claim_status: String = r.get(2)?;
+                let kind: String = r.get(3)?;
+                let predicate: Option<String> = r.get(4)?;
+                let subject: String = r.get(5)?;
+                let object: Option<String> = r.get(6)?;
+                let payload: String = r.get(7)?;
+                let payload_schema: i64 = r.get(8)?;
+                let decision = same_as_adjudication_record::decode_same_as_adjudication(
+                    &same_as_adjudication_record::StoredAdjudicationRow {
+                        writer_class: writer_class.as_str(),
+                        claim_status: claim_status.as_str(),
+                        kind: kind.as_str(),
+                        predicate: predicate.as_deref(),
+                        subject: subject.as_str(),
+                        object: object.as_deref(),
+                        payload: payload.as_str(),
+                        payload_schema,
+                    },
+                )
+                .map_err(|e| StoreError::CorruptRelationshipProjectionRow {
+                    detail: format!("generation {generation}: {e}"),
+                })?;
+                relationship_projection::fold_same_as_adjudication(&mut acc, &decision, generation);
+                head = generation;
+            }
+
+            let mut upsert = tx.prepare(
+                "INSERT INTO relationships_projection
+                     (low, high, decided_generation, candidate_observation_id,
+                      adjudicator, decided_at_ms, decided_at_domain)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+                 ON CONFLICT(low, high) DO UPDATE SET
+                     decided_generation = excluded.decided_generation,
+                     candidate_observation_id = excluded.candidate_observation_id,
+                     adjudicator = excluded.adjudicator,
+                     decided_at_ms = excluded.decided_at_ms,
+                     decided_at_domain = excluded.decided_at_domain",
+            )?;
+            for r in acc.values() {
+                // `DomainInstant::ms` is a `u64` and a SQLite INTEGER is signed,
+                // so the top half of the domain has no storage. REFUSED, not
+                // saturated: clamping would write a different instant from the
+                // one the decision recorded, and this column is what an
+                // operator reads to place the decision in time. Reachable from
+                // a payload carrying a `ms` above `i64::MAX` -- the decoder
+                // admits it (it is a valid `u64`) and this is where it stops.
+                let decided_at_ms = i64::try_from(r.decided_at.ms).map_err(|_| {
+                    StoreError::CorruptRelationshipProjectionRow {
+                        detail: format!(
+                            "generation {}: decided_at.ms {} exceeds the storable range",
+                            r.decided_generation, r.decided_at.ms
+                        ),
+                    }
+                })?;
+                upsert.execute(params![
+                    r.pair.low().as_str(),
+                    r.pair.high().as_str(),
+                    r.decided_generation,
+                    r.candidate_observation_id.as_str(),
+                    r.adjudicator.as_str(),
+                    decided_at_ms,
+                    relationship_projection::clock_domain_token(r.decided_at.domain),
+                ])?;
+            }
+
+            // WITHDRAWALS. A seeded key the fold no longer holds was withdrawn
+            // by a decision in this range, and an upsert-only writer would
+            // leave it standing -- the table would keep asserting an identity
+            // the newest authorized decision revoked. Scoped to the keys this
+            // fold SEEDED rather than "delete everything not in `acc`", so a
+            // fold and a concurrent one cannot delete each other's rows.
+            let mut drop =
+                tx.prepare("DELETE FROM relationships_projection WHERE low = ?1 AND high = ?2")?;
+            for key in &seeded {
+                if !acc.contains_key(key) {
+                    drop.execute(params![key.0.as_str(), key.1.as_str()])?;
+                }
+            }
+
+            tx.execute(
+                "INSERT INTO projection_checkpoint (name, generation, state_digest)
+                 VALUES (?1, ?2, ?3)
+                 ON CONFLICT(name) DO UPDATE SET
+                     generation = excluded.generation,
+                     state_digest = excluded.state_digest",
+                params![
+                    relationship_projection::RELATIONSHIP_PROJECTION,
+                    head,
+                    relationship_projection::state_digest_of(&acc)
+                ],
+            )?;
+        }
+        tx.commit()?;
+        Ok(head)
+    }
+
+    /// **One relationship, by canonical pair** — a point read.
+    ///
+    /// `WHERE low = ?1 AND high = ?2` against `PRIMARY KEY (low, high)`, so the
+    /// result is at most one row regardless of how many relationships the fleet
+    /// has accumulated. STRUCTURALLY bounded, in the sense
+    /// `ci/store_boundedness_baseline.json` records for `current`.
+    ///
+    /// This exists because the first draft of
+    /// [`WorldStore::relationship_provenance`] answered a one-pair question by
+    /// calling [`WorldStore::load_relationship_projection`] and indexing the
+    /// result — a whole-table scan behind a point-read signature, which is
+    /// defect #1441's exact shape and was caught by the boundedness gate rather
+    /// than by review.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::CorruptRelationshipProjectionRow`] if the row cannot be
+    /// read back faithfully.
+    pub fn relationship(
+        &self,
+        pair: &kirra_world::same_as_candidate::CandidatePair,
+    ) -> Result<Option<relationship_projection::ProjectedRelationship>, StoreError> {
+        if !self.has_relationship_projection()? {
+            return Ok(None);
+        }
+        let mut stmt = self.conn.prepare(
+            "SELECT low, high, decided_generation, candidate_observation_id,
+                    adjudicator, decided_at_ms, decided_at_domain
+             FROM relationships_projection WHERE low = ?1 AND high = ?2",
+        )?;
+        match stmt.query_row(params![pair.low().as_str(), pair.high().as_str()], |r| {
+            Ok(relationship_from_row(r))
+        }) {
+            Ok(row) => Ok(Some(row?)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Every relationship that currently holds, keyed by canonical pair.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::CorruptRelationshipProjectionRow`] if a stored row cannot
+    /// be read back faithfully.
+    pub fn load_relationship_projection(
+        &self,
+    ) -> Result<
+        std::collections::BTreeMap<
+            relationship_projection::PairKey,
+            relationship_projection::ProjectedRelationship,
+        >,
+        StoreError,
+    > {
+        let mut out = std::collections::BTreeMap::new();
+        if !self.has_relationship_projection()? {
+            return Ok(out);
+        }
+        let mut stmt = self.conn.prepare(
+            "SELECT low, high, decided_generation, candidate_observation_id,
+                    adjudicator, decided_at_ms, decided_at_domain
+             FROM relationships_projection ORDER BY low ASC, high ASC",
+        )?;
+        let mut rows = stmt.query([])?;
+        while let Some(r) = rows.next()? {
+            let row = relationship_from_row(r)?;
+            out.insert(relationship_projection::pair_key(&row.pair), row);
+        }
+        Ok(out)
+    }
+
+    /// A digest over the relationship projection, in key order.
+    ///
+    /// # Errors
+    ///
+    /// As [`WorldStore::load_relationship_projection`].
+    pub fn relationship_projection_state_digest(&self) -> Result<String, StoreError> {
+        Ok(relationship_projection::state_digest_of(
+            &self.load_relationship_projection()?,
+        ))
+    }
+
+    /// **How well a promoted relationship's candidate evidence still resolves.**
+    ///
+    /// The read side of the scope statement in
+    /// [`crate::relationship_projection`]: the relationship is authoritative as
+    /// adjudicated, and this answers the *separate* question of whether the
+    /// proposal it cites is still in the log.
+    ///
+    /// It returns box 4b's [`CitationResolution`] rather than a boolean, and
+    /// that is the structural half of "must not be upgraded to fully
+    /// evidenced": `Resolved` cannot be constructed without a visible carrier,
+    /// so a compacted candidate degrades to `Dangling { PossiblyCompacted }` by
+    /// construction rather than by a caller remembering to check.
+    ///
+    /// `Ok(None)` means no such relationship holds — distinct from a
+    /// relationship whose evidence dangles, which is `Some(Dangling)`.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::CorruptRelationshipProjectionRow`] if the row cannot be
+    /// read back, or [`StoreError::Sqlite`] on storage failure.
+    ///
+    /// [`CitationResolution`]: provenance_graph::CitationResolution
+    pub fn relationship_provenance(
+        &self,
+        pair: &kirra_world::same_as_candidate::CandidatePair,
+    ) -> Result<Option<provenance_graph::CitationResolution>, StoreError> {
+        use provenance_graph::CitationLookup as _;
+
+        let Some(row) = self.relationship(pair)? else {
+            return Ok(None);
+        };
+        // Pinned at the DECIDING generation, not at the head. The question is
+        // whether the evidence that decision rested on is still visible, and
+        // resolving at the head would let an observation appended afterwards
+        // stand in for one that was compacted away -- box 4b's historical
+        // visibility rule, applied to the one pin that makes it meaningful.
+        let at = row.decided_generation;
+        let carriers = self.carriers(row.candidate_observation_id.as_str(), at)?;
+        let spans = self.compacted_spans(at)?;
+        Ok(Some(provenance_graph::resolve_citation(
+            &carriers, at, &spans,
+        )))
+    }
+
     /// Every projected entity, keyed by id.
     ///
     /// # Errors
@@ -3674,6 +4055,79 @@ impl WorldStore {
 // ===========================================================================
 
 /// Columns the fold reads, in one place so the two readers cannot drift.
+/// Decode one `relationships_projection` row, fail-closed.
+///
+/// **Refuses, never repairs.** The columns are written only by the fold, so a
+/// row that disagrees with itself means the file was edited underneath the
+/// store — and a rebuildable view's recovery is
+/// [`WorldStore::rebuild_relationship_projection`], not a guess at what an
+/// operator decided.
+///
+/// Shared by the whole-table load and the point read so the two cannot come to
+/// disagree about what a stored row means. Column order is the one both
+/// statements select.
+fn relationship_from_row(
+    r: &rusqlite::Row<'_>,
+) -> Result<relationship_projection::ProjectedRelationship, StoreError> {
+    let low: String = r.get(0)?;
+    let high: String = r.get(1)?;
+    let decided_generation: i64 = r.get(2)?;
+    let candidate_observation_id: String = r.get(3)?;
+    let adjudicator: String = r.get(4)?;
+    let decided_at_ms: i64 = r.get(5)?;
+    let decided_at_domain: String = r.get(6)?;
+
+    // Through the domain constructors. A row whose ids no longer parse was not
+    // written by the fold.
+    let low_id = kirra_world::reference::EntityId::new(low.as_str()).map_err(|e| {
+        StoreError::CorruptRelationshipProjectionRow {
+            detail: format!("low `{low}`: {e}"),
+        }
+    })?;
+    let high_id = kirra_world::reference::EntityId::new(high.as_str()).map_err(|e| {
+        StoreError::CorruptRelationshipProjectionRow {
+            detail: format!("high `{high}`: {e}"),
+        }
+    })?;
+    let pair =
+        kirra_world::same_as_candidate::CandidatePair::new(low_id, high_id).map_err(|e| {
+            StoreError::CorruptRelationshipProjectionRow {
+                detail: format!("({low}, {high}): {e}"),
+            }
+        })?;
+    // Checked, not repaired: `CandidatePair::new` canonicalises, so a row stored
+    // the wrong way round would come back looking correct while colliding on
+    // one key with the row that was stored correctly.
+    if pair.low().as_str() != low {
+        return Err(StoreError::CorruptRelationshipProjectionRow {
+            detail: format!("stored pair ({low}, {high}) is not in canonical order"),
+        });
+    }
+    // The inverse of the fold's write-side refusal. A negative stored value is
+    // not a reading on any clock; the fold cannot write one.
+    let decided_ms =
+        u64::try_from(decided_at_ms).map_err(|_| StoreError::CorruptRelationshipProjectionRow {
+            detail: format!("decided_at_ms {decided_at_ms} is negative"),
+        })?;
+    let domain = relationship_projection::clock_domain_from_token(decided_at_domain.as_str())
+        .ok_or_else(|| StoreError::CorruptRelationshipProjectionRow {
+            detail: format!(
+                "decided_at_domain `{decided_at_domain}` is not a clock this build knows"
+            ),
+        })?;
+
+    Ok(relationship_projection::ProjectedRelationship {
+        pair,
+        decided_generation,
+        candidate_observation_id,
+        adjudicator,
+        decided_at: kirra_world::observation::DomainInstant {
+            ms: decided_ms,
+            domain,
+        },
+    })
+}
+
 const CLAIM_COLUMNS: &str = "subject, predicate, object, kind, payload, frame_id, map_id, \
      source, valid_from_ms, valid_to_ms, txn_time_ms, generation, event_id, chain_digest, \
      origin, corroboration, corroboration_n, adjudication";

--- a/crates/kirra-world-store/src/relationship_projection.rs
+++ b/crates/kirra-world-store/src/relationship_projection.rs
@@ -1,0 +1,294 @@
+//! **Promoted `same_as` identity as a projection** — `WM_SCOPE.md` §5 box 5a.
+//!
+//! Box 2a built the production door that writes a `same_as` *candidate*; box 2b
+//! built the door that lets an authorized adjudicator judge a **persisted**
+//! candidate and record the decision. This folds those decisions into the
+//! relationships that currently hold.
+//!
+//! # Scope, stated before the code
+//!
+//! > The relationship projection is authoritative over promoted identity
+//! > decisions, not over continued retention of the candidate evidence that
+//! > motivated them. If cited candidate evidence is compacted, the relationship
+//! > remains valid as adjudicated, while its explanatory provenance may degrade.
+//!
+//! That separation is what `KIRRA-WM-IDENTITY-FRESHNESS-001` already ruled at
+//! the freshness layer — a promoted `same_as` is `Timeless` *as an adjudicated
+//! identity fact* — carried down into storage. The projection row holds the
+//! decision; the candidate it cites is `retention_class = "raw"` and may be
+//! compacted out from under it. See *Provenance is a citation, not a flag*.
+//!
+//! # Operator-authored promotions are the only production input today
+//!
+//! Said plainly rather than left to be inferred from the fold's filter.
+//! `KIRRA-WM-PROMOTION-001` v1 authorizes `SourceClass::Operator` and nothing
+//! else, `AdjudicationAuthority::new` refuses every other class, and
+//! `WorldStore::adjudicate_same_as` is the only writer of the rows this folds.
+//! So every row in this table traces to a human decision. An automated
+//! adjudicator is not merely unimplemented — it is unruled.
+//!
+//! # What it consumes, and what it will not invent
+//!
+//! * `kind = same_as_adjudication` at `claim_status = 'confirmed'` **only**. A
+//!   candidate is `claim_status = 'candidate'` and is therefore not selected —
+//!   the same predicate `WorldStore::fold_entity_range` inherits, and the reason
+//!   a matcher cannot reach this table by proposing harder.
+//! * The pair comes from the row's indexed `subject`/`object`, in the canonical
+//!   order [`CandidatePair`] fixes. [`decode_same_as_adjudication`] refuses a row
+//!   stored the other way round rather than repairing it.
+//! * **No transitive closure.** `KIRRA-WM-TRANSITIVITY-001` permits *resolution*
+//!   to traverse accepted merges and forbids this layer from emitting the
+//!   traversed relation as evidence. `A=B` promoted and `B=C` promoted yield two
+//!   rows here, never three. There is no closure step to disable — the fold
+//!   touches exactly the one pair its input names, which is why
+//!   `promotion_never_synthesises_a_transitive_relation` can assert the absence
+//!   rather than the fold having declined to add it.
+//!
+//! [`CandidatePair`]: kirra_world::same_as_candidate::CandidatePair
+//! [`decode_same_as_adjudication`]:
+//!     crate::same_as_adjudication_record::decode_same_as_adjudication
+//!
+//! # A later decision supersedes an earlier one, and a non-promotion WITHDRAWS
+//!
+//! `KIRRA-WM-IDENTITY-FRESHNESS-001`: the identity decision *"remains valid
+//! until changed by later adjudication"*. So the fold consumes **every**
+//! confirmed decision about a pair, not only the promotions, and the newest one
+//! wins. The table then holds only the pairs whose newest decision is
+//! `Promoted`.
+//!
+//! [`Outcome::Rejected`] withdrawing a prior promotion is uncontroversial.
+//! [`Outcome::Unresolved`] withdrawing one is a **choice this box makes**, and
+//! the alternative is real: an operator recording *"I can no longer tell"* might
+//! mean *leave the earlier decision standing*. It is not taken, for one reason —
+//! the log does not record which they meant, so abstaining would make the
+//! table's contents depend on a distinction nothing wrote down, and it would err
+//! toward continuing to assert an identity the most recent authorized decision
+//! declined to affirm. Withdrawal is the direction that fails closed.
+//!
+//! If operators want abstain semantics, that is a ruling and a new
+//! [`Outcome`] variant, not a quiet change here — the exhaustive match in
+//! [`fold_same_as_adjudication`] makes adding one a compile error.
+//!
+//! # Provenance is a citation, not a flag
+//!
+//! The row stores `candidate_observation_id` — the id of the judged proposal —
+//! and **no** "fully evidenced" boolean. That is the structural half of the
+//! scope statement above: there is no field that could be left `true` after the
+//! evidence was compacted, because there is no field. Whether that citation
+//! still resolves is answered by asking, through
+//! `WorldStore::relationship_provenance`, which returns box 4b's
+//! [`CitationResolution`] — a type whose `Resolved` variant cannot be produced
+//! without a visible carrier. After compaction the honest answer degrades to
+//! `Dangling { PossiblyCompacted }` while the relationship itself is untouched,
+//! which is exactly what
+//! `a_promoted_relationship_survives_compaction_of_its_candidate` proves.
+//!
+//! [`CitationResolution`]: crate::provenance_graph::CitationResolution
+//!
+//! # No DDL in the ratified surface, and no schema bump
+//!
+//! `WM2_EVENT_SCHEMA.md` §7 names `relationships_projection` under *what this
+//! ruling does not decide* — a rebuildable view that follows from the fold.
+//! `SCHEMA_VERSION` is untouched, and the DDL is installed **by the first fold,
+//! never at `open`**, for [`crate::entity_projection`]'s reason: ADR-0041 D-20's
+//! `log_only_bytes` is the size of a store holding only the log, and adding root
+//! pages at `open` would move that figure for a store that never projects.
+
+use std::collections::BTreeMap;
+
+use kirra_world::observation::DomainInstant;
+use kirra_world::same_as_adjudication::Outcome;
+use kirra_world::same_as_candidate::CandidatePair;
+
+use crate::same_as_adjudication_record::StoredAdjudication;
+
+/// The lazily-installed projection table. See the module docs for why this is
+/// not schema DDL and why it is not installed at `open`.
+pub const RELATIONSHIP_PROJECTION_V1: &str = r#"
+CREATE TABLE IF NOT EXISTS relationships_projection (
+    low                      TEXT    NOT NULL,
+    high                     TEXT    NOT NULL,
+    -- The confirmed adjudication event that put this row here. An operator
+    -- reads it to find the decision, and the fold records it so a superseding
+    -- decision is visibly newer rather than merely different.
+    decided_generation       INTEGER NOT NULL,
+    -- The persisted candidate the decision judged. A CITATION, not a flag:
+    -- there is deliberately no "fully evidenced" column, because a compacted
+    -- candidate would leave one reading true. See the module docs.
+    candidate_observation_id TEXT    NOT NULL,
+    adjudicator              TEXT    NOT NULL,
+    decided_at_ms            INTEGER NOT NULL,
+    decided_at_domain        TEXT    NOT NULL,
+    PRIMARY KEY (low, high)
+);
+"#;
+
+/// This projection's checkpoint name.
+///
+/// Its own, not the entity projection's: the two folds consume different row
+/// kinds and advance independently, and sharing a cursor would make one fold's
+/// progress silently skip the other's input.
+pub const RELATIONSHIP_PROJECTION: &str = "relationships_projection";
+
+/// The accumulator key — the canonical pair, as two ids.
+///
+/// A tuple rather than a joined string: two entity ids that concatenate to the
+/// same bytes under some separator would collide on one row, and the ids are
+/// caller-supplied.
+pub type PairKey = (String, String);
+
+/// The key a pair folds under.
+#[must_use]
+pub fn pair_key(pair: &CandidatePair) -> PairKey {
+    (
+        pair.low().as_str().to_owned(),
+        pair.high().as_str().to_owned(),
+    )
+}
+
+/// One relationship that currently holds.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectedRelationship {
+    /// The pair, canonically ordered.
+    pub pair: CandidatePair,
+    /// The generation of the confirmed adjudication that promoted it.
+    pub decided_generation: i64,
+    /// The persisted candidate that decision judged. May no longer resolve —
+    /// see the module docs.
+    pub candidate_observation_id: String,
+    /// Who decided.
+    pub adjudicator: String,
+    /// When they decided, on a named clock.
+    pub decided_at: DomainInstant,
+}
+
+// SEMANTICS-PIN-BEGIN: relationship_fold
+//
+// Digested by `ci/check_world_semantics.py` and pinned in
+// `semantics::SEMANTICS` — see `crate::semantics` for the two-check rationale.
+
+/// **The pure fold step.** Apply one confirmed decision to the accumulator.
+///
+/// `BTreeMap` rather than `HashMap` for [`crate::projection::fold_all`]'s
+/// reason: the state digest is taken over iteration order, and a digest that
+/// depended on hash seeding would compare unequal to itself.
+///
+/// # Ordering is a precondition, not a guard
+///
+/// Callers apply this in generation order — `WorldStore::fold_relationship_range`
+/// does, by `ORDER BY generation ASC`. There is deliberately no
+/// `if generation < existing.decided_generation { return }` check: on the one
+/// caller that exists it can never be true, and a comparison that is always
+/// false reads as the enforcement and stops a reader looking for the real one.
+/// (The same defect this crate already removed once, from
+/// `WorldStore::adjudicate_same_as`.)
+///
+/// # The accumulator holds only what currently holds
+///
+/// A withdrawn pair is REMOVED rather than kept with a rejected marker. That is
+/// what lets an incremental fold seed itself from the stored rows — which carry
+/// promotions only — and still reach the same state a rebuild from generation 0
+/// reaches, without the table needing to store decisions it does not publish.
+pub fn fold_same_as_adjudication(
+    acc: &mut BTreeMap<PairKey, ProjectedRelationship>,
+    decision: &StoredAdjudication,
+    generation: i64,
+) {
+    let key = pair_key(&decision.pair);
+    // Exhaustive, no wildcard: a new `Outcome` variant must be a COMPILE error
+    // here rather than silently taking whichever arm a `_` fell into. Adding
+    // one is a ruling about what it does to a standing promotion.
+    match decision.outcome {
+        Outcome::Promoted => {
+            acc.insert(
+                key,
+                ProjectedRelationship {
+                    pair: decision.pair.clone(),
+                    decided_generation: generation,
+                    candidate_observation_id: decision.candidate_observation_id.clone(),
+                    adjudicator: decision.adjudicator.clone(),
+                    decided_at: decision.decided_at,
+                },
+            );
+        }
+        // Both WITHDRAW a standing promotion, and on a pair that was never
+        // promoted both are no-ops. See the module docs for why `Unresolved`
+        // is a withdrawal rather than an abstention.
+        Outcome::Rejected | Outcome::Unresolved => {
+            acc.remove(&key);
+        }
+    }
+}
+
+/// Fold a whole sequence of `(generation, decision)` in order.
+#[must_use]
+pub fn fold_all<'a, I>(decisions: I) -> BTreeMap<PairKey, ProjectedRelationship>
+where
+    I: IntoIterator<Item = (i64, &'a StoredAdjudication)>,
+{
+    let mut acc = BTreeMap::new();
+    for (generation, d) in decisions {
+        fold_same_as_adjudication(&mut acc, d, generation);
+    }
+    acc
+}
+
+// SEMANTICS-PIN-END: relationship_fold
+
+/// The stored spelling of a clock domain.
+#[must_use]
+pub fn clock_domain_token(domain: kirra_world::observation::ClockDomain) -> &'static str {
+    match domain {
+        kirra_world::observation::ClockDomain::Boundary => "boundary",
+        kirra_world::observation::ClockDomain::System => "system",
+    }
+}
+
+/// The inverse of [`clock_domain_token`].
+///
+/// `None` for a token this build does not know. Not defaulted: AOU-TIMESYNC-001
+/// makes the clock a stated property of a timestamp, and guessing which one a
+/// row meant is how a boundary instant gets compared against a system one.
+#[must_use]
+pub fn clock_domain_from_token(token: &str) -> Option<kirra_world::observation::ClockDomain> {
+    match token {
+        "boundary" => Some(kirra_world::observation::ClockDomain::Boundary),
+        "system" => Some(kirra_world::observation::ClockDomain::System),
+        _ => None,
+    }
+}
+
+/// A digest over a relationship accumulator, in key order.
+///
+/// Takes the accumulator rather than reading the table, so the value written
+/// into the checkpoint is the one the fold actually produced.
+///
+/// **`decided_generation` and the citation are inside it**, not just the pair.
+/// Digesting membership alone would rate two projections equal when they agree
+/// on *which* pairs hold but disagree on which decision put them there — and
+/// that is the field an operator follows to the decision, so the
+/// rebuild-equals-incremental check would pass while pointing two stores at
+/// different history. Exactly the reason
+/// [`crate::entity_projection::state_digest_of`] covers the contradiction
+/// payload rather than the flag.
+#[must_use]
+pub fn state_digest_of(rows: &BTreeMap<PairKey, ProjectedRelationship>) -> String {
+    let mut buf = String::new();
+    for ((low, high), r) in rows {
+        buf.push_str(low);
+        buf.push('\u{1f}');
+        buf.push_str(high);
+        buf.push('\u{1f}');
+        buf.push_str(&r.decided_generation.to_string());
+        buf.push('\u{1f}');
+        buf.push_str(&r.candidate_observation_id);
+        buf.push('\u{1f}');
+        buf.push_str(&r.adjudicator);
+        buf.push('\u{1f}');
+        buf.push_str(&r.decided_at.ms.to_string());
+        buf.push('\u{1f}');
+        buf.push_str(clock_domain_token(r.decided_at.domain));
+        buf.push('\u{1e}');
+    }
+    crate::sha256_hex(buf.as_bytes())
+}

--- a/crates/kirra-world-store/src/same_as_adjudication_record.rs
+++ b/crates/kirra-world-store/src/same_as_adjudication_record.rs
@@ -249,3 +249,333 @@ pub fn adjudication_columns(pair: &CandidatePair) -> (String, String) {
         pair.high().as_str().to_owned(),
     )
 }
+
+// ---------------------------------------------------------------------------
+// Reading a stored adjudication back — Tier 5 box 5a.
+// ---------------------------------------------------------------------------
+
+/// A stored adjudication row's columns, as the decoder needs them.
+#[derive(Debug, Clone, Copy)]
+pub struct StoredAdjudicationRow<'a> {
+    /// `world_events.writer_class`.
+    pub writer_class: &'a str,
+    /// `world_events.claim_status`.
+    pub claim_status: &'a str,
+    /// `world_events.kind`.
+    pub kind: &'a str,
+    /// `world_events.predicate`.
+    pub predicate: Option<&'a str>,
+    /// `world_events.subject` — the pair's low entity.
+    pub subject: &'a str,
+    /// `world_events.object` — the pair's high entity.
+    pub object: Option<&'a str>,
+    /// `world_events.payload`.
+    pub payload: &'a str,
+    /// `world_events.payload_schema`.
+    pub payload_schema: i64,
+}
+
+/// What a stored `same_as` adjudication says, read back from its row.
+///
+/// # Why this is not a [`SameAsAdjudication`]
+///
+/// It would be one field short of honest. [`same_as_adjudication_provenance`]
+/// writes the judged candidate first and then `cited`, **deduplicated**, into
+/// one flat column — so a caller who also named the candidate in `cited` and one
+/// who did not produce the identical row. Reconstructing `SameAsAdjudication`
+/// would have to invent a `cited` list, and the only available guess (the whole
+/// provenance column) attributes a citation the writer may never have made.
+///
+/// So this carries exactly the fields the row records unambiguously, and the
+/// projection that consumes it needs none of the rest. A decoder that returned
+/// a richer type than the row supports would be manufacturing the difference.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoredAdjudication {
+    /// The pair decided about, in canonical order.
+    pub pair: CandidatePair,
+    /// What was decided.
+    pub outcome: Outcome,
+    /// The persisted candidate this decision judged.
+    pub candidate_observation_id: String,
+    /// Who decided.
+    pub adjudicator: String,
+    /// When they decided, on a named clock.
+    pub decided_at: kirra_world::observation::DomainInstant,
+}
+
+/// Why a stored adjudication row could not be read back.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AdjudicationDecodeError {
+    /// The row's columns do not describe an authorized `same_as` decision.
+    NotAnAdjudicationRow {
+        /// What disagreed.
+        detail: String,
+    },
+    /// The payload was written under an encoding this build does not have.
+    UnsupportedSchema {
+        /// The row's `payload_schema`.
+        found: i64,
+        /// The one this build reads.
+        supported: i64,
+    },
+    /// The payload is not the JSON object this encoding writes.
+    Malformed {
+        /// The parse failure.
+        detail: String,
+    },
+    /// A payload field is absent or the wrong shape.
+    Field {
+        /// Which field.
+        key: &'static str,
+        /// How it disagreed.
+        detail: String,
+    },
+    /// The domain refused a value the row carried.
+    Domain {
+        /// The domain's own message.
+        detail: String,
+    },
+}
+
+impl std::fmt::Display for AdjudicationDecodeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotAnAdjudicationRow { detail } => {
+                write!(f, "not a same_as adjudication row: {detail}")
+            }
+            Self::UnsupportedSchema { found, supported } => {
+                write!(f, "payload_schema {found} is not the supported {supported}")
+            }
+            Self::Malformed { detail } => write!(f, "malformed adjudication payload: {detail}"),
+            Self::Field { key, detail } => write!(f, "field `{key}`: {detail}"),
+            Self::Domain { detail } => write!(f, "{detail}"),
+        }
+    }
+}
+
+impl std::error::Error for AdjudicationDecodeError {}
+
+fn payload_object(
+    v: &serde_json::Value,
+) -> Result<&serde_json::Map<String, serde_json::Value>, AdjudicationDecodeError> {
+    v.as_object()
+        .ok_or_else(|| AdjudicationDecodeError::Malformed {
+            detail: "payload is not a JSON object".to_owned(),
+        })
+}
+
+fn string_field<'a>(
+    obj: &'a serde_json::Map<String, serde_json::Value>,
+    key: &'static str,
+) -> Result<&'a str, AdjudicationDecodeError> {
+    match obj.get(key) {
+        None => Err(AdjudicationDecodeError::Field {
+            key,
+            detail: "absent".to_owned(),
+        }),
+        Some(v) => v.as_str().ok_or(AdjudicationDecodeError::Field {
+            key,
+            detail: "not a string".to_owned(),
+        }),
+    }
+}
+
+/// **Read a stored adjudication row back, fail-closed.**
+///
+/// Every column the write door pins is checked on the way out, for the reason
+/// [`crate::candidate_record::decode_candidate`] records: the door governs what
+/// *this crate* writes, and a decoder that trusted the door would be trusting
+/// the one thing a row from anywhere else could differ in.
+///
+/// # The pair's order is checked, not repaired
+///
+/// [`CandidatePair::new`] canonicalizes, so handing it a row whose `subject` and
+/// `object` were stored the wrong way round would return a correct-looking pair
+/// and silently hide that the row disagrees with the writer's own convention.
+/// The order is therefore asserted after construction: `subject` must be the
+/// low entity. A projection keyed on the pair cannot afford a repair it never
+/// reported, because the repaired and unrepaired rows would collide on one key
+/// while claiming different provenance.
+///
+/// # Errors
+///
+/// [`AdjudicationDecodeError`], per variant.
+pub fn decode_same_as_adjudication(
+    row: &StoredAdjudicationRow<'_>,
+) -> Result<StoredAdjudication, AdjudicationDecodeError> {
+    let StoredAdjudicationRow {
+        writer_class,
+        claim_status,
+        kind,
+        predicate,
+        subject,
+        object,
+        payload,
+        payload_schema,
+    } = *row;
+
+    let authorized_class =
+        source_class_token(kirra_world::same_as_adjudication::AUTHORIZED_ADJUDICATOR_CLASS);
+    if writer_class != authorized_class {
+        return Err(AdjudicationDecodeError::NotAnAdjudicationRow {
+            detail: format!(
+                "writer_class is `{writer_class}`, expected `{authorized_class}` \
+                 (KIRRA-WM-PROMOTION-001 admits one adjudicating class)"
+            ),
+        });
+    }
+    if claim_status != crate::ClaimStatus::Confirmed.as_str() {
+        return Err(AdjudicationDecodeError::NotAnAdjudicationRow {
+            detail: format!("claim_status is `{claim_status}`, expected `confirmed`"),
+        });
+    }
+    if kind != SAME_AS_ADJUDICATION_KIND {
+        return Err(AdjudicationDecodeError::NotAnAdjudicationRow {
+            detail: format!("kind is `{kind}`, expected `{SAME_AS_ADJUDICATION_KIND}`"),
+        });
+    }
+    match predicate {
+        Some(p) if p == ADJUDICATION_PREDICATE_TOKEN => {}
+        Some(p) => {
+            return Err(AdjudicationDecodeError::NotAnAdjudicationRow {
+                detail: format!("predicate is `{p}`, expected `{ADJUDICATION_PREDICATE_TOKEN}`"),
+            })
+        }
+        None => {
+            return Err(AdjudicationDecodeError::NotAnAdjudicationRow {
+                detail: "no predicate".to_owned(),
+            })
+        }
+    }
+    // ANY other version, not merely a newer one -- `decode_candidate`'s reason.
+    if payload_schema != SAME_AS_ADJUDICATION_PAYLOAD_SCHEMA {
+        return Err(AdjudicationDecodeError::UnsupportedSchema {
+            found: payload_schema,
+            supported: SAME_AS_ADJUDICATION_PAYLOAD_SCHEMA,
+        });
+    }
+    let Some(high) = object else {
+        return Err(AdjudicationDecodeError::NotAnAdjudicationRow {
+            detail: "no object: a same_as decision names two entities".to_owned(),
+        });
+    };
+
+    let low_id = kirra_world::reference::EntityId::new(subject).map_err(|e| {
+        AdjudicationDecodeError::Domain {
+            detail: format!("subject: {e}"),
+        }
+    })?;
+    let high_id = kirra_world::reference::EntityId::new(high).map_err(|e| {
+        AdjudicationDecodeError::Domain {
+            detail: format!("object: {e}"),
+        }
+    })?;
+    let pair =
+        CandidatePair::new(low_id, high_id).map_err(|e| AdjudicationDecodeError::Domain {
+            detail: e.to_string(),
+        })?;
+    if pair.low().as_str() != subject {
+        return Err(AdjudicationDecodeError::NotAnAdjudicationRow {
+            detail: format!(
+                "the stored pair is not in canonical order: subject `{subject}` is not the low \
+                 entity of ({}, {})",
+                pair.low().as_str(),
+                pair.high().as_str()
+            ),
+        });
+    }
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(payload).map_err(|e| AdjudicationDecodeError::Malformed {
+            detail: e.to_string(),
+        })?;
+    let root = payload_object(&parsed)?;
+
+    let outcome_str = string_field(root, "outcome")?;
+    let outcome =
+        outcome_from_token(outcome_str).ok_or_else(|| AdjudicationDecodeError::Field {
+            key: "outcome",
+            detail: format!("`{outcome_str}` is not a decision this build knows"),
+        })?;
+
+    let candidate_observation_id = string_field(root, "candidate_observation_id")?.to_owned();
+    // Parsed, not merely copied: this id is the citation a reader follows back
+    // to the judged proposal, and one that is not an admissible ObservationId
+    // resolves to nothing while looking like evidence.
+    ObservationId::new(candidate_observation_id.as_str()).map_err(|e| {
+        AdjudicationDecodeError::Field {
+            key: "candidate_observation_id",
+            detail: e.to_string(),
+        }
+    })?;
+
+    let authority = root
+        .get("authority")
+        .ok_or(AdjudicationDecodeError::Field {
+            key: "authority",
+            detail: "absent".to_owned(),
+        })?;
+    let authority = payload_object(authority)?;
+    let payload_class = string_field(authority, "source_class")?;
+    // The payload's own record of the class, checked against the column. They
+    // are written from one value, so a row where they disagree was not written
+    // by this door -- and taking either one as the truth would pick a winner.
+    if payload_class != authorized_class {
+        return Err(AdjudicationDecodeError::NotAnAdjudicationRow {
+            detail: format!(
+                "payload authority.source_class is `{payload_class}`, expected \
+                 `{authorized_class}`"
+            ),
+        });
+    }
+    let adjudicator = string_field(authority, "identity")?.to_owned();
+    // Through the domain constructor rather than trusted: an empty adjudicator
+    // is a decision nobody signed, which `AdjudicationAuthority::new` refuses at
+    // write time and a reader must refuse at read time for the same reason.
+    AdjudicationAuthority::new(
+        kirra_world::same_as_adjudication::AUTHORIZED_ADJUDICATOR_CLASS,
+        adjudicator.clone(),
+    )
+    .map_err(|e| AdjudicationDecodeError::Domain {
+        detail: e.to_string(),
+    })?;
+
+    let decided = root
+        .get("decided_at")
+        .ok_or(AdjudicationDecodeError::Field {
+            key: "decided_at",
+            detail: "absent".to_owned(),
+        })?;
+    let decided = payload_object(decided)?;
+    // `as_u64`, matching `DomainInstant::ms`. A negative JSON number is not a
+    // reading on any clock, and coercing one would put an instant before the
+    // epoch into a field nothing else in the store can express.
+    let ms = decided
+        .get("ms")
+        .and_then(serde_json::Value::as_u64)
+        .ok_or(AdjudicationDecodeError::Field {
+            key: "decided_at.ms",
+            detail: "absent, negative, or not an integer".to_owned(),
+        })?;
+    let domain = match string_field(decided, "domain")? {
+        "boundary" => kirra_world::observation::ClockDomain::Boundary,
+        "system" => kirra_world::observation::ClockDomain::System,
+        other => {
+            return Err(AdjudicationDecodeError::Field {
+                key: "decided_at.domain",
+                detail: format!(
+                    "`{other}` is not a clock this build knows — \
+                     AOU-TIMESYNC-001 forbids guessing a domain"
+                ),
+            })
+        }
+    };
+
+    Ok(StoredAdjudication {
+        pair,
+        outcome,
+        candidate_observation_id,
+        adjudicator,
+        decided_at: kirra_world::observation::DomainInstant { ms, domain },
+    })
+}

--- a/crates/kirra-world-store/src/semantics.rs
+++ b/crates/kirra-world-store/src/semantics.rs
@@ -82,6 +82,8 @@ use crate::entity_projection::{
     self, contradiction_json, lifecycle_token, origin_of, redirect_json, ProjectedEntity,
 };
 use crate::projection::{self, ProjectedClaim};
+use crate::relationship_projection::{self, PairKey, ProjectedRelationship};
+use crate::same_as_adjudication_record::StoredAdjudication;
 use crate::subject_projection::{self, ProjectedSubject, SubjectKey, SubjectObservation};
 
 /// A versioned reducer.
@@ -120,6 +122,16 @@ pub enum RuleId {
     /// evidence while looking identical — and unlike a page cursor, the
     /// difference is a statement about where a fact came from.
     CitationResolution,
+    /// [`crate::relationship_projection::fold_same_as_adjudication`] — the
+    /// promoted-`same_as` fold.
+    ///
+    /// It decides which pairs the store reports as the same thing, so a change
+    /// here alters a derived answer in the most direct way any rule in this
+    /// table can. It also decides what a NON-promotion does to a standing
+    /// promotion, which is a policy choice (`Unresolved` withdraws rather than
+    /// abstains) rather than a mechanical one — exactly the kind of decision a
+    /// version exists to make visible when it changes.
+    RelationshipFold,
 }
 
 impl RuleId {
@@ -136,6 +148,7 @@ impl RuleId {
             Self::SubjectSummaryFold => "subject_summary_fold",
             Self::LineageSelection => "lineage_selection",
             Self::CitationResolution => "citation_resolution",
+            Self::RelationshipFold => "relationship_fold",
         }
     }
 
@@ -151,6 +164,7 @@ impl RuleId {
             RuleId::SubjectSummaryFold,
             RuleId::LineageSelection,
             RuleId::CitationResolution,
+            RuleId::RelationshipFold,
         ]
     }
 }
@@ -246,6 +260,14 @@ pub const SEMANTICS: &[RuleSpec] = &[
         source_pin: "07e6d2b8b7d86207a61231c7dfa1e4df46be0240632bba3d15e171e42a5d7b4b",
         source_file: "crates/kirra-world-store/src/provenance_graph.rs",
         span: "citation_resolution",
+    },
+    RuleSpec {
+        rule: RuleId::RelationshipFold,
+        version: 1,
+        corpus_digest: "0cc3e211f39f90c9e0243525d1e5a5d83449ed930fc72e50f474c60eb7797986",
+        source_pin: "e82c8a546104d622f71bb2c12e63670ad4c8a0733ac02eb88e2c7138b991b6b8",
+        source_file: "crates/kirra-world-store/src/relationship_projection.rs",
+        span: "relationship_fold",
     },
 ];
 
@@ -781,6 +803,82 @@ pub fn render_provenance(tree: &crate::provenance_graph::ProvenanceTree) -> Stri
     out
 }
 
+/// The relationship fold's corpus input, as `(generation, decision)`.
+///
+/// Every entry discriminates a behaviour, and the last three are the ones a
+/// happy-path corpus would miss:
+///
+/// * `(a, b)` promoted — the base case.
+/// * `(b, c)` promoted — a **second, distinct pair**, so a fold that keyed on
+///   one entity rather than on the pair collides visibly. It is also what makes
+///   the absence of `(a, c)` in the rendering meaningful: a fold that closed
+///   transitively would render a third row.
+/// * `(a, b)` **rejected** — a withdrawal, which must remove the earlier row
+///   rather than sit beside it.
+/// * `(a, b)` **re-promoted** — the withdrawal is not terminal, and the row
+///   that comes back names the NEW decision.
+/// * `(b, c)` **unresolved** — the policy choice. A fold that treated
+///   `Unresolved` as an abstention leaves this pair standing and renders
+///   differently, which is what pins the choice to this version rather than to
+///   a comment.
+///
+/// The generation ORDER is load-bearing for the same reason
+/// [`world_current_corpus`] records: a fold is observable only through its
+/// FINAL state, so a divergence that later converges is invisible. Each of the
+/// three policy entries is therefore the LAST word about its pair.
+#[must_use]
+pub fn relationship_corpus() -> Vec<(i64, StoredAdjudication)> {
+    let pair = |a: &str, b: &str| {
+        kirra_world::same_as_candidate::CandidatePair::new(
+            EntityId::new(a).expect("corpus entity"),
+            EntityId::new(b).expect("corpus entity"),
+        )
+        .expect("corpus pair")
+    };
+    let decision = |a: &str, b: &str, outcome, ms: u64, candidate: &str| StoredAdjudication {
+        pair: pair(a, b),
+        outcome,
+        candidate_observation_id: candidate.to_owned(),
+        adjudicator: "corpus-operator".to_owned(),
+        decided_at: DomainInstant {
+            ms,
+            domain: ClockDomain::System,
+        },
+    };
+    use kirra_world::same_as_adjudication::Outcome;
+    vec![
+        (1, decision("a", "b", Outcome::Promoted, 100, "cand-ab-1")),
+        (2, decision("b", "c", Outcome::Promoted, 101, "cand-bc-1")),
+        (3, decision("a", "b", Outcome::Rejected, 102, "cand-ab-1")),
+        (4, decision("a", "b", Outcome::Promoted, 103, "cand-ab-2")),
+        (5, decision("b", "c", Outcome::Unresolved, 104, "cand-bc-1")),
+    ]
+}
+
+/// Render a folded relationship accumulator.
+///
+/// Rendered rather than hashed at the assertion site so a failure shows **what**
+/// changed. Carries `decided_generation` and the cited candidate, not just the
+/// pair: a fold that kept the right pairs under the wrong decisions would
+/// otherwise render identically.
+#[must_use]
+pub fn render_relationships(rows: &BTreeMap<PairKey, ProjectedRelationship>) -> String {
+    let mut out = String::new();
+    for ((low, high), r) in rows {
+        out.push_str(low);
+        out.push(FIELD);
+        out.push_str(high);
+        out.push(FIELD);
+        out.push_str(&r.decided_generation.to_string());
+        out.push(FIELD);
+        out.push_str(&r.candidate_observation_id);
+        out.push(FIELD);
+        out.push_str(&r.decided_at.ms.to_string());
+        out.push(ROW);
+    }
+    out
+}
+
 /// **Run one rule's corpus through the real reducer and render the result.**
 ///
 /// This is the value the declared [`RuleSpec::corpus_digest`] is a digest of. It
@@ -849,6 +947,12 @@ pub fn corpus_rendering(rule: RuleId) -> String {
                 out.push(ROW);
             }
             out
+        }
+        RuleId::RelationshipFold => {
+            let corpus = relationship_corpus();
+            render_relationships(&relationship_projection::fold_all(
+                corpus.iter().map(|(g, d)| (*g, d)),
+            ))
         }
     }
 }

--- a/crates/kirra-world-store/src/semantics.rs
+++ b/crates/kirra-world-store/src/semantics.rs
@@ -264,7 +264,7 @@ pub const SEMANTICS: &[RuleSpec] = &[
     RuleSpec {
         rule: RuleId::RelationshipFold,
         version: 1,
-        corpus_digest: "0cc3e211f39f90c9e0243525d1e5a5d83449ed930fc72e50f474c60eb7797986",
+        corpus_digest: "db4975d3adc118885e0c180c58ac45311272df617e0b9f00333571b14cff3b95",
         source_pin: "e82c8a546104d622f71bb2c12e63670ad4c8a0733ac02eb88e2c7138b991b6b8",
         source_file: "crates/kirra-world-store/src/relationship_projection.rs",
         span: "relationship_fold",
@@ -822,6 +822,14 @@ pub fn render_provenance(tree: &crate::provenance_graph::ProvenanceTree) -> Stri
 ///   differently, which is what pins the choice to this version rather than to
 ///   a comment.
 ///
+/// The **adjudicator and the clock domain vary across entries**, and the entry
+/// that SURVIVES the fold (generation 4) is the one carrying the odd values.
+/// Both halves are load-bearing: a corpus where every decision named one
+/// operator on one clock renders identically under a reducer that hardcodes
+/// them, and a corpus where the odd values appear only on a withdrawn row
+/// renders identically too, because a fold is observable only through its
+/// final state.
+///
 /// The generation ORDER is load-bearing for the same reason
 /// [`world_current_corpus`] records: a fold is observable only through its
 /// FINAL state, so a divergence that later converges is invisible. Each of the
@@ -835,32 +843,103 @@ pub fn relationship_corpus() -> Vec<(i64, StoredAdjudication)> {
         )
         .expect("corpus pair")
     };
-    let decision = |a: &str, b: &str, outcome, ms: u64, candidate: &str| StoredAdjudication {
+    let decision = |a: &str,
+                    b: &str,
+                    outcome,
+                    ms: u64,
+                    domain: ClockDomain,
+                    adjudicator: &str,
+                    candidate: &str| StoredAdjudication {
         pair: pair(a, b),
         outcome,
         candidate_observation_id: candidate.to_owned(),
-        adjudicator: "corpus-operator".to_owned(),
-        decided_at: DomainInstant {
-            ms,
-            domain: ClockDomain::System,
-        },
+        adjudicator: adjudicator.to_owned(),
+        decided_at: DomainInstant { ms, domain },
     };
     use kirra_world::same_as_adjudication::Outcome;
+    let sys = ClockDomain::System;
     vec![
-        (1, decision("a", "b", Outcome::Promoted, 100, "cand-ab-1")),
-        (2, decision("b", "c", Outcome::Promoted, 101, "cand-bc-1")),
-        (3, decision("a", "b", Outcome::Rejected, 102, "cand-ab-1")),
-        (4, decision("a", "b", Outcome::Promoted, 103, "cand-ab-2")),
-        (5, decision("b", "c", Outcome::Unresolved, 104, "cand-bc-1")),
+        (
+            1,
+            decision(
+                "a",
+                "b",
+                Outcome::Promoted,
+                100,
+                sys,
+                "operator-1",
+                "cand-ab-1",
+            ),
+        ),
+        (
+            2,
+            decision(
+                "b",
+                "c",
+                Outcome::Promoted,
+                101,
+                sys,
+                "operator-1",
+                "cand-bc-1",
+            ),
+        ),
+        (
+            3,
+            decision(
+                "a",
+                "b",
+                Outcome::Rejected,
+                102,
+                sys,
+                "operator-1",
+                "cand-ab-1",
+            ),
+        ),
+        // The surviving row. Its adjudicator and its CLOCK DOMAIN both differ
+        // from every other entry, which is what makes the rendering able to see
+        // them -- see the doc above.
+        (
+            4,
+            decision(
+                "a",
+                "b",
+                Outcome::Promoted,
+                103,
+                ClockDomain::Boundary,
+                "operator-2",
+                "cand-ab-2",
+            ),
+        ),
+        (
+            5,
+            decision(
+                "b",
+                "c",
+                Outcome::Unresolved,
+                104,
+                sys,
+                "operator-1",
+                "cand-bc-1",
+            ),
+        ),
     ]
 }
 
 /// Render a folded relationship accumulator.
 ///
 /// Rendered rather than hashed at the assertion site so a failure shows **what**
-/// changed. Carries `decided_generation` and the cited candidate, not just the
-/// pair: a fold that kept the right pairs under the wrong decisions would
-/// otherwise render identically.
+/// changed. Carries **every field the projection persists** — the pair,
+/// `decided_generation`, the cited candidate, the adjudicator, and the decided
+/// instant with its CLOCK DOMAIN — because a fold that kept the right pairs
+/// under the wrong decisions would otherwise render identically.
+///
+/// The adjudicator and the domain were added on review of #1467. Adding the
+/// fields is only half of it and the cheaper half: a corpus in which every
+/// entry carries the same adjudicator and the same clock renders identically
+/// under a reducer that hardcodes them, so the fields would have been ceremony.
+/// [`relationship_corpus`] therefore VARIES both, and
+/// `the_relationship_corpus_catches_a_dropped_adjudicator_or_clock_domain` is
+/// the control that says so.
 #[must_use]
 pub fn render_relationships(rows: &BTreeMap<PairKey, ProjectedRelationship>) -> String {
     let mut out = String::new();
@@ -873,7 +952,13 @@ pub fn render_relationships(rows: &BTreeMap<PairKey, ProjectedRelationship>) -> 
         out.push(FIELD);
         out.push_str(&r.candidate_observation_id);
         out.push(FIELD);
+        out.push_str(&r.adjudicator);
+        out.push(FIELD);
         out.push_str(&r.decided_at.ms.to_string());
+        out.push(FIELD);
+        out.push_str(relationship_projection::clock_domain_token(
+            r.decided_at.domain,
+        ));
         out.push(ROW);
     }
     out

--- a/crates/kirra-world-store/tests/semantics_corpus.rs
+++ b/crates/kirra-world-store/tests/semantics_corpus.rs
@@ -787,6 +787,76 @@ fn the_relationship_corpus_catches_transitive_closure() {
     assert_variant_is_caught(RuleId::RelationshipFold, "transitive_closure", &closed);
 }
 
+/// **A rendering that drops the adjudicator, or the clock domain, or both.**
+///
+/// Raised on review of #1467: the first draft rendered neither, so a reducer
+/// that hardcoded an adjudicator or coerced every instant onto one clock would
+/// have folded the corpus to the same digest.
+///
+/// The variant here is a rendering rather than a fold, deliberately. What is
+/// under test is whether the CORPUS carries enough variation for those fields
+/// to be observable — and that question is answered by removing them from the
+/// rendering and seeing whether anything moves. If the corpus named one
+/// operator on one clock, this test would fail, which is exactly the signal it
+/// exists to give.
+#[test]
+fn the_relationship_corpus_catches_a_dropped_adjudicator_or_clock_domain() {
+    use kirra_world_store::relationship_projection::{self, PairKey, ProjectedRelationship};
+    use std::collections::BTreeMap;
+
+    fn render_without(
+        rows: &BTreeMap<PairKey, ProjectedRelationship>,
+        adjudicator: bool,
+        domain: bool,
+    ) -> String {
+        let mut out = String::new();
+        for ((low, high), r) in rows {
+            out.push_str(low);
+            out.push('\u{1f}');
+            out.push_str(high);
+            out.push('\u{1f}');
+            out.push_str(&r.decided_generation.to_string());
+            out.push('\u{1f}');
+            out.push_str(&r.candidate_observation_id);
+            out.push('\u{1f}');
+            if adjudicator {
+                out.push_str(&r.adjudicator);
+            }
+            out.push('\u{1f}');
+            out.push_str(&r.decided_at.ms.to_string());
+            out.push('\u{1f}');
+            if domain {
+                out.push_str(relationship_projection::clock_domain_token(
+                    r.decided_at.domain,
+                ));
+            }
+            out.push('\u{1e}');
+        }
+        out
+    }
+
+    let folded =
+        relationship_projection::fold_all(relationship_corpus().iter().map(|(g, d)| (*g, d)));
+    // Sanity: rendering WITH both must reproduce the real one, or the variants
+    // below would be differing for the wrong reason.
+    assert_eq!(
+        render_without(&folded, true, true),
+        corpus_rendering(RuleId::RelationshipFold),
+        "the variant renderer must agree with the real one when it drops nothing"
+    );
+
+    assert_variant_is_caught(
+        RuleId::RelationshipFold,
+        "adjudicator_dropped",
+        &render_without(&folded, false, true),
+    );
+    assert_variant_is_caught(
+        RuleId::RelationshipFold,
+        "clock_domain_dropped",
+        &render_without(&folded, true, false),
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Coverage of the control table itself
 // ---------------------------------------------------------------------------

--- a/crates/kirra-world-store/tests/semantics_corpus.rs
+++ b/crates/kirra-world-store/tests/semantics_corpus.rs
@@ -74,8 +74,9 @@ use kirra_world_store::provenance_graph::{
     ProvenanceTree,
 };
 use kirra_world_store::semantics::{
-    self, corpus_digest, corpus_rendering, entity_corpus, render_entities, render_subjects,
-    render_world_current, subject_corpus, world_current_corpus, RuleId, SEMANTICS,
+    self, corpus_digest, corpus_rendering, entity_corpus, relationship_corpus, render_entities,
+    render_relationships, render_subjects, render_world_current, subject_corpus,
+    world_current_corpus, RuleId, SEMANTICS,
 };
 use kirra_world_store::subject_projection::{
     ProjectedSubject, SubjectKey, SubjectObservation, SummaryKind,
@@ -659,6 +660,133 @@ fn the_lineage_corpus_catches_dropping_unconfirmed_candidates() {
     );
 }
 
+// --- relationship_fold ---------------------------------------------------
+
+/// Fold the relationship corpus with a caller-supplied outcome policy.
+///
+/// The three variants below differ only in what a non-`Promoted` decision does,
+/// which is the whole of this reducer's discretion — the promotion arm has no
+/// choices to get wrong.
+fn fold_relationships_with(
+    withdraws: impl Fn(kirra_world::same_as_adjudication::Outcome) -> bool,
+) -> String {
+    use kirra_world::same_as_adjudication::Outcome;
+    use kirra_world_store::relationship_projection::{PairKey, ProjectedRelationship};
+
+    let mut acc: std::collections::BTreeMap<PairKey, ProjectedRelationship> =
+        std::collections::BTreeMap::new();
+    for (generation, d) in relationship_corpus() {
+        let key = (
+            d.pair.low().as_str().to_owned(),
+            d.pair.high().as_str().to_owned(),
+        );
+        if d.outcome == Outcome::Promoted {
+            acc.insert(
+                key,
+                ProjectedRelationship {
+                    pair: d.pair.clone(),
+                    decided_generation: generation,
+                    candidate_observation_id: d.candidate_observation_id.clone(),
+                    adjudicator: d.adjudicator.clone(),
+                    decided_at: d.decided_at,
+                },
+            );
+        } else if withdraws(d.outcome) {
+            acc.remove(&key);
+        }
+    }
+    render_relationships(&acc)
+}
+
+/// **`Unresolved` treated as an abstention.** The policy choice box 5a made,
+/// as a variant: a fold that leaves a standing promotion alone when the
+/// operator says "I can no longer tell" keeps `(b, c)` in the projection.
+///
+/// This is the control that pins the choice to the version rather than to a
+/// paragraph — changing the policy now moves the digest.
+#[test]
+fn the_relationship_corpus_catches_unresolved_abstaining() {
+    use kirra_world::same_as_adjudication::Outcome;
+    assert_variant_is_caught(
+        RuleId::RelationshipFold,
+        "unresolved_abstains",
+        &fold_relationships_with(|o| o == Outcome::Rejected),
+    );
+}
+
+/// **A rejection treated as an abstention.** The stronger version of the same
+/// axis: a fold that never withdraws keeps every pair it ever promoted, so the
+/// projection would go on asserting an identity an operator explicitly revoked.
+#[test]
+fn the_relationship_corpus_catches_a_fold_that_never_withdraws() {
+    assert_variant_is_caught(
+        RuleId::RelationshipFold,
+        "never_withdraws",
+        &fold_relationships_with(|_| false),
+    );
+}
+
+/// **Transitive closure.** `(a, b)` and `(b, c)` are each promoted, so a fold
+/// that emitted the traversed relation would render a third row.
+/// `KIRRA-WM-TRANSITIVITY-001` forbids that, and this is what makes the
+/// corpus able to see it rather than merely not doing it.
+#[test]
+fn the_relationship_corpus_catches_transitive_closure() {
+    use kirra_world::same_as_adjudication::Outcome;
+    use kirra_world_store::relationship_projection::{
+        fold_same_as_adjudication, ProjectedRelationship,
+    };
+
+    // The real fold, then ONE round of closure over whatever it produced --
+    // which is the smallest version of the rule this layer is forbidden to
+    // have. It runs against the corpus at the point where (a, b) and (b, c)
+    // are both standing, so a closure step has something to close.
+    let mut acc = std::collections::BTreeMap::new();
+    for (generation, d) in relationship_corpus() {
+        // Stop before the trailing `Unresolved`, which withdraws (b, c) and
+        // would leave the closure with nothing to do -- the corpus would then
+        // fail to discriminate a rule it is supposed to see.
+        if d.outcome == Outcome::Unresolved {
+            break;
+        }
+        fold_same_as_adjudication(&mut acc, &d, generation);
+    }
+    let held: Vec<ProjectedRelationship> = acc.values().cloned().collect();
+    for left in &held {
+        for right in &held {
+            if left.pair.high() == right.pair.low() {
+                let synthesized = kirra_world::same_as_candidate::CandidatePair::new(
+                    left.pair.low().clone(),
+                    right.pair.high().clone(),
+                )
+                .expect("a distinct synthesized pair");
+                acc.insert(
+                    (
+                        synthesized.low().as_str().to_owned(),
+                        synthesized.high().as_str().to_owned(),
+                    ),
+                    ProjectedRelationship {
+                        pair: synthesized,
+                        decided_generation: left.decided_generation,
+                        candidate_observation_id: left.candidate_observation_id.clone(),
+                        adjudicator: left.adjudicator.clone(),
+                        decided_at: left.decided_at,
+                    },
+                );
+            }
+        }
+    }
+    let closed = render_relationships(&acc);
+
+    // Non-vacuity: the variant must actually have synthesized something, or
+    // this test would pass by comparing two renderings of the same prefix.
+    assert!(
+        closed.contains("a\u{1f}c"),
+        "the closure variant must have produced (a, c): {closed:?}"
+    );
+    assert_variant_is_caught(RuleId::RelationshipFold, "transitive_closure", &closed);
+}
+
 // ---------------------------------------------------------------------------
 // Coverage of the control table itself
 // ---------------------------------------------------------------------------
@@ -679,6 +807,7 @@ fn every_rule_has_at_least_one_sensitivity_control() {
         RuleId::SubjectSummaryFold,
         RuleId::LineageSelection,
         RuleId::CitationResolution,
+        RuleId::RelationshipFold,
     ];
     for rule in RuleId::all() {
         assert!(

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -1102,6 +1102,86 @@ does not describe is how a residue disappears.
       because whether a matcher's PROPOSAL goes stale is a separate question this
       ruling does not answer.
 
+- [x] **5a — The relationship projection. DONE 2026-08-20.**
+      `kirra_world_store::relationship_projection` + `relationships_projection`,
+      folding **confirmed `same_as` adjudications** into the relationships that
+      currently hold. This is the far end of the chain the pre-5a audit traced:
+      real producer → sanctioned candidate write (2a) → persisted candidate →
+      authorized adjudication (2b) → confirmed event → **projection**. Its whole
+      test suite lives in `kirra-world-ingest`, so every relationship it asserts
+      about was proposed by the real matcher and promoted by a real
+      `AdjudicationAuthority`; nothing is hand-appended except where a test is
+      deliberately forging a row the production doors refuse to write.
+
+      **The scope it was built to**, recorded because it separates two things
+      that are easy to fuse:
+
+      > The relationship projection is authoritative over promoted identity
+      > decisions, not over continued retention of the candidate evidence that
+      > motivated them. If cited candidate evidence is compacted, the
+      > relationship remains valid as adjudicated, while its explanatory
+      > provenance may degrade.
+
+      That is `KIRRA-WM-IDENTITY-FRESHNESS-001` carried into storage. The row
+      cites `candidate_observation_id` and carries **no** "fully evidenced"
+      flag — there is no field that could be left reading `true` after the
+      candidate was compacted. Whether the citation still resolves is asked
+      through `relationship_provenance`, which returns box 4b's
+      `CitationResolution`, whose `Resolved` variant cannot be constructed
+      without a visible carrier.
+
+      **Operator-authored promotions are the only production input today.**
+      `KIRRA-WM-PROMOTION-001` v1 authorizes `SourceClass::Operator` and nothing
+      else, so every row traces to a human decision. An automated adjudicator is
+      unruled, not merely unimplemented.
+
+      **Decisions this box made, each with a control:**
+
+      | Decision | Control |
+      |---|---|
+      | A later non-promotion WITHDRAWS a standing promotion | `a_later_rejection_withdraws_a_standing_promotion` |
+      | `Unresolved` withdraws rather than abstains | `a_later_unresolved_withdraws_a_standing_promotion`, plus the `unresolved_abstains` corpus variant |
+      | No transitive closure (`KIRRA-WM-TRANSITIVITY-001`) | `promotion_never_synthesises_a_transitive_relation`, plus the `transitive_closure` corpus variant |
+      | Provenance is pinned at the DECIDING generation, not the head | `a_later_carrier_of_the_same_id_does_not_resurrect_compacted_evidence` |
+      | A relationship survives compaction of its candidate | `a_promoted_relationship_survives_compaction_of_its_candidate` |
+      | Rebuild-from-zero equals an incremental fold | `incremental_folding_equals_rebuild_from_zero` |
+
+      The reducer is versioned as `RuleId::RelationshipFold` v1 with three
+      sensitivity controls, so changing the withdrawal policy moves a digest
+      rather than a paragraph.
+
+      **Two things this box got wrong and the gates caught**, recorded because
+      both are the same defect class this file keeps finding — a claim outrunning
+      its evidence:
+
+      1. The comment justifying seeding the fold from stored rows named the
+         WRONG failure. Mutating the seed to empty left all thirteen tests green,
+         because every pair in the determinism test was touched by the tail. The
+         real failure is that the withdrawal sweep DELETES a relationship
+         promoted below the checkpoint and untouched since — silent data loss on
+         an ordinary fold, opposite in direction to the stale row the comment
+         predicted. `a_relationship_promoted_below_the_checkpoint_survives_a_later_unrelated_fold`
+         now names it.
+      2. `relationship_provenance` answered a one-pair question by loading the
+         whole projection — defect #1441's exact shape, behind a point-read
+         signature. The query-boundedness gate found it, not review. It is now
+         the `relationship` point read on `PRIMARY KEY (low, high)`.
+
+      **OPEN, and stated rather than implied: this projection has no domain
+      consumer yet.** Rule 1 ("every new declaration needs a production
+      consumer") is not satisfied by 5a alone; it is satisfied by the sequence
+      5a → typed `Related` query through `QueryEngine` → a real consumer, of
+      which this is the first step. If that sequence stalls, this table and its
+      fold are the thing to delete, not to document.
+
+      **FOLLOW-UP RULING owed:** does promotion PROTECT the supporting candidate
+      evidence from compaction, or is *protected adjudication + degradable
+      provenance* the intended model? 5a inherits the second honestly (the
+      candidate is `retention_class = "raw"`, the decision is `"adjudication"`
+      and protected) and does not decide it. The measurement the ruling needs now
+      exists: `a_promoted_relationship_survives_compaction_of_its_candidate`
+      shows exactly what the projection inherits when the evidence goes.
+
 - [x] **2c — Deterministic resolution over promoted identity. DONE 2026-08-20.**
       `kirra_world::adjudication::promote_confirmed_same_as` is the join: it asks
       `confirmed_relations` WHICH pairs are confirmed and turns each into a
@@ -3522,7 +3602,11 @@ Before any code:
    `kirra_world_store::retention_driver` and `::retention_sweeper` HEALED and
    their baseline entries retired in the same PR, which is the witness this box
    was chosen for.
-4. Revisit semantic projections, **based on a real consumer**.
+4. ~~Revisit semantic projections.~~ **relationships half done 2026-08-20** —
+   `relationship_projection`, over the real 2a/2b/2c chain. The **consumer**
+   half of rule 1 is NOT yet paid: the next two steps are the typed `Related`
+   query through `QueryEngine` and then a consumer that asks it. Capabilities
+   and map layers remain unstarted and still gated on a consumer.
 5. Design commands (5c.1).
 6. Complete the missing typed queries (5c.2).
 7. Rule event emission — before any event code (5c.3).
@@ -3549,10 +3633,14 @@ Tiers 2 and 4 spent their residuals removing.
 
 ### The remaining §8 boxes, restated
 
-- [ ] **5a — Semantic projections** beyond `world_current`: relationships,
-      capabilities, map layers. Gated on a real consumer per rule 1, and note
-      the identity-relations predecessor (`same_as_adjudication`) is still
-      awaiting box 2c.
+- [~] **5a — Semantic projections** beyond `world_current`. The
+      **relationships** half is DONE 2026-08-20 (see the box above):
+      `relationships_projection` folds confirmed `same_as` adjudications, over
+      the completed 2a → 2b → 2c chain rather than over fixtures. Capabilities
+      and map layers are NOT started and stay gated on a real consumer per rule
+      1. The relationships half is deliberately ahead of its consumer by two
+      boxes — the typed `Related` query and then the consumer — and that debt is
+      recorded at the box rather than treated as paid.
 - [x] **5b — Retention policy driver. DONE 2026-08-19.** ADR-0040 promoted this
       to a **Tier 1 exit criterion** (§4); the *deciding* half landed 2026-08-06
       as `kirra_world::retention`, the *acting* half as

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -1167,6 +1167,35 @@ does not describe is how a residue disappears.
          signature. The query-boundedness gate found it, not review. It is now
          the `relationship` point read on `PRIMARY KEY (low, high)`.
 
+      **Two more found on review of the PR**, both real and both the same
+      shape — a stated guarantee wider than its enforcement:
+
+      3. `relationship_from_row` validated `low`/`high` through the domain and
+         refused a non-canonical pair, but admitted **any**
+         `candidate_observation_id` and an **empty adjudicator** — while its own
+         doc said "refuses, never repairs". The reviewer's predicted mechanism
+         was wrong (an inadmissible id does not error downstream; `carriers`
+         matches nothing and the answer degrades to `Dangling`), and the wrong
+         mechanism is the worse one: `Dangling` reads as *"the evidence was
+         compacted"* when the truth is *"this row was edited"*. Both fields now
+         go through the same domain constructors the write side uses, with
+         `a_projection_row_with_an_inadmissible_citation_is_refused` and
+         `a_projection_row_signed_by_nobody_is_refused`.
+      4. The reducer's corpus rendering omitted `adjudicator` and the decided
+         instant's **clock domain**, so a reducer that hardcoded either would
+         have kept the semantics digest green. Adding the fields is the cheap
+         half and alone would have been ceremony — the corpus named ONE operator
+         on ONE clock, so a hardcoding reducer would still render identically.
+         `relationship_corpus` now VARIES both, with the odd values on the entry
+         that SURVIVES the fold (a fold is observable only through its final
+         state, so odd values on a withdrawn row would pin nothing), and
+         `the_relationship_corpus_catches_a_dropped_adjudicator_or_clock_domain`
+         is the control. `RelationshipFold` stays **v1**: the reducer is
+         byte-identical (its `source_pin` did not move) and v1 had never left
+         this PR, so there is no recorded history for the re-pinned
+         `corpus_digest` to contradict. A stronger corpus for an unchanged
+         reducer is not a behaviour change.
+
       **OPEN, and stated rather than implied: this projection has no domain
       consumer yet.** Rule 1 ("every new declaration needs a production
       consumer") is not satisfied by 5a alone; it is satisfied by the sequence


### PR DESCRIPTION
`relationships_projection` folds **confirmed `same_as` adjudications** into the relationships that currently hold. This is the far end of the chain the pre-5a audit traced and found broken at its first link:

```
real producer → sanctioned candidate write (2a) → persisted candidate
  → authorized adjudication (2b) → confirmed event → PROJECTION
```

The whole test suite lives in `kirra-world-ingest`, not in the store crate, so every relationship it asserts about was proposed by the real matcher and promoted by a real `AdjudicationAuthority`. Nothing is hand-appended except where a test is deliberately forging a row the production doors refuse to write — and each of those says so.

## The scope it was built to

> The relationship projection is authoritative over promoted identity decisions, not over continued retention of the candidate evidence that motivated them. If cited candidate evidence is compacted, the relationship remains valid as adjudicated, while its explanatory provenance may degrade.

That is `KIRRA-WM-IDENTITY-FRESHNESS-001` carried into storage. The row cites `candidate_observation_id` and carries **no** "fully evidenced" flag — there is no field that could be left reading `true` after the candidate was compacted. Whether the citation still resolves is asked through `relationship_provenance`, which returns box 4b's `CitationResolution`, whose `Resolved` variant cannot be constructed without a visible carrier. Structural, not remembered.

**Operator-authored promotions are the only production input today.** `KIRRA-WM-PROMOTION-001` v1 authorizes `SourceClass::Operator` and nothing else. An automated adjudicator is unruled, not merely unimplemented.

## Decisions, each with a control that kills its mutation

| Decision | Control |
|---|---|
| A later non-promotion **withdraws** a standing promotion | `a_later_rejection_withdraws_a_standing_promotion` |
| `Unresolved` withdraws rather than abstains | `a_later_unresolved_withdraws_a_standing_promotion` + the `unresolved_abstains` corpus variant |
| No transitive closure (`KIRRA-WM-TRANSITIVITY-001`) | `promotion_never_synthesises_a_transitive_relation` + the `transitive_closure` corpus variant |
| Provenance is pinned at the **deciding** generation, not the head | `a_later_carrier_of_the_same_id_does_not_resurrect_compacted_evidence` |
| A relationship survives compaction of its candidate | `a_promoted_relationship_survives_compaction_of_its_candidate` |
| Rebuild-from-zero equals an incremental fold | `incremental_folding_equals_rebuild_from_zero` |

Six mutations were run against the suite; each reds exactly its own test. The reducer is versioned as `RuleId::RelationshipFold` v1 with three sensitivity controls, so changing the withdrawal policy moves a digest rather than a paragraph.

`Unresolved` withdrawing is a **choice**, not a mechanical consequence. The alternative — abstain, leave the earlier decision standing — is defensible, and was not taken because the log does not record which the operator meant, so abstaining would make the table's contents depend on a distinction nothing wrote down while erring toward continuing to assert an identity the most recent authorized decision declined to affirm.

## Two things this got wrong, and what caught them

**1. The seed comment named the wrong failure.** Mutating `fold_relationship_range` to seed its accumulator from empty instead of from the stored rows left **all thirteen tests green** — every pair in the determinism test happened to be touched by the tail, so a fold that had forgotten the earlier state still agreed with one that had not. The real failure is the opposite of the one the comment predicted: the withdrawal sweep *deletes* a relationship promoted below the checkpoint and untouched since — silent data loss on an ordinary incremental fold. `a_relationship_promoted_below_the_checkpoint_survives_a_later_unrelated_fold` now names it, and the comment records that it is a measured claim.

**2. `relationship_provenance` was unbounded.** It answered a one-pair question by loading the whole projection and indexing the result — defect #1441's exact shape, behind a point-read signature. The query-boundedness gate found it; review did not. It is now the `relationship` point read on `PRIMARY KEY (low, high)`.

## Open, stated rather than implied

**This projection has no domain consumer yet.** Rule 1 is satisfied by the sequence 5a → typed `Related` query through `QueryEngine` → a real consumer, of which this is step one. If that sequence stalls, this table and its fold are the thing to delete, not to document. Recorded at the box in `WM_SCOPE.md` rather than treated as paid.

**Follow-up ruling owed, deliberately not made here:** does promotion *protect* supporting candidate evidence from compaction, or is *protected adjudication + degradable provenance* the intended model? 5a inherits the second honestly (candidate is `retention_class = "raw"`, decision is `"adjudication"` and protected). The measurement that ruling needs now exists.

## Verification

- 270 workspace test binaries green, zero failures
- 32 python CI gates green (`check_decision_floor.py` needs a coverage export and is not runnable standalone)
- clippy clean but for one pre-existing warning in `tests/claim_at_generation.rs`
- rustdoc unresolved links unchanged at 14 vs the base commit
- both CI baselines diff **purely additively** (no reordered or reworded existing rows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_