### PR TITLE
Box 5c: the identity rescue — Related reaching a real proposal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2363,6 +2363,9 @@ dependencies = [
  "kirra-core",
  "kirra-planner",
  "kirra-proposal-context",
+ "kirra-world",
+ "kirra-world-ingest",
+ "kirra-world-service",
  "kirra-world-store",
 ]
 

--- a/crates/kirra-mission-orchestrator/Cargo.toml
+++ b/crates/kirra-mission-orchestrator/Cargo.toml
@@ -24,6 +24,19 @@ kirra-proposal-context = { path = "../kirra-proposal-context" }
 kirra-planner = { path = "../kirra-planner" }
 
 [dev-dependencies]
+# Box 5c's identity-rescue differential builds its promoted `same_as` through
+# the REAL production chain -- the matcher proposes, an operator adjudicates --
+# rather than hand-writing a projection row. A closure proof over data no
+# producer can create would not be a closure proof. Dev-only.
+kirra-world-ingest = { path = "../kirra-world-ingest" }
+# The domain vocabulary the adjudication door takes: AdjudicationAuthority,
+# Outcome, MatcherIdentity, DomainInstant. Dev-only, same as the rest.
+kirra-world = { path = "../kirra-world" }
+# The sanctioned answer boundary. Box 5c's non-vacuity check asks whether the
+# fixture really promoted anything, and rule 5 of the boundedness gate is right
+# that a test is still a domain consumer: it goes through `QueryEngine` like
+# everyone else rather than reaching into the store.
+kirra-world-service = { path = "../kirra-world-service" }
 # Fixture only: the differential harness needs a CorridorSource and the frozen
 # contract to build a PlanInput and to digest the enforced envelope. A DEV edge —
 # the shipped crate names no checker-input type it does not forward.

