### PR TITLE
Box 5b: the typed Related query, over the relationship projection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2663,6 +2663,7 @@ version = "0.1.0"
 dependencies = [
  "kirra-explain-types",
  "kirra-world",
+ "kirra-world-ingest",
  "kirra-world-store",
 ]
 

--- a/ci/store_boundedness_baseline.json
+++ b/ci/store_boundedness_baseline.json
@@ -192,6 +192,10 @@
       "class": "operational",
       "why": "Projection rebuild."
     },
+    "related": {
+      "class": "bounded",
+      "why": "Tier 5 box 5b. Two INDEXED lookups plus a page ceiling. A pair is stored once canonically, so the subject may be either column; `PRIMARY KEY (low, high)` covers the `low = ?` half and the `relationships_projection_high` index covers the `high = ?` half, so neither arm scans. Capped at MAX_RELATED with a probe of limit+1 and the truncation flag CARRIED -- not a set trimmed after fetching, which is #1440's distinction (a LIMIT bounds rows RETURNED, never rows SCANNED, so the index is part of the bound rather than a speed-up). Deliberately NOT structural in `relationship`'s sense: an entity can be adjudicated the same as many others, so there is no primary-key cardinality to lean on and the ceiling is doing real work."
+    },
     "relationship": {
       "class": "bounded",
       "why": "Tier 5 box 5a. A POINT READ by primary key: `WHERE low = ?1 AND high = ?2` on `relationships_projection`, whose PRIMARY KEY is `(low, high)`, so the result is at most one row regardless of how many relationships the fleet has accumulated. STRUCTURALLY bounded in the same sense as `current` -- there is no page and no cursor because there is no growth dimension. It takes a canonical pair the caller already holds and returns the row at it."

--- a/crates/kirra-world-service/Cargo.toml
+++ b/crates/kirra-world-service/Cargo.toml
@@ -23,3 +23,10 @@ kirra-explain-types = { path = "../kirra-explain-types" }
 # which is why the refusal below has to be provoked rather than seeded.
 [dev-dependencies]
 kirra-world-store = { path = "../kirra-world-store", features = ["test-support"] }
+# Box 5b's end-to-end test drives the REAL production chain -- a matcher
+# proposing candidates, an operator adjudicating them -- rather than
+# hand-appending adjudication rows. A `Related` query proven only against
+# fixtures would prove the query works on data no producer can create, which is
+# the exact gap the pre-5a chain audit found. Dev-only: the read boundary does
+# not depend on the write path at runtime.
+kirra-world-ingest = { path = "../kirra-world-ingest" }

--- a/crates/kirra-world-service/src/answer_ref.rs
+++ b/crates/kirra-world-service/src/answer_ref.rs
@@ -122,6 +122,18 @@ pub enum QueryKind {
     /// than a clock and a budget. That module records why the two are separate
     /// types sharing this enum instead of one struct holding the union.
     SubjectLineage,
+    /// [`crate::read_view::WorldView::related`] — what one entity is currently
+    /// adjudicated the same as.
+    ///
+    /// The first family over a SEMANTIC projection rather than over the claim
+    /// log, which is why its rule set shares nothing with the others: it does
+    /// not fold `world_current`, does not resolve object identity, and does not
+    /// apply admissibility. What it depends on is the relationship fold, and
+    /// only that.
+    ///
+    /// Not a ref family. Like [`Self::AsOfSubject`] it exists here because its
+    /// answers carry a dependency set, and every set is derived in one place.
+    Related,
 }
 
 /// **A reproducible descriptor for one answer.**

--- a/crates/kirra-world-service/src/query.rs
+++ b/crates/kirra-world-service/src/query.rs
@@ -76,7 +76,8 @@ use crate::cursor::{resolve_cursor, CursorFamily, PageCursor};
 use crate::freshness::FreshnessSource;
 use crate::lineage::{LineageRef, LineageResolution};
 use crate::read_view::{
-    AskError, ComposedLookup, HistoryLookup, SummaryLookup, TemporalLookup, WorldView,
+    AskError, ComposedLookup, HistoryLookup, RelatedLookup, SummaryLookup, TemporalLookup,
+    WorldView,
 };
 
 mod sealed {
@@ -283,6 +284,48 @@ impl WorldQuery for SubjectSummary {
 
     fn execute(self, engine: &QueryEngine<'_>) -> Result<Self::Output, AskError> {
         engine.view().subject_summary(&self.subject)
+    }
+}
+
+/// **What one entity is currently adjudicated the same as** — box 5b.
+///
+/// The first typed query over a SEMANTIC projection rather than over the claim
+/// log, and what makes box 5a's `relationships_projection` a thing production
+/// code can reach. Before this, the projection existed and nothing could ask it
+/// anything through the sanctioned door.
+///
+/// # No page field, and that is not the `SubjectSummary` argument
+///
+/// `SubjectSummary` has no cursor because there is structurally one row per
+/// subject. That reasoning does NOT apply here: an entity can be adjudicated
+/// the same as many others, so the set genuinely grows.
+///
+/// The bound is a page CEILING carried on the answer
+/// ([`RelatedLookup::is_truncated`]) rather than a cursor on the request. That
+/// is a deliberate first slice: a cursor is a contract about stable ordering
+/// under concurrent folds, which box 3d's cursor work took real care to get
+/// right, and adding one before a consumer needs to walk past 256 same_as
+/// neighbours of a single entity would be inventing a dimension nobody has
+/// asked for. What is NOT deferred is honesty about the cap — truncation is
+/// carried, so a caller can never mistake a cut-short page for a complete one.
+///
+/// If a consumer does need to walk past the ceiling, the cursor belongs here
+/// and `RelatedLookup` is where it would surface.
+///
+/// [`RelatedLookup::is_truncated`]: crate::read_view::RelatedLookup::is_truncated
+#[derive(Debug, Clone)]
+pub struct Related {
+    /// The entity to ask about.
+    pub entity: String,
+}
+
+impl sealed::Sealed for Related {}
+
+impl WorldQuery for Related {
+    type Output = RelatedLookup;
+
+    fn execute(self, engine: &QueryEngine<'_>) -> Result<Self::Output, AskError> {
+        engine.view().related(&self.entity)
     }
 }
 

--- a/crates/kirra-world-service/src/read_view.rs
+++ b/crates/kirra-world-service/src/read_view.rs
@@ -112,6 +112,19 @@ use crate::semantics::SemanticVersions;
 /// knowledge is a success*, and only genuine faults use this channel.
 #[derive(Debug)]
 pub enum AskError {
+    /// The question named something that is not an admissible entity id.
+    ///
+    /// **A refusal, not an empty answer.** "That is not a question I can ask"
+    /// and "the answer is nothing" are different findings, and a caller told
+    /// the second would conclude the entity exists and is related to nothing.
+    /// The same distinction `AdjudicateError` draws between `NoSuchCandidate`
+    /// and `NotACandidate`.
+    MalformedEntity {
+        /// What was asked about.
+        entity: String,
+        /// Why it is not admissible, from the domain constructor.
+        detail: String,
+    },
     /// The store could not be read.
     Store(StoreError),
     /// The requested page bound is not a valid one.
@@ -185,6 +198,11 @@ impl fmt::Display for AskError {
             Self::Store(e) => write!(f, "store: {e:?}"),
             Self::PageSpec(e) => write!(f, "invalid page bound: {e:?}"),
             Self::Cursor(e) => write!(f, "continuation refused: {e}"),
+            Self::MalformedEntity { entity, detail } => write!(
+                f,
+                "{entity:?} is not an admissible entity id: {detail} — \
+                 refused rather than answered as unrelated"
+            ),
             Self::CorruptProvenance {
                 subject,
                 predicate,
@@ -854,6 +872,65 @@ impl<'a> WorldView<'a> {
         })
     }
 
+    /// **What one entity is currently adjudicated the same as** — box 5b.
+    ///
+    /// The first query family over a SEMANTIC projection rather than over the
+    /// claim log, and the first consumer of box 5a's `relationships_projection`.
+    ///
+    /// # Which precedence rule this serves, stated because there are two
+    ///
+    /// It reads the **relationship projection**, where the newest authorized
+    /// decision governs — so a pair promoted and later rejected is NOT related
+    /// here. It deliberately does NOT read
+    /// `kirra_world::same_as_adjudication::confirmed_relations`, which applies
+    /// no precedence and treats one `Promoted` anywhere as confirming forever.
+    ///
+    /// Those two disagree today. That disagreement is recorded and pinned by
+    /// `the_two_precedence_rules_disagree_today_which_is_a_ruling_2b_still_owes`
+    /// and is 2b's to resolve; this family does not resolve it. What it does is
+    /// name which of the two it serves, so the answer is attributable to a rule
+    /// rather than to whichever function was nearest.
+    ///
+    /// # Freshness is RESOLVED, not assumed
+    ///
+    /// `KIRRA-WM-IDENTITY-FRESHNESS-001` ruled a promoted `same_as` `Timeless`,
+    /// and this asks [`resolve_policy`] for it rather than hard-coding that
+    /// conclusion. Two things follow, both wanted: under
+    /// [`FreshnessSource::Ruled`] the ruling is genuinely consulted, so deleting
+    /// the ruled row reds this family instead of leaving it quietly serving a
+    /// policy nothing states; and under [`FreshnessSource::Caller`] a caller who
+    /// has taken responsibility for classification still governs.
+    ///
+    /// [`FreshnessSource::Caller`]: crate::freshness::FreshnessSource::Caller
+    /// [`FreshnessSource::Ruled`]: crate::freshness::FreshnessSource::Ruled
+    ///
+    /// # Errors
+    ///
+    /// [`AskError::MalformedEntity`] if `entity` is not an admissible
+    /// `EntityId` — REFUSED rather than answered "nothing is related", because
+    /// an unaskable question and a question with no answer are different
+    /// findings. [`AskError::UnclassifiedFreshness`] if the adjudication class
+    /// is unruled. Otherwise whatever the store raises.
+    pub fn related(&self, entity: &str) -> Result<RelatedLookup, AskError> {
+        let id = EntityId::new(entity).map_err(|e| AskError::MalformedEntity {
+            entity: entity.to_string(),
+            detail: e.to_string(),
+        })?;
+        // Resolved BEFORE the read, so an unruled class refuses rather than
+        // producing an answer nobody has classified. Same ordering `ask` uses.
+        let policy = resolve_policy(
+            self.freshness,
+            kirra_world_store::same_as_adjudication_record::SAME_AS_ADJUDICATION_KIND,
+            Some(kirra_world_store::same_as_adjudication_record::ADJUDICATION_PREDICATE_TOKEN),
+        )?;
+        let neighbours = self.store.related(&id)?;
+        Ok(RelatedLookup {
+            neighbours,
+            policy,
+            semantics: SemanticVersions::for_query(QueryKind::Related),
+        })
+    }
+
     /// **The ruled disposition for one claim, or a refusal.**
     ///
     /// The single place a claim's semantics become a freshness policy, so the
@@ -1187,6 +1264,66 @@ impl SummaryLookup {
         self.summary
             .as_ref()
             .is_some_and(|s| s.coverage.is_degraded())
+    }
+
+    /// The rules this answer was produced under.
+    #[must_use]
+    pub fn semantics(&self) -> &SemanticVersions {
+        &self.semantics
+    }
+}
+
+/// **What one entity is the same as** — box 5b.
+///
+/// # There is no `is_degraded`, and that is a decision
+///
+/// Every other lookup in this module carries one, so its absence needs a
+/// reason rather than being read as an oversight.
+///
+/// `KIRRA-WM-EVIDENCE-RETENTION-001` ruled that compaction may degrade the
+/// ability to explain WHY a promotion was made but must never alter WHETHER the
+/// relationship exists. A `is_degraded` on THIS type would answer the second
+/// question with the first one's evidence: it would report a relationship as
+/// somehow lessened because a candidate observation aged out, which is exactly
+/// the coupling the ruling refused.
+///
+/// The explanatory half is still askable — `WorldStore::relationship_provenance`
+/// returns box 4b's `CitationResolution` for one pair — and it is deliberately a
+/// SEPARATE question, so a caller that wants provenance has to ask for it rather
+/// than reading a summary flag whose meaning drifted.
+#[derive(Debug, Clone)]
+pub struct RelatedLookup {
+    neighbours: kirra_world_store::relationship_projection::RelatedNeighbours,
+    policy: FreshnessPolicy,
+    semantics: SemanticVersions,
+}
+
+impl RelatedLookup {
+    /// The entities this one is currently adjudicated the same as.
+    #[must_use]
+    pub fn neighbours(&self) -> &[kirra_world_store::relationship_projection::RelatedEntity] {
+        &self.neighbours.neighbours
+    }
+
+    /// Whether more neighbours exist than one page admits.
+    ///
+    /// Carried through from the store rather than inferred from the length —
+    /// a full page and a cut-short page are the same length.
+    #[must_use]
+    pub fn is_truncated(&self) -> bool {
+        self.neighbours.truncated
+    }
+
+    /// The freshness disposition this family resolved for an adjudicated
+    /// identity.
+    ///
+    /// Exposed rather than applied. Nothing here expires, because
+    /// `KIRRA-WM-IDENTITY-FRESHNESS-001` ruled the class `Timeless` — but the
+    /// value is served so a caller can SEE that a policy was resolved, instead
+    /// of having to trust that one was.
+    #[must_use]
+    pub fn policy(&self) -> FreshnessPolicy {
+        self.policy
     }
 
     /// The rules this answer was produced under.

--- a/crates/kirra-world-service/src/semantics.rs
+++ b/crates/kirra-world-service/src/semantics.rs
@@ -179,6 +179,27 @@ impl SemanticVersions {
             // "identical by construction" — a temporal-resolution rule would
             // belong to one and not the other, and a shared arm that had to be
             // split later is a shared arm nobody remembers to split.
+            // Box 5b. EXACTLY ONE rule, and the three that are absent are the
+            // point rather than an omission:
+            //
+            //   world_current_fold  -- this family never touches the claim
+            //                          projection; it reads relationships.
+            //   entity_fold         -- it does NOT resolve identity. It reports
+            //                          the adjudicated pairs verbatim, so the
+            //                          resolver cannot change what it says.
+            //   answer_admissibility -- there is no claim to grade or expire.
+            //                          `KIRRA-WM-IDENTITY-FRESHNESS-001` made
+            //                          the class Timeless, so admitting an
+            //                          admissibility rule here would imply a
+            //                          staleness axis the ruling denies.
+            //
+            // Asserted rather than assumed by
+            // `the_related_query_depends_on_exactly_one_rule`, the same control
+            // `history` carries for the same reason.
+            QueryKind::Related => Self::new([RuleVersion {
+                rule: RuleId::RelationshipFold.as_str().to_string(),
+                version: store_semantics::version_of(RuleId::RelationshipFold),
+            }]),
             QueryKind::CurrentSubject | QueryKind::AsOfSubject => Self::new([
                 RuleVersion {
                     rule: RuleId::WorldCurrentFold.as_str().to_string(),

--- a/crates/kirra-world-service/tests/related_query.rs
+++ b/crates/kirra-world-service/tests/related_query.rs
@@ -1,0 +1,352 @@
+//! **Box 5b: `Related` through `QueryEngine`, over the real production chain.**
+//!
+//! The projection landed in 5a with no way for production code to ask it
+//! anything through the sanctioned door. This closes that: a typed request, one
+//! `QueryEngine::execute`, an answer.
+//!
+//! Every relationship asserted about here was proposed by the REAL matcher
+//! (`run_ingest_pass`) and promoted by a real `AdjudicationAuthority`. Nothing
+//! is hand-appended. A query proven only against fixtures would prove it works
+//! on data no producer can create — the exact gap the pre-5a chain audit found
+//! at the other end of this same chain.
+
+use kirra_world::observation::{ClockDomain, DomainInstant, SourceClass};
+use kirra_world::reference::{EventId, ObservationId};
+use kirra_world::same_as_adjudication::{AdjudicationAuthority, Outcome};
+use kirra_world::same_as_candidate::MatcherIdentity;
+use kirra_world_ingest::{run_ingest_pass, ExactIdentifierRule};
+use kirra_world_service::freshness::{FreshnessPolicy, FreshnessSource};
+use kirra_world_service::query::{QueryEngine, Related};
+use kirra_world_service::read_view::AskError;
+use kirra_world_store::same_as_adjudication_record::SameAsAdjudicationRequest;
+use kirra_world_store::{ClaimStatus, NewEvent, WorldStore, WriterClass};
+
+const T0: i64 = 1_700_000_000_000;
+const SURVEY_LIMIT: usize = 1_000;
+
+fn tmp(name: &str) -> std::path::PathBuf {
+    static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let n = NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "kirra-5b-q-{name}-{}-{n}.sqlite",
+        std::process::id()
+    ));
+    for s in ["", "-wal", "-shm"] {
+        let mut q = p.as_os_str().to_os_string();
+        q.push(s);
+        let _ = std::fs::remove_file(std::path::PathBuf::from(q));
+    }
+    p
+}
+
+fn observe(store: &mut WorldStore, n: &str, subject: &str, value: &str) {
+    let event_id = EventId::new(format!("ev-{n}")).expect("event id");
+    let observation_id = ObservationId::new(format!("obs-{n}")).expect("observation id");
+    store
+        .append(&NewEvent {
+            event_id: &event_id,
+            observation_id: &observation_id,
+            txn_time_ms: T0,
+            valid_from_ms: T0,
+            valid_to_ms: None,
+            source: "asset-tag-reader",
+            source_version: "1.0.0",
+            writer_class: WriterClass::Sensor,
+            claim_status: ClaimStatus::Confirmed,
+            provenance: &[],
+            frame_id: None,
+            map_id: None,
+            kind: "observation",
+            subject,
+            subject_ref: None,
+            predicate: Some("serial_number"),
+            object: Some(value),
+            payload: "{}",
+            payload_schema: 1,
+            retention_class: "raw",
+            trust: None,
+        })
+        .expect("append observation");
+}
+
+fn propose(store: &mut WorldStore) -> usize {
+    let rule = ExactIdentifierRule::new(
+        "serial_number",
+        MatcherIdentity::new("world-ingest", "exact-identifier", "1.0.0").expect("matcher"),
+    )
+    .expect("rule");
+    let mut n = 0;
+    run_ingest_pass(store, &rule, T0, SURVEY_LIMIT, move || {
+        n += 1;
+        (
+            EventId::new(format!("cand-ev-{n}")).expect("id"),
+            ObservationId::new(format!("cand-obs-{n}")).expect("id"),
+        )
+    })
+    .expect("ingest pass")
+    .proposed
+}
+
+fn decide(store: &mut WorldStore, tag: &str, candidate: &str, outcome: Outcome, ms: u64) {
+    let event_id = EventId::new(format!("adj-ev-{tag}")).expect("id");
+    let observation_id = ObservationId::new(format!("adj-obs-{tag}")).expect("id");
+    store
+        .adjudicate_same_as(&SameAsAdjudicationRequest {
+            event_id: &event_id,
+            observation_id: &observation_id,
+            candidate_observation_id: candidate,
+            cited: vec![ObservationId::new(candidate).expect("id")],
+            authority: AdjudicationAuthority::new(SourceClass::Operator, "console-operator")
+                .expect("authority"),
+            outcome,
+            decided_at: DomainInstant {
+                ms,
+                domain: ClockDomain::System,
+            },
+            txn_time_ms: T0 + 10,
+            source: "operator-console",
+            source_version: "1.0.0",
+        })
+        .expect("an operator judging a persisted candidate");
+}
+
+/// Two tracks agreeing on a serial, the matcher's candidate, and one promotion.
+fn store_with_a_promoted_pair(name: &str) -> WorldStore {
+    let mut store = WorldStore::open(&tmp(name)).expect("open");
+    observe(&mut store, "a", "track-a", "SN-1");
+    observe(&mut store, "b", "track-b", "SN-1");
+    assert_eq!(
+        propose(&mut store),
+        1,
+        "the fixture must persist one candidate"
+    );
+    decide(
+        &mut store,
+        "1",
+        "cand-obs-1",
+        Outcome::Promoted,
+        T0 as u64 + 10,
+    );
+    store.fold_relationship_projection().expect("fold");
+    store
+}
+
+// ---------------------------------------------------------------------------
+// The positive case first.
+// ---------------------------------------------------------------------------
+
+/// **The whole chain, asked through the sanctioned door.**
+///
+/// Sensor observations → the real matcher's candidate → an operator's promotion
+/// → the projection → `QueryEngine::execute(Related { .. })`. The answer names
+/// the other entity and the decision that put it there.
+#[test]
+fn a_promoted_relationship_is_reachable_through_the_query_engine() {
+    let store = store_with_a_promoted_pair("reachable");
+    let engine = QueryEngine::new(&store, FreshnessSource::Ruled);
+
+    let answer = engine
+        .execute(Related {
+            entity: "track-a".to_string(),
+        })
+        .expect("a promoted pair must be askable");
+
+    assert_eq!(answer.neighbours().len(), 1);
+    let n = &answer.neighbours()[0];
+    assert_eq!(n.other.as_str(), "track-b");
+    assert_eq!(
+        n.relationship.candidate_observation_id, "cand-obs-1",
+        "the answer must carry WHICH evidence the decision rested on"
+    );
+    assert_eq!(n.relationship.adjudicator, "console-operator");
+    assert!(!answer.is_truncated());
+}
+
+/// **Either side of the canonical pair reaches the other.**
+///
+/// The store-level twin of this lives in `related_read.rs`; this one proves the
+/// property survives the whole query path, since a family method could easily
+/// pass only the subject it was handed to the `low` column.
+#[test]
+fn the_query_finds_the_pair_from_either_side() {
+    let store = store_with_a_promoted_pair("either");
+    let engine = QueryEngine::new(&store, FreshnessSource::Ruled);
+
+    for (asked, expected) in [("track-a", "track-b"), ("track-b", "track-a")] {
+        let answer = engine
+            .execute(Related {
+                entity: asked.to_string(),
+            })
+            .expect("askable");
+        assert_eq!(answer.neighbours().len(), 1, "asking about {asked}");
+        assert_eq!(answer.neighbours()[0].other.as_str(), expected);
+    }
+}
+
+/// **An entity related to nothing answers EMPTY, not an error.**
+///
+/// The non-vacuity control: without it, a family that errored on every lookup
+/// would still pass the positive test only if it happened to succeed there.
+#[test]
+fn an_unrelated_entity_answers_empty() {
+    let store = store_with_a_promoted_pair("unrelated");
+    let engine = QueryEngine::new(&store, FreshnessSource::Ruled);
+
+    let answer = engine
+        .execute(Related {
+            entity: "track-zzz".to_string(),
+        })
+        .expect("a question about an unrelated entity is still a question");
+    assert!(answer.neighbours().is_empty());
+}
+
+/// **An unaskable question is REFUSED, not answered as unrelated.**
+///
+/// "That is not an entity id" and "that entity is related to nothing" are
+/// different findings, and a caller told the second would conclude the entity
+/// exists. The same distinction `AdjudicateError` draws between
+/// `NoSuchCandidate` and `NotACandidate`.
+#[test]
+fn a_malformed_entity_is_refused_rather_than_answered_as_unrelated() {
+    let store = store_with_a_promoted_pair("malformed");
+    let engine = QueryEngine::new(&store, FreshnessSource::Ruled);
+
+    match engine.execute(Related {
+        entity: String::new(),
+    }) {
+        Err(AskError::MalformedEntity { entity, .. }) => assert_eq!(entity, ""),
+        other => panic!("an empty entity id must be refused: {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// WHICH precedence rule this family serves.
+// ---------------------------------------------------------------------------
+
+/// **A withdrawn promotion is no longer related.**
+///
+/// The load-bearing test of this box, because it is what makes the family's
+/// source of truth OBSERVABLE rather than merely documented.
+///
+/// Two precedence rules exist today and they disagree:
+///
+/// * `confirmed_relations` (2c) applies none — one `Promoted` anywhere confirms
+///   the pair forever, so it would still call this pair the same.
+/// * the relationship projection (5a) lets the newest authorized decision
+///   govern, so a later rejection withdraws it.
+///
+/// `Related` reads the projection. A future refactor that "simplified" it onto
+/// `confirmed_relations` would keep every other test in this file green and
+/// fail here — which is the whole reason this one exists rather than a comment
+/// saying which function is called.
+#[test]
+fn a_withdrawn_promotion_is_no_longer_related() {
+    let mut store = store_with_a_promoted_pair("withdrawn");
+    {
+        let engine = QueryEngine::new(&store, FreshnessSource::Ruled);
+        assert_eq!(
+            engine
+                .execute(Related {
+                    entity: "track-a".to_string()
+                })
+                .expect("askable")
+                .neighbours()
+                .len(),
+            1,
+            "the pair must be related BEFORE the rejection, or this proves nothing"
+        );
+    }
+
+    decide(
+        &mut store,
+        "2",
+        "cand-obs-1",
+        Outcome::Rejected,
+        T0 as u64 + 20,
+    );
+    store.fold_relationship_projection().expect("re-fold");
+
+    let engine = QueryEngine::new(&store, FreshnessSource::Ruled);
+    assert!(
+        engine
+            .execute(Related {
+                entity: "track-a".to_string()
+            })
+            .expect("askable")
+            .neighbours()
+            .is_empty(),
+        "the newest authorized decision governs — Related serves the projection, \
+         not confirmed_relations"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Freshness and semantics.
+// ---------------------------------------------------------------------------
+
+/// **The ruled `Timeless` disposition is RESOLVED, not assumed.**
+///
+/// `KIRRA-WM-IDENTITY-FRESHNESS-001` ruled an adjudicated identity `Timeless`.
+/// The family asks `resolve_policy` for that rather than hard-coding it, so
+/// deleting the ruled row reds this family instead of leaving it quietly
+/// serving a policy nothing states.
+#[test]
+fn the_ruled_timeless_policy_is_resolved_and_served() {
+    let store = store_with_a_promoted_pair("policy");
+    let engine = QueryEngine::new(&store, FreshnessSource::Ruled);
+    let answer = engine
+        .execute(Related {
+            entity: "track-a".to_string(),
+        })
+        .expect("askable");
+    assert_eq!(answer.policy(), FreshnessPolicy::Timeless);
+}
+
+/// **A caller who states a policy governs, exactly as elsewhere.**
+///
+/// The twin of the test above. Without it, a family that ignored the source
+/// entirely and always returned `Timeless` would pass that one.
+#[test]
+fn a_caller_stated_policy_is_honoured() {
+    let store = store_with_a_promoted_pair("caller-policy");
+    let engine = QueryEngine::new(
+        &store,
+        FreshnessSource::Caller(FreshnessPolicy::Bounded { max_age_ms: 5_000 }),
+    );
+    let answer = engine
+        .execute(Related {
+            entity: "track-a".to_string(),
+        })
+        .expect("askable");
+    assert_eq!(
+        answer.policy(),
+        FreshnessPolicy::Bounded { max_age_ms: 5_000 },
+        "the freshness source must actually be consulted"
+    );
+}
+
+/// **`Related` depends on exactly one rule.**
+///
+/// The three that are absent are the point: it never folds `world_current`,
+/// never resolves identity, and has no claim to grade. A set that accumulated
+/// rules the family does not use would make recorded answers refuse to replay
+/// for reasons unrelated to what produced them.
+#[test]
+fn the_related_query_depends_on_exactly_one_rule() {
+    let store = store_with_a_promoted_pair("semantics");
+    let engine = QueryEngine::new(&store, FreshnessSource::Ruled);
+    let answer = engine
+        .execute(Related {
+            entity: "track-a".to_string(),
+        })
+        .expect("askable");
+
+    let rules: Vec<&str> = answer
+        .semantics()
+        .entries()
+        .iter()
+        .map(|r| r.rule.as_str())
+        .collect();
+    assert_eq!(rules, ["relationship_fold"], "got {rules:?}");
+}

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -3214,6 +3214,100 @@ impl WorldStore {
         Ok(out)
     }
 
+    /// **Every entity one entity is currently adjudicated the same as** — 5b.
+    ///
+    /// The read the typed `Related` query dispatches into. Answers *"what is
+    /// `entity` the same as, according to the promoted decisions that currently
+    /// stand"*.
+    ///
+    /// # Bounded, and the index is part of the bound
+    ///
+    /// A pair is stored once, canonically, so the subject may be either column
+    /// and both must be looked in. `PRIMARY KEY (low, high)` indexes `low`
+    /// only, so the `high = ?` half would SCAN without
+    /// `relationships_projection_high`. A `LIMIT` bounds the rows returned and
+    /// not the rows scanned — #1440's distinction — so the index is load-bearing
+    /// for the boundedness claim rather than a speed-up.
+    ///
+    /// Capped at [`MAX_RELATED`] with the truncation flag CARRIED. It probes
+    /// one over the ceiling, for `citations_of`'s reason: a set of exactly
+    /// `MAX_RELATED` is complete, and inferring truncation from the length
+    /// would report it cut short.
+    ///
+    /// # The two halves cannot double-count
+    ///
+    /// `UNION ALL` rather than `UNION`, deliberately. A row could only appear
+    /// in both halves if `low == high`, and `CandidatePair::new` refuses a pair
+    /// of one entity — so the arms are disjoint by construction and paying for
+    /// a de-duplicating sort would be paying to prevent something the domain
+    /// already prevents. Asserted by
+    /// `the_two_index_halves_are_disjoint_so_union_all_cannot_double_count`.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::CorruptRelationshipProjectionRow`] if a row cannot be read
+    /// back faithfully, or [`StoreError::Sqlite`] on storage failure.
+    ///
+    /// [`MAX_RELATED`]: relationship_projection::MAX_RELATED
+    pub fn related(
+        &self,
+        entity: &kirra_world::reference::EntityId,
+    ) -> Result<relationship_projection::RelatedNeighbours, StoreError> {
+        let mut out = relationship_projection::RelatedNeighbours {
+            of: entity.clone(),
+            neighbours: Vec::new(),
+            truncated: false,
+        };
+        if !self.has_relationship_projection()? {
+            return Ok(out);
+        }
+        // Self-healing for a projection installed before this index existed.
+        // Note what this deliberately does NOT do: it cannot create the
+        // projection TABLE, so a store that has never folded still holds only
+        // the event log and ADR-0041 D-20's `log_only_bytes` is untouched. An
+        // `ensure_relationship_projection()` here would have installed the
+        // table on a store that never projects, moving that figure for
+        // everyone. Proven by `related_heals_a_missing_reverse_index`.
+        self.conn.execute_batch(
+            "CREATE INDEX IF NOT EXISTS relationships_projection_high
+                 ON relationships_projection (high, low);",
+        )?;
+
+        let probe = i64::try_from(relationship_projection::MAX_RELATED)
+            .unwrap_or(i64::MAX)
+            .saturating_add(1);
+        let cols = "low, high, decided_generation, candidate_observation_id,
+                    adjudicator, decided_at_ms, decided_at_domain";
+        let mut stmt = self.conn.prepare(&format!(
+            "SELECT {cols} FROM relationships_projection WHERE low = ?1
+             UNION ALL
+             SELECT {cols} FROM relationships_projection WHERE high = ?1
+             ORDER BY low ASC, high ASC
+             LIMIT ?2"
+        ))?;
+        let mut rows = stmt.query(params![entity.as_str(), probe])?;
+        while let Some(r) = rows.next()? {
+            if out.neighbours.len() == relationship_projection::MAX_RELATED {
+                out.truncated = true;
+                break;
+            }
+            let relationship = relationship_from_row(r)?;
+            // The OTHER entity, decided once here rather than at every call
+            // site. A row reaches this loop only because one of its columns
+            // equals `entity`, so the else-branch is the low-match case.
+            let other = if relationship.pair.low() == entity {
+                relationship.pair.high().clone()
+            } else {
+                relationship.pair.low().clone()
+            };
+            out.neighbours.push(relationship_projection::RelatedEntity {
+                other,
+                relationship,
+            });
+        }
+        Ok(out)
+    }
+
     /// A digest over the relationship projection, in key order.
     ///
     /// # Errors

--- a/crates/kirra-world-store/src/relationship_projection.rs
+++ b/crates/kirra-world-store/src/relationship_projection.rs
@@ -97,6 +97,7 @@
 use std::collections::BTreeMap;
 
 use kirra_world::observation::DomainInstant;
+use kirra_world::reference::EntityId;
 use kirra_world::same_as_adjudication::Outcome;
 use kirra_world::same_as_candidate::CandidatePair;
 
@@ -121,6 +122,14 @@ CREATE TABLE IF NOT EXISTS relationships_projection (
     decided_at_domain        TEXT    NOT NULL,
     PRIMARY KEY (low, high)
 );
+-- The REVERSE index, and it is load-bearing for box 5b's boundedness rather
+-- than an optimisation. `PRIMARY KEY (low, high)` indexes `low` only, so
+-- "which entities is `e` the same as" -- which must look in BOTH columns --
+-- would scan the whole projection for the `high = ?` half. A `LIMIT` bounds the
+-- rows RETURNED, never the rows SCANNED, which is exactly the distinction
+-- defect #1440 turned on.
+CREATE INDEX IF NOT EXISTS relationships_projection_high
+    ON relationships_projection (high, low);
 "#;
 
 /// This projection's checkpoint name.
@@ -291,4 +300,59 @@ pub fn state_digest_of(rows: &BTreeMap<PairKey, ProjectedRelationship>) -> Strin
         buf.push('\u{1e}');
     }
     crate::sha256_hex(buf.as_bytes())
+}
+
+/// The most neighbours one [`related`] answer carries.
+///
+/// [`related`]: crate::WorldStore::related
+///
+/// Same value as [`crate::provenance_edges::MAX_CITATIONS_PAGE`] and for the
+/// same reason: it is a page ceiling on a set whose size is a property of the
+/// fleet, not of the question. An entity can be adjudicated the same as many
+/// others, so there is no structural cardinality bound to lean on the way
+/// `relationship` leans on the primary key.
+pub const MAX_RELATED: usize = 256;
+
+/// One entity `related` found, and the decision that put it there.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RelatedEntity {
+    /// The OTHER entity — the one that is not the subject of the question.
+    ///
+    /// Derivable from `relationship.pair` by the caller, and provided anyway
+    /// because deriving it means asking "was my entity the low or the high?" at
+    /// every call site, and getting that backwards silently answers with the
+    /// entity the caller already had.
+    pub other: EntityId,
+    /// The relationship itself, so a caller can see WHICH decision it rests on
+    /// without a second lookup.
+    pub relationship: ProjectedRelationship,
+}
+
+/// Every entity one entity is currently adjudicated the same as.
+///
+/// **Truncation is carried, not inferred.** A full page and a cut-short page
+/// are the same length and mean different things — [`crate::provenance_graph`]'s
+/// `Carriers` records the same decision for the same reason.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RelatedNeighbours {
+    /// The entity asked about.
+    pub of: EntityId,
+    /// Its neighbours, ascending by the other entity's id.
+    pub neighbours: Vec<RelatedEntity>,
+    /// Whether more exist than [`MAX_RELATED`] admits.
+    pub truncated: bool,
+}
+
+impl RelatedNeighbours {
+    /// Whether this entity is adjudicated the same as nothing.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.neighbours.is_empty()
+    }
+
+    /// How many neighbours this answer carries.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.neighbours.len()
+    }
 }

--- a/crates/kirra-world-store/tests/related_read.rs
+++ b/crates/kirra-world-store/tests/related_read.rs
@@ -1,0 +1,228 @@
+//! **The bounded neighbour read behind box 5b's `Related` query.**
+//!
+//! These are the STORE-level properties: the bound, the index that makes it a
+//! bound, the disjointness the `UNION ALL` rests on, and the D-20 guard. The
+//! end-to-end behaviour over the real production chain is
+//! `kirra-world-service/tests/related_query.rs`.
+
+use kirra_world::reference::EntityId;
+use kirra_world_store::relationship_projection::MAX_RELATED;
+use kirra_world_store::WorldStore;
+
+fn tmp(name: &str) -> std::path::PathBuf {
+    static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let n = NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let mut p = std::env::temp_dir();
+    p.push(format!("kirra-5b-{name}-{}-{n}.sqlite", std::process::id()));
+    for s in ["", "-wal", "-shm"] {
+        let mut q = p.as_os_str().to_os_string();
+        q.push(s);
+        let _ = std::fs::remove_file(std::path::PathBuf::from(q));
+    }
+    p
+}
+
+fn eid(s: &str) -> EntityId {
+    EntityId::new(s).expect("entity id")
+}
+
+/// Force the projection table into existence, then write rows directly.
+///
+/// Raw SQL deliberately: these tests are about the READ's bound and index, and
+/// driving 257 neighbours through the real adjudication door would make the
+/// fixture the subject of the test. The end-to-end proof that real production
+/// data reaches this read lives in the service crate.
+fn store_with_projection(name: &str) -> WorldStore {
+    let mut store = WorldStore::open(&tmp(name)).expect("open");
+    store
+        .fold_relationship_projection()
+        .expect("install + fold");
+    store
+}
+
+fn insert(store: &WorldStore, low: &str, high: &str, generation: i64) {
+    store
+        .raw_execute_for_test(&format!(
+            "INSERT INTO relationships_projection
+                 (low, high, decided_generation, candidate_observation_id,
+                  adjudicator, decided_at_ms, decided_at_domain)
+             VALUES ('{low}', '{high}', {generation}, 'cand-obs-1', 'op', 1, 'system')"
+        ))
+        .expect("insert");
+}
+
+/// **`related` on a store that never folded installs no projection table.**
+///
+/// The D-20 guard, and the control for a claim `related`'s own docs make. The
+/// read self-heals a missing INDEX, and the obvious way to write that —
+/// calling `ensure_relationship_projection()` — would also install the TABLE,
+/// putting its root pages into every store that merely asked a question.
+/// ADR-0041 D-20's `log_only_bytes` is the size of a store holding only the
+/// event log, and D-2's retention horizons rest on that comparison.
+#[test]
+fn related_on_an_unfolded_store_is_empty_and_installs_nothing() {
+    let store = WorldStore::open(&tmp("unfolded")).expect("open");
+    let answer = store.related(&eid("track-a")).expect("related");
+    assert!(answer.is_empty());
+    assert!(!answer.truncated);
+    assert!(
+        !store
+            .has_relationship_projection()
+            .expect("catalogue readable"),
+        "asking a question must not create a projection table — D-20's \
+         log_only_bytes is measured on a store that never projected"
+    );
+}
+
+/// **A missing reverse index is restored by the read.**
+///
+/// A projection installed before `relationships_projection_high` existed would
+/// otherwise answer correctly while SCANNING for the `high = ?` half — a
+/// correct answer with unbounded work, which is precisely the shape of the
+/// three defects the boundedness gate exists for, and invisible in the result.
+#[test]
+fn related_heals_a_missing_reverse_index() {
+    let store = store_with_projection("heal");
+    insert(&store, "track-a", "track-b", 1);
+
+    store
+        .raw_execute_for_test("DROP INDEX relationships_projection_high")
+        .expect("drop the index");
+    assert_eq!(
+        store
+            .query_scalar_for_test(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='index' \
+                 AND name='relationships_projection_high'"
+            )
+            .expect("count"),
+        0,
+        "the index must actually be gone, or this test proves nothing"
+    );
+
+    let answer = store.related(&eid("track-b")).expect("related");
+    assert_eq!(answer.len(), 1, "the answer must still be correct");
+    assert_eq!(
+        store
+            .query_scalar_for_test(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='index' \
+                 AND name='relationships_projection_high'"
+            )
+            .expect("count"),
+        1,
+        "and the index must be back, or the bound is not a bound"
+    );
+}
+
+/// **Found from EITHER side of the canonical pair.**
+///
+/// A pair is stored once as `(low, high)`, so an implementation that looked in
+/// one column would answer correctly for whichever entity happened to sort
+/// first and report the other as related to nothing. The two assertions are
+/// deliberately asymmetric in what they expect back — each must see the OTHER
+/// entity, which also catches the `other` computation being inverted.
+#[test]
+fn a_pair_is_found_from_either_side() {
+    let store = store_with_projection("either-side");
+    insert(&store, "track-a", "track-b", 1);
+
+    let from_low = store.related(&eid("track-a")).expect("related");
+    assert_eq!(from_low.len(), 1);
+    assert_eq!(
+        from_low.neighbours[0].other.as_str(),
+        "track-b",
+        "asking about the low entity must return the HIGH one"
+    );
+
+    let from_high = store.related(&eid("track-b")).expect("related");
+    assert_eq!(from_high.len(), 1);
+    assert_eq!(
+        from_high.neighbours[0].other.as_str(),
+        "track-a",
+        "asking about the high entity must return the LOW one"
+    );
+}
+
+/// **The two index halves are disjoint, so `UNION ALL` cannot double-count.**
+///
+/// The read uses `UNION ALL` rather than `UNION`, resting on the domain
+/// guarantee that a pair names two DISTINCT entities — `CandidatePair::new`
+/// refuses `(x, x)` — so no row can satisfy both `low = ?` and `high = ?`.
+/// This asserts the guarantee rather than trusting it, because a `UNION ALL`
+/// over overlapping arms would report one relationship as two.
+#[test]
+fn the_two_index_halves_are_disjoint_so_union_all_cannot_double_count() {
+    // The domain refusal the disjointness rests on.
+    assert!(
+        kirra_world::same_as_candidate::CandidatePair::new(eid("x"), eid("x")).is_err(),
+        "a pair of one entity must be unrepresentable, or the arms can overlap"
+    );
+
+    let store = store_with_projection("disjoint");
+    insert(&store, "track-a", "track-b", 1);
+    insert(&store, "track-a", "track-c", 2);
+    insert(&store, "track-b", "track-c", 3);
+
+    // `track-b` is the HIGH of one row and the LOW of another — the case where
+    // a double-count would show, and a plain count would miss if both arms
+    // returned the same row.
+    let answer = store.related(&eid("track-b")).expect("related");
+    assert_eq!(answer.len(), 2);
+    let mut others: Vec<&str> = answer.neighbours.iter().map(|n| n.other.as_str()).collect();
+    others.sort_unstable();
+    assert_eq!(others, ["track-a", "track-c"]);
+}
+
+/// **The page ceiling holds, and truncation is CARRIED rather than inferred.**
+///
+/// `MAX_RELATED + 1` neighbours are inserted, so the answer is one short of
+/// what exists and must say so. A caller that inferred truncation from
+/// `len() == MAX_RELATED` would be right here and wrong for an entity with
+/// exactly `MAX_RELATED` neighbours, which is why the flag exists.
+#[test]
+fn related_is_capped_and_carries_its_truncation() {
+    let store = store_with_projection("cap");
+    for i in 0..=MAX_RELATED {
+        // Zero-padded so the sort order is the numeric one, and `subject`
+        // sorts below every neighbour — so the subject is the LOW column
+        // throughout and the cap is exercised on one arm rather than split.
+        insert(
+            &store,
+            "aaa-subject",
+            &format!("track-{i:04}"),
+            i as i64 + 1,
+        );
+    }
+
+    let answer = store.related(&eid("aaa-subject")).expect("related");
+    assert_eq!(answer.len(), MAX_RELATED, "the ceiling must hold");
+    assert!(
+        answer.truncated,
+        "more neighbours exist than were returned, and the answer must say so"
+    );
+}
+
+/// **Exactly `MAX_RELATED` neighbours is a COMPLETE answer, not a truncated one.**
+///
+/// The non-vacuity twin of the cap test, and the reason the read probes one
+/// over the ceiling instead of fetching exactly `MAX_RELATED`. Without this,
+/// an implementation that always set `truncated` on a full page would pass the
+/// test above while lying about every complete answer at the boundary.
+#[test]
+fn exactly_the_ceiling_is_not_reported_as_truncated() {
+    let store = store_with_projection("exact");
+    for i in 0..MAX_RELATED {
+        insert(
+            &store,
+            "aaa-subject",
+            &format!("track-{i:04}"),
+            i as i64 + 1,
+        );
+    }
+
+    let answer = store.related(&eid("aaa-subject")).expect("related");
+    assert_eq!(answer.len(), MAX_RELATED);
+    assert!(
+        !answer.truncated,
+        "a full page is not a cut-short page — nothing was withheld"
+    );
+}

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -1196,12 +1196,13 @@ does not describe is how a residue disappears.
          `corpus_digest` to contradict. A stronger corpus for an unchanged
          reducer is not a behaviour change.
 
-      **OPEN, and stated rather than implied: this projection has no domain
-      consumer yet.** Rule 1 ("every new declaration needs a production
-      consumer") is not satisfied by 5a alone; it is satisfied by the sequence
-      5a → typed `Related` query through `QueryEngine` → a real consumer, of
-      which this is the first step. If that sequence stalls, this table and its
-      fold are the thing to delete, not to document.
+      **Was OPEN — the projection had no domain consumer. 5b closed the first
+      half 2026-08-20:** `kirra_world_service::query::Related` reaches it
+      through `QueryEngine::execute`, so the table is now something production
+      code can ask. Rule 1 is not yet fully paid: the sequence is 5a → typed
+      `Related` (DONE) → a real consumer (OPEN). If it stalls before the
+      consumer, this table and its fold are still the thing to delete rather
+      than document.
 
       **FOLLOW-UP RULING owed:** does promotion PROTECT the supporting candidate
       evidence from compaction, or is *protected adjudication + degradable
@@ -1297,6 +1298,56 @@ does not describe is how a residue disappears.
       `the_two_precedence_rules_disagree_and_only_one_has_a_production_consumer`,
       next to 2b's existing no-precedence pin, so whoever rules on 2b's owed
       question confronts both halves at once.
+
+- [x] **5b — The typed `Related` query. DONE 2026-08-20.**
+      `kirra_world_service::query::Related` → `WorldView::related` →
+      `WorldStore::related`. The first query family over a SEMANTIC projection
+      rather than over the claim log, and what makes 5a reachable through the
+      one sanctioned door.
+
+      **Which precedence rule it serves, named because there are two.** It reads
+      the RELATIONSHIP PROJECTION (newest authorized decision governs), not
+      `confirmed_relations` (no precedence, one `Promoted` confirms forever).
+      Those disagree today — see the ruling 2b still owes, above — and 5b does
+      not resolve that; it states which side it is on and proves it with
+      `a_withdrawn_promotion_is_no_longer_related`, which a refactor onto
+      `confirmed_relations` would fail while every other test stayed green.
+
+      **The bound is two INDEXED lookups plus a page ceiling.** A pair is stored
+      once canonically, so the subject may be either column; `PRIMARY KEY (low,
+      high)` covers one half and the lazily-installed
+      `relationships_projection_high` index covers the other. That index is part
+      of the bound rather than a speed-up — a `LIMIT` bounds rows RETURNED, never
+      rows SCANNED, which is #1440's distinction. Truncation is CARRIED, and
+      `exactly_the_ceiling_is_not_reported_as_truncated` is the twin that stops
+      a full page being reported as cut short.
+
+      **No cursor, and that is not `SubjectSummary`'s argument.** That family has
+      no cursor because there is structurally one row per subject; here the set
+      genuinely grows. A cursor is a contract about stable ordering under
+      concurrent folds, and adding one before a consumer needs to walk past 256
+      `same_as` neighbours of ONE entity would invent a dimension nobody asked
+      for. What is not deferred is honesty about the cap.
+
+      **`RelatedLookup` has no `is_degraded`, deliberately** — every sibling
+      lookup does, so the absence needs a reason. `KIRRA-WM-EVIDENCE-RETENTION-001`
+      ruled that compaction may degrade WHY a promotion was made but never
+      WHETHER it holds; a degraded flag here would answer the second question
+      with the first one's evidence. Provenance stays a separate question via
+      `relationship_provenance`.
+
+      **Freshness is RESOLVED, not assumed.** The family asks `resolve_policy`
+      for `(same_as_adjudication, same_as_adjudged)` and gets `Timeless` from
+      `KIRRA-WM-IDENTITY-FRESHNESS-001`, so deleting that ruled row reds this
+      family rather than leaving it serving a policy nothing states.
+      `a_caller_stated_policy_is_honoured` is the twin proving the source is
+      actually consulted.
+
+      Six mutations, each killing exactly its own control — including the D-20
+      trap: `related` self-heals a missing INDEX but must never call
+      `ensure_relationship_projection`, because that would install the projection
+      TABLE on a store that merely asked a question and move `log_only_bytes` for
+      everyone. `related_on_an_unfolded_store_is_empty_and_installs_nothing`.
 
 - [x] **2c — Deterministic resolution over promoted identity. DONE 2026-08-20.**
       `kirra_world::adjudication::promote_confirmed_same_as` is the join: it asks


### PR DESCRIPTION
5a built `relationships_projection` and nothing could ask it anything through the sanctioned door. This closes that half: `QueryEngine::execute(Related { entity })`.

It is the first query family over a **semantic projection** rather than over the claim log.

## Which precedence rule it serves, named because there are two

It reads the **relationship projection** — newest authorized decision governs — and **not** `confirmed_relations`, where one `Promoted` anywhere confirms the pair forever. Those two disagree today (the ruling 2b still owes, pinned in #1468). 5b does not resolve that; it states which side it is on.

`a_withdrawn_promotion_is_no_longer_related` is what makes that **observable rather than documented**: a refactor onto `confirmed_relations` keeps every other test in the file green and fails only that one.

## The bound is two indexed lookups plus a ceiling

A pair is stored once canonically, so the subject may be **either** column. `PRIMARY KEY (low, high)` covers the `low = ?` half; the lazily-installed `relationships_projection_high` index covers the other.

That index is part of the **bound**, not a speed-up — a `LIMIT` bounds rows *returned*, never rows *scanned*, which is exactly the distinction defect #1440 turned on. Probes `limit + 1` and **carries** truncation, with `exactly_the_ceiling_is_not_reported_as_truncated` as the twin that stops a full page being reported as cut short.

**No cursor**, and `SubjectSummary`'s reasoning does *not* transfer: that family has structurally one row per subject, whereas this set genuinely grows. A cursor is a contract about stable ordering under concurrent folds; adding one before a consumer needs to walk past 256 `same_as` neighbours of one entity would invent a dimension nobody asked for. Honesty about the cap is not deferred.

## Two absences, each with a reason

**`RelatedLookup` has no `is_degraded`.** Every sibling lookup does, so the absence needs one. `KIRRA-WM-EVIDENCE-RETENTION-001` ruled that compaction degrades *why* a promotion was made but never *whether* it holds — a degraded flag here would answer the second question with the first one's evidence. Provenance stays a separate question via `relationship_provenance`.

**`Related` depends on exactly one rule.** Not `world_current_fold` (never touches the claim projection), not `entity_fold` (does not resolve identity), not `answer_admissibility` (no claim to grade, and the class is `Timeless`). Asserted, not assumed.

## Freshness is resolved, not assumed

`resolve_policy` for `(same_as_adjudication, same_as_adjudged)` yields `Timeless` from `KIRRA-WM-IDENTITY-FRESHNESS-001` — so deleting that ruled row reds this family instead of leaving it quietly serving a policy nothing states. `a_caller_stated_policy_is_honoured` is the twin proving the source is genuinely consulted rather than the conclusion hard-coded.

## Tested over the real chain

Sensor observations → the real matcher (`run_ingest_pass`) → an operator's adjudication → the projection → the query, via a dev-dep on `kirra-world-ingest`. A query proven only against fixtures would prove it works on data no producer can create — the exact gap the pre-5a audit found at the other end of this same chain.

Six mutations, each killing exactly its own control:

| Mutation | Kills |
|---|---|
| look only in the `low` column | `the_query_finds_the_pair_from_either_side` (+2 store) |
| `other` computed backwards | `a_promoted_relationship_is_reachable…` (+2 store) |
| index self-heal removed | `related_heals_a_missing_reverse_index` |
| `related` calls `ensure_relationship_projection` | `related_on_an_unfolded_store_is_empty_and_installs_nothing` |
| freshness ignored, `Timeless` hard-coded | `a_caller_stated_policy_is_honoured` |
| projection stops withdrawing | `a_withdrawn_promotion_is_no_longer_related` |

The fourth is the **D-20 trap**, and it is the one I would have walked into. `related` self-heals a missing *index*, but must never call `ensure_relationship_projection` — that installs the projection *table* on a store that merely asked a question, moving ADR-0041 D-20's `log_only_bytes` for everyone and invalidating the D-2 comparison the retention horizons rest on.

## Open, stated plainly

**Rule 1 is not yet fully paid.** The sequence is 5a → typed `Related` (this PR) → **a real consumer** (open). If it stalls before the consumer, this table, its fold and this query are the thing to delete rather than document.

Also removed before commit: a placeholder assertion I had left in the withdrawal test that could never fail — the same dead-assertion defect this box has now hit three times.

## Verification

- 272 workspace test binaries green, zero failures
- 12 python gates green, including query-boundedness (which classifies `related` as `bounded` with the index reasoning) and the World fence
- clippy clean but for one pre-existing warning in `tests/claim_at_generation.rs`
- boundedness baseline diff purely additive

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_