### PR TITLE
Read-only relationship endpoint, on the World side rather than the verifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2639,6 +2639,8 @@ name = "kirra-world-explain-service"
 version = "0.1.0"
 dependencies = [
  "kirra-explain-types",
+ "kirra-world",
+ "kirra-world-ingest",
  "kirra-world-service",
  "kirra-world-store",
  "serde_json",

--- a/crates/kirra-explain-types/src/lib.rs
+++ b/crates/kirra-explain-types/src/lib.rs
@@ -550,3 +550,138 @@ mod tests {
         assert!(empty.root().is_none());
     }
 }
+
+// ---------------------------------------------------------------------------
+// Relationship status — the read-only identity view.
+// ---------------------------------------------------------------------------
+
+/// The contract version for the relationship view.
+///
+/// Versioned SEPARATELY from [`EXPLANATION_ARTIFACT_VERSION`]. They describe
+/// different things and will change for different reasons; one number for both
+/// would force a lockstep bump on every consumer of either.
+pub const RELATIONS_VIEW_VERSION: u32 = 1;
+
+/// The route prefix the relationship view is served on.
+///
+/// A PREFIX rather than a whole path, because the subject travels in the path.
+/// Shared so the producer's route table and any client agree by construction
+/// rather than by two string literals that match today.
+pub const RELATIONS_PATH_PREFIX: &str = "/relations/";
+
+/// How well the evidence behind a relation still resolves.
+///
+/// The four cases are not a severity scale and must not be collapsed into one.
+/// `KIRRA-WM-EVIDENCE-RETENTION-001` ruled that compaction may degrade the
+/// ability to explain WHY a promotion was made but never WHETHER it holds — so
+/// every variant here describes the EXPLANATION, and none of them qualifies the
+/// relation itself.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProvenanceStanding {
+    /// Exactly one visible record carries the cited evidence.
+    Resolved,
+    /// The evidence is gone and a compacted span could have held it. The
+    /// relation stands; its explanation has decayed.
+    ///
+    /// Distinct from [`Self::Dangling`], and ADR-0041 §11.3 forbids collapsing
+    /// them: *whatever carried this was deleted* and *nothing ever carried
+    /// this* are different findings about the record.
+    Degraded,
+    /// No visible record carries it, and no compaction could explain that.
+    /// Something is wrong with the citation itself.
+    Dangling,
+    /// Several records carry the cited id, so the evidence cannot be attributed
+    /// to one. Reported rather than reduced — picking the newest would name one
+    /// record as the source of something the store cannot attribute.
+    Plural,
+}
+
+/// One pair this subject is currently adjudicated the same as.
+///
+/// # What is deliberately absent
+///
+/// **No outcome field.** Every pair in this view is related BY PROMOTION —
+/// `KIRRA-WM-ADJUDICATION-PRECEDENCE-001` means a withdrawn pair is simply not
+/// here. An `outcome` could therefore only ever read `promoted`, and a constant
+/// field invites a consumer to branch on something that cannot vary.
+///
+/// **No adjudicator class.** For the same reason: `KIRRA-WM-PROMOTION-001` v1
+/// authorizes `SourceClass::Operator` and nothing else, so a class field is a
+/// second constant. Every `adjudicator` below is a human operator, and that is
+/// a property of the ruling rather than of the row.
+///
+/// **No queryable handle.** No `AnswerRef`, no cursor, no generation as a
+/// number — see [`Self::decision_marker`].
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct RelatedPair {
+    /// The canonical pair's low entity.
+    pub low: String,
+    /// The canonical pair's high entity.
+    pub high: String,
+    /// The OTHER entity — the one that is not the subject asked about.
+    ///
+    /// Derivable from the pair, and provided anyway: deriving it means asking
+    /// *was my subject the low or the high* at every call site, and getting
+    /// that backwards silently answers with the entity the caller already had.
+    pub other: String,
+    /// Who decided. An operator identity, never a service account: see the
+    /// type's note on the absent class field.
+    pub adjudicator: String,
+    /// **An opaque marker for the decision that put this row here.**
+    ///
+    /// Stated precisely, because "opaque" is easy to overclaim. It is derived
+    /// from the deciding record's log coordinate and is stable for a given
+    /// decision, so an operator CAN correlate it with the audit record — which
+    /// is the point of serving it at all.
+    ///
+    /// What the contract does not promise: that it is a number, that it orders,
+    /// or that any endpoint accepts it. No route on this service takes a
+    /// decision marker as input, which is what keeps it from becoming the
+    /// queryable handle `KIRRA-WM-EXPLAIN-NEUTRALITY` forbids — a client cannot
+    /// use it to ask for anything.
+    pub decision_marker: String,
+    /// How well the evidence behind this relation still resolves.
+    pub provenance: ProvenanceStanding,
+}
+
+/// What one subject is currently adjudicated the same as.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct RelationsView {
+    /// The subject asked about, echoed so a stored response is self-describing.
+    pub subject: String,
+    /// The pairs currently in effect, ascending by the other entity.
+    pub related: Vec<RelatedPair>,
+    /// Whether more relations exist than one page carries.
+    ///
+    /// Carried rather than inferred from the length: a full page and a
+    /// cut-short page are the same length and mean different things.
+    pub truncated: bool,
+}
+
+/// The tagged outcome of a relationship request.
+///
+/// Always the thing in the body, for [`ExplainOutcome`]'s reason: a client
+/// decodes exactly one type, and *the service is down* never looks like *this
+/// subject is related to nothing*.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "outcome", rename_all = "snake_case")]
+pub enum RelationsOutcome {
+    /// The question was answered. `related` may be empty — that is an answer.
+    Related {
+        /// The view.
+        view: RelationsView,
+    },
+    /// The subject is not an askable entity identity. A REFUSAL, distinct from
+    /// an empty answer: told the latter, a caller concludes the entity exists.
+    NotAnEntity {
+        /// Why it was not admissible.
+        reason: String,
+    },
+    /// The producer could not answer. Never confusable with "related to
+    /// nothing".
+    Unavailable {
+        /// What went wrong, in operator-readable terms.
+        reason: String,
+    },
+}