--- a/crates/kirra-mission-orchestrator/tests/tier_2_5_closure.rs
+++ b/crates/kirra-mission-orchestrator/tests/tier_2_5_closure.rs
@@ -390,3 +390,373 @@ fn the_coordinate_comes_from_configuration_not_from_the_world() {
         "the coordinate is configuration's to supply — changing it must change the plan"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Box 5c — the IDENTITY-RESCUE differential.
+//
+// The same closure argument as above, over a different kind of world knowledge:
+// not "where the package is" but "which two destinations an operator decided
+// are the same place". This is what pays Rule 1 for the 5a/5b slice — the
+// relationship projection reaching a real production behaviour path.
+// ---------------------------------------------------------------------------
+
+/// The candidates for the rescue scenario. `dock_b_annex` is deliberately NOT
+/// among them: the caller offers two destinations, and the world names a third.
+fn rescue_candidates() -> Vec<ContextId> {
+    vec![id("dock_a"), id("dock_b")]
+}
+
+/// A store where the package was last seen at `dock_b_annex` — a place the
+/// caller never offered — optionally with `dock_b_annex` adjudicated the same
+/// as `dock_b`.
+///
+/// The promotion is built through the REAL chain: two observations agreeing on
+/// an identifier, the real matcher proposing the pair, an operator adjudicating
+/// it, the projection folded. Nothing is hand-written into
+/// `relationships_projection`.
+fn store_for_rescue(promote_partner: Option<&str>, name: &str) -> (WorldStore, std::path::PathBuf) {
+    use kirra_world::observation::{ClockDomain, DomainInstant, SourceClass};
+    use kirra_world::reference::ObservationId as ObsId;
+    use kirra_world::same_as_adjudication::{AdjudicationAuthority, Outcome};
+    use kirra_world::same_as_candidate::MatcherIdentity;
+    use kirra_world_ingest::{run_ingest_pass, ExactIdentifierRule};
+    use kirra_world_store::same_as_adjudication_record::SameAsAdjudicationRequest;
+
+    let path = tmp(name);
+    let mut store = WorldStore::open(&path).expect("open");
+
+    let mut observe = |n: &str, subject: &str, predicate: &str, object: &str| {
+        let event_id = EventId::new(format!("ev-{n}")).expect("event id");
+        let observation_id = ObservationId::new(format!("obs-{n}")).expect("observation id");
+        store
+            .append(&NewEvent {
+                event_id: &event_id,
+                observation_id: &observation_id,
+                txn_time_ms: T0,
+                valid_from_ms: T0,
+                valid_to_ms: None,
+                source: "warehouse-scanner",
+                source_version: "1.0.0",
+                writer_class: WriterClass::Sensor,
+                claim_status: ClaimStatus::Confirmed,
+                provenance: &[],
+                frame_id: None,
+                map_id: None,
+                kind: "mission",
+                subject,
+                subject_ref: None,
+                predicate: Some(predicate),
+                object: Some(object),
+                payload: "{}",
+                payload_schema: 1,
+                retention_class: "raw",
+                trust: None,
+            })
+            .expect("append");
+    };
+
+    // The world's fact: the package is at a place the caller did not offer.
+    observe("last-seen", "package_17", "last_seen_at", "dock_b_annex");
+    // The evidence the matcher will act on: two dock records sharing a code.
+    if let Some(partner) = promote_partner {
+        observe("code-1", partner, "facility_code", "FC-42");
+        observe("code-2", "dock_b_annex", "facility_code", "FC-42");
+    }
+    store.fold().expect("fold claims");
+
+    if promote_partner.is_some() {
+        let rule = ExactIdentifierRule::new(
+            "facility_code",
+            MatcherIdentity::new("world-ingest", "exact-identifier", "1.0.0").expect("matcher"),
+        )
+        .expect("rule");
+        let mut n = 0;
+        let report = run_ingest_pass(&mut store, &rule, T0, 1_000, move || {
+            n += 1;
+            (
+                EventId::new(format!("cand-ev-{n}")).expect("id"),
+                ObservationId::new(format!("cand-obs-{n}")).expect("id"),
+            )
+        })
+        .expect("ingest pass");
+        assert_eq!(report.proposed, 1, "the matcher must propose the dock pair");
+
+        let event_id = EventId::new("adj-ev-1").expect("id");
+        let observation_id = ObservationId::new("adj-obs-1").expect("id");
+        store
+            .adjudicate_same_as(&SameAsAdjudicationRequest {
+                event_id: &event_id,
+                observation_id: &observation_id,
+                candidate_observation_id: "cand-obs-1",
+                cited: vec![ObsId::new("cand-obs-1").expect("id")],
+                authority: AdjudicationAuthority::new(SourceClass::Operator, "yard-supervisor")
+                    .expect("authority"),
+                outcome: Outcome::Promoted,
+                decided_at: DomainInstant {
+                    ms: T0 as u64 + 10,
+                    domain: ClockDomain::System,
+                },
+                txn_time_ms: T0 + 10,
+                source: "operator-console",
+                source_version: "1.0.0",
+            })
+            .expect("an operator judging a persisted candidate");
+    }
+    // Folded in BOTH runs. Run A has an empty projection rather than no
+    // projection, so the two runs differ in what was DECIDED and not in whether
+    // the fold ever ran — otherwise the difference could be attributed to the
+    // projection's existence instead of to the promotion.
+    store
+        .fold_relationship_projection()
+        .expect("fold relationships");
+    (store, path)
+}
+
+fn rescue_context(promote_partner: Option<&str>, name: &str) -> ProposalContext {
+    let (store, path) = store_for_rescue(promote_partner, name);
+    let ctx = mission_context(
+        &store,
+        &id("package_17"),
+        &id("last_seen_at"),
+        &rescue_candidates(),
+        T0,
+        None,
+    )
+    .expect("context");
+    drop(store);
+    let _ = std::fs::remove_file(&path);
+    ctx
+}
+
+/// **THE 5c CLOSURE ASSERTION — a promoted `same_as` changes the proposal, and
+/// changes nothing the checker reads.**
+///
+/// Two runs of one scenario. In both, the world says the package was last seen
+/// at `dock_b_annex`, which the caller never offered as a destination. The runs
+/// differ in exactly one thing: whether an operator has adjudicated
+/// `dock_b_annex` and `dock_b` the same place.
+///
+/// * Run A — no promotion. Nothing matches, the caller's own goal stands.
+/// * Run B — promoted. The context prefers `dock_b`, and a real
+///   `GeometricPlanner` proposes a different trajectory.
+///
+/// And the checker's inputs are the same BORROW in both runs, not two that
+/// happen to match — the corridor and object slice are re-borrowed by
+/// production planner code, so `ptr::eq` can say so.
+///
+/// > World may change what is proposed. It may not change the inputs from which
+/// > the checker derives what is permitted.
+#[test]
+fn a_promoted_same_as_changes_the_proposal_and_not_the_checkers_inputs() {
+    let corridor = MockCorridorSource::straight_5m_half_width(100.0);
+    let objects: Vec<PerceivedObject> = Vec::new();
+    let lanes: Vec<LaneBoundary> = Vec::new();
+    let base = world(&corridor, &objects, &lanes);
+    let missions = missions();
+
+    // Run A — the operator has not decided the two docks are one place.
+    let ctx_a = rescue_context(None, "rescue-unpromoted");
+    let mut planner_a = GeometricPlanner::default();
+    let (plan_a, applied_a) = plan_with_context(&mut planner_a, &base, &ctx_a, &missions);
+
+    // Run B — they have.
+    let ctx_b = rescue_context(Some("dock_b"), "rescue-promoted");
+    let mut planner_b = GeometricPlanner::default();
+    let (plan_b, applied_b) = plan_with_context(&mut planner_b, &base, &ctx_b, &missions);
+
+    // --- the PROPOSAL differs -------------------------------------------
+    assert_eq!(
+        applied_a,
+        ContextApplication::NoPreference,
+        "without the promotion, a place the caller never offered is no preference"
+    );
+    assert_eq!(
+        applied_b,
+        ContextApplication::Applied(id("dock_b")),
+        "with it, the world's fact reaches a destination the caller DID offer"
+    );
+    assert_ne!(
+        proposal_digest(&plan_a),
+        proposal_digest(&plan_b),
+        "a promoted same_as must change the proposal a REAL planner produces"
+    );
+
+    // --- the CHECKER'S INPUTS do not ------------------------------------
+    assert!(
+        std::ptr::eq(
+            base.map as *const _,
+            &corridor as &dyn CorridorSource as *const _
+        ),
+        "the corridor the planner saw is the caller's, unwrapped"
+    );
+    assert!(
+        std::ptr::eq(base.objects, objects.as_slice()),
+        "the object slice the planner saw is the caller's, unrebuilt"
+    );
+    assert_eq!(
+        corridor_digest(&corridor),
+        corridor_digest(&corridor),
+        "the corridor's drivable space is unchanged across the pair"
+    );
+    // The contract identity is unreachable from this path by construction, for
+    // the reason the closure test above records at length: `PlanInput` carries
+    // no `VehicleKinematicsContract` and this host has no access to one.
+}
+
+/// **The identity step is reported as a symbolic triple, not folded away.**
+///
+/// The context must say WHY `dock_b` was preferred when the world's own fact
+/// named `dock_b_annex`. Without this, a consumer rendering an explanation
+/// would have to claim the world said something it did not.
+#[test]
+fn the_rescue_reports_both_the_worlds_fact_and_the_identity_step() {
+    let ctx = rescue_context(Some("dock_b"), "rescue-facts");
+    let facts: Vec<(&str, &str, &str)> = ctx
+        .hints()
+        .iter()
+        .filter_map(|h| match h {
+            kirra_proposal_context::ContextHint::MissionFact {
+                subject,
+                relation,
+                object,
+            } => Some((subject.as_str(), relation.as_str(), object.as_str())),
+            _ => None,
+        })
+        .collect();
+
+    assert!(
+        facts.contains(&("package_17", "last_seen_at", "dock_b_annex")),
+        "the world's own fact must name what the world ACTUALLY said: {facts:?}"
+    );
+    assert!(
+        facts.contains(&("dock_b_annex", "same_as", "dock_b")),
+        "and the identity step must be visible as its own triple: {facts:?}"
+    );
+}
+
+/// **A WITHDRAWN promotion rescues nothing.**
+///
+/// The precedence rule, carried all the way to a proposal. `Related` reads the
+/// relationship projection, where the newest authorized decision governs — so an
+/// operator who promotes and then rejects has un-decided it, and the planner
+/// goes back to the caller's own goal.
+///
+/// This is the test that would fail if the rescue were ever refactored onto
+/// `confirmed_relations`, where one `Promoted` confirms forever.
+#[test]
+fn a_withdrawn_promotion_does_not_rescue_the_candidate() {
+    use kirra_world::observation::{ClockDomain, DomainInstant, SourceClass};
+    use kirra_world::reference::ObservationId as ObsId;
+    use kirra_world::same_as_adjudication::{AdjudicationAuthority, Outcome};
+    use kirra_world_store::same_as_adjudication_record::SameAsAdjudicationRequest;
+
+    let (mut store, path) = store_for_rescue(Some("dock_b"), "rescue-withdrawn");
+
+    // Non-vacuity: the promotion is doing the work BEFORE it is withdrawn.
+    let before = mission_context(
+        &store,
+        &id("package_17"),
+        &id("last_seen_at"),
+        &rescue_candidates(),
+        T0,
+        None,
+    )
+    .expect("context");
+    assert_eq!(
+        before.preferred_destination(),
+        Some(&id("dock_b")),
+        "the promotion must rescue first, or the withdrawal proves nothing"
+    );
+
+    let event_id = EventId::new("adj-ev-2").expect("id");
+    let observation_id = ObservationId::new("adj-obs-2").expect("id");
+    store
+        .adjudicate_same_as(&SameAsAdjudicationRequest {
+            event_id: &event_id,
+            observation_id: &observation_id,
+            candidate_observation_id: "cand-obs-1",
+            cited: vec![ObsId::new("cand-obs-1").expect("id")],
+            authority: AdjudicationAuthority::new(SourceClass::Operator, "yard-supervisor")
+                .expect("authority"),
+            outcome: Outcome::Rejected,
+            decided_at: DomainInstant {
+                ms: T0 as u64 + 20,
+                domain: ClockDomain::System,
+            },
+            txn_time_ms: T0 + 20,
+            source: "operator-console",
+            source_version: "1.0.0",
+        })
+        .expect("the operator changes their mind");
+    store.fold_relationship_projection().expect("re-fold");
+
+    let after = mission_context(
+        &store,
+        &id("package_17"),
+        &id("last_seen_at"),
+        &rescue_candidates(),
+        T0,
+        None,
+    )
+    .expect("context");
+    assert_eq!(
+        after.preferred_destination(),
+        None,
+        "a withdrawn promotion must stop rescuing — the newest decision governs"
+    );
+
+    drop(store);
+    let _ = std::fs::remove_file(&path);
+}
+
+/// **World may not introduce a destination the caller did not offer.**
+///
+/// The authority boundary, asserted directly rather than left to emerge from
+/// the other tests. The world's fact names `dock_b_annex`, and an operator has
+/// promoted `dock_b_annex same_as dock_c` — but `dock_c` is not in the caller's
+/// candidate list. The rescue must decline.
+///
+/// This is the difference between *selecting among already-valid mission
+/// choices* and *reasoning arbitrarily over World*. A rescue that preferred
+/// `dock_c` would be World placing a destination, and `MissionTable` would then
+/// be the only thing standing between a promoted relation and a coordinate —
+/// which is a configuration lookup, not an authority boundary.
+#[test]
+fn the_rescue_cannot_introduce_a_destination_the_caller_did_not_offer() {
+    let ctx = rescue_context(Some("dock_c"), "rescue-outside");
+    assert_eq!(
+        ctx.preferred_destination(),
+        None,
+        "a promoted relation to a NON-candidate must not become a preference"
+    );
+    assert!(
+        !ctx.hints().iter().any(|h| matches!(
+            h,
+            kirra_proposal_context::ContextHint::PreferDestination(id) if id.as_str() == "dock_c"
+        )),
+        "and dock_c must appear nowhere as a destination"
+    );
+    // Non-vacuity: the promotion really exists and really names dock_c — this
+    // is a refusal, not a fixture that quietly failed to promote anything.
+    let (store, path) = store_for_rescue(Some("dock_c"), "rescue-outside-check");
+    // Through the sanctioned door, not into the store. Rule 5 of the
+    // boundedness gate caught the first draft of this reaching past the engine
+    // -- correctly: a test asking a domain question is still a domain consumer.
+    let engine = kirra_world_service::query::QueryEngine::new(
+        &store,
+        kirra_world_service::freshness::FreshnessSource::Ruled,
+    );
+    let related = engine
+        .execute(kirra_world_service::query::Related {
+            entity: "dock_b_annex".to_string(),
+        })
+        .expect("related");
+    assert_eq!(
+        related.neighbours().len(),
+        1,
+        "the fixture must have promoted something"
+    );
+    assert_eq!(related.neighbours()[0].other.as_str(), "dock_c");
+    drop(store);
+    let _ = std::fs::remove_file(&path);
+}

--- a/crates/kirra-proposal-context/src/lib.rs
+++ b/crates/kirra-proposal-context/src/lib.rs
@@ -59,7 +59,7 @@
 use kirra_world::resolution::RefusalReason;
 use kirra_world::trust::{TrustGrade, Validity};
 use kirra_world_service::freshness::{FreshnessPolicy, FreshnessSource};
-use kirra_world_service::query::{Ask, QueryEngine};
+use kirra_world_service::query::{Ask, QueryEngine, Related};
 use kirra_world_service::read_view::{AskError, ObjectIdentity, UnknownReason, WorldLookup};
 use kirra_world_store::WorldStore;
 
@@ -393,6 +393,17 @@ fn mirror_resolution(identity: &ObjectIdentity) -> ObjectResolution {
     }
 }
 
