### PR TITLE
KIRRA-WM-EVIDENCE-RETENTION-001: decision durability is not evidence durability

### DIFF
--- a/crates/kirra-world-ingest/tests/relationship_projection.rs
+++ b/crates/kirra-world-ingest/tests/relationship_projection.rs
@@ -940,3 +940,105 @@ fn a_projection_row_signed_by_nobody_is_refused() {
         other => panic!("an unsigned decision must be refused: {other:?}"),
     }
 }
+
+/// **`KIRRA-WM-EVIDENCE-RETENTION-001`'s caveat, as a mechanical check.**
+///
+/// > Compaction may degrade the ability to explain WHY a promotion was made,
+/// > but it must never silently alter WHETHER the promoted relationship exists.
+///
+/// `a_promoted_relationship_survives_compaction_of_its_candidate` shows the
+/// relationship is still *there* and its citation degraded. This asserts the
+/// stronger and more mechanical half: the projection's **state digest** is
+/// unchanged across the compaction and a full rebuild after it.
+///
+/// The digest is the right instrument because of what it covers — the pair,
+/// `decided_generation`, the cited candidate id, the adjudicator, and the
+/// decided instant. So a change that altered *whether* the relationship exists,
+/// or *which decision* put it there, moves it; a change that only degraded the
+/// *explanation* cannot. That is exactly the line the ruling draws, and it is
+/// drawn here by a value rather than by a paragraph.
+///
+/// # The two halves must both hold, in the same run
+///
+/// Asserting digest-equality alone would pass on a store where the compaction
+/// silently did nothing, and asserting the degradation alone would pass on a
+/// store that lost the relationship entirely. Neither is the ruled behaviour.
+/// So this pins the conjunction: the explanation moved `Resolved` →
+/// `Dangling { PossiblyCompacted }`, and the relationship state did not move at
+/// all.
+#[test]
+fn compaction_degrades_the_explanation_and_never_the_relationship() {
+    let mut store = two_tracks_and_a_candidate("ruling-caveat");
+    decide(
+        &mut store,
+        "1",
+        "cand-obs-1",
+        Outcome::Promoted,
+        T0 as u64 + 10,
+    );
+    store.fold_relationship_projection().expect("fold");
+
+    let key = pair("track-a", "track-b");
+    let before_digest = store
+        .relationship_projection_state_digest()
+        .expect("digest");
+    let candidate_generation = match store
+        .relationship_provenance(&key)
+        .expect("provenance")
+        .expect("the relationship holds")
+    {
+        CitationResolution::Resolved { target_generation } => target_generation,
+        other => panic!("the explanation must be intact before compaction: {other:?}"),
+    };
+
+    let outcome = store
+        .compact_range(candidate_generation, candidate_generation, T0 + 100)
+        .expect("a raw candidate is compactable; the protected decision is not");
+    assert!(
+        outcome.removed > 0,
+        "the compaction must have removed something, or nothing is being tested"
+    );
+
+    // --- WHETHER: unchanged, and unchanged again after a rebuild from zero ---
+    assert_eq!(
+        store
+            .relationship_projection_state_digest()
+            .expect("digest"),
+        before_digest,
+        "compaction must not alter whether the promoted relationship exists"
+    );
+    store.rebuild_relationship_projection().expect("rebuild");
+    assert_eq!(
+        store
+            .relationship_projection_state_digest()
+            .expect("digest"),
+        before_digest,
+        "and a rebuild from the surviving log must reach the same state — the \
+         decision is durable because it is itself protected evidence, not \
+         because the projection table happened to still hold the row"
+    );
+
+    // --- WHY: degraded, honestly, and not collapsed ---
+    match store
+        .relationship_provenance(&key)
+        .expect("provenance")
+        .expect("the relationship still holds")
+    {
+        CitationResolution::Dangling {
+            reason: DanglingReason::PossiblyCompacted { spans, truncated },
+        } => {
+            assert!(!truncated);
+            assert!(
+                spans.contains(&candidate_generation),
+                "the degraded answer must name the compaction citation an \
+                 investigator would go and read: {spans:?}"
+            );
+        }
+        other => panic!(
+            "the explanation must degrade to PossiblyCompacted — never stay \
+             Resolved (fabricated evidence) and never become NeverVisible \
+             (§11.3's forbidden collapse of 'deleted' into 'never recorded'): \
+             {other:?}"
+        ),
+    }
+}