--- a/crates/kirra-world-explain-service/Cargo.toml
+++ b/crates/kirra-world-explain-service/Cargo.toml
@@ -60,3 +60,16 @@ kirra-world-service = { path = "../kirra-world-service" }
 kirra-world-store = { path = "../kirra-world-store" }
 kirra-explain-types = { path = "../kirra-explain-types" }
 serde_json = "1"
+
+[dev-dependencies]
+# The relationship-endpoint tests build their promoted pair through the REAL
+# chain -- the matcher proposes, an operator adjudicates -- rather than writing
+# a projection row. An endpoint proven only over hand-made data would prove it
+# serves data no producer can create. Dev-only: the producer itself depends on
+# neither at runtime.
+kirra-world-ingest = { path = "../kirra-world-ingest" }
+kirra-world = { path = "../kirra-world" }
+# `test-support` for `query_scalar_for_test`: the compaction test needs the
+# candidate's generation, and inferring it from insertion order would bake in
+# "generations are dense" -- which compaction itself makes false.
+kirra-world-store = { path = "../kirra-world-store", features = ["test-support"] }

--- a/crates/kirra-world-explain-service/src/service.rs
+++ b/crates/kirra-world-explain-service/src/service.rs
@@ -46,8 +46,12 @@
 //! outcome is always the tagged [`ExplainOutcome`] in the body, and a client
 //! decodes exactly one type.
 
-use kirra_explain_types::{ExplainCurrentSubject, ExplainOutcome, EXPLAIN_CURRENT_SUBJECT_PATH};
+use kirra_explain_types::{
+    ExplainCurrentSubject, ExplainOutcome, RelationsOutcome, EXPLAIN_CURRENT_SUBJECT_PATH,
+    RELATIONS_PATH_PREFIX,
+};
 use kirra_world_service::explain_subject::{explain_current_subject, ExplainError};
+use kirra_world_service::relations::{current_relations, RelationsError};
 use kirra_world_store::WorldStore;
 
 /// The contract version this service serves, echoed on `/health`.
@@ -112,6 +116,29 @@ pub fn dispatch(store: &WorldStore, method: &str, path: &str, body: &[u8]) -> Re
                 .to_string(),
             ),
         },
+        // The relationship view. A GET with the subject in the PATH, which is
+        // the one place this service accepts a caller-supplied value in a URL
+        // -- see `subject_from_path` for why the parse is fail-closed rather
+        // than forgiving.
+        ("GET", p) if p.starts_with(RELATIONS_PATH_PREFIX) => match subject_from_path(p) {
+            Some(subject) => relations(store, subject),
+            None => Response::relations(
+                "400 Bad Request",
+                &RelationsOutcome::NotAnEntity {
+                    reason: "the path segment after /relations/ must be one non-empty \
+                             subject with no encoding and no further segments"
+                        .to_string(),
+                },
+            ),
+        },
+        // A known prefix with the wrong verb. READ-ONLY is the whole contract,
+        // so a POST or DELETE here is worth naming rather than 404-ing as an
+        // unknown route -- a client that thinks it can write should be told it
+        // cannot, not told the road does not exist.
+        (_, p) if p.starts_with(RELATIONS_PATH_PREFIX) => Response::json(
+            "405 Method Not Allowed",
+            format!("{{\"error\":\"use GET {RELATIONS_PATH_PREFIX}{{subject}} — this service is read-only\"}}"),
+        ),
         // A known path with the wrong verb is a distinct mistake from an
         // unknown one, and saying so costs nothing.
         (_, EXPLAIN_CURRENT_SUBJECT_PATH) => Response::json(
@@ -119,6 +146,60 @@ pub fn dispatch(store: &WorldStore, method: &str, path: &str, body: &[u8]) -> Re
             format!("{{\"error\":\"use POST {EXPLAIN_CURRENT_SUBJECT_PATH}\"}}"),
         ),
         _ => Response::json("404 Not Found", "{\"error\":\"unknown route\"}".to_string()),