+/// The relation an identity-rescue step is reported under.
+///
+/// Mirrors the store's own predicate token rather than re-spelling it, so the
+/// symbol a consumer reads is the one the log records. Built through
+/// [`ContextId::new`] like every other id that crosses the seam; the token is a
+/// non-empty constant, so the `expect` cannot fire.
+fn same_as_relation() -> ContextId {
+    ContextId::new(kirra_world_store::candidate_record::CANDIDATE_PREDICATE_TOKEN)
+        .expect("the same_as predicate token is a non-empty constant")
+}
+
 /// Derive proposal-shaping context from what Kirra World knows about `subject`.
 ///
 /// The one behaviour, kept deliberately tiny: if the world holds a claim
@@ -472,6 +483,11 @@ pub fn mission_context(
     // could not be used.
     let mut unresolved: Option<ObjectResolution> = None;
 
+    // The object the world named but the caller did not offer. Recorded on the
+    // way past so the identity rescue below has something to ask about, WITHOUT
+    // a second walk of the answers.
+    let mut unmatched_object: Option<String> = None;
+
     let matched = answers.iter().find_map(|a| {
         if a.predicate()? != relation.as_str() {
             return None;
@@ -485,7 +501,10 @@ pub fn mission_context(
             unresolved.get_or_insert_with(|| mirror_resolution(a.object_identity()));
             return None;
         };
-        let candidate = candidates.iter().find(|c| c.as_str() == object)?;
+        let Some(candidate) = candidates.iter().find(|c| c.as_str() == object) else {
+            unmatched_object.get_or_insert_with(|| object.to_owned());
+            return None;
+        };
         Some((candidate, a))
     });
 
@@ -497,6 +516,84 @@ pub fn mission_context(
             ));
         }
     }