--- a/crates/kirra-world-store/tests/same_as_promotion.rs
+++ b/crates/kirra-world-store/tests/same_as_promotion.rs
@@ -294,6 +294,12 @@ fn re_affirming_a_pair_keeps_the_earliest_beginning() {
 /// This test exists so the behaviour cannot change by accident before someone
 /// rules on it. If last-write-wins is the intent, this test is the one that
 /// should fail first, and it should be changed deliberately in 2b.
+///
+/// **Box 5a has since answered the same question the other way for its own
+/// projection** — see
+/// `the_two_precedence_rules_disagree_and_only_one_has_a_production_consumer`
+/// immediately below, which pins the disagreement rather than leaving it to be
+/// discovered by whoever wires the next consumer.
 #[test]
 fn promoted_then_rejected_still_promotes_today_which_is_a_ruling_2b_owes() {
     let c = candidate("a", "b");
@@ -307,6 +313,87 @@ fn promoted_then_rejected_still_promotes_today_which_is_a_ruling_2b_owes() {
         promoted.len(),
         1,
         "today a later rejection does not un-confirm: {promoted:?}"
+    );
+}
+
+/// **The two precedence rules over `same_as` decisions DISAGREE.** Recorded,
+/// not endorsed — and measured, not inferred.
+///
+/// Two rules now read the same adjudication history and answer differently
+/// about a pair that was promoted and later rejected:
+///
+/// | Rule | Promoted-then-rejected | Consumer |
+/// |---|---|---|
+/// | `confirmed_relations` (2c, pure) | **still confirmed** — no precedence, one `Promoted` anywhere confirms | tests only |
+/// | `relationship_projection::fold_all` (5a) | **withdrawn** — last decision wins | `relationships_projection` |
+///
+/// # This is latent, not live, and the distinction is load-bearing
+///
+/// Stating it precisely because "two projections disagree" would be a much
+/// more serious claim than what is actually true, and the difference was
+/// established by running it rather than by reading:
+///
+/// * `promote_confirmed_same_as` has **no production caller** — every call site
+///   in the tree is a test.
+/// * The entity fold consumes `kind = "identity_adjudication"`, while
+///   `WorldStore::adjudicate_same_as` writes `kind = "same_as_adjudication"`.
+///   Different kinds, so the store's entity projection never sees a `same_as`
+///   decision at all: after a promote-then-reject, `resolve` answers `Unknown`,
+///   not a stale merge.
+///
+/// So no shipped path today can be asked the same question twice and get two
+/// answers. What exists is a **trap for the next step**: the typed `Related`
+/// query has to choose a source of truth, and the two available sources do not
+/// agree. Choosing by accident is exactly how the second answer that drifts
+/// gets created — which is the hazard 2c's own docs name and decline to create.
+///
+/// This test fails the moment either rule changes, so whoever rules on 2b's
+/// owed question has to confront both halves at once instead of one.
+#[test]
+fn the_two_precedence_rules_disagree_and_only_one_has_a_production_consumer() {
+    use kirra_world::same_as_adjudication::confirmed_relations;
+    use kirra_world_store::relationship_projection;
+    use kirra_world_store::same_as_adjudication_record::StoredAdjudication;
+
+    let c = candidate("a", "b");
+    let history = [
+        decide(&c, Outcome::Promoted, 10),
+        decide(&c, Outcome::Rejected, 20),
+    ];
+
+    // Rule 1 -- 2c's pure promotion path. No precedence.
+    assert_eq!(
+        confirmed_relations(&history).len(),
+        1,
+        "2c: one Promoted anywhere confirms the pair, however many rejections follow"
+    );
+
+    // Rule 2 -- 5a's fold, over the SAME decisions in the same order.
+    let stored: Vec<StoredAdjudication> = history
+        .iter()
+        .map(|a| StoredAdjudication {
+            pair: a.pair().clone(),
+            outcome: a.outcome(),
+            candidate_observation_id: a.candidate_observation_id().as_str().to_owned(),
+            adjudicator: a.authority().adjudicator().to_owned(),
+            decided_at: a.decided_at(),
+        })
+        .collect();
+    let folded = relationship_projection::fold_all(
+        stored.iter().enumerate().map(|(i, d)| (i as i64 + 1, d)),
+    );
+    assert!(
+        folded.is_empty(),
+        "5a: the newest authorized decision governs, so the pair is withdrawn: {folded:?}"
+    );
+
+    // The disagreement itself, asserted rather than left implicit in the two
+    // numbers above -- so the failure message says what is wrong, not just that
+    // a count moved.
+    assert_ne!(
+        confirmed_relations(&history).len(),
+        folded.len(),
+        "if these ever agree, one of the two precedence rules changed and this          pin should be retired deliberately rather than deleted to make a build green"
     );
 }
 

--- a/crates/kirra-world-store/tests/same_as_promotion.rs
+++ b/crates/kirra-world-store/tests/same_as_promotion.rs
@@ -393,7 +393,8 @@ fn the_two_precedence_rules_disagree_and_only_one_has_a_production_consumer() {
     assert_ne!(
         confirmed_relations(&history).len(),
         folded.len(),
-        "if these ever agree, one of the two precedence rules changed and this          pin should be retired deliberately rather than deleted to make a build green"
+        "if these ever agree, one of the two precedence rules changed; retire this \
+         pin deliberately rather than deleting it to make a build green"
     );
 }
 

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -1210,6 +1210,93 @@ does not describe is how a residue disappears.
       and protected) and does not decide it. The measurement the ruling needs now
       exists: `a_promoted_relationship_survives_compaction_of_its_candidate`
       shows exactly what the projection inherits when the evidence goes.