+    }
+}
+
+/// Encode a relationship outcome, with [`Response::outcome`]'s failure rule: a
+/// serializer error becomes a literal `unavailable` body rather than a panic or
+/// an empty `{}`, because this process must never answer with something a
+/// consumer could read as an answer.
+impl Response {
+    fn relations(status: &'static str, outcome: &RelationsOutcome) -> Self {
+        match serde_json::to_string(outcome) {
+            Ok(body) => Self::json(status, body),
+            Err(_) => Self::json(
+                "500 Internal Server Error",
+                "{\"outcome\":\"unavailable\",\"reason\":\"the relationship view could not be encoded\"}"
+                    .to_string(),
+            ),
+        }
+    }
+}
+
+/// The subject from `/relations/{subject}`, or `None` if the path is not that.
+///
+/// **Fail-closed, and deliberately not a URL decoder.** A percent-escape or a
+/// further path segment is REFUSED rather than half-interpreted: this service
+/// has no encoding contract, and guessing one means two spellings of a subject
+/// could reach the store as different strings — or worse, the same one. A
+/// caller with an exotic subject id gets a clear refusal instead of a silently
+/// wrong answer, and adding an encoding later is a contract decision rather
+/// than a bug fix.
+fn subject_from_path(path: &str) -> Option<&str> {
+    let rest = path.strip_prefix(RELATIONS_PATH_PREFIX)?;
+    if rest.is_empty() || rest.contains('/') || rest.contains('%') || rest.contains('?') {
+        return None;
+    }
+    Some(rest)
+}
+
+/// The relationship view, with every failure mapped to a case a caller matches.
+fn relations(store: &WorldStore, subject: &str) -> Response {
+    match current_relations(store, subject) {
+        // A subject related to nothing is an ANSWER, and 200. Encoding it as a
+        // 404 is how clients learn to read "the service is down" and "no
+        // relations" as the same thing.
+        Ok(view) => Response::relations("200 OK", &RelationsOutcome::Related { view }),
+        Err(RelationsError::NotAnEntity { detail }) => Response::relations(
+            "400 Bad Request",
+            &RelationsOutcome::NotAnEntity { reason: detail },
+        ),
+        Err(e) => Response::relations(
+            "503 Service Unavailable",
+            &RelationsOutcome::Unavailable {
+                reason: e.to_string(),
+            },
+        ),
     }
 }
 