+
+    // --- The identity rescue, box 5c -------------------------------------
+    //
+    // The world named an object the caller did not offer. Before reporting no
+    // preference, ask whether that object is ADJUDICATED THE SAME AS one the
+    // caller did offer: "the package was last seen at dock_b_annex, and an
+    // operator decided dock_b_annex is dock_b."
+    //
+    // WHAT THIS MAY AND MAY NOT DO, because this is the seam the whole tier is
+    // about. It SELECTS from `candidates` — the caller's own list — and can
+    // therefore only ever reorder choices the caller had already declared
+    // valid. It cannot introduce a destination, and it emits no quantity: the
+    // identity step crosses as a `MissionFact` triple, which is symbolic.
+    // Turning a chosen symbol into coordinates remains configuration's job
+    // (`MissionTable`), which is why World cannot place anything.
+    //
+    // "Selects, never invents" turns out to be STRUCTURAL as well as
+    // documented, and that was discovered rather than designed, so it is worth
+    // stating precisely rather than claiming more than is true. `matched` is
+    // `Option<(&ContextId, &WorldAnswer)>` whose first element borrows from
+    // `candidates`, and `preferred` flows from it straight into
+    // `PreferDestination`. Two attempts to mutate this rescue into choosing a
+    // NON-candidate -- picking the projection's first neighbour, and widening
+    // the search to an owned list of neighbours -- were both refused by the
+    // borrow checker, because the value has nowhere to live that outlives the
+    // arm. An author would have to change the binding's type first.
+    //
+    // The honest claim is therefore "the obvious mutation does not compile",
+    // NOT "this is impossible". A determined restructure could own the value,
+    // and `the_rescue_cannot_introduce_a_destination_the_caller_did_not_offer`
+    // is what catches that -- a behavioural control, because the type-level one
+    // is a happy accident and accidents are not guarantees.
+    //
+    // EXACTLY ONE extra query, and that is structural rather than a budget:
+    // `world_current`'s primary key is `(subject, predicate_key)`, so an `Ask`
+    // yields at most ONE answer naming `relation`, hence at most one unmatched
+    // object to ask about. There is no arbitrary "first" being picked here.
+    //
+    // PROMOTED relations only, and never transitively closed — `Related` reads
+    // the relationship projection, where the newest authorized decision governs
+    // and `KIRRA-WM-TRANSITIVITY-001` keeps the answer pairwise. A rejected or
+    // withdrawn promotion rescues nothing, which
+    // `a_withdrawn_promotion_does_not_rescue_the_candidate` pins.
+    let mut identity_step: Option<(ContextId, ContextId)> = None;
+    let matched = match (matched, unmatched_object.as_deref()) {
+        (None, Some(object)) => {
+            let related = engine.execute(Related {
+                entity: object.to_owned(),
+            })?;
+            // The caller's OWN ordering breaks a tie when several neighbours
+            // are candidates. Their preference is the right authority here —
+            // World has no basis for ranking two destinations the caller
+            // already considers valid, and picking by the projection's key
+            // order would let entity-id spelling decide a mission.
+            let chosen = candidates.iter().find(|c| {
+                related
+                    .neighbours()
+                    .iter()
+                    .any(|n| n.other.as_str() == c.as_str())
+            });
+            match (chosen, ContextId::new(object)) {
+                (Some(c), Some(from)) => {
+                    identity_step = Some((from, c.clone()));
+                    // The ANSWER is still the original claim: its trust and
+                    // freshness describe the fact the world served, and the
+                    // identity step is reported separately rather than folded
+                    // into it. Grading the rescue as if it were the claim would
+                    // attribute the adjudication's authority to a sensor.
+                    answers
+                        .iter()
+                        .find(|a| a.predicate() == Some(relation.as_str()))
+                        .map(|a| (c, a))
+                }
+                _ => None,
+            }
+        }
+        (m, _) => m,
+    };
 
     let Some((preferred, answer)) = matched else {
         return Ok(ProposalContext::silent(
@@ -553,18 +650,39 @@ pub fn mission_context(
         }
     };
 
+    // The world's own fact names what the world ACTUALLY said. On the rescue
+    // path that is the unmatched object, not the chosen candidate — reporting
+    // the destination here would erase the step that got us to it and make the
+    // context claim the world said something it did not.
+    let stated_object = identity_step
+        .as_ref()
+        .map_or_else(|| preferred.clone(), |(from, _)| from.clone());
+
+    let mut hints = vec![
+        ContextHint::PreferDestination(preferred.clone()),
+        ContextHint::CandidatePriority(priority),
+        ContextHint::MissionFact {
+            subject: subject.clone(),
+            relation: relation.clone(),
+            object: stated_object,
+        },
+    ];
+    // The identity step, as its own symbolic triple, so the chain of reasoning
+    // is auditable from the context alone: `subject --relation--> X` and
+    // `X --same_as--> preferred`. A consumer that ignores it still gets the
+    // same preference; one that renders an explanation can say WHY.
+    if let Some((from, to)) = identity_step {
+        hints.push(ContextHint::MissionFact {
+            subject: from,
+            relation: same_as_relation(),
+            object: to,
+        });
+    }
+    hints.push(ContextHint::FactTrust(grade));
+    hints.push(ContextHint::FactFreshness(freshness));
+
     Ok(ProposalContext {
-        hints: vec![
-            ContextHint::PreferDestination(preferred.clone()),
-            ContextHint::CandidatePriority(priority),
-            ContextHint::MissionFact {
-                subject: subject.clone(),
-                relation: relation.clone(),
-                object: preferred.clone(),
-            },
-            ContextHint::FactTrust(grade),
-            ContextHint::FactFreshness(freshness),
-        ],
+        hints,
         silence: None,
     })
 }

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -1196,13 +1196,10 @@ does not describe is how a residue disappears.
          `corpus_digest` to contradict. A stronger corpus for an unchanged
          reducer is not a behaviour change.
 
-      **Was OPEN — the projection had no domain consumer. 5b closed the first
-      half 2026-08-20:** `kirra_world_service::query::Related` reaches it
-      through `QueryEngine::execute`, so the table is now something production
-      code can ask. Rule 1 is not yet fully paid: the sequence is 5a → typed
-      `Related` (DONE) → a real consumer (OPEN). If it stalls before the
-      consumer, this table and its fold are still the thing to delete rather
-      than document.
+      **CLOSED 2026-08-20 by 5c.** Rule 1 is paid: 5a → typed `Related` (5b) →
+      `mission_context`'s identity rescue (5c), which changes what a REAL
+      `GeometricPlanner` proposes. The projection is load-bearing on a
+      production behaviour path, not just reachable.
 
       **FOLLOW-UP RULING owed:** does promotion PROTECT the supporting candidate
       evidence from compaction, or is *protected adjudication + degradable
@@ -1348,6 +1345,60 @@ does not describe is how a residue disappears.
       `ensure_relationship_projection`, because that would install the projection
       TABLE on a store that merely asked a question and move `log_only_bytes` for
       everyone. `related_on_an_unfolded_store_is_empty_and_installs_nothing`.
+
+- [x] **5c — The identity rescue: `Related` reaching a real proposal. DONE 2026-08-20.**
+      The consumer that pays Rule 1 for the whole 5a/5b slice, chosen over Mick
+      narration deliberately — narration is too easy to satisfy without proving
+      the projection influences operational behaviour.
+
+      **The behaviour, kept narrow.** When the world holds
+      `subject --relation--> X` and `X` is NOT among the caller's candidates,
+      `mission_context` asks `Related(X)`; if `X` is adjudicated the same as a
+      candidate the caller DID offer, that candidate is preferred. *"The package
+      was last seen at dock_b_annex, and an operator decided dock_b_annex is
+      dock_b."*
+
+      **It selects; it does not invent.** The choice comes from `candidates` —
+      the caller's own list — so World can only reorder options already declared
+      valid. Turning a chosen symbol into coordinates stays configuration's job
+      (`MissionTable`). `the_rescue_cannot_introduce_a_destination_the_caller_did_not_offer`
+      asserts that directly rather than leaving it to emerge: a promoted
+      relation to a NON-candidate is refused.
+
+      **The seam stays symbolic.** The identity step crosses as a
+      `ContextHint::MissionFact` triple — no new variant, no quantity — so
+      `ci/check_proposal_context_symbolic.py` is unaffected. The context reports
+      BOTH the world's own fact (naming what the world actually said, the
+      unmatched object) and the identity step, so the chain of reasoning is
+      auditable from the context alone.
+
+      **Exactly one extra query, structurally.** `world_current`'s primary key is
+      `(subject, predicate_key)`, so an `Ask` yields at most one answer naming
+      the relation, hence at most one object to ask about. No arbitrary "first"
+      is picked.
+
+      **Acceptance is the Tier 2.5 differential**, per §5.5's own standard:
+      `a_promoted_same_as_changes_the_proposal_and_not_the_checkers_inputs`
+      drives a real `GeometricPlanner` twice over one scenario differing only in
+      whether an operator promoted the relation. The proposal differs; the
+      corridor and object slice are the SAME BORROW (`ptr::eq`), re-borrowed by
+      production planner code; the contract identity is unreachable from this
+      path by construction. The promotion is built through the real chain —
+      matcher proposes, operator adjudicates — not hand-written into the
+      projection.
+
+      **Found while building it, recorded because it was discovered rather than
+      designed:** "selects, never invents" is also STRUCTURAL. `preferred`
+      borrows from `candidates`, so two attempts to mutate the rescue into
+      choosing a non-candidate were refused by the borrow checker. The honest
+      claim is *the obvious mutation does not compile*, not *this is
+      impossible* — a restructure could own the value, which is why the
+      behavioural control carries the guarantee.
+
+      **The boundedness gate caught the test, not the code.** Rule 5 fired on the
+      non-vacuity check reaching `store.related` directly; it now goes through
+      `QueryEngine` like every other domain consumer. A test asking a domain
+      question is still a domain consumer.
 
 - [x] **2c — Deterministic resolution over promoted identity. DONE 2026-08-20.**
       `kirra_world::adjudication::promote_confirmed_same_as` is the join: it asks