+      **RULED — see `KIRRA-WM-EVIDENCE-RETENTION-001` below.**
+
+- [x] **`KIRRA-WM-EVIDENCE-RETENTION-001` — RULED 2026-08-20.**
+      **Decision durability is not evidence durability.**
+
+      > Promotion does **not** protect supporting candidate evidence from
+      > compaction. The adjudication remains durable and authoritative; the
+      > candidate evidence may age out under retention policy, and provenance
+      > must degrade honestly when that happens.
+
+      The decision survives because it is *itself* protected adjudication
+      evidence (`retention_class = "adjudication"`, and
+      `compaction::is_protected` holds for every class but `"raw"`), not because
+      anything downstream is pinning the proposal that motivated it.
+
+      **The caveat, which is the operative half:**
+
+      > Compaction may degrade the ability to explain WHY a promotion was made,
+      > but it must never silently alter WHETHER the promoted relationship
+      > exists.
+
+      # Why the alternative was refused
+
+      Protecting every supporting candidate would couple identity durability to
+      raw-evidence retention and produce a **reachability-based retention
+      graph**: one promotion would begin pinning evidence indefinitely, and every
+      future retention decision would then have to understand adjudication
+      citation reachability before it could delete anything. That is a large,
+      permanent constraint on the retention planner bought to preserve
+      explanatory detail — which Tier 4 already reports the loss of, honestly,
+      for free.
+
+      # What makes this a ruling and not a description
+
+      **Nothing changed in the code.** This ratifies behaviour 5a already had,
+      and a no-change ruling has one failure mode: nothing stops it drifting.
+      So the caveat is pinned by the exact behaviour 5a measured, in
+      `crates/kirra-world-ingest/tests/relationship_projection.rs`:
+
+      | Ruled | Pinned by |
+      |---|---|
+      | the promoted relationship survives candidate compaction | `a_promoted_relationship_survives_compaction_of_its_candidate` |
+      | the protected adjudication row remains | that test compacts ONLY the candidate's generation; the decision's class refuses |
+      | existence is **byte-identically** unaltered | `compaction_degrades_the_explanation_and_never_the_relationship` — the projection state digest before compaction equals the digest after compaction AND a full rebuild |
+      | provenance does not fabricate resolution | the same test: `Resolved` before, never `Resolved` after |
+      | it becomes `Dangling { PossiblyCompacted }` | the same test, naming the span |
+      | it does **not** collapse to `NeverVisible` | the same test — §11.3's forbidden collapse |
+      | the identity decision stays valid | `KIRRA-WM-IDENTITY-FRESHNESS-001` (`Timeless`) |
+
+      The digest comparison is what makes the caveat mechanical rather than
+      aspirational: a change that altered *whether* the relationship exists moves
+      the digest, and a change that only degraded the *explanation* does not.
+
+      # Scope, stated so it is not read wider than it is
+
+      This rules the relationship between **promotion and compaction**. It does
+      not rule how long raw candidates live — that is retention policy, and
+      `KIRRA-WM-IDENTITY-FRESHNESS-001` already declined to rule whether a
+      matcher's PROPOSAL goes stale.
+
+      # Found while recording this ruling: TWO precedence rules now disagree
+
+      Not part of this ruling, and surfaced here because the **next** step is
+      where it bites.
+
+      | Rule | Promoted-then-rejected | Production consumer |
+      |---|---|---|
+      | `confirmed_relations` (2c, pure) | still confirmed — no precedence | **none** (tests only) |
+      | `relationship_projection::fold_all` (5a) | withdrawn — last decision wins | `relationships_projection` |
+
+      5a decided the withdrawal question for its own fold, carefully, and in
+      isolation — without checking what the neighbouring rule over the same
+      evidence already did. That is the "second answer that drifts" 2c's own
+      docs name as the thing to avoid, created by the box that quoted them.
+
+      **It is latent, not live**, and the difference was established by RUNNING
+      it rather than reading: `promote_confirmed_same_as` has no production
+      caller, and the entity fold consumes `kind = "identity_adjudication"`
+      while `adjudicate_same_as` writes `kind = "same_as_adjudication"` — so
+      after a promote-then-reject, `resolve` answers `Unknown`, not a stale
+      merge. No shipped path can be asked the same question twice today.
+
+      What it is, is **a trap for the typed `Related` query**, which must pick a
+      source of truth from two that do not agree. Pinned by
+      `the_two_precedence_rules_disagree_and_only_one_has_a_production_consumer`,
+      next to 2b's existing no-precedence pin, so whoever rules on 2b's owed
+      question confronts both halves at once.
 
 - [x] **2c — Deterministic resolution over promoted identity. DONE 2026-08-20.**
       `kirra_world::adjudication::promote_confirmed_same_as` is the join: it asks

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -1231,7 +1231,7 @@ does not describe is how a residue disappears.
       > but it must never silently alter WHETHER the promoted relationship
       > exists.
 