--- a/crates/kirra-world-explain-service/tests/relations_route.rs
+++ b/crates/kirra-world-explain-service/tests/relations_route.rs
@@ -1,0 +1,353 @@
+//! **The read-only relationship endpoint — route policy and wire behaviour.**
+//!
+//! `GET /relations/{subject}` is the second capability-specific route on this
+//! producer, and the same argument governs it as the first: the route table IS
+//! the security boundary, so it is tested as policy rather than through a
+//! network round trip.
+//!
+//! Every relation asserted about here was proposed by the REAL matcher and
+//! promoted by a real `AdjudicationAuthority`. An endpoint proven over
+//! hand-written projection rows would prove it serves data no producer can
+//! create.
+
+use kirra_explain_types::{ProvenanceStanding, RelationsOutcome, RELATIONS_PATH_PREFIX};
+use kirra_world::observation::{ClockDomain, DomainInstant, SourceClass};
+use kirra_world::reference::{EventId, ObservationId};
+use kirra_world::same_as_adjudication::{AdjudicationAuthority, Outcome};
+use kirra_world::same_as_candidate::MatcherIdentity;
+use kirra_world_explain_service::service::dispatch;
+use kirra_world_ingest::{run_ingest_pass, ExactIdentifierRule};
+use kirra_world_store::same_as_adjudication_record::SameAsAdjudicationRequest;
+use kirra_world_store::{ClaimStatus, NewEvent, WorldStore, WriterClass};
+
+const T0: i64 = 1_700_000_000_000;
+
+fn tmp(name: &str) -> std::path::PathBuf {
+    static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let n = NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "kirra-relations-{name}-{}-{n}.sqlite",
+        std::process::id()
+    ));
+    for s in ["", "-wal", "-shm"] {
+        let mut q = p.as_os_str().to_os_string();
+        q.push(s);
+        let _ = std::fs::remove_file(std::path::PathBuf::from(q));
+    }
+    p
+}
+
+fn observe(store: &mut WorldStore, n: &str, subject: &str, value: &str) {
+    let event_id = EventId::new(format!("ev-{n}")).expect("id");
+    let observation_id = ObservationId::new(format!("obs-{n}")).expect("id");
+    store
+        .append(&NewEvent {
+            event_id: &event_id,
+            observation_id: &observation_id,
+            txn_time_ms: T0,
+            valid_from_ms: T0,
+            valid_to_ms: None,
+            source: "asset-tag-reader",
+            source_version: "1.0.0",
+            writer_class: WriterClass::Sensor,
+            claim_status: ClaimStatus::Confirmed,
+            provenance: &[],
+            frame_id: None,
+            map_id: None,
+            kind: "observation",
+            subject,
+            subject_ref: None,
+            predicate: Some("serial_number"),
+            object: Some(value),
+            payload: "{}",
+            payload_schema: 1,
+            retention_class: "raw",
+            trust: None,
+        })
+        .expect("append");
+}
+
+/// A store holding one promoted `track-a` = `track-b`, via the real chain.
+fn store_with_a_promoted_pair(name: &str) -> (WorldStore, std::path::PathBuf) {
+    let path = tmp(name);
+    let mut store = WorldStore::open(&path).expect("open");
+    observe(&mut store, "a", "track-a", "SN-1");
+    observe(&mut store, "b", "track-b", "SN-1");
+
+    let rule = ExactIdentifierRule::new(
+        "serial_number",
+        MatcherIdentity::new("world-ingest", "exact-identifier", "1.0.0").expect("matcher"),
+    )
+    .expect("rule");
+    let mut n = 0;
+    let report = run_ingest_pass(&mut store, &rule, T0, 1_000, move || {
+        n += 1;
+        (
+            EventId::new(format!("cand-ev-{n}")).expect("id"),
+            ObservationId::new(format!("cand-obs-{n}")).expect("id"),
+        )
+    })
+    .expect("pass");
+    assert_eq!(report.proposed, 1);
+
+    let event_id = EventId::new("adj-ev-1").expect("id");
+    let observation_id = ObservationId::new("adj-obs-1").expect("id");
+    store
+        .adjudicate_same_as(&SameAsAdjudicationRequest {
+            event_id: &event_id,
+            observation_id: &observation_id,
+            candidate_observation_id: "cand-obs-1",
+            cited: vec![ObservationId::new("cand-obs-1").expect("id")],
+            authority: AdjudicationAuthority::new(SourceClass::Operator, "yard-supervisor")
+                .expect("authority"),
+            outcome: Outcome::Promoted,
+            decided_at: DomainInstant {
+                ms: T0 as u64 + 10,
+                domain: ClockDomain::System,
+            },
+            txn_time_ms: T0 + 10,
+            source: "operator-console",
+            source_version: "1.0.0",
+        })
+        .expect("promote");
+    store.fold_relationship_projection().expect("fold");
+    (store, path)
+}
+
+fn get(store: &WorldStore, subject: &str) -> (String, RelationsOutcome) {
+    let r = dispatch(
+        store,
+        "GET",
+        &format!("{RELATIONS_PATH_PREFIX}{subject}"),
+        b"",
+    );
+    let outcome =
+        serde_json::from_str::<RelationsOutcome>(&r.body).expect("the body decodes as one type");
+    (r.status.to_string(), outcome)
+}
+
+// ---------------------------------------------------------------------------
+// The answer.
+// ---------------------------------------------------------------------------
+
+/// **A promoted pair is served, with its provenance standing.**
+#[test]
+fn a_promoted_pair_is_served_with_resolved_provenance() {
+    let (store, path) = store_with_a_promoted_pair("served");
+    let (status, outcome) = get(&store, "track-a");
+
+    assert_eq!(status, "200 OK");
+    let RelationsOutcome::Related { view } = outcome else {
+        panic!("expected a view, got {outcome:?}");
+    };
+    assert_eq!(view.subject, "track-a");
+    assert_eq!(view.related.len(), 1);
+    let r = &view.related[0];
+    assert_eq!(r.low, "track-a");
+    assert_eq!(r.high, "track-b");
+    assert_eq!(
+        r.other, "track-b",
+        "the OTHER entity, not the one asked about"
+    );
+    assert_eq!(r.adjudicator, "yard-supervisor");
+    assert_eq!(
+        r.provenance,
+        ProvenanceStanding::Resolved,
+        "the candidate is still in the log"
+    );
+    assert!(!r.decision_marker.is_empty());
+    assert!(!view.truncated);
+
+    drop(store);
+    let _ = std::fs::remove_file(&path);
+}
+
+/// **A subject related to nothing is an ANSWER, and 200.**
+///
+/// Encoding it as 404 is how clients learn to read "the service is down" and
+/// "there are no relations" as the same thing.
+#[test]
+fn a_subject_related_to_nothing_answers_200_with_an_empty_view() {
+    let (store, path) = store_with_a_promoted_pair("empty");
+    let (status, outcome) = get(&store, "track-zzz");
+
+    assert_eq!(status, "200 OK");
+    let RelationsOutcome::Related { view } = outcome else {
+        panic!("expected an empty view, got {outcome:?}");
+    };
+    assert!(view.related.is_empty());
+
+    drop(store);
+    let _ = std::fs::remove_file(&path);
+}
+
+/// **An unaskable subject is REFUSED, not answered as unrelated.**
+#[test]
+fn a_malformed_subject_is_refused_rather_than_answered_as_unrelated() {
+    let (store, path) = store_with_a_promoted_pair("malformed");
+    // A whitespace-only subject: `EntityId::new` refuses it, and the refusal
+    // must reach the wire as its own case.
+    let (status, outcome) = get(&store, "   ");
+    assert_eq!(status, "400 Bad Request");
+    assert!(
+        matches!(outcome, RelationsOutcome::NotAnEntity { .. }),
+        "got {outcome:?}"
+    );
+
+    drop(store);
+    let _ = std::fs::remove_file(&path);
+}
+
+/// **Compacting the cited candidate degrades the provenance and leaves the
+/// relation standing** — `KIRRA-WM-EVIDENCE-RETENTION-001`, at the wire.
+///
+/// The endpoint is where that ruling becomes visible to an operator rather than
+/// only to a test, which is the reason provenance is on this contract at all.
+/// `Degraded` and not `Dangling`: ADR-0041 §11.3 forbids reporting deleted
+/// evidence as never-recorded.
+#[test]
+fn compacting_the_candidate_degrades_provenance_and_keeps_the_relation() {
+    let (mut store, path) = store_with_a_promoted_pair("compacted");
+
+    // Before: resolved. Without this the assertion below could not tell
+    // "degraded" from "never resolved in the first place".
+    let (_, before) = get(&store, "track-a");
+    let RelationsOutcome::Related { view } = before else {
+        panic!("expected a view")
+    };
+    assert_eq!(view.related[0].provenance, ProvenanceStanding::Resolved);
+
+    // The candidate is `retention_class = "raw"`; the adjudication is
+    // protected, so only the evidence can go.
+    let candidate_generation = store
+        .query_scalar_for_test(
+            "SELECT generation FROM world_events WHERE observation_id = 'cand-obs-1'",
+        )
+        .expect("find the candidate");
+    let outcome = store
+        .compact_range(candidate_generation, candidate_generation, T0 + 100)
+        .expect("compacting a raw candidate is permitted");
+    assert!(outcome.removed > 0);
+
+    let (status, after) = get(&store, "track-a");
+    assert_eq!(status, "200 OK");
+    let RelationsOutcome::Related { view } = after else {
+        panic!("the relation must survive compaction of its evidence")
+    };
+    assert_eq!(view.related.len(), 1, "the relation still holds");
+    assert_eq!(
+        view.related[0].provenance,
+        ProvenanceStanding::Degraded,
+        "and its explanation has decayed — not vanished, and not still Resolved"
+    );
+
+    drop(store);
+    let _ = std::fs::remove_file(&path);
+}
+
+// ---------------------------------------------------------------------------
+// Route policy — READ-ONLY, capability-specific, fail-closed path parse.
+// ---------------------------------------------------------------------------
+
+/// **The endpoint is read-only, and says so.**
+///
+/// A write verb on a known prefix is a 405 rather than a 404: a client that
+/// thinks it can adjudicate through this service should be told it cannot, not
+/// told the road does not exist. Adjudication is `KIRRA-WM-PROMOTION-001`
+/// territory and needs authentication this process does not have.
+#[test]
+fn write_verbs_are_refused_on_the_relations_prefix() {
+    let (store, path) = store_with_a_promoted_pair("readonly");
+    for method in ["POST", "PUT", "PATCH", "DELETE"] {
+        let r = dispatch(&store, method, "/relations/track-a", b"{}");
+        assert_eq!(r.status, "405 Method Not Allowed", "{method}");
+        assert!(r.body.contains("read-only"), "{method}: {}", r.body);
+    }
+    drop(store);
+    let _ = std::fs::remove_file(&path);
+}
+
+/// **The path parse is fail-closed and is not a URL decoder.**
+///
+/// Each of these is refused rather than half-interpreted. Guessing an encoding
+/// means two spellings of a subject could reach the store as different strings,
+/// or — worse — as the same one.
+#[test]
+fn ambiguous_paths_are_refused_rather_than_interpreted() {
+    let (store, path) = store_with_a_promoted_pair("paths");
+    for p in [
+        "/relations/",                // no subject
+        "/relations/track-a/extra",   // a further segment
+        "/relations/track%2Da",       // percent-encoding, unsupported
+        "/relations/track-a?depth=3", // a query knob
+    ] {
+        let r = dispatch(&store, "GET", p, b"");
+        assert_eq!(r.status, "400 Bad Request", "{p} -> {}", r.body);
+    }
+    drop(store);
+    let _ = std::fs::remove_file(&path);
+}
+
+/// **No generic ask-World route appeared.**
+///
+/// The near-miss list the explanation route already carries, extended to this
+/// one. Capability-specific by construction means the table has no entry a
+/// client could steer.
+#[test]
+fn plausible_near_misses_are_not_routes() {
+    let (store, path) = store_with_a_promoted_pair("nearmiss");
+    for p in [
+        "/relations",
+        "/relation/track-a",
+        "/related/track-a",
+        "/relations/track-a/provenance",
+        "/query",
+        "/ask",
+    ] {
+        let r = dispatch(&store, "GET", p, b"");
+        assert!(
+            r.status.starts_with("404") || r.status.starts_with("400"),
+            "{p} must not be a served route, got {}",
+            r.status
+        );
+    }
+    drop(store);
+    let _ = std::fs::remove_file(&path);
+}
+
+/// **The wire carries no handle back into the World.**
+///
+/// A structural read of the serialized body: no field a client could feed to
+/// another endpoint. `decision_marker` is the one correlatable value and no
+/// route accepts it — asserted here by sending it back and getting a 404.
+#[test]
+fn the_wire_carries_nothing_a_client_could_ask_with() {
+    let (store, path) = store_with_a_promoted_pair("nohandle");
+    let r = dispatch(&store, "GET", "/relations/track-a", b"");
+    for forbidden in ["answer_ref", "cursor", "generation\"", "lineage", "query"] {
+        assert!(
+            !r.body.contains(forbidden),
+            "the body exposes `{forbidden}`: {}",
+            r.body
+        );
+    }
+
+    let view: RelationsOutcome = serde_json::from_str(&r.body).expect("decode");
+    let RelationsOutcome::Related { view } = view else {
+        panic!("expected a view")
+    };
+    let marker = &view.related[0].decision_marker;
+    let echoed = dispatch(&store, "GET", &format!("/relations/{marker}"), b"");
+    // It parses as a subject and answers "nothing" -- it is a string, not a
+    // key. What matters is that no route TAKES it as a decision coordinate.
+    assert_eq!(echoed.status, "200 OK");
+    assert!(
+        echoed.body.contains("\"related\":[]"),
+        "a marker must not resolve to anything: {}",
+        echoed.body
+    );
+
+    drop(store);
+    let _ = std::fs::remove_file(&path);
+}

