### PR TITLE
KIRRA-WM-ADJUDICATION-PRECEDENCE-001: the latest decision determines identity

### DIFF
--- a/ci/store_boundedness_baseline.json
+++ b/ci/store_boundedness_baseline.json
@@ -212,6 +212,10 @@
       "class": "bounded",
       "why": "Tier 5 box 5a. Three bounded steps and no scan: the point read above, then `carriers` (capped at MAX_CARRIERS + a truncation flag) and `compacted_spans` (capped at MAX_COMPACTED_SPANS), both of which box 4b already bounds and classifies. Answers whether ONE relationship's cited candidate is still visible; it cannot be used to enumerate anything."
     },
+    "relationships_in_effect_at": {
+      "class": "operational",
+      "why": "Tier 2 box 2b's precedence ruling. A HISTORICAL replay: folds every confirmed same_as adjudication at or below a generation cut, from empty, to reproduce the relationships that held there. Whole-prefix by construction and deliberately so -- the ruling's historical half is 'what did the record say then', which cannot be answered from a page. Classified operational rather than bounded for the same reason `identity_view_at`'s whole-graph sibling is: it is a replay, not an interactive read, and no request path calls it. A bounded historical relationship query would need its own cursor design and is not owed until a consumer asks for one."
+    },
     "same_as_candidate_exists": {
       "class": "operational",
       "why": "Box 2a's producer-side idempotence point-read. EXISTS over one canonical pair plus matcher version, so it returns at most one row by construction; operational for the same reason as identifier_agreements -- a producer asking 'have I already said this', not a consumer asking what is true."

--- a/ci/world_semantics_baseline.json
+++ b/ci/world_semantics_baseline.json
@@ -60,7 +60,7 @@
       {
         "version": 1,
         "corpus_digest": "db4975d3adc118885e0c180c58ac45311272df617e0b9f00333571b14cff3b95",
-        "source_pin": "e82c8a546104d622f71bb2c12e63670ad4c8a0733ac02eb88e2c7138b991b6b8"
+        "source_pin": "ecdeeb08a7d7822479342150529ef99f095791294e7c5acca5fad8d103be4525"
       }
     ]
   }

--- a/crates/kirra-world-ingest/tests/persisted_adjudication.rs
+++ b/crates/kirra-world-ingest/tests/persisted_adjudication.rs
@@ -513,8 +513,18 @@ fn re_adjudicating_the_same_persisted_pair_does_not_inflate_corroboration() {
     }
 
     assert_eq!(decisions.len(), 3, "three records were genuinely written");
+    // Numbered in the order they were written, because
+    // `KIRRA-WM-ADJUDICATION-PRECEDENCE-001` makes that order part of the
+    // question. Three PROMOTIONS with nothing between them leave one relation
+    // in effect, so the answer is unchanged by the ruling — which is the point
+    // of keeping this case: precedence must not disturb re-affirmation.
+    let history: Vec<(i64, &SameAsAdjudication)> = decisions
+        .iter()
+        .enumerate()
+        .map(|(i, a)| (i as i64 + 1, a))
+        .collect();
     assert_eq!(
-        corroboration_count(&decisions),
+        corroboration_count(history),
         1,
         "but one pair is one corroboration, however many times it is affirmed"
     );

--- a/crates/kirra-world-store/src/lib.rs
+++ b/crates/kirra-world-store/src/lib.rs
@@ -3308,6 +3308,87 @@ impl WorldStore {
         Ok(out)
     }
 
+    /// **The relationships that held as of a past generation** — the historical
+    /// half of `KIRRA-WM-ADJUDICATION-PRECEDENCE-001`.
+    ///
+    /// A promotion later withdrawn is gone from the CURRENT projection, and it
+    /// must still be visible at the coordinate where it held — otherwise the
+    /// ruling would not merely reorder the present, it would erase the past.
+    ///
+    /// # Folded from EMPTY, and from the LOG
+    ///
+    /// Both halves matter and each has a wrong version that compiles.
+    ///
+    /// From the **log**, not `relationships_projection`: that table is a cache
+    /// of one point on the temporal surface — latest known — and every other
+    /// point has to be replayed. `WorldStore::identity_view_at` carries the same
+    /// note for identity, and relationships are not an exception to it.
+    ///
+    /// From **empty**, not from the stored rows.
+    /// [`WorldStore::fold_relationship_range`] seeds from the projection because
+    /// an incremental fold's withdrawal sweep needs to know what it is
+    /// withdrawing. Seeding a HISTORICAL fold that way would start it from
+    /// today's state and apply an old prefix on top — leaving every relationship
+    /// promoted after the cut already present, which is precisely what this
+    /// query exists to prevent, arriving through the one line that looks like
+    /// reuse.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::CorruptRelationshipProjectionRow`] if a log row cannot be
+    /// decoded, or [`StoreError::Sqlite`] on storage failure.
+    pub fn relationships_in_effect_at(
+        &self,
+        at_generation: i64,
+    ) -> Result<
+        std::collections::BTreeMap<
+            relationship_projection::PairKey,
+            relationship_projection::ProjectedRelationship,
+        >,
+        StoreError,
+    > {
+        let mut acc = std::collections::BTreeMap::new();
+        let mut stmt = self.conn.prepare(
+            "SELECT generation, writer_class, claim_status, kind, predicate,
+                    subject, object, payload, payload_schema
+             FROM world_events
+             WHERE generation <= ?1 AND claim_status = 'confirmed' AND kind = ?2
+             ORDER BY generation ASC",
+        )?;
+        let mut rows = stmt.query(params![
+            at_generation,
+            same_as_adjudication_record::SAME_AS_ADJUDICATION_KIND
+        ])?;
+        while let Some(r) = rows.next()? {
+            let generation: i64 = r.get(0)?;
+            let writer_class: String = r.get(1)?;
+            let claim_status: String = r.get(2)?;
+            let kind: String = r.get(3)?;
+            let predicate: Option<String> = r.get(4)?;
+            let subject: String = r.get(5)?;
+            let object: Option<String> = r.get(6)?;
+            let payload: String = r.get(7)?;
+            let payload_schema: i64 = r.get(8)?;
+            let decision = same_as_adjudication_record::decode_same_as_adjudication(
+                &same_as_adjudication_record::StoredAdjudicationRow {
+                    writer_class: writer_class.as_str(),
+                    claim_status: claim_status.as_str(),
+                    kind: kind.as_str(),
+                    predicate: predicate.as_deref(),
+                    subject: subject.as_str(),
+                    object: object.as_deref(),
+                    payload: payload.as_str(),
+                    payload_schema,
+                },
+            )
+            .map_err(|e| StoreError::CorruptRelationshipProjectionRow {
+                detail: format!("generation {generation}: {e}"),
+            })?;
+            relationship_projection::fold_same_as_adjudication(&mut acc, &decision, generation);
+        }
+        Ok(acc)
+    }
+
     /// A digest over the relationship projection, in key order.
     ///
     /// # Errors

--- a/crates/kirra-world-store/src/relationship_projection.rs
+++ b/crates/kirra-world-store/src/relationship_projection.rs
@@ -98,7 +98,7 @@ use std::collections::BTreeMap;
 
 use kirra_world::observation::DomainInstant;
 use kirra_world::reference::EntityId;
-use kirra_world::same_as_adjudication::Outcome;
+use kirra_world::same_as_adjudication::leaves_pair_related;
 use kirra_world::same_as_candidate::CandidatePair;
 
 use crate::same_as_adjudication_record::StoredAdjudication;