-      # Why the alternative was refused
+      **Why the alternative was refused:**
 
       Protecting every supporting candidate would couple identity durability to
       raw-evidence retention and produce a **reachability-based retention
@@ -1242,7 +1242,7 @@ does not describe is how a residue disappears.
       explanatory detail — which Tier 4 already reports the loss of, honestly,
       for free.
 
-      # What makes this a ruling and not a description
+      **What makes this a ruling and not a description:**
 
       **Nothing changed in the code.** This ratifies behaviour 5a already had,
       and a no-change ruling has one failure mode: nothing stops it drifting.
@@ -1263,14 +1263,14 @@ does not describe is how a residue disappears.
       aspirational: a change that altered *whether* the relationship exists moves
       the digest, and a change that only degraded the *explanation* does not.
 
-      # Scope, stated so it is not read wider than it is
+      **Scope, stated so it is not read wider than it is:**
 
       This rules the relationship between **promotion and compaction**. It does
       not rule how long raw candidates live — that is retention policy, and
       `KIRRA-WM-IDENTITY-FRESHNESS-001` already declined to rule whether a
       matcher's PROPOSAL goes stale.
 
-      # Found while recording this ruling: TWO precedence rules now disagree
+      **Found while recording this ruling: TWO precedence rules now disagree.**
 
       Not part of this ruling, and surfaced here because the **next** step is
       where it bites.