### PR DESCRIPTION
The consumer that pays **Rule 1** for the whole 5a/5b slice, closing the vertical:

```
promoted same_as → relationships_projection → Related query → mission_context
    → changed proposal → unchanged checker inputs
```

Chosen over Mick narration deliberately: narration is too easy to satisfy without proving the projection influences operational behaviour.

## The behaviour, kept narrow

When the world holds `subject --relation--> X` and `X` is **not** among the caller's candidates, `mission_context` asks `Related(X)`. If `X` is adjudicated the same as a candidate the caller *did* offer, that candidate is preferred.

> *The package was last seen at `dock_b_annex`, and an operator decided `dock_b_annex` is `dock_b`.*

**It selects; it does not invent.** The choice comes from `candidates` — the caller's own list — so World can only reorder options already declared valid. Turning a chosen symbol into coordinates stays configuration's job (`MissionTable`).

That is asserted **directly** by `the_rescue_cannot_introduce_a_destination_the_caller_did_not_offer` rather than left to emerge from the other tests: a promoted relation to a non-candidate is refused, and the fixture's non-vacuity check confirms the promotion really exists and really names the outsider.

**Exactly one extra query, structurally.** `world_current`'s primary key is `(subject, predicate_key)`, so an `Ask` yields at most one answer naming the relation — hence at most one object to ask about. No arbitrary "first" is being picked.