--- a/crates/kirra-world-service/src/lib.rs
+++ b/crates/kirra-world-service/src/lib.rs
@@ -39,6 +39,7 @@ pub mod freshness;
 pub mod lineage;
 pub mod query;
 pub mod read_view;
+pub mod relations;
 pub mod semantics;
 
 // Both edges exercised, so the proposed three-node graph is genuinely built and

--- a/crates/kirra-world-service/src/relations.rs
+++ b/crates/kirra-world-service/src/relations.rs
@@ -1,0 +1,228 @@
+//! **The relationship view — World-side semantics for the read-only endpoint.**
+//!
+//! ```text
+//! relationships_projection
+//!       ↓  QueryEngine::execute(Related { .. })      the SANCTIONED query
+//! THIS MODULE                                        the projection to neutral
+//!       ↓  RelationsView                             the wire contract
+//! kirra-world-explain-service                        the PROCESS BOUNDARY
+//! ```
+//!
+//! # Why the mapping lives here and not in the producer
+//!
+//! `ci/check_query_boundedness.py` rule 5 refuses a consumer that reaches past
+//! the query engine, and the explain producer is a consumer by that gate's
+//! definition. So every World-aware step — asking the engine, resolving
+//! provenance, deciding which distinctions survive — happens behind this
+//! boundary, and what is left in the producer is transport.
+//!
+//! That is the same split box 4c.1 arrived at for explanations, and it was not
+//! a free choice there either: the gate forced it, and the result was better
+//! than the version that had interpretation on both sides of a socket.
+//!
+//! # What crosses, and what cannot
+//!
+//! The output is [`RelationsView`], which lives in `kirra-explain-types` — the
+//! crate `ci/check_explain_artifact_neutral.py` guards. It cannot name a World
+//! type, so nothing on the wire is a handle into the store: no `AnswerRef`, no
+//! cursor, no projection row. A consumer receives strings and a closed enum,
+//! and there is nothing it could feed back to ask for more.
+
+use kirra_explain_types::{ProvenanceStanding, RelatedPair, RelationsView};
+use kirra_world::reference::EntityId;
+use kirra_world_store::provenance_graph::{CitationResolution, DanglingReason};
+use kirra_world_store::WorldStore;
+
+use crate::freshness::FreshnessSource;
+use crate::query::{QueryEngine, Related};
+use crate::read_view::AskError;
+
+/// Why a relationship view could not be produced.
+#[derive(Debug)]
+pub enum RelationsError {
+    /// The subject is not an admissible entity identity.
+    ///
+    /// Kept apart from every other failure so the producer can answer
+    /// `NotAnEntity` rather than `Unavailable`: *that is not a thing you can
+    /// ask about* and *I could not answer* are different, and a caller told the
+    /// second will retry forever.
+    NotAnEntity {
+        /// The domain constructor's reason.
+        detail: String,
+    },
+    /// The World boundary could not serve the question.
+    Ask(AskError),
+}
+
+impl std::fmt::Display for RelationsError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotAnEntity { detail } => write!(f, "not an entity identity: {detail}"),
+            Self::Ask(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for RelationsError {}
+
+impl From<AskError> for RelationsError {
+    fn from(e: AskError) -> Self {
+        Self::Ask(e)
+    }
+}
+
+/// Map box 4b's citation resolution onto the wire's four cases.
+///
+/// The `Dangling` split is the load-bearing part and is NOT a severity
+/// judgement: `PossiblyCompacted` becomes `Degraded` because
+/// `KIRRA-WM-EVIDENCE-RETENTION-001` ruled that retention may take the
+/// explanation while leaving the relation intact, and `NeverVisible` stays
+/// `Dangling` because nothing was ever recorded there. ADR-0041 §11.3 forbids
+/// collapsing those two, and a wire type with one "missing" case would collapse
+/// them at the boundary no matter how carefully the store kept them apart.
+///
+/// Exhaustive with no wildcard: a new resolution variant is a compile error
+/// here rather than silently taking whichever arm a `_` fell into.
+#[must_use]
+fn standing_of(resolution: &CitationResolution) -> ProvenanceStanding {
+    match resolution {
+        CitationResolution::Resolved { .. } => ProvenanceStanding::Resolved,
+        CitationResolution::Plural { .. } => ProvenanceStanding::Plural,
+        CitationResolution::Dangling { reason } => match reason {
+            DanglingReason::PossiblyCompacted { .. } => ProvenanceStanding::Degraded,
+            DanglingReason::NeverVisible => ProvenanceStanding::Dangling,
+        },
+    }
+}
+
+/// **What one subject is currently adjudicated the same as.**
+///
+/// # Errors
+///
+/// [`RelationsError::NotAnEntity`] if `subject` is not an admissible entity id
+/// — refused rather than answered as "related to nothing", because a caller
+/// told the latter concludes the entity exists. [`RelationsError::Ask`] for
+/// anything the boundary raises.
+pub fn current_relations(
+    store: &WorldStore,
+    subject: &str,
+) -> Result<RelationsView, RelationsError> {
+    let id = EntityId::new(subject).map_err(|e| RelationsError::NotAnEntity {
+        detail: e.to_string(),
+    })?;
+
+    // Through the ONE sanctioned door. Not `store.related` directly: this crate
+    // implements the boundary, so it *may* reach the store, and doing it anyway
+    // would put a second answer next to the typed one and make rule 5 a rule
+    // about other people's code.
+    let engine = QueryEngine::new(store, FreshnessSource::Ruled);
+    let answer = engine.execute(Related {
+        entity: subject.to_owned(),
+    })?;
+
+    let mut related = Vec::with_capacity(answer.neighbours().len());
+    for neighbour in answer.neighbours() {
+        let pair = &neighbour.relationship.pair;
+        // Provenance is asked PER PAIR and through the same bounded primitive
+        // 5b classified. `Ok(None)` cannot arise here -- the pair came out of
+        // the projection a moment ago -- but it is mapped rather than unwrapped
+        // so a concurrent rebuild degrades to an honest `Dangling` instead of a
+        // panic in a read-only endpoint.
+        let standing = store
+            .relationship_provenance(pair)
+            .map_err(|e| RelationsError::Ask(AskError::Store(e)))?
+            .as_ref()
+            .map_or(ProvenanceStanding::Dangling, standing_of);
+
+        related.push(RelatedPair {
+            low: pair.low().as_str().to_owned(),
+            high: pair.high().as_str().to_owned(),
+            other: neighbour.other.as_str().to_owned(),
+            adjudicator: neighbour.relationship.adjudicator.clone(),
+            decision_marker: decision_marker(neighbour.relationship.decided_generation),
+            provenance: standing,
+        });
+    }
+
+    Ok(RelationsView {
+        subject: id.as_str().to_owned(),
+        related,
+        truncated: answer.is_truncated(),
+    })
+}
+
+/// Render a deciding log coordinate as the wire's opaque decision marker.
+///
+/// One function so the producer cannot invent a second spelling, and so the
+/// "opaque" claim has a single place to be true. See
+/// [`kirra_explain_types::RelatedPair::decision_marker`] for exactly what the
+/// contract does and does not promise about it.
+#[must_use]
+fn decision_marker(generation: i64) -> String {
+    format!("d-{generation}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// **All four provenance cases map distinctly.**
+    ///
+    /// Two of them (`Resolved`, `Degraded`) are reachable end-to-end and are
+    /// proven that way in the producer's tests. `Plural` and the
+    /// `NeverVisible` half of dangling need a store shaped in ways an ordinary
+    /// promotion cannot produce, so they are pinned here at the mapping instead
+    /// — stated plainly rather than left as a gap someone discovers later.
+    ///
+    /// The load-bearing assertion is the LAST one: `PossiblyCompacted` and
+    /// `NeverVisible` must not both become the same wire case. ADR-0041 §11.3
+    /// forbids collapsing *whatever carried this was deleted* into *nothing
+    /// ever carried this*, and a wire enum with one "missing" variant would do
+    /// exactly that at the boundary, however carefully the store kept them
+    /// apart upstream.
+    #[test]
+    fn every_citation_resolution_maps_to_a_distinct_standing() {
+        assert_eq!(
+            standing_of(&CitationResolution::Resolved {
+                target_generation: 7
+            }),
+            ProvenanceStanding::Resolved
+        );
+        assert_eq!(
+            standing_of(&CitationResolution::Plural {
+                target_generations: vec![7, 9],
+                truncated: false,
+            }),
+            ProvenanceStanding::Plural
+        );
+        let compacted = standing_of(&CitationResolution::Dangling {
+            reason: DanglingReason::PossiblyCompacted {
+                spans: vec![3],
+                truncated: false,
+            },
+        });
+        let never = standing_of(&CitationResolution::Dangling {
+            reason: DanglingReason::NeverVisible,
+        });
+        assert_eq!(compacted, ProvenanceStanding::Degraded);
+        assert_eq!(never, ProvenanceStanding::Dangling);
+        assert_ne!(
+            compacted, never,
+            "compacted evidence and never-recorded evidence must not collapse \
+             into one wire case"
+        );
+    }
+
+    /// The marker is opaque in the one sense the contract claims: it is not
+    /// the bare number, so a consumer cannot mistake it for an index and no
+    /// route accepts it back.
+    #[test]
+    fn a_decision_marker_is_not_a_bare_generation() {
+        let m = decision_marker(41);
+        assert_ne!(m, "41");
+        assert!(
+            m.contains("41"),
+            "it must still correlate with the record: {m}"
+        );
+    }
+}


### PR DESCRIPTION
`GET /relations/{subject}` on `kirra-world-explain-service`.

## Why not on the verifier

The consumer was first scoped as an endpoint on `kirra-verifier`. That is a **Fence B breach** — `kirra-verifier` is one of ten safety roots and its dependency closure may not reach `kirra-world*`.

The fence had already anticipated this request: it **reserves** `KIRRA_WORLD_URL`, `KIRRA_WORLD_ENDPOINT`, `kirra-world-service.service` and `/var/lib/kirra/world/`. The intended topology is a separate World process, so this lands there — on the crate whose role is already *"the World-side process that exposes bounded, presentation-safe artifacts."*

## The split follows 4c.1's, and rule 5 forces it

The producer is a *consumer* by the boundedness gate's definition, so every World-aware step — asking the engine, resolving provenance, deciding which distinctions survive — lives behind `kirra_world_service::relations`. The producer keeps transport.

Verified rather than asserted: no direct store domain read appears anywhere in the producer crate, and the gate is green.

What crosses is `RelationsView` in `kirra-explain-types`, the crate the neutrality gate guards, so nothing on the wire can be a handle into the store.

## Two fields the scope asked for are deliberately absent

Same reason both times — **a constant field invites a consumer to branch on something that cannot vary**:

- **`outcome`** — every pair in the view is related *by promotion*, because `KIRRA-WM-ADJUDICATION-PRECEDENCE-001` means a withdrawn pair is simply not there. It could only ever read `promoted`.
- **adjudicator class** — `KIRRA-WM-PROMOTION-001` v1 authorizes `Operator` and nothing else. Every adjudicator is a human operator; that is a property of the ruling, not of the row.

Both are documented on the type so the absence reads as a decision.

## The decision marker

Opaque in the one sense the contract claims, stated precisely rather than overclaimed: derived from the deciding log coordinate and stable, so an operator **can** correlate it with the audit record — which is why it is served at all — but **no route accepts it as input**, which is what keeps it from being a queryable handle. There's a test that echoes a marker back as a subject and confirms it resolves to nothing.

## Provenance keeps §11.3's distinction at the boundary

| store | wire |
|---|---|
| `Resolved` | `resolved` |
| `Plural` | `plural` |
| `Dangling { PossiblyCompacted }` | **`degraded`** |
| `Dangling { NeverVisible }` | **`dangling`** |

A wire enum with one "missing" case would collapse *deleted* into *never recorded* however carefully the store kept them apart upstream.

`Resolved` and `Degraded` are proven **end to end** — promote through the real chain, compact the raw candidate, watch the relation survive while its explanation decays. `Plural` and `NeverVisible` are pinned at the mapping instead, because they need a store shaped in ways an ordinary promotion cannot produce. Stated as such rather than left as a gap someone finds later.

## Route policy

- Path parse is **fail-closed and not a URL decoder** — a percent-escape, query string or further segment is refused rather than half-interpreted. Guessing an encoding means two spellings of a subject could reach the store as different strings, or as the same one.
- Write verbs on the prefix are **405 with a "read-only" message**, not 404. A client that thinks it can adjudicate here should be told it cannot; adjudication is `KIRRA-WM-PROMOTION-001` territory and needs authentication this process does not have.
- A subject related to nothing is **200 with an empty view**. Encoding it as 404 is how clients learn to read "the service is down" and "no relations" as the same thing.
- A malformed subject is **400 `NotAnEntity`**, distinct from an empty answer.

## Mutations — and one contaminated result

| Mutation | Kills |
|---|---|
| `PossiblyCompacted` collapses into `Dangling` | the compaction test + the mapping unit test |
| path parse becomes forgiving | 2 route-policy tests |
| write verbs fall through to 404 | the read-only test |

The third was **contaminated on its first run**: a scripted deletion removed an inert span, the suite stayed green, and it looked like a surviving mutation. Redone as a verified one-token edit it kills the test it should. The first result is discarded, and recorded here rather than quietly dropped.

## Verification

- Fence B **INTACT**, 42/42 fence self-tests
- 16 python gates green, including neutrality (+ its self-tests) and query-boundedness
- 273 workspace test binaries green
- clippy clean

Disk was exhausted mid-run (`ld terminated with signal 7` with 71M free); `cargo clean` resolved it. Infra, not code.

## Not in this PR, deliberately

**The console UI.** The endpoint is fully testable on its own — serialization, refusal and degradation semantics, fence integrity — and the console becomes a pure consumer of an already-reviewed HTTP contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_