### PR DESCRIPTION
**RULED:** promotion does **not** protect supporting candidate evidence from compaction. The adjudication remains durable and authoritative; the candidate evidence may age out under retention policy, and provenance must degrade honestly when that happens.

The decision survives because it is *itself* protected adjudication evidence (`retention_class = "adjudication"`), not because anything downstream pins the proposal that motivated it.

**The caveat, which is the operative half:**

> Compaction may degrade the ability to explain WHY a promotion was made, but it must never silently alter WHETHER the promoted relationship exists.

## Why the alternative was refused

Protecting every supporting candidate would couple identity durability to raw-evidence retention and produce a **reachability-based retention graph**: one promotion would begin pinning evidence indefinitely, and every future retention decision would then have to understand adjudication citation reachability before it could delete anything. That is a large, permanent constraint on the retention planner, bought to preserve explanatory detail that Tier 4 already reports the loss of, honestly, for free.

## Nothing changed in the code — which is the risk

This ratifies behaviour 5a already had. A no-change ruling has exactly one failure mode: nothing stops it drifting. So the caveat is now mechanical rather than aspirational.

`compaction_degrades_the_explanation_and_never_the_relationship` asserts, **in one run**:

| Half | Assertion |
|---|---|
| **WHETHER** — unaltered | the projection state digest is byte-identical across the compaction, *and* across a full rebuild after it |
| **WHY** — degraded honestly | the citation moves `Resolved` → `Dangling { PossiblyCompacted }`, naming the span |
| not fabricated | never stays `Resolved` |
| not collapsed | never becomes `NeverVisible` — §11.3's forbidden collapse of *deleted* into *never recorded* |

Both halves together, deliberately: digest-equality alone would pass on a compaction that silently did nothing, and degradation alone would pass on a store that lost the relationship entirely. Neither is the ruled behaviour.

The digest is the right instrument because of what it covers — pair, `decided_generation`, cited candidate, adjudicator, decided instant. A change that altered *whether* the relationship exists moves it; a change that only degraded the *explanation* cannot.

**The mutation is the refused alternative itself:** a fold that drops a relationship whose cited candidate no longer resolves. It kills exactly the two compaction tests and nothing else.

## Found while recording this ruling: two precedence rules disagree

Not part of the ruling. Surfaced because the **next** step is where it bites.

| Rule | Promoted-then-rejected | Production consumer |
|---|---|---|
| `confirmed_relations` (2c, pure) | still confirmed — no precedence | **none** (tests only) |
| `relationship_projection::fold_all` (5a) | withdrawn — last decision wins | `relationships_projection` |

5a decided the withdrawal question carefully and **in isolation**, without checking what the neighbouring rule over the same evidence already did. That is the "second answer that drifts" 2c's own docs name as the thing to avoid — created by the box that quoted them.

**It is latent, not live**, and that was established by *running* it rather than reading:

- `promote_confirmed_same_as` has no production caller — every call site is a test.
- The entity fold consumes `kind = "identity_adjudication"`; `adjudicate_same_as` writes `kind = "same_as_adjudication"`. Different kinds, so after a promote-then-reject `resolve` answers `Unknown`, not a stale merge.

No shipped path today can be asked the same question twice and get two answers. What it *is* is a **trap for the typed `Related` query**, which must pick a source of truth from two that do not agree. Pinned by `the_two_precedence_rules_disagree_and_only_one_has_a_production_consumer`, placed next to 2b's existing no-precedence pin so whoever rules on 2b's owed question confronts both halves at once.

## Scope, so it is not read wider than it is

This rules the relationship between **promotion and compaction**. It does not rule how long raw candidates live — that is retention policy, and `KIRRA-WM-IDENTITY-FRESHNESS-001` already declined to rule whether a matcher's *proposal* goes stale.

## Verification

- **Docs and tests only — no production code changed.**
- 35 test binaries green across the three crates touched (`kirra-world`, `kirra-world-store`, `kirra-world-ingest`)
- 16 python CI gates green
- the refused-alternative mutation discriminates exactly the two compaction tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_