## The seam stays symbolic

The identity step crosses as a `ContextHint::MissionFact` triple — **no new variant, no quantity** — so `check_proposal_context_symbolic.py` is unaffected.

The context reports **both** the world's own fact (naming the *unmatched* object — what the world actually said) **and** the identity step, so the chain of reasoning is auditable from the context alone. Reporting the chosen destination as the world's fact would erase the step that got there, and make the context claim the world said something it did not.

## Acceptance: the Tier 2.5 differential

Per §5.5's own standard. `a_promoted_same_as_changes_the_proposal_and_not_the_checkers_inputs` runs a real `GeometricPlanner` twice over one scenario differing in exactly one thing — whether an operator promoted the relation:

| | Run A | Run B |
|---|---|---|
| promotion | absent | present |
| `ContextApplication` | `NoPreference` | `Applied(dock_b)` |
| proposal | caller's own goal | different trajectory |
| corridor / objects | **same borrow** (`ptr::eq`) | **same borrow** |
| contract identity | unreachable by construction | unreachable |

The promotion is built through the **real chain** — the matcher proposes, an operator adjudicates, the projection folds — not hand-written into `relationships_projection`. Both runs fold the projection, so they differ in what was *decided*, not in whether the fold ever ran.

`a_withdrawn_promotion_does_not_rescue_the_candidate` carries 5b's precedence rule all the way to a proposal: promote then reject, and the planner returns to the caller's goal. That is the test a refactor onto `confirmed_relations` would fail.

## Two things worth flagging

**A structural property I discovered rather than designed.** "Selects, never invents" is also enforced by the type: `preferred` borrows from `candidates`, and two attempts to mutate the rescue into choosing a non-candidate were both refused by the borrow checker. The honest claim is *the obvious mutation does not compile*, **not** *this is impossible* — a restructure could own the value. That is why the behavioural control carries the guarantee and the type-level accident is only recorded.

**The boundedness gate caught my test, not my code.** Rule 5 fired on the non-vacuity check reaching `store.related` directly. It now goes through `QueryEngine` — a test asking a domain question is still a domain consumer, and the gate was right.

## Boundary invariants held

- `kirra-planner` remains World-blind — untouched.
- The orchestrator remains the only place combining World context with proposal generation.
- Both fences intact: `check_kirra_world_bidirectional_fence.py`, `check_mick_actuation_fence.py`.
- New deps are **dev-only** (`kirra-world-ingest`, `kirra-world`, `kirra-world-service` on the orchestrator's test target).

## Verification

- 272 workspace test binaries green
- 15 python gates green, including the symbolic-seam gate + its 18 self-tests
- four mutations recorded; `candidates.first()` (World ignoring the projection) kills four tests, rescue-disabled kills three
- clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_