@@ -204,28 +204,32 @@ pub fn fold_same_as_adjudication(
     generation: i64,
 ) {
     let key = pair_key(&decision.pair);
-    // Exhaustive, no wildcard: a new `Outcome` variant must be a COMPILE error
-    // here rather than silently taking whichever arm a `_` fell into. Adding
-    // one is a ruling about what it does to a standing promotion.
-    match decision.outcome {
-        Outcome::Promoted => {
-            acc.insert(
-                key,
-                ProjectedRelationship {
-                    pair: decision.pair.clone(),
-                    decided_generation: generation,
-                    candidate_observation_id: decision.candidate_observation_id.clone(),
-                    adjudicator: decision.adjudicator.clone(),
-                    decided_at: decision.decided_at,
-                },
-            );
-        }
-        // Both WITHDRAW a standing promotion, and on a pair that was never
-        // promoted both are no-ops. See the module docs for why `Unresolved`
-        // is a withdrawal rather than an abstention.
-        Outcome::Rejected | Outcome::Unresolved => {
-            acc.remove(&key);
-        }
+    // THE RULE IS NOT WRITTEN HERE. `leaves_pair_related` is
+    // `KIRRA-WM-ADJUDICATION-PRECEDENCE-001`'s single definition, in the domain
+    // crate, and this fold calls it rather than matching on `Outcome` itself.
+    //
+    // That indirection is the whole point and it is not stylistic. Until the
+    // ruling, this fold matched `Outcome` here while
+    // `same_as_adjudication::confirmed_relations` matched it there — and the two
+    // disagreed, one saying the latest decision governs and the other saying any
+    // historical promotion confirms forever. Two deterministic readings of one
+    // operator history. A shared predicate makes that particular drift
+    // impossible rather than merely tested for; the conformance corpus covers
+    // the ORDERING half, which cannot be shared because one side folds
+    // incrementally and the other walks a whole history.
+    if leaves_pair_related(decision.outcome) {
+        acc.insert(
+            key,
+            ProjectedRelationship {
+                pair: decision.pair.clone(),
+                decided_generation: generation,
+                candidate_observation_id: decision.candidate_observation_id.clone(),
+                adjudicator: decision.adjudicator.clone(),
+                decided_at: decision.decided_at,
+            },
+        );
+    } else {
+        acc.remove(&key);
     }
 }
 

--- a/crates/kirra-world-store/src/semantics.rs
+++ b/crates/kirra-world-store/src/semantics.rs
@@ -265,7 +265,7 @@ pub const SEMANTICS: &[RuleSpec] = &[
         rule: RuleId::RelationshipFold,
         version: 1,
         corpus_digest: "db4975d3adc118885e0c180c58ac45311272df617e0b9f00333571b14cff3b95",
-        source_pin: "e82c8a546104d622f71bb2c12e63670ad4c8a0733ac02eb88e2c7138b991b6b8",
+        source_pin: "ecdeeb08a7d7822479342150529ef99f095791294e7c5acca5fad8d103be4525",
         source_file: "crates/kirra-world-store/src/relationship_projection.rs",
         span: "relationship_fold",
     },

--- a/crates/kirra-world-store/tests/same_as_promotion.rs
+++ b/crates/kirra-world-store/tests/same_as_promotion.rs
@@ -166,8 +166,12 @@ fn resolved(s: &WorldStore, id: &str) -> ResolutionOutcome {
 /// here asserts that a module is reachable.
 #[test]
 fn a_confirmed_same_as_changes_what_b_resolves_to() {
-    let promoted = promote_confirmed_same_as(&[decide(&candidate("a", "b"), Outcome::Promoted, 5)])
-        .expect("promotion");
+    let promoted = promote_confirmed_same_as(&numbered([decide(
+        &candidate("a", "b"),
+        Outcome::Promoted,
+        5,
+    )]))
+    .expect("promotion");
     assert_eq!(promoted.len(), 1, "one confirmed pair, one merge");
 
     // WITHOUT the promotion: `b` is its own entity.
@@ -193,10 +197,10 @@ fn a_confirmed_same_as_changes_what_b_resolves_to() {
 /// and `Outcome` would be decoration.
 #[test]
 fn a_rejected_pair_does_not_move_identity() {
-    let promoted = promote_confirmed_same_as(&[
+    let promoted = promote_confirmed_same_as(&numbered([
         decide(&candidate("c", "d"), Outcome::Rejected, 5),
         decide(&candidate("e", "f"), Outcome::Unresolved, 6),
-    ])
+    ]))
     .expect("promotion");
     assert!(
         promoted.is_empty(),
@@ -219,10 +223,18 @@ fn a_rejected_pair_does_not_move_identity() {
 /// requirement as a test rather than a comment.
 #[test]
 fn promotion_does_not_depend_on_which_side_was_named_first() {
-    let one = promote_confirmed_same_as(&[decide(&candidate("a", "b"), Outcome::Promoted, 5)])
-        .expect("promotion");
-    let other = promote_confirmed_same_as(&[decide(&candidate("b", "a"), Outcome::Promoted, 5)])
-        .expect("promotion");
+    let one = promote_confirmed_same_as(&numbered([decide(
+        &candidate("a", "b"),
+        Outcome::Promoted,
+        5,
+    )]))
+    .expect("promotion");
+    let other = promote_confirmed_same_as(&numbered([decide(
+        &candidate("b", "a"),
+        Outcome::Promoted,
+        5,
+    )]))
+    .expect("promotion");
     assert_eq!(
         one, other,
         "canonical pairing must make the order irrelevant"
@@ -244,7 +256,7 @@ fn the_promoted_merge_cites_the_adjudications_evidence() {
     )
     .expect("adjudication");
 
-    let promoted = promote_confirmed_same_as(&[adj]).expect("promotion");
+    let promoted = promote_confirmed_same_as(&numbered([adj])).expect("promotion");
     let IdentityAdjudication::Merge(m) = &promoted[0] else {
         panic!("expected a merge, got {:?}", promoted[0]);
     };
@@ -268,10 +280,10 @@ fn the_promoted_merge_cites_the_adjudications_evidence() {
 #[test]
 fn re_affirming_a_pair_keeps_the_earliest_beginning() {
     let c = candidate("a", "b");
-    let promoted = promote_confirmed_same_as(&[
+    let promoted = promote_confirmed_same_as(&numbered([
         decide(&c, Outcome::Promoted, 90),
         decide(&c, Outcome::Promoted, 20),
-    ])
+    ]))
     .expect("promotion");
 
     assert_eq!(promoted.len(), 1, "one pair, one merge: {promoted:?}");
@@ -282,120 +294,304 @@ fn re_affirming_a_pair_keeps_the_earliest_beginning() {
     );
 }
 
-/// **A pair promoted and then rejected is STILL promoted today.** Recorded, not
-/// endorsed.
+/// **A pair promoted and then rejected is NOT promoted** — the ruling, at 2c.
 ///
-/// `confirmed_relations` filters `is_confirmed()` across every record and
-/// applies no precedence, so one `Promoted` anywhere in the history confirms the
-/// pair however many rejections follow. Box 2c consumes that verdict rather than
-/// re-deriving it — whether a re-adjudicated pair stays confirmed is box 2b's
-/// question, and answering it here would create a second answer that drifts.
+/// This test used to assert the opposite, under the name
+/// `promoted_then_rejected_still_promotes_today_which_is_a_ruling_2b_owes`. It
+/// existed to record a behaviour nobody endorsed and to fail the moment someone
+/// ruled, so the ruling could not be made by accident. It has now done exactly
+/// that: `KIRRA-WM-ADJUDICATION-PRECEDENCE-001` adopted latest-decision-wins,
+/// this test broke, and its expectation was changed deliberately rather than
+/// deleted to make a build green.
 ///
-/// This test exists so the behaviour cannot change by accident before someone
-/// rules on it. If last-write-wins is the intent, this test is the one that
-/// should fail first, and it should be changed deliberately in 2b.
-///
-/// **Box 5a has since answered the same question the other way for its own
-/// projection** — see
-/// `the_two_precedence_rules_disagree_and_only_one_has_a_production_consumer`
-/// immediately below, which pins the disagreement rather than leaving it to be
-/// discovered by whoever wires the next consumer.
+/// 2c gets this for free — `promote_confirmed_same_as` asks
+/// `promotions_in_effect` rather than filtering on `Outcome::Promoted` itself,
+/// which is why one ruling moved both layers.
 #[test]
-fn promoted_then_rejected_still_promotes_today_which_is_a_ruling_2b_owes() {
+fn a_promotion_the_operator_withdrew_does_not_reach_the_identity_path() {
     let c = candidate("a", "b");
-    let promoted = promote_confirmed_same_as(&[
+    let promoted = promote_confirmed_same_as(&numbered([
         decide(&c, Outcome::Promoted, 10),
         decide(&c, Outcome::Rejected, 20),
-    ])
+    ]))
     .expect("promotion");
 
-    assert_eq!(
-        promoted.len(),
-        1,
-        "today a later rejection does not un-confirm: {promoted:?}"
+    assert!(
+        promoted.is_empty(),
+        "the newest authorized decision governs, so no merge is emitted: {promoted:?}"
     );
 }
 
-/// **The two precedence rules over `same_as` decisions DISAGREE.** Recorded,
-/// not endorsed — and measured, not inferred.
+/// **A withdrawal RESETS when the identity began.**
 ///
-/// Two rules now read the same adjudication history and answer differently
-/// about a pair that was promoted and later rejected:
+/// The second half of the ruling, and the one a latest-decision-wins rule does
+/// not settle on its own. `promote_confirmed_same_as` dates an identity from
+/// the EARLIEST promotion in its current unbroken run — so re-affirming a pair
+/// does not move its start date, while a rejection followed by a fresh
+/// promotion does.
 ///
-/// | Rule | Promoted-then-rejected | Consumer |
-/// |---|---|---|
-/// | `confirmed_relations` (2c, pure) | **still confirmed** — no precedence, one `Promoted` anywhere confirms | tests only |
-/// | `relationship_projection::fold_all` (5a) | **withdrawn** — last decision wins | `relationships_projection` |
-///
-/// # This is latent, not live, and the distinction is load-bearing
-///
-/// Stating it precisely because "two projections disagree" would be a much
-/// more serious claim than what is actually true, and the difference was
-/// established by running it rather than by reading:
-///
-/// * `promote_confirmed_same_as` has **no production caller** — every call site
-///   in the tree is a test.
-/// * The entity fold consumes `kind = "identity_adjudication"`, while
-///   `WorldStore::adjudicate_same_as` writes `kind = "same_as_adjudication"`.
-///   Different kinds, so the store's entity projection never sees a `same_as`
-///   decision at all: after a promote-then-reject, `resolve` answers `Unknown`,
-///   not a stale merge.
-///
-/// So no shipped path today can be asked the same question twice and get two
-/// answers. What exists is a **trap for the next step**: the typed `Related`
-/// query has to choose a source of truth, and the two available sources do not
-/// agree. Choosing by accident is exactly how the second answer that drifts
-/// gets created — which is the hazard 2c's own docs name and decline to create.
-///
-/// This test fails the moment either rule changes, so whoever rules on 2b's
-/// owed question has to confront both halves at once instead of one.
+/// Without this, "earliest promotion wins" would reach back across a withdrawal
+/// and date the identity from a decision the operator had already un-made.
 #[test]
-fn the_two_precedence_rules_disagree_and_only_one_has_a_production_consumer() {
+fn a_re_promotion_after_a_withdrawal_is_dated_from_the_new_run() {
+    let c = candidate("a", "b");
+    let promoted = promote_confirmed_same_as(&numbered([
+        decide(&c, Outcome::Promoted, 10),
+        decide(&c, Outcome::Rejected, 20),
+        decide(&c, Outcome::Promoted, 30),
+        decide(&c, Outcome::Promoted, 40),
+    ]))
+    .expect("promotion");
+
+    assert_eq!(promoted.len(), 1);
+    let IdentityAdjudication::Merge(merge) = &promoted[0] else {
+        panic!("expected a merge, got {:?}", promoted[0]);
+    };
+    assert_eq!(
+        merge.at(),
+        at(30),
+        "the identity began at the first promotion of the CURRENT run, not the \
+         withdrawn one at 10 and not the re-affirmation at 40"
+    );
+}
+
+/// Persist one candidate, then promote it and reject it, through the REAL doors.
+///
+/// Returns the generations of the two adjudications, which are the T1 and T2
+/// coordinates the historical query is asked at. Taken from the store rather
+/// than counted, because generations are not dense once compaction has run.
+/// Attach generations in recorded order.
+///
+/// Every call reads as a HISTORY rather than a bag now, which is the visible
+/// consequence of `KIRRA-WM-ADJUDICATION-PRECEDENCE-001`: the order decisions
+/// were recorded in is part of the question, so a caller cannot ask without
+/// saying what that order was.
+fn numbered(
+    records: impl IntoIterator<Item = SameAsAdjudication>,
+) -> Vec<(i64, SameAsAdjudication)> {
+    records
+        .into_iter()
+        .enumerate()
+        .map(|(i, a)| (i as i64 + 1, a))
+        .collect()
+}
+
+fn promote_then_reject(store: &mut WorldStore) -> (i64, i64) {
+    use kirra_world::observation::{Confidence, ConfidenceBasis, SourceClass};
+    use kirra_world::same_as_candidate::{MatcherIdentity, SameAsCandidate};
+    use kirra_world_store::candidate_record::CandidateRow;
+    use kirra_world_store::same_as_adjudication_record::SameAsAdjudicationRequest;
+
+    let cand_event = EventId::new("cand-ev-1").expect("id");
+    let cand_obs = ObservationId::new("cand-obs-1").expect("id");
+    let proposal = SameAsCandidate::propose(
+        CandidatePair::new(eid("a"), eid("b")).expect("distinct"),
+        MatcherIdentity::new("world-ingest", "exact-identifier", "1.0.0").expect("matcher"),
+        Confidence::new(None, ConfidenceBasis::Unspecified, None).expect("confidence"),
+        vec![obs(OBS)],
+    )
+    .expect("candidate");
+    store
+        .append_same_as_candidate(
+            &CandidateRow {
+                event_id: &cand_event,
+                observation_id: &cand_obs,
+                txn_time_ms: 1,
+                valid_from_ms: 1,
+                source: "world-ingest",
+                source_version: "1.0.0",
+            },
+            &proposal,
+        )
+        .expect("persist the candidate");
+
+    let mut decide_through_the_door = |tag: &str, outcome: Outcome, ms: u64| -> i64 {
+        let event_id = EventId::new(format!("adj-ev-{tag}")).expect("id");
+        let observation_id = ObservationId::new(format!("adj-obs-{tag}")).expect("id");
+        store
+            .adjudicate_same_as(&SameAsAdjudicationRequest {
+                event_id: &event_id,
+                observation_id: &observation_id,
+                candidate_observation_id: "cand-obs-1",
+                cited: vec![obs(OBS)],
+                authority: AdjudicationAuthority::new(SourceClass::Operator, "console-operator")
+                    .expect("authority"),
+                outcome,
+                decided_at: at(ms),
+                txn_time_ms: ms as i64,
+                source: "operator-console",
+                source_version: "1.0.0",
+            })
+            .expect("an operator judging a persisted candidate");
+        store.head_generation_for_test().expect("head")
+    };
+
+    let t1 = decide_through_the_door("1", Outcome::Promoted, 10);
+    let t2 = decide_through_the_door("2", Outcome::Rejected, 20);
+    (t1, t2)
+}
+
+/// **THE CONFORMANCE PROOF — both precedence rules, one answer.**
+///
+/// `KIRRA-WM-ADJUDICATION-PRECEDENCE-001` replaced a contradiction. Until it
+/// was ruled, two deterministic readings of one operator history disagreed:
+///
+/// | Rule | Promoted-then-rejected (before the ruling) |
+/// |---|---|
+/// | `confirmed_relations` (2c, pure) | still confirmed — one `Promoted` anywhere confirmed forever |
+/// | `relationship_projection::fold_all` (5a) | withdrawn — the latest decision governs |
+///
+/// The ruling adopted the second reading and made both sides derive from it:
+/// the EFFECT half is `leaves_pair_related`, called by both, so it cannot drift
+/// at all. The ORDERING half cannot be shared — one side folds incrementally
+/// and the other walks a whole history — so it is proven here instead, over a
+/// corpus chosen so each row discriminates something.
+///
+/// This test replaces the pin that used to assert the two DISAGREED. That pin
+/// did its job: it made whoever ruled confront both halves at once.
+#[test]
+fn both_precedence_rules_agree_on_every_history_in_the_corpus() {
     use kirra_world::same_as_adjudication::confirmed_relations;
     use kirra_world_store::relationship_projection;
     use kirra_world_store::same_as_adjudication_record::StoredAdjudication;
 
-    let c = candidate("a", "b");
-    let history = [
-        decide(&c, Outcome::Promoted, 10),
-        decide(&c, Outcome::Rejected, 20),
+    // Each row is (label, the decisions in RECORDED order, does the pair end up
+    // related). The `related` column IS the ruling, written as data.
+    let corpus: &[(&str, &[Outcome], bool)] = &[
+        ("promoted", &[Outcome::Promoted], true),
+        ("rejected", &[Outcome::Rejected], false),
+        ("unresolved", &[Outcome::Unresolved], false),
+        // The historic disagreement, now agreed.
+        (
+            "promoted_then_rejected",
+            &[Outcome::Promoted, Outcome::Rejected],
+            false,
+        ),
+        (
+            "promoted_then_unresolved",
+            &[Outcome::Promoted, Outcome::Unresolved],
+            false,
+        ),
+        // Order matters, and this row is what proves it: the same two decisions
+        // as the row above, reversed, give the opposite answer. A rule that
+        // ignored order entirely would answer both identically.
+        (
+            "rejected_then_promoted",
+            &[Outcome::Rejected, Outcome::Promoted],
+            true,
+        ),
+        (
+            "promoted_rejected_repromoted",
+            &[Outcome::Promoted, Outcome::Rejected, Outcome::Promoted],
+            true,
+        ),
+        (
+            "promoted_twice",
+            &[Outcome::Promoted, Outcome::Promoted],
+            true,
+        ),
+        (
+            "promoted_rejected_then_unresolved",
+            &[Outcome::Promoted, Outcome::Rejected, Outcome::Unresolved],
+            false,
+        ),
     ];
 
-    // Rule 1 -- 2c's pure promotion path. No precedence.
-    assert_eq!(
-        confirmed_relations(&history).len(),
-        1,
-        "2c: one Promoted anywhere confirms the pair, however many rejections follow"
-    );
+    let c = candidate("a", "b");
+    for (label, outcomes, expected_related) in corpus {
+        let history: Vec<SameAsAdjudication> = outcomes
+            .iter()
+            .enumerate()
+            .map(|(i, o)| decide(&c, *o, 10 + i as u64))
+            .collect();
+        let numbered: Vec<(i64, &SameAsAdjudication)> = history
+            .iter()
+            .enumerate()
+            .map(|(i, a)| (i as i64 + 1, a))
+            .collect();
 
-    // Rule 2 -- 5a's fold, over the SAME decisions in the same order.
-    let stored: Vec<StoredAdjudication> = history
-        .iter()
-        .map(|a| StoredAdjudication {
-            pair: a.pair().clone(),
-            outcome: a.outcome(),
-            candidate_observation_id: a.candidate_observation_id().as_str().to_owned(),
-            adjudicator: a.authority().adjudicator().to_owned(),
-            decided_at: a.decided_at(),
-        })
-        .collect();
-    let folded = relationship_projection::fold_all(
-        stored.iter().enumerate().map(|(i, d)| (i as i64 + 1, d)),
-    );
+        // Side 1 -- the domain's whole-history walk.
+        let domain_related = !confirmed_relations(numbered.iter().copied()).is_empty();
+
+        // Side 2 -- the store's incremental fold, over the SAME order.
+        let stored: Vec<StoredAdjudication> = history
+            .iter()
+            .map(|a| StoredAdjudication {
+                pair: a.pair().clone(),
+                outcome: a.outcome(),
+                candidate_observation_id: a.candidate_observation_id().as_str().to_owned(),
+                adjudicator: a.authority().adjudicator().to_owned(),
+                decided_at: a.decided_at(),
+            })
+            .collect();
+        let folded = relationship_projection::fold_all(
+            stored.iter().enumerate().map(|(i, d)| (i as i64 + 1, d)),
+        );
+        let store_related = !folded.is_empty();
+
+        // Both must match the RULING, not merely each other. Asserting only
+        // agreement would pass if both sides were wrong in the same direction,
+        // which is exactly what a shared helper makes easy to do.
+        assert_eq!(
+            domain_related, *expected_related,
+            "{label}: the domain rule disagrees with the ruling"
+        );
+        assert_eq!(
+            store_related, *expected_related,
+            "{label}: the store fold disagrees with the ruling"
+        );
+        assert_eq!(
+            domain_related, store_related,
+            "{label}: the two rules disagree with each other"
+        );
+    }
+}
+
+/// **T1/T2 — the ruling changes the present without erasing the past.**
+///
+/// The acceptance shape the ruling was scoped to:
+///
+/// ```text
+///   T1  Promote(A,B)          -> current: related
+///   T2  Reject(A,B)           -> current: NOT related  (the ruled precedence)
+///       query as of T1        -> STILL related         (history is intact)
+/// ```
+///
+/// The third line is the one that makes the ruling honest rather than merely
+/// decisive. Precedence reorders what holds NOW; a promotion that genuinely
+/// held between T1 and T2 must still be visible at a coordinate inside that
+/// window, or the ruling would be rewriting the record instead of reading it.
+#[test]
+fn precedence_governs_the_present_and_leaves_the_past_intact() {
+    let path = tmp("t1-t2");
+    let mut store = WorldStore::open(&path).expect("open");
+    let (t1, t2) = promote_then_reject(&mut store);
+
+    // --- the present, under the ruled precedence ------------------------
+    store.fold_relationship_projection().expect("fold");
     assert!(
-        folded.is_empty(),
-        "5a: the newest authorized decision governs, so the pair is withdrawn: {folded:?}"
+        store
+            .load_relationship_projection()
+            .expect("load")
+            .is_empty(),
+        "T2: the newest authorized decision governs, so the pair is withdrawn"
     );
 
-    // The disagreement itself, asserted rather than left implicit in the two
-    // numbers above -- so the failure message says what is wrong, not just that
-    // a count moved.
-    assert_ne!(
-        confirmed_relations(&history).len(),
-        folded.len(),
-        "if these ever agree, one of the two precedence rules changed; retire this \
-         pin deliberately rather than deleting it to make a build green"
+    // --- the past, unchanged --------------------------------------------
+    let at_t1 = store.relationships_in_effect_at(t1).expect("historical");
+    assert_eq!(
+        at_t1.len(),
+        1,
+        "as of T1 the promotion held, and the ruling must not erase that"
     );
+    let at_t2 = store.relationships_in_effect_at(t2).expect("historical");
+    assert!(
+        at_t2.is_empty(),
+        "as of T2 the rejection had landed, so the pair is withdrawn there too"
+    );
+
+    drop(store);
+    let _ = std::fs::remove_file(&path);
 }
 
 // ---------------------------------------------------------------------------
@@ -418,10 +614,10 @@ fn the_two_precedence_rules_disagree_and_only_one_has_a_production_consumer() {
 #[test]
 fn a_cross_domain_re_affirmation_is_refused_rather_than_ordered() {
     let c = candidate("a", "b");
-    let err = promote_confirmed_same_as(&[
+    let err = promote_confirmed_same_as(&numbered([
         decide_on(&c, Outcome::Promoted, 90, ClockDomain::System),
         decide_on(&c, Outcome::Promoted, 20, ClockDomain::Boundary),
-    ])
+    ]))
     .expect_err("two clock domains must not be ordered");
 
     let AdjudicationError::PromotionDomainsDiffer { pair } = err else {
@@ -444,10 +640,10 @@ fn a_cross_domain_re_affirmation_is_refused_rather_than_ordered() {
 #[test]
 fn the_only_thing_that_refuses_it_is_only_the_domains() {
     let c = candidate("a", "b");
-    let promoted = promote_confirmed_same_as(&[
+    let promoted = promote_confirmed_same_as(&numbered([
         decide_on(&c, Outcome::Promoted, 90, ClockDomain::Boundary),
         decide_on(&c, Outcome::Promoted, 20, ClockDomain::Boundary),
-    ])
+    ]))
     .expect("one clock domain orders fine");
 
     assert_eq!(promoted.len(), 1, "one pair, one merge: {promoted:?}");
@@ -482,8 +678,9 @@ fn feeding_the_same_adjudications_in_either_order_yields_the_same_merges() {
     let ab = decide(&candidate("a", "b"), Outcome::Promoted, 5);
     let cd = decide(&candidate("c", "d"), Outcome::Promoted, 7);
 
-    let forward = promote_confirmed_same_as(&[ab.clone(), cd.clone()]).expect("promotion");
-    let reversed = promote_confirmed_same_as(&[cd, ab]).expect("promotion");
+    let forward =
+        promote_confirmed_same_as(&numbered([ab.clone(), cd.clone()])).expect("promotion");
+    let reversed = promote_confirmed_same_as(&numbered([cd, ab])).expect("promotion");
 
     assert_eq!(forward.len(), 2, "two pairs, two merges: {forward:?}");
     assert_eq!(

--- a/crates/kirra-world/src/adjudication.rs
+++ b/crates/kirra-world/src/adjudication.rs
@@ -105,7 +105,7 @@ use crate::observation::DomainInstant;
 use crate::reference::EntityId;
 use crate::reference::ObservationId;
 // Box 2c: the promotion boundary consumes 2b's verdict and 2a's canonical pair.
-use crate::same_as_adjudication::{confirmed_relations, SameAsAdjudication};
+use crate::same_as_adjudication::{promotions_in_effect, SameAsAdjudication};
 use crate::same_as_candidate::CandidatePair;
 use core::cmp::Ordering;
 
@@ -974,12 +974,12 @@ impl IdentityAdjudication {
 ///   cross-domain comparison and this refuses with it: picking one would be
 ///   confidently wrong about when an identity began.
 pub fn promote_confirmed_same_as(
-    adjudications: &[SameAsAdjudication],
+    history: &[(i64, SameAsAdjudication)],
 ) -> Result<Vec<IdentityAdjudication>, AdjudicationError> {
-    // BTreeSet iteration order is the canonical pair order, so WHICH merges come
-    // out, in what order, and in which direction do not depend on how
-    // `adjudications` is arranged. The citation order INSIDE a merge does --
-    // it is first-seen across the slice.
+    // BTreeMap iteration order is the canonical pair order, so WHICH merges come
+    // out, in what order, and in which direction do not depend on how `history`
+    // is arranged. The citation order INSIDE a merge does -- it is first-seen
+    // across the pair's in-effect run.
     //
     // That asymmetry is deliberate, not an oversight. `Justification` preserves
     // recorded order on purpose ("a constructor that tidied it would be editing
@@ -988,26 +988,33 @@ pub fn promote_confirmed_same_as(
     // that the same log yield the same IDENTITY -- which entity resolves to
     // which -- and that half IS arrangement-independent. Citation order is
     // provenance, not identity.
-    let confirmed = confirmed_relations(adjudications);
-    let mut promoted = Vec::with_capacity(confirmed.len());
+    //
+    // `promotions_in_effect` is the authority on WHICH pairs and on WHICH
+    // promotions support them, under KIRRA-WM-ADJUDICATION-PRECEDENCE-001.
+    // Deliberately not re-derived here by filtering on `Outcome::Promoted`:
+    // that is exactly the second answer that drifted, and this layer asking 2b
+    // rather than restating it is what stops it drifting again.
+    let in_effect = promotions_in_effect(history.iter().map(|(g, a)| (*g, a)));
+    let mut promoted = Vec::with_capacity(in_effect.len());
 
-    for pair in &confirmed {
+    for (pair, run) in &in_effect {
         let mut cited: Vec<ObservationId> = Vec::new();
         let mut began: Option<DomainInstant> = None;
 
-        for a in adjudications
-            .iter()
-            .filter(|a| a.is_confirmed() && a.pair() == pair)
-        {
+        // The pair's UNBROKEN run of promotions since the last withdrawal, not
+        // every promotion in history. A promotion an operator later withdrew
+        // does not support the current identity, so neither does its evidence
+        // and neither does its date.
+        for a in run {
             for observation in a.cited() {
                 if !cited.contains(observation) {
                     cited.push(observation.clone());
                 }
             }
-            // EARLIEST promotion wins: re-affirming a pair does not move when it
-            // became identity. Compared through `DomainInstant::compare`, which
-            // refuses across clock domains rather than ordering by raw
-            // milliseconds.
+            // EARLIEST promotion in the current run wins: re-affirming a pair
+            // does not move when it became identity, while a withdrawal resets
+            // it. Compared through `DomainInstant::compare`, which refuses
+            // across clock domains rather than ordering by raw milliseconds.
             began = Some(match began {
                 None => a.decided_at(),
                 Some(prev) => match a.decided_at().compare(&prev) {
@@ -1022,8 +1029,8 @@ pub fn promote_confirmed_same_as(
             });
         }
 
-        // Unreachable: `confirmed_relations` only yields pairs some record
-        // promoted. Skipped rather than unwrapped so a future change to 2b's
+        // Unreachable: `promotions_in_effect` yields only pairs whose run is
+        // non-empty. Skipped rather than unwrapped so a future change to 2b's
         // predicate degrades to "promotes nothing" instead of a panic in the
         // identity path.
         let Some(at) = began else { continue };

--- a/crates/kirra-world/src/same_as_adjudication.rs
+++ b/crates/kirra-world/src/same_as_adjudication.rs
@@ -45,7 +45,7 @@
 //! Rulings: `KIRRA-WM-CLUSTERING-001`, `KIRRA-WM-TRANSITIVITY-001`,
 //! `KIRRA-WM-PROMOTION-001`.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 use crate::observation::{DomainInstant, SourceClass};
 use crate::reference::ObservationId;
@@ -287,30 +287,172 @@ impl SameAsAdjudication {
     }
 }
 
-/// The relations **confirmed** by a set of adjudications.
+// PRECEDENCE-RULE-BEGIN
+//
+// `KIRRA-WM-ADJUDICATION-PRECEDENCE-001`. Everything between these markers is
+// the ONE definition of which adjudication governs a pair. Both the
+// whole-history view below and `kirra_world_store::relationship_projection`'s
+// incremental fold call into it, so the two cannot answer differently.
+
+/// **Does the decision in effect leave the pair related?**
 ///
-/// Promoted pairs only, deduplicated. There is deliberately no closure sibling:
+/// The effect half of `KIRRA-WM-ADJUDICATION-PRECEDENCE-001`, and the one place
+/// it is written. The store's incremental fold calls this rather than matching
+/// on [`Outcome`] itself — which is what stops the two sides drifting, as they
+/// had by 5c: this layer said *one `Promoted` anywhere confirms forever* while
+/// the projection said *the latest decision governs*, and both claimed to be
+/// reading the same operator history.
+///
+/// Exhaustive with no wildcard, deliberately: a new [`Outcome`] variant becomes
+/// a COMPILE error here, in one place, instead of silently taking whichever arm
+/// a `_` fell into in two.
+#[must_use]
+pub fn leaves_pair_related(outcome: Outcome) -> bool {
+    match outcome {
+        Outcome::Promoted => true,
+        // Both WITHDRAW. `Unresolved` withdrawing rather than abstaining is the
+        // choice box 5a recorded: the log does not say which the operator
+        // meant, so abstaining would make the answer depend on a distinction
+        // nothing wrote down while continuing to assert an identity the newest
+        // authorized decision declined to affirm.
+        Outcome::Rejected | Outcome::Unresolved => false,
+    }
+}
+
+/// **The promotions currently supporting each related pair.**
+///
+/// The ordering half of `KIRRA-WM-ADJUDICATION-PRECEDENCE-001`: decisions are
+/// applied in **generation** order, and a pair is related when its most recent
+/// run of decisions since the last withdrawal contains at least one promotion.
+///
+/// Only currently-related pairs appear. The `Vec` is that pair's **unbroken run
+/// of promotions since the last withdrawal**, in generation order — which is
+/// what lets a caller answer *when did this begin* and *on what evidence*
+/// without walking the history a second time under a different rule.
+///
+/// # Two questions, one walk
+///
+/// *Which pairs are related* is decided by the latest decision. *When the
+/// relation began* is the earliest promotion in the CURRENT run — so
+/// re-affirming a pair does not move its start date, while a rejection resets
+/// it. Both fall out of one pass, which is the point: the alternative is two
+/// passes under two rules that can disagree, and that is the defect this ruling
+/// exists to close.
+///
+/// Evidence follows the same line. A promotion that was later withdrawn does
+/// not support the current relation, so its citations are dropped when the run
+/// resets — citing them would be citing evidence for a decision an operator
+/// un-made.
+///
+/// # Why generation and not `decided_at`
+///
+/// `decided_at` is on the record and is NOT the precedence key. That is
+/// surprising enough to justify, and the reasons are of three different kinds —
+/// worth separating, because one is an implementation constraint rather than a
+/// semantic argument and should not be dressed as one.
+///
+/// **Semantic.** An adjudication is an ACT on the record by an authorized
+/// party, not an observation of the world. `crate::projection`'s claim fold
+/// orders on valid time precisely because a claim is about the world — when the
+/// fact held matters more than when we heard it. A decision is the opposite: an
+/// operator cannot retroactively un-make a decision already recorded and acted
+/// upon, so a backdated decision arriving today must not silently override this
+/// morning's.
+///
+/// **Totality.** Generation is a total order and always present.
+/// [`DomainInstant`] refuses cross-domain comparison — correctly — so a
+/// `decided_at` rule would have to refuse a pair whose decisions sit on
+/// different clocks, turning an ordinary question into an error.
+///
+/// **Implementation, stated as such.** An incremental fold requires the
+/// ordering key to BE the fold order. Under `decided_at`, an out-of-order
+/// arrival would change the answer for a pair already folded, forcing a rebuild
+/// from generation 0 every time — so `decided_at` precedence is not merely a
+/// different rule, it is incompatible with the projection's design.
+///
+/// # The limitation this accepts, recorded rather than hidden
+///
+/// **AOU-ADJUDICATION-ORDER-001.** An adjudication reaching the log out of
+/// decision order — an offline operator console syncing later — takes
+/// precedence over decisions recorded before it, even though it was decided
+/// earlier. A deployment that queues decisions offline must either record them
+/// in decision order or accept that the record's order is the authority. A real
+/// cost of the rule, not a defect in it.
+pub fn promotions_in_effect<'a, I>(
+    history: I,
+) -> BTreeMap<CandidatePair, Vec<&'a SameAsAdjudication>>
+where
+    I: IntoIterator<Item = (i64, &'a SameAsAdjudication)>,
+{
+    let mut ordered: Vec<(i64, &'a SameAsAdjudication)> = history.into_iter().collect();
+    // Sorted rather than assumed: this is the whole-history entry point and a
+    // caller may hand it a log slice in any order. The store's fold takes its
+    // ordering from `ORDER BY generation ASC` instead, and the two agreeing on
+    // arbitrary histories is what the conformance corpus checks.
+    ordered.sort_by_key(|(generation, _)| *generation);
+
+    let mut runs: BTreeMap<CandidatePair, Vec<&'a SameAsAdjudication>> = BTreeMap::new();
+    for (_, decision) in ordered {
+        let run = runs.entry(decision.pair().clone()).or_default();
+        if leaves_pair_related(decision.outcome()) {
+            run.push(decision);
+        } else {
+            // The withdrawal resets the run. Kept as an EMPTY entry rather than
+            // removed, so the two states stay distinguishable inside this walk;
+            // the empty ones are dropped below.
+            run.clear();
+        }
+    }
+    runs.retain(|_, run| !run.is_empty());
+    runs
+}
+
+// PRECEDENCE-RULE-END
+
+/// The relations that **currently hold**.
+///
+/// Deduplicated, and governed by `KIRRA-WM-ADJUDICATION-PRECEDENCE-001`: a pair
+/// is related when the decision IN EFFECT for it is `Promoted`, not when any
+/// historical decision was.
+///
+/// # What changed, and why the old reading was wrong
+///
+/// This used to be `filter(is_confirmed)` across every record — one `Promoted`
+/// anywhere confirmed the pair however many rejections followed. That put it in
+/// direct contradiction with the relationship projection, which has always let
+/// the newest authorized decision govern. Two deterministic readings of one
+/// operator history cannot both be authoritative, and this was the wrong one:
+/// it made an operator's rejection unable to undo their own promotion.
+///
+/// There is deliberately no closure sibling:
 /// `KIRRA-WM-TRANSITIVITY-001` permits resolution (2c) to traverse accepted
 /// merges transitively, but forbids this layer from *emitting* the traversed
 /// relation as evidence. `A=B` and `B=C` yield two confirmed relations here,
 /// never three.
 #[must_use]
-pub fn confirmed_relations(adjudications: &[SameAsAdjudication]) -> BTreeSet<CandidatePair> {
-    adjudications
-        .iter()
-        .filter(|a| a.is_confirmed())
-        .map(|a| a.pair().clone())
-        .collect()
+pub fn confirmed_relations<'a, I>(history: I) -> BTreeSet<CandidatePair>
+where
+    I: IntoIterator<Item = (i64, &'a SameAsAdjudication)>,
+{
+    promotions_in_effect(history).into_keys().collect()
 }
 
-/// `Corroboration(n)` — **distinct confirmed relations**.
+/// `Corroboration(n)` — **distinct relations currently in effect**.
 ///
 /// Not adjudication records, and not candidate votes. Counting records would
 /// let re-adjudicating one pair inflate trust; counting votes would let a
 /// matcher do it, which `KIRRA-WM-PROMOTION-001` bars outright.
+///
+/// Under `KIRRA-WM-ADJUDICATION-PRECEDENCE-001` this counts relations that
+/// currently HOLD — a promoted-then-rejected pair contributes nothing. Counting
+/// "ever promoted" would let a withdrawn decision keep propping up a trust
+/// grade, which is the same inflation by a slower route.
 #[must_use]
-pub fn corroboration_count(adjudications: &[SameAsAdjudication]) -> usize {
-    confirmed_relations(adjudications).len()
+pub fn corroboration_count<'a, I>(history: I) -> usize
+where
+    I: IntoIterator<Item = (i64, &'a SameAsAdjudication)>,
+{
+    confirmed_relations(history).len()
 }
 
 #[cfg(test)]
@@ -319,6 +461,21 @@ mod tests {
     use crate::observation::{ClockDomain, Confidence, ConfidenceBasis};
     use crate::reference::EntityId;
     use crate::same_as_candidate::{MatcherIdentity, SameAsCandidate};
+
+    /// Attach generations in slice order — the order a log would have recorded
+    /// these decisions.
+    ///
+    /// Every test below reads as a HISTORY now rather than a bag, which is the
+    /// visible consequence of `KIRRA-WM-ADJUDICATION-PRECEDENCE-001`: the order
+    /// decisions were recorded in is part of the question, so a caller cannot
+    /// ask it without saying what that order was.
+    fn in_order(records: &[SameAsAdjudication]) -> Vec<(i64, &SameAsAdjudication)> {
+        records
+            .iter()
+            .enumerate()
+            .map(|(i, a)| (i as i64 + 1, a))
+            .collect()
+    }
 
     const OBS_A: &str = "01ARZ3NDEKTSV4RRFFQ69G5FAV";
     const OBS_B: &str = "01ARZ3NDEKTSV4RRFFQ69G5FAW";
@@ -425,7 +582,7 @@ mod tests {
         assert_eq!(rejection.cited(), &[obs(OBS_A)]);
         assert_eq!(c, before, "the candidate survives its own rejection");
         assert_eq!(c.support(), &[obs(OBS_A)], "and still carries its evidence");
-        assert_eq!(corroboration_count(&[rejection]), 0);
+        assert_eq!(corroboration_count(in_order(&[rejection])), 0);
     }
 
     /// **`A=B` and `B=C` do not produce `A=C`.**
@@ -441,7 +598,7 @@ mod tests {
             Outcome::Promoted,
             OBS_B,
         );
-        let confirmed = confirmed_relations(&[ab, bc]);
+        let confirmed = confirmed_relations(in_order(&[ab, bc]));
 
         assert_eq!(confirmed.len(), 2, "exactly the two promoted pairs");
         let ac = CandidatePair::new(ent("robot-a"), ent("robot-c")).expect("distinct");
@@ -460,7 +617,7 @@ mod tests {
         let third = decide(&c, Outcome::Promoted, OBS_C);
 
         assert_eq!(
-            corroboration_count(&[first, again, third]),
+            corroboration_count(in_order(&[first, again, third])),
             1,
             "three promotions of one relation is one corroborated relation"
         );
@@ -479,7 +636,7 @@ mod tests {
             decide(&cd, Outcome::Rejected, OBS_B),
             decide(&ef, Outcome::Unresolved, OBS_C),
         ];
-        assert_eq!(corroboration_count(&records), 1);
+        assert_eq!(corroboration_count(in_order(&records)), 1);
 
         // The candidates themselves still contribute nothing, whatever happened
         // to them — 2a's bar is not relaxed by 2b existing.
@@ -534,7 +691,7 @@ mod tests {
                 OBS_C,
             ),
         ];
-        let keys = confirmed_relations(&records);
+        let keys = confirmed_relations(in_order(&records));
         assert_eq!(
             keys.len(),
             3,
@@ -547,7 +704,7 @@ mod tests {
             );
         }
         // And the count agrees with the set: no path counts records instead.
-        assert_eq!(corroboration_count(&records), keys.len());
+        assert_eq!(corroboration_count(in_order(&records)), keys.len());
     }
 
     /// Pair order does not create a second confirmed relation, since `same_as`
@@ -564,6 +721,6 @@ mod tests {
             Outcome::Promoted,
             OBS_B,
         );
-        assert_eq!(corroboration_count(&[ab, ba]), 1);
+        assert_eq!(corroboration_count(in_order(&[ab, ba])), 1);
     }
 }

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -1082,6 +1082,71 @@ does not describe is how a residue disappears.
       exist to be loaded. The decoder's check stays because `decode_candidate` is
       public and total and a future non-SQLite backend has no v8 trigger.
 
+- [x] **`KIRRA-WM-ADJUDICATION-PRECEDENCE-001` — RULED 2026-08-21.** For a pair
+      with several adjudications over time, **the latest applicable decision
+      determines current identity**, ordered by GENERATION — the order the log
+      recorded them.
+
+      > `Promoted` establishes the relation. A later `Rejected` or `Unresolved`
+      > withdraws it. A relation dates from the earliest promotion in its
+      > current unbroken run, so re-affirming does not move its start and a
+      > withdrawal resets it. Historical queries still reproduce the state that
+      > held at an earlier coordinate.
+
+      **What it replaced was a contradiction, not a gap.**
+      `confirmed_relations` held that one `Promoted` anywhere confirmed a pair
+      forever; the relationship projection held that the newest decision
+      governs. Two deterministic readings of one operator history, and they
+      cannot both be authoritative. The projection's reading was adopted: the
+      alternative makes an operator's rejection unable to undo their own
+      promotion.
+
+      **Generation, not `decided_at`, and the reasons are of three kinds** —
+      separated because one is an implementation constraint and should not be
+      dressed as a semantic argument. *Semantic:* an adjudication is an ACT on
+      the record, not an observation of the world, so unlike a claim (where
+      valid time leads) a backdated decision must not override one already
+      recorded and acted upon. *Totality:* generation is total and always
+      present, while `DomainInstant` rightly refuses cross-domain comparison.
+      *Implementation:* an incremental fold requires the ordering key to BE the
+      fold order — under `decided_at`, an out-of-order arrival would force a
+      rebuild from generation 0 every time.
+
+      **`AOU-ADJUDICATION-ORDER-001`**, the cost accepted rather than hidden: a
+      decision reaching the log out of decision order — an offline console
+      syncing later — takes precedence over decisions recorded before it. A
+      deployment queueing decisions offline must record them in decision order
+      or accept that the record's order is the authority.
+
+      **Both sides now derive from it, by two different mechanisms**, because
+      the rule has two halves and only one can be shared. The EFFECT half is
+      `same_as_adjudication::leaves_pair_related`, called by the domain walk AND
+      by the store's fold — that drift is now impossible rather than tested for.
+      The ORDERING half cannot be shared (one side folds incrementally, the
+      other walks a whole history), so it is proven by a conformance corpus of
+      nine histories asserted against the ruling — **not merely against each
+      other**, since a shared predicate makes both-wrong-together easy; verified
+      by flipping the shared predicate and watching the corpus expectation fire
+      rather than the agreement assertion.
+
+      **Corroboration counts relations IN EFFECT**, not "ever promoted" — a
+      withdrawn decision propping up a trust grade is the same inflation
+      `KIRRA-WM-PROMOTION-001` bars, by a slower route.
+
+      **Acceptance:** `precedence_governs_the_present_and_leaves_the_past_intact`
+      — T1 promote, T2 reject, current is withdrawn, and
+      `relationships_in_effect_at(T1)` still shows the promotion. The historical
+      half is what makes the ruling a reading of the record rather than a
+      rewrite of it.
+
+      **Scope note, corrected from an earlier overstatement.** The contradiction
+      was LATENT, not live: `confirmed_relations` was reachable only from tests
+      (`promote_confirmed_same_as` has no production caller, and the entity fold
+      consumes a different `kind`), while the projection reading is live via 5c.
+      The pinned test recorded that accurately; a session summary did not. The
+      ruling is still worth making before a third surface — an operator console
+      — is built on either reading.
+
 - [x] **`KIRRA-WM-IDENTITY-FRESHNESS-001` — RULED 2026-08-20.** An adjudicated
       identity decision is **`Timeless`**.
 


### PR DESCRIPTION
**RULED.** For a pair with several adjudications over time, the **latest applicable decision determines current identity**, ordered by **generation** — the order the log recorded them.

> `Promoted` establishes the relation. A later `Rejected` or `Unresolved` withdraws it. A relation dates from the earliest promotion in its **current unbroken run**, so re-affirming does not move its start and a withdrawal resets it. Historical queries still reproduce the state that held at an earlier coordinate.

## What this replaced was a contradiction, not a gap

| Rule | Promoted-then-rejected, before |
|---|---|
| `confirmed_relations` (2c) | still confirmed — one `Promoted` anywhere confirmed forever |
| relationship projection (5a) | withdrawn — the latest decision governs |

Two deterministic readings of one operator history. The projection's reading is adopted: the alternative makes an operator's rejection unable to undo their own promotion.

## Generation, not `decided_at` — three kinds of reason

Separated deliberately, because one is an implementation constraint and should not be dressed as a semantic argument.

- **Semantic.** An adjudication is an *act on the record*, not an observation of the world. Unlike a claim — where valid time leads, and `projection::supersedes` says why — a backdated decision must not override one already recorded and acted upon.
- **Totality.** Generation is a total order and always present. `DomainInstant` rightly refuses cross-domain comparison, so a `decided_at` rule would have to *error* on a pair whose decisions sit on different clocks.
- **Implementation, stated as such.** An incremental fold requires the ordering key to *be* the fold order. Under `decided_at`, an out-of-order arrival changes the answer for a pair already folded — forcing a rebuild from generation 0 every time. It is not merely a different rule; it is incompatible with the projection's design.

**`AOU-ADJUDICATION-ORDER-001`** — the cost, accepted rather than hidden: a decision reaching the log out of decision order (an offline console syncing later) takes precedence over decisions recorded before it. A deployment queueing decisions offline must record them in decision order or accept that the record's order is the authority.

## Both sides derive from the rule — by two mechanisms, because only one half can be shared

- **Effect half** → `same_as_adjudication::leaves_pair_related`, called by the domain walk **and** the store's fold. That drift is now *impossible*, not tested for.
- **Ordering half** → cannot be shared: one side folds incrementally, the other walks a whole history. Proven instead by a conformance corpus of nine histories.

The corpus asserts both sides **against the ruling**, not merely against each other — a shared predicate makes both-wrong-together easy. That distinction is verified rather than claimed: flipping `leaves_pair_related` makes the *corpus expectation* fire (`unresolved: the domain rule disagrees with the ruling`), not the agreement assertion.

Corroboration now counts relations **in effect**. Counting "ever promoted" would let a withdrawn decision prop up a trust grade — the inflation `KIRRA-WM-PROMOTION-001` bars, by a slower route.

## Acceptance — T1/T2

```
T1  Promote(A,B)    -> current: related
T2  Reject(A,B)     -> current: NOT related   (the ruled precedence)
    as of T1        -> STILL related          (history intact)
```

`relationships_in_effect_at` is new and folds **from empty, from the log** — not from the projection, which is a cache of one point on the temporal surface. Seeding it from stored rows would start from today's state and apply an old prefix on top, which is exactly what the query exists to prevent.

The third line is what makes this a *reading* of the record rather than a rewrite of it. The fixture drives the real doors and takes T1/T2 from the store rather than counting, since generations are not dense after compaction.

## Mutations — each side separately, so neither masks the other

| Mutation | Kills |
|---|---|
| domain reverts to any-promotion-confirms | 3 tests |
| store drops its withdrawal | 2 tests |
| shared predicate flips `Unresolved` | 2 tests, via the corpus *expectation* |

## The old pin did its job

`promoted_then_rejected_still_promotes_today_which_is_a_ruling_2b_owes` recorded a behaviour nobody endorsed and broke the moment someone ruled. Its expectation was changed **deliberately**, not deleted to make a build green.

## Scope note — correcting an overstatement of mine

The contradiction was **latent, not live**. `confirmed_relations` was reachable only from tests (`promote_confirmed_same_as` has no production caller, and the entity fold consumes a different `kind`), while the projection reading is live via 5c. So no shipped path could be asked the same question twice and get two answers.

The pinned test recorded that accurately; my session summary did not, and said "a live production path". Ruling before a third surface is built on either reading remains the right order — but the urgency was lower than I stated.

## Verification

- 272 workspace test binaries green
- 15 python gates green
- `relationship_fold`'s **source pin moved with an unchanged corpus digest** — the semantics gate's "refactor" row — so `source_pin` is re-pinned and `version`/`corpus_digest` are untouched, verified by diff
- clippy clean but for one pre-existing warning
- boundedness baseline additive; `relationships_in_effect_at` classified `operational` with its reasoning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_