### PR TITLE
console: read-only asset-identity view over the World relations endpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2342,6 +2342,12 @@ jobs:
         run: npm run typecheck
       - name: Lint
         run: npm run lint
+      # The cross-language contract. `contracts/world_relations_v1.json` is
+      # emitted by a Rust test and decoded here by the hand-written TypeScript
+      # contract, so a Rust field rename reds one test on each side rather than
+      # rendering wrong in production.
+      - name: Contract conformance — the World relations fixture decodes
+        run: npm run test:contract
       - name: Production build
         run: npm run build
       - name: Install smoke browser

--- a/console/app/api/world/relations/[subject]/route.ts
+++ b/console/app/api/world/relations/[subject]/route.ts
@@ -1,0 +1,108 @@
+import { type NextRequest, NextResponse } from 'next/server'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+// Server-side proxy to kirra-world-explain-service.
+//
+//   Browser → THIS ROUTE → kirra-world-explain-service (loopback) → QueryEngine
+//
+// THE BROWSER NEVER TALKS TO KIRRA WORLD. That is the whole point of the route
+// existing rather than the page fetching the World service directly.
+//
+// The World process has no authentication of its own — it refuses a
+// non-loopback bind unless KIRRA_WORLD_EXPLAIN_ALLOW_NONLOCAL=1 precisely
+// because of that. Pointing a browser at it would mean setting that flag, which
+// converts an on-box service into an exposed one to save a hop. The console
+// already owns browser-facing auth, session handling, origin policy and future
+// access control; this route is where that ownership is exercised.
+//
+// Server env (NOT NEXT_PUBLIC — stays server-side):
+//   KIRRA_WORLD_URL   base URL of the World explain service. Unset → demo mode.
+//                     Expected to be loopback; see the note above.
+
+const UPSTREAM_TIMEOUT_MS = 10_000
+
+// A subject is one path segment. The World service refuses an encoded or
+// multi-segment subject, and this refuses the same shapes BEFORE the hop —
+// fail-closed at the edge, so a malformed request never reaches the World
+// process at all. The two refusals agreeing is not duplication: this one keeps
+// junk off the wire, and the World one is what holds if anything else ever
+// calls it.
+const SUBJECT = /^[A-Za-z0-9._:-]{1,128}$/
+
+function log(fields: Record<string, unknown>) {
+  console.log(JSON.stringify({ ts: new Date().toISOString(), src: 'kirra-world-proxy', ...fields }))
+}
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ subject: string }> },
+) {
+  const started = Date.now()
+  const reqId = crypto.randomUUID()
+  const { subject } = await params
+
+  const respond = (res: NextResponse, extra?: Record<string, unknown>) => {
+    res.headers.set('x-request-id', reqId)
+    log({ reqId, subject, status: res.status, ms: Date.now() - started, ...extra })
+    return res
+  }
+
+  if (!SUBJECT.test(subject ?? '')) {
+    // The World service's own vocabulary, so the console renders one shape
+    // whether the refusal happened here or upstream.
+    return respond(
+      NextResponse.json(
+        { outcome: 'not_an_entity', reason: 'the subject must be one unencoded path segment' },
+        { status: 400 },
+      ),
+    )
+  }
+
+  const base = process.env.KIRRA_WORLD_URL?.replace(/\/+$/, '')
+  if (!base) {
+    return respond(
+      NextResponse.json(
+        { outcome: 'unavailable', reason: 'Kirra World is not configured for this console' },
+        { status: 503, headers: { 'x-kirra-mode': 'demo' } },
+      ),
+      { mode: 'demo' },
+    )
+  }
+
+  try {
+    const upstream = await fetch(`${base}/relations/${subject}`, {
+      method: 'GET',
+      headers: { accept: 'application/json' },
+      cache: 'no-store',
+      signal: AbortSignal.any([req.signal, AbortSignal.timeout(UPSTREAM_TIMEOUT_MS)]),
+    })
+    const body = await upstream.text()
+    // Passed through verbatim: the World service already speaks the tagged
+    // outcome the console decodes, and re-wrapping it here would create a
+    // second place the contract is expressed.
+    return respond(
+      new NextResponse(body, {
+        status: upstream.status,
+        headers: { 'content-type': 'application/json', 'cache-control': 'no-store' },
+      }),
+      { upstream: upstream.status },
+    )
+  } catch (e) {
+    const detail = String((e as Error)?.message ?? e)
+    const timedOut = (e as Error)?.name === 'TimeoutError' || detail.includes('timeout')
+    // Detail stays in the server log. The client gets the contract's own
+    // `unavailable` case — never something it could mistake for an answer.
+    return respond(
+      NextResponse.json(
+        {
+          outcome: 'unavailable',
+          reason: timedOut ? 'Kirra World did not respond in time' : 'Kirra World is unreachable',
+        },
+        { status: timedOut ? 504 : 502 },
+      ),
+      { error: detail },
+    )
+  }
+}

--- a/console/app/identity/page.tsx
+++ b/console/app/identity/page.tsx
@@ -1,0 +1,185 @@
+'use client'
+
+import { useState } from 'react'
+import { Panel } from '@/components/ui/primitives'
+import {
+  decodeRelationsOutcome,
+  PROVENANCE_PRESENTATION,
+  RelationsContractError,
+  type RelationsOutcome,
+} from '@/lib/world/relations'
+
+// Read-only view of what Kirra World currently considers the same asset.
+//
+// SCOPE, deliberately small: it answers one operator question — "what is this
+// the same as, who decided, and can that decision still be explained" — and
+// nothing else. There is no adjudication control here. Deciding identity is
+// KIRRA-WM-PROMOTION-001 territory and requires an authenticated operator; a
+// console button would be the second way to do it and the unauthenticated one.
+//
+// Every fetch goes to the console's own server route, never to Kirra World.
+// See app/api/world/relations/[subject]/route.ts for why.
+
+type State =
+  | { kind: 'idle' }
+  | { kind: 'loading' }
+  | { kind: 'answered'; outcome: RelationsOutcome }
+  | { kind: 'broken'; detail: string }
+
+export default function IdentityPage() {
+  const [subject, setSubject] = useState('')
+  const [state, setState] = useState<State>({ kind: 'idle' })
+
+  async function look(e: React.FormEvent) {
+    e.preventDefault()
+    const q = subject.trim()
+    if (!q) return
+    setState({ kind: 'loading' })
+    try {
+      const res = await fetch(`/api/world/relations/${encodeURIComponent(q)}`, {
+        cache: 'no-store',
+      })
+      // A non-2xx still carries the contract's own tagged body, so it is
+      // decoded rather than turned into a generic error — that is what keeps
+      // "no relations" and "the service is down" distinguishable.
+      setState({ kind: 'answered', outcome: decodeRelationsOutcome(await res.json()) })
+    } catch (err) {
+      // A CONTRACT failure is not a transport failure and must not be shown as
+      // one: it means this console and Kirra World disagree about the shape of
+      // the world, and rendering a partial view would be the collapse the
+      // decoder refused.
+      setState({
+        kind: 'broken',
+        detail:
+          err instanceof RelationsContractError
+            ? `${err.message} — this console will not render a view it cannot fully decode.`
+            : 'Kirra World could not be reached.',
+      })
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-[1100px] space-y-6 p-6">
+      <div>
+        <h1 className="font-display text-xl font-semibold text-ink">Asset Identity</h1>
+        <p className="font-mono text-[11px] text-faint">
+          kirra world · read-only · promoted same_as relations
+        </p>
+      </div>
+
+      <Panel title="Look up an asset" subtitle="what is this the same as?">
+        <form onSubmit={look} className="flex flex-wrap gap-2">
+          <input
+            value={subject}
+            onChange={(e) => setSubject(e.target.value)}
+            placeholder="track-a"
+            aria-label="Asset identifier"
+            className="min-w-[16rem] flex-1 rounded border border-white/10 bg-black/30 px-3 py-2 font-mono text-sm text-ink outline-none focus:border-white/30"
+          />
+          <button
+            type="submit"
+            className="rounded border border-white/15 bg-white/5 px-4 py-2 font-mono text-sm text-ink hover:bg-white/10"
+          >
+            Look up
+          </button>
+        </form>
+      </Panel>
+
+      {state.kind === 'loading' && (
+        <Panel title="Asking Kirra World">
+          <p className="font-mono text-[12px] text-faint">…</p>
+        </Panel>
+      )}
+
+      {state.kind === 'broken' && (
+        <Panel title="No answer">
+          <p className="text-sm text-rose-300">{state.detail}</p>
+        </Panel>
+      )}
+
+      {state.kind === 'answered' && <Answer outcome={state.outcome} />}
+    </div>
+  )
+}
+
+function Answer({ outcome }: { outcome: RelationsOutcome }) {
+  if (outcome.outcome === 'not_an_entity') {
+    return (
+      <Panel title="Not an asset identity">
+        {/* Distinct from "related to nothing" on purpose: told the latter, an
+            operator concludes the asset exists. */}
+        <p className="text-sm text-amber-300">{outcome.reason}</p>
+      </Panel>
+    )
+  }
+  if (outcome.outcome === 'unavailable') {
+    return (
+      <Panel title="Kirra World unavailable">
+        <p className="text-sm text-rose-300">{outcome.reason}</p>
+        <p className="mt-2 font-mono text-[11px] text-faint">
+          This is not an answer about the asset. Nothing here says whether it has relations.
+        </p>
+      </Panel>
+    )
+  }
+
+  const { view } = outcome
+  if (view.related.length === 0) {
+    return (
+      <Panel title={`${view.subject} — no relations`}>
+        <p className="text-sm text-ink">
+          Kirra World holds no promoted <span className="font-mono">same_as</span> relation for this
+          asset.
+        </p>
+      </Panel>
+    )
+  }
+
+  return (
+    <Panel
+      title={`${view.subject} — ${view.related.length} relation${view.related.length === 1 ? '' : 's'}`}
+      subtitle="adjudicated by an operator"
+    >
+      <div className="space-y-3">
+        {view.related.map((r) => {
+          const p = PROVENANCE_PRESENTATION[r.provenance]
+          return (
+            <div
+              key={`${r.low}|${r.high}`}
+              className="rounded border border-white/10 bg-black/20 p-3"
+            >
+              <div className="flex flex-wrap items-baseline justify-between gap-2">
+                <div className="font-mono text-sm text-ink">
+                  same as <span className="font-semibold">{r.other}</span>
+                </div>
+                {/* The provenance badge. Glyph + LABEL, never colour alone —
+                    the distinction has to survive greyscale, a screenshot and
+                    a reader who cannot separate the hues. */}
+                <span
+                  className={`rounded border px-2 py-0.5 font-mono text-[11px] ${p.tone}`}
+                  title={p.sentence}
+                >
+                  <span aria-hidden="true">{p.glyph}</span> {p.label}
+                </span>
+              </div>
+              <p className="mt-1 text-[12px] text-faint">{p.sentence}</p>
+              <div className="mt-2 grid grid-cols-1 gap-x-6 gap-y-1 font-mono text-[11px] text-faint sm:grid-cols-2">
+                <div>
+                  decided by <span className="text-ink">{r.adjudicator}</span>
+                </div>
+                <div>
+                  decision <span className="text-ink">{r.decision_marker}</span>
+                </div>
+              </div>
+            </div>
+          )
+        })}
+        {view.truncated && (
+          <p className="font-mono text-[11px] text-amber-300">
+            More relations exist than are shown here.
+          </p>
+        )}
+      </div>
+    </Panel>
+  )
+}

--- a/console/components/shell/nav-items.ts
+++ b/console/components/shell/nav-items.ts
@@ -1,11 +1,13 @@
-import { LayoutDashboard, Globe, Boxes, ShieldCheck, Activity, Radio, Route, Rss, Brain, Bell, AlertTriangle, FileCheck2, BarChart3, Database, FileText, Settings, Crosshair } from 'lucide-react'
+import { LayoutDashboard, Globe, Boxes, ShieldCheck, Activity, Radio, Route, Rss, Brain, Bell, AlertTriangle, FileCheck2, BarChart3, Database, FileText, Settings, Crosshair, Link2 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 
 // `preview: true` marks a route whose screen renders bundled mock data (no live
 // verifier endpoint behind it). The sidebar renders a small "preview" tag so the
 // live-backed routes stand out — the nav-level complement to the per-page
 // DemoBadge ("SIMULATED DATA"). Live-backed routes (live/fleet/oversight/events/
-// incidents/compliance) carry no flag.
+// incidents/identity/compliance) carry no flag. `/identity` is unflagged because
+// it never renders mock data: with no World service configured it reports the
+// answer as unavailable rather than inventing one.
 export interface NavItem { href: string; label: string; icon: LucideIcon; preview?: boolean }
 export interface NavGroup { label: string; items: NavItem[] }
 
@@ -31,6 +33,7 @@ export const navGroups: NavGroup[] = [
       { href: '/doer-bound', label: 'Doer Bound', icon: Crosshair, preview: true },
       { href: '/events', label: 'Events', icon: Bell },
       { href: '/incidents', label: 'Incident Review', icon: AlertTriangle },
+      { href: '/identity', label: 'Asset Identity', icon: Link2 },
       { href: '/compliance', label: 'Compliance', icon: FileCheck2 },
     ],
   },

--- a/console/lib/world/relations.test.mjs
+++ b/console/lib/world/relations.test.mjs
@@ -1,0 +1,181 @@
+// Conformance: the hand-written TypeScript contract decodes the CANONICAL
+// fixture that Rust emits, and fails closed on everything it should.
+//
+//   node --test lib/world/relations.test.mjs
+//
+// The fixture is `contracts/world_relations_v1.json`, written by
+// `crates/kirra-explain-types/tests/relations_contract_fixture.rs`. Neither
+// tree owns it. A Rust change that adds, removes, renames or reshapes a field
+// moves that file, and this test is what turns the move into a red build here
+// instead of a wrong render in production.
+//
+// The fixture is a LIST of outcome documents, one per variant, because the two
+// variants this console must render most carefully are the refusals — a fixture
+// built from the happy path would have left `not_an_entity` and `unavailable`
+// free to drift, and those are exactly the two that must never be mistaken for
+// "related to nothing".
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const FIXTURE = join(here, '../../../contracts/world_relations_v1.json')
+
+// The decoder is TypeScript, so this test reads the source and evaluates the
+// parts it needs rather than importing a build artifact. Keeping the test
+// dependency-free is deliberate: a conformance check that needs a bundler is a
+// conformance check that gets skipped when the bundler breaks.
+const SOURCE = readFileSync(join(here, 'relations.ts'), 'utf8')
+
+function loadFixture() {
+  const docs = JSON.parse(readFileSync(FIXTURE, 'utf8'))
+  assert.ok(Array.isArray(docs), 'the fixture is a list of outcome documents')
+  return docs
+}
+
+function only(docs, outcome) {
+  const found = docs.filter((d) => d.outcome === outcome)
+  assert.equal(found.length, 1, `expected exactly one "${outcome}" document, got ${found.length}`)
+  return found[0]
+}
+
+test('the fixture carries every outcome variant the console switches on', () => {
+  const docs = loadFixture()
+  const tags = docs.map((d) => d.outcome).sort()
+  assert.deepEqual(
+    tags,
+    ['not_an_entity', 'related', 'unavailable'],
+    'a variant missing here is a variant free to drift',
+  )
+
+  // Every tag must have a decoder arm. A Rust-side rename would show up as a
+  // fixture tag with no `case` for it, which is what this catches.
+  for (const tag of tags) {
+    assert.ok(
+      SOURCE.includes(`case '${tag}':`) || SOURCE.includes(`case '${tag}': {`),
+      `the decoder has no arm for outcome "${tag}"`,
+    )
+  }
+})
+
+test('both refusals carry a reason, so neither renders as an empty answer', () => {
+  const docs = loadFixture()
+  for (const outcome of ['not_an_entity', 'unavailable']) {
+    const doc = only(docs, outcome)
+    assert.equal(typeof doc.reason, 'string', `${outcome}.reason must be a string`)
+    assert.ok(doc.reason.trim().length > 0, `${outcome}.reason must not be empty`)
+    // No `view`: a refusal that carried one could be rendered as a relation
+    // list, which is the collapse these variants exist to prevent.
+    assert.ok(!('view' in doc), `${outcome} must not carry a view`)
+  }
+})
+
+test('the fixture carries every field the contract declares', () => {
+  const doc = only(loadFixture(), 'related')
+  assert.ok(Array.isArray(doc.view.related))
+  assert.equal(typeof doc.view.subject, 'string')
+  assert.equal(typeof doc.view.truncated, 'boolean')
+  assert.equal(doc.view.truncated, true, 'truncated must be exercised as true, not merely present')
+
+  // Every field named in the TS interface must be present on every row. This
+  // is the half that catches a RENAME: if Rust renames `decision_marker`, the
+  // fixture no longer has it and this fails, naming the field.
+  const FIELDS = ['low', 'high', 'other', 'adjudicator', 'decision_marker', 'provenance']
+  for (const [i, row] of doc.view.related.entries()) {
+    for (const f of FIELDS) {
+      assert.ok(f in row, `related[${i}] is missing "${f}" — the Rust contract moved`)
+    }
+    // And no field the console does not know about is silently ignored in the
+    // FIXTURE. (The decoder tolerates extras at runtime, deliberately; the
+    // fixture is the place to notice one.)
+    for (const k of Object.keys(row)) {
+      assert.ok(FIELDS.includes(k), `related[${i}] has unknown field "${k}" — decide how it renders`)
+    }
+  }
+})
+
+test('the fixture exercises all four provenance states', () => {
+  const doc = only(loadFixture(), 'related')
+  const seen = new Set(doc.view.related.map((r) => r.provenance))
+  assert.deepEqual(
+    [...seen].sort(),
+    ['dangling', 'degraded', 'plural', 'resolved'],
+    'a fixture missing a state would let that state drift unnoticed',
+  )
+})
+
+test('every provenance state the fixture carries has a presentation', () => {
+  const doc = only(loadFixture(), 'related')
+  for (const row of doc.view.related) {
+    // The presentation table is the UI's promise that the four stay distinct.
+    // Matched out of source rather than imported so this test needs no build.
+    const block = SOURCE.slice(SOURCE.indexOf('PROVENANCE_PRESENTATION'))
+    assert.ok(
+      new RegExp(`\\b${row.provenance}:\\s*\\{`).test(block),
+      `no presentation for "${row.provenance}" — a state without one would render as nothing`,
+    )
+  }
+})
+
+test('the four presentations are distinct in TEXT, not only in colour', () => {
+  const block = SOURCE.slice(SOURCE.indexOf('PROVENANCE_PRESENTATION'))
+  const labels = [...block.matchAll(/label:\s*'([^']+)'/g)].map((m) => m[1])
+  const glyphs = [...block.matchAll(/glyph:\s*'([^']+)'/g)].map((m) => m[1])
+  assert.equal(labels.length, 4, `expected four labels, got ${labels.length}`)
+  assert.equal(new Set(labels).size, 4, `labels collide: ${labels.join(', ')}`)
+  assert.equal(new Set(glyphs).size, 4, `glyphs collide: ${glyphs.join(', ')}`)
+
+  // THE LOAD-BEARING ONE: a weaker state may not read as a stronger one. The
+  // check is textual and blunt on purpose — it catches the specific collapse
+  // that would be easiest to introduce and hardest to notice.
+  const degraded = block.slice(block.indexOf('degraded:'))
+  assert.ok(
+    /compact/i.test(degraded),
+    'the degraded presentation must say the evidence was compacted, not merely that it is absent',
+  )
+  const dangling = block.slice(block.indexOf('dangling:'))
+  assert.ok(
+    /do not read this as evidence that was successfully observed/i.test(dangling),
+    'the dangling presentation must refuse to imply the evidence was observed',
+  )
+  const plural = block.slice(block.indexOf('plural:'))
+  assert.ok(
+    /no single one of them is authoritative/i.test(plural),
+    'the plural presentation must not present one carrier as authoritative',
+  )
+})
+
+test('the contract version matches the Rust side', () => {
+  const m = SOURCE.match(/RELATIONS_VIEW_VERSION\s*=\s*(\d+)/)
+  assert.ok(m, 'the console must declare a contract version')
+  assert.equal(m[1], '1', 'a version bump in Rust must be a deliberate act here too')
+})
+
+test('the decoder refuses an unknown provenance state rather than falling back', () => {
+  // Asserted against the SOURCE because importing TypeScript needs a build.
+  // The property under test is a policy statement, and the policy is that no
+  // fallback exists: there must be no `?? 'unknown'`, no default arm, and the
+  // membership check must throw.
+  assert.ok(
+    /PROVENANCE_STATES\.includes\(provenance\)/.test(SOURCE),
+    'the decoder must check membership explicitly',
+  )
+  assert.ok(
+    !/provenance[^\n]*\?\?\s*'/.test(SOURCE),
+    'the decoder must not coalesce an unknown provenance to a fallback',
+  )
+  assert.ok(
+    /may not fall back/.test(SOURCE),
+    'the refusal must say why, so the next author does not add the fallback back',
+  )
+})
+
+test('the decoder refuses an unknown outcome tag rather than guessing', () => {
+  assert.ok(
+    /refusing rather than guessing/.test(SOURCE),
+    'an unrecognised outcome must throw, not render as one of the known three',
+  )
+})

--- a/console/lib/world/relations.ts
+++ b/console/lib/world/relations.ts
@@ -1,0 +1,184 @@
+// The Kirra World relationship contract, hand-written and conformance-tested.
+//
+// THIS IS A SECOND DEFINITION of a contract whose source of truth is Rust
+// (`crates/kirra-explain-types`). That is a real risk and it is answered, not
+// waved at: `contracts/world_relations_v1.json` is emitted by a Rust test and
+// decoded by `relations.test.mjs` with the decoder below. A Rust change that
+// adds, removes, renames or reshapes a field reds one test on each side.
+//
+// Rust→TypeScript generation was considered and deliberately deferred. It adds
+// a codegen subsystem before anyone knows whether Kirra World will have one JS
+// consumer or twenty; the fixture buys the property that matters now and can be
+// replaced by generation later without either side having built against it.
+
+/** The contract version this console understands. Bumping it in Rust must be a
+ *  deliberate act here too — the conformance test pins the number. */
+export const RELATIONS_VIEW_VERSION = 1
+
+/**
+ * How well the evidence behind a relation still resolves.
+ *
+ * Four states, and they are NOT a severity scale. Every one of them describes
+ * the EXPLANATION; none qualifies whether the relation holds. That separation
+ * is KIRRA-WM-EVIDENCE-RETENTION-001, and it is the reason the UI may never
+ * collapse a weaker state into a stronger one.
+ */
+export type ProvenanceStanding = 'resolved' | 'degraded' | 'dangling' | 'plural'
+
+const PROVENANCE_STATES: readonly string[] = ['resolved', 'degraded', 'dangling', 'plural']
+
+/** One pair the subject is currently adjudicated the same as. */
+export interface RelatedPair {
+  low: string
+  high: string
+  /** The OTHER entity — the one that is not the subject asked about. */
+  other: string
+  adjudicator: string
+  /** Opaque. Correlates with the audit record; no endpoint accepts it back. */
+  decision_marker: string
+  provenance: ProvenanceStanding
+}
+
+export interface RelationsView {
+  subject: string
+  related: RelatedPair[]
+  /** More relations exist than this page carries. Carried, never inferred. */
+  truncated: boolean
+}
+
+export type RelationsOutcome =
+  | { outcome: 'related'; view: RelationsView }
+  | { outcome: 'not_an_entity'; reason: string }
+  | { outcome: 'unavailable'; reason: string }
+
+/** Thrown when a payload does not match the contract. Never swallowed. */
+export class RelationsContractError extends Error {
+  constructor(message: string) {
+    super(`world relations contract: ${message}`)
+    this.name = 'RelationsContractError'
+  }
+}
+
+function str(o: Record<string, unknown>, key: string, where: string): string {
+  const v = o[key]
+  if (typeof v !== 'string') throw new RelationsContractError(`${where}.${key} is not a string`)
+  return v
+}
+
+/**
+ * Decode one payload, FAIL-CLOSED.
+ *
+ * An unknown provenance state THROWS. It is not mapped to a fallback, and that
+ * is the tightening this contract exists to carry: a newly-added Rust state
+ * must break this console until somebody decides how it is presented, because
+ * the alternative is a new evidence state silently rendering as whatever the
+ * fallback happened to be — and the fallback would be a stronger claim than the
+ * truth in at least one direction.
+ *
+ * Unknown OUTCOME tags throw for the same reason. Unknown extra FIELDS are
+ * tolerated: Rust's `deny_unknown_fields` governs what the producer accepts,
+ * whereas an extra field arriving here means the producer is ahead of this
+ * console, and refusing to render a relation because a field we do not use
+ * appeared would take the console down for an additive change.
+ */
+export function decodeRelationsOutcome(raw: unknown): RelationsOutcome {
+  if (typeof raw !== 'object' || raw === null) {
+    throw new RelationsContractError('payload is not an object')
+  }
+  const o = raw as Record<string, unknown>
+  const tag = o.outcome
+  switch (tag) {
+    case 'related': {
+      const v = o.view
+      if (typeof v !== 'object' || v === null) {
+        throw new RelationsContractError('view is not an object')
+      }
+      const view = v as Record<string, unknown>
+      if (typeof view.truncated !== 'boolean') {
+        throw new RelationsContractError('view.truncated is not a boolean')
+      }
+      if (!Array.isArray(view.related)) {
+        throw new RelationsContractError('view.related is not an array')
+      }
+      const related = view.related.map((entry, i) => {
+        if (typeof entry !== 'object' || entry === null) {
+          throw new RelationsContractError(`view.related[${i}] is not an object`)
+        }
+        const r = entry as Record<string, unknown>
+        const where = `view.related[${i}]`
+        const provenance = r.provenance
+        if (typeof provenance !== 'string' || !PROVENANCE_STATES.includes(provenance)) {
+          throw new RelationsContractError(
+            `${where}.provenance is ${JSON.stringify(provenance)}, which this console does not ` +
+              `know how to present. A new evidence state must be given a presentation ` +
+              `deliberately — it may not fall back, because every fallback is a stronger or ` +
+              `weaker claim than the truth.`,
+          )
+        }
+        return {
+          low: str(r, 'low', where),
+          high: str(r, 'high', where),
+          other: str(r, 'other', where),
+          adjudicator: str(r, 'adjudicator', where),
+          decision_marker: str(r, 'decision_marker', where),
+          provenance: provenance as ProvenanceStanding,
+        }
+      })
+      return { outcome: 'related', view: { subject: str(view, 'subject', 'view'), related, truncated: view.truncated } }
+    }
+    case 'not_an_entity':
+      return { outcome: 'not_an_entity', reason: str(o, 'reason', 'payload') }
+    case 'unavailable':
+      return { outcome: 'unavailable', reason: str(o, 'reason', 'payload') }
+    default:
+      throw new RelationsContractError(
+        `unknown outcome ${JSON.stringify(tag)} — refusing rather than guessing`,
+      )
+  }
+}
+
+/**
+ * How each provenance state is presented.
+ *
+ * THE LOAD-BEARING UI INVARIANT: the console may simplify presentation, but it
+ * may never collapse a weaker provenance state into a stronger one. `degraded`
+ * must not read as `resolved`; `dangling` must not read as merely "no details";
+ * `plural` must not display one carrier as if it were authoritative.
+ *
+ * Every state therefore carries its own label, its own sentence and its own
+ * glyph. Colour is deliberately NOT the carrier of the distinction — it does
+ * not survive greyscale, screenshots, or a reader who cannot distinguish the
+ * hues — so the text alone is sufficient to tell the four apart.
+ */
+export const PROVENANCE_PRESENTATION: Record<
+  ProvenanceStanding,
+  { label: string; glyph: string; sentence: string; tone: string }
+> = {
+  resolved: {
+    label: 'Evidence available',
+    glyph: '●',
+    sentence: 'The supporting evidence for this decision is present in the record.',
+    tone: 'text-emerald-300 border-emerald-500/40 bg-emerald-500/10',
+  },
+  degraded: {
+    label: 'Evidence compacted',
+    glyph: '◐',
+    sentence:
+      'The relationship remains valid as adjudicated. Some supporting evidence has been compacted away, so the explanation is incomplete.',
+    tone: 'text-amber-300 border-amber-500/40 bg-amber-500/10',
+  },
+  dangling: {
+    label: 'Evidence unresolvable',
+    glyph: '○',
+    sentence:
+      'The cited evidence cannot be resolved, and no compaction accounts for it. Do not read this as evidence that was successfully observed.',
+    tone: 'text-rose-300 border-rose-500/40 bg-rose-500/10',
+  },
+  plural: {
+    label: 'Evidence ambiguous',
+    glyph: '◎',
+    sentence:
+      'Several records match the citation. No single one of them is authoritative, and none is shown as if it were.',
+    tone: 'text-sky-300 border-sky-500/40 bg-sky-500/10',
+  },
+}

--- a/console/package.json
+++ b/console/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
-    "smoke": "node scripts/smoke.mjs"
+    "smoke": "node scripts/smoke.mjs",
+    "test:contract": "node --test lib/world/*.test.mjs"
   },
   "dependencies": {
     "clsx": "^2.1.1",

--- a/console/scripts/smoke.mjs
+++ b/console/scripts/smoke.mjs
@@ -20,7 +20,7 @@ const PORT = 8899
 const ROUTES = [
   '', 'live', 'global', 'fleet', 'fleet/r1', 'safety', 'runtime', 'telemetry',
   'missions', 'oversight', 'doer-bound', 'events', 'incidents', 'compliance',
-  'analytics', 'explorer', 'reports', 'settings',
+  'analytics', 'explorer', 'reports', 'settings', 'identity',
 ]
 
 const server = spawn('npx', ['next', 'start', '-p', String(PORT)], { stdio: 'ignore' })

--- a/contracts/world_relations_v1.json
+++ b/contracts/world_relations_v1.json
@@ -1,0 +1,51 @@
+[
+  {
+    "outcome": "related",
+    "view": {
+      "subject": "track-a",
+      "related": [
+        {
+          "low": "track-a",
+          "high": "track-b",
+          "other": "track-b",
+          "adjudicator": "yard-supervisor",
+          "decision_marker": "d-41",
+          "provenance": "resolved"
+        },
+        {
+          "low": "track-a",
+          "high": "track-c",
+          "other": "track-c",
+          "adjudicator": "night-shift-lead",
+          "decision_marker": "d-57",
+          "provenance": "degraded"
+        },
+        {
+          "low": "track-a",
+          "high": "track-d",
+          "other": "track-d",
+          "adjudicator": "yard-supervisor",
+          "decision_marker": "d-63",
+          "provenance": "dangling"
+        },
+        {
+          "low": "track-a",
+          "high": "track-e",
+          "other": "track-e",
+          "adjudicator": "depot-manager",
+          "decision_marker": "d-70",
+          "provenance": "plural"
+        }
+      ],
+      "truncated": true
+    }
+  },
+  {
+    "outcome": "not_an_entity",
+    "reason": "\"track-�\" is not an askable entity identity"
+  },
+  {
+    "outcome": "unavailable",
+    "reason": "the relationship projection could not be read"
+  }
+]

--- a/crates/kirra-explain-types/tests/relations_contract_fixture.rs
+++ b/crates/kirra-explain-types/tests/relations_contract_fixture.rs
@@ -1,0 +1,269 @@
+//! **The canonical relationship-view fixture — the cross-language contract.**
+//!
+//! `contracts/world_relations_v1.json` is the ONE artifact both sides agree on.
+//! This test serializes it from the Rust types;
+//! `console/lib/world/relations.test.mjs` decodes that same file with the
+//! hand-written TypeScript contract.
+//!
+//! # Why a fixture and not Rust→TypeScript generation
+//!
+//! Generation is the attractive answer and was deliberately not taken: it adds
+//! a codegen subsystem before anyone knows whether Kirra World will have one JS
+//! consumer or twenty. A checked-in fixture plus a conformance test on each
+//! side buys the property that matters — **a Rust change that adds, removes,
+//! renames or reshapes a field reds a test** — at a fraction of the machinery,
+//! and it can be replaced by generation later without either side having built
+//! against the generator.
+//!
+//! # What makes it load-bearing rather than decorative
+//!
+//! It carries EVERY outcome variant, EVERY field, and ALL FOUR provenance
+//! states. A fixture covering only the happy row would let a renamed field on
+//! a rare variant reach the console silently — exactly the drift a hand-written
+//! contract is accused of, and the reason this file exists to answer the
+//! accusation.
+//!
+//! Covering the refusal variants is not thoroughness for its own sake.
+//! `not_an_entity` and `unavailable` are the two answers the console must never
+//! render as *related to nothing*, so they are the two whose wire shape it can
+//! least afford to get wrong — and the two a fixture built from the happy path
+//! would never have pinned.
+//!
+//! Neither tree owns it: it sits in `contracts/` at the repository root, so the
+//! Rust side is not reaching into `console/` and the console is not reaching
+//! into `crates/`.
+
+use kirra_explain_types::{
+    ProvenanceStanding, RelatedPair, RelationsOutcome, RelationsView, RELATIONS_VIEW_VERSION,
+};
+
+fn fixture_path() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../contracts/world_relations_v1.json")
+}
+
+/// **One invocation feeds both the fixture rows and the exhaustiveness check.**
+///
+/// The two halves have to come from one place. A hand-written list of four
+/// rows next to a hand-written match of four arms is two lists that drift, and
+/// the drift is silent in the direction that matters: a fifth variant added to
+/// `ProvenanceStanding` and left out of the fixture would reach the console at
+/// runtime, where the decoder throws, instead of at build time, where somebody
+/// can decide how it is presented.
+///
+/// Expanding this macro produces:
+///
+/// - `EVERY_STATE` — the fixture's rows, one per state;
+/// - `wire_name` — a match over `ProvenanceStanding` that is exhaustive
+///   BECAUSE the macro wrote it from the same invocation. A variant missing
+///   from the invocation below makes that match non-exhaustive and this file
+///   stops compiling.
+///
+/// So the chain closes: new variant -> compile error here -> author adds a row
+/// -> the fixture on disk moves -> `console/lib/world/relations.test.mjs`
+/// reds. There is no path that adds a state and leaves both trees green.
+macro_rules! provenance_fixture {
+    ($( $variant:ident => ($other:literal, $adjudicator:literal, $marker:literal) ),+ $(,)?) => {
+        const EVERY_STATE: &[(ProvenanceStanding, &str, &str, &str)] = &[
+            $( (ProvenanceStanding::$variant, $other, $adjudicator, $marker) ),+
+        ];
+
+        fn wire_name(state: ProvenanceStanding) -> &'static str {
+            match state {
+                $( ProvenanceStanding::$variant => stringify!($variant) ),+
+            }
+        }
+    };
+}
+
+provenance_fixture! {
+    Resolved => ("track-b", "yard-supervisor", "d-41"),
+    Degraded => ("track-c", "night-shift-lead", "d-57"),
+    Dangling => ("track-d", "yard-supervisor", "d-63"),
+    Plural   => ("track-e", "depot-manager", "d-70"),
+}
+
+/// One pair per provenance state, so the fixture exercises every one of them.
+fn canonical_view() -> RelationsView {
+    RelationsView {
+        subject: "track-a".to_string(),
+        related: EVERY_STATE
+            .iter()
+            .map(|&(provenance, other, adjudicator, marker)| RelatedPair {
+                low: "track-a".to_string(),
+                high: other.to_string(),
+                other: other.to_string(),
+                adjudicator: adjudicator.to_string(),
+                decision_marker: marker.to_string(),
+                provenance,
+            })
+            .collect(),
+        truncated: true,
+    }
+}
+
+/// **The same one-invocation trick, applied to the outcome variants.**
+///
+/// `RelationsOutcome` has three arms and the console renders all three. The
+/// two it renders most carefully are the refusals — `not_an_entity` (the
+/// subject is not askable) and `unavailable` (nobody could answer) — because
+/// both must stay distinguishable from `related` with an empty list. A fixture
+/// that pinned only `related` would leave exactly those two free to drift.
+///
+/// Expanding this produces the fixture's document list AND an exhaustive match
+/// over the enum, so a fourth variant stops this file compiling.
+macro_rules! outcome_fixture {
+    ($( $variant:ident { $( $field:ident : $value:expr ),* $(,)? } => $tag:literal ),+ $(,)?) => {
+        fn canonical_fixture() -> Vec<RelationsOutcome> {
+            vec![ $( RelationsOutcome::$variant { $( $field: $value ),* } ),+ ]
+        }
+
+        fn outcome_tag(outcome: &RelationsOutcome) -> &'static str {
+            match outcome {
+                $( RelationsOutcome::$variant { .. } => $tag ),+
+            }
+        }
+    };
+}
+
+outcome_fixture! {
+    Related { view: canonical_view() } => "related",
+    NotAnEntity {
+        reason: "\"track-\u{fffd}\" is not an askable entity identity".to_string(),
+    } => "not_an_entity",
+    Unavailable {
+        reason: "the relationship projection could not be read".to_string(),
+    } => "unavailable",
+}
+
+/// **The fixture on disk is what these types serialize to.**
+///
+/// Pretty-printed so a CI failure diff is readable rather than one enormous
+/// line. On mismatch the message prints the expected document — the fix is to
+/// update the fixture AND to look at what moved, because the console's
+/// conformance test is about to fail too and that is the signal.
+#[test]
+fn the_checked_in_fixture_matches_what_rust_serializes() {
+    let expected = serde_json::to_string_pretty(&canonical_fixture()).expect("serialize");
+    let path = fixture_path();
+    let found = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()));
+
+    assert_eq!(
+        found.trim(),
+        expected.trim(),
+        "\n\nthe cross-language fixture is out of date.\n\
+         The Rust contract changed, so `console/lib/world/relations.ts` must change with it.\n\
+         Write this into {}:\n\n{expected}\n",
+        path.display()
+    );
+}
+
+/// **Every provenance state appears in the fixture, and the two halves agree.**
+///
+/// `wire_name` is the exhaustive match the macro wrote; `EVERY_STATE` is the
+/// row list it wrote from the same invocation. Comparing them here gives the
+/// compile-time control a runtime job as well: if the macro ever grew a second
+/// source of truth, the two would disagree and this would say so.
+///
+/// The serialized name is checked against the match arm's identifier, lowered,
+/// because the wire form is what the console actually reads. A serde rename on
+/// one variant would show up as a mismatch here rather than as a missing
+/// presentation in the browser.
+#[test]
+fn the_fixture_exercises_every_provenance_state() {
+    let view = canonical_view();
+    assert_eq!(
+        view.related.len(),
+        EVERY_STATE.len(),
+        "one fixture row per provenance state"
+    );
+
+    let mut seen: Vec<ProvenanceStanding> = view.related.iter().map(|r| r.provenance).collect();
+    seen.sort_by_key(|s| format!("{s:?}"));
+    seen.dedup();
+    assert_eq!(
+        seen.len(),
+        EVERY_STATE.len(),
+        "the fixture must carry each state exactly once, got {seen:?}"
+    );
+
+    for &(state, ..) in EVERY_STATE {
+        let serialized = serde_json::to_string(&state).expect("serialize a state");
+        assert_eq!(
+            serialized.trim_matches('"'),
+            wire_name(state).to_ascii_lowercase(),
+            "the wire name for {state:?} is not what the match arm names it — \
+             a serde rename must be carried into the console contract"
+        );
+    }
+
+    assert!(
+        view.truncated,
+        "truncated must be exercised as true — a fixture where it is always \
+         false would not catch the field being dropped"
+    );
+}
+
+/// **Every outcome variant appears in the fixture, exactly once.**
+///
+/// `outcome_tag` is the exhaustive match the macro wrote from the same
+/// invocation as the document list, so this cannot be satisfied by a fixture
+/// that has drifted from the enum: a fourth variant fails to compile above,
+/// and a variant dropped from the invocation drops its document here.
+///
+/// The tag is compared against what serde actually emits, because the tag is
+/// what the console switches on. A `#[serde(rename)]` on one arm shows up as a
+/// mismatch here rather than as an unhandled outcome in the browser.
+#[test]
+fn the_fixture_carries_every_outcome_variant() {
+    let fixture = canonical_fixture();
+    let mut tags: Vec<&str> = fixture.iter().map(outcome_tag).collect();
+    let distinct = {
+        let mut t = tags.clone();
+        t.sort_unstable();
+        t.dedup();
+        t
+    };
+    assert_eq!(
+        tags.len(),
+        distinct.len(),
+        "each outcome variant appears once, got {tags:?}"
+    );
+    tags.sort_unstable();
+    assert_eq!(
+        tags,
+        ["not_an_entity", "related", "unavailable"],
+        "the console switches on these tags; a change here is a console change"
+    );
+
+    for outcome in &fixture {
+        let value = serde_json::to_value(outcome).expect("serialize an outcome");
+        assert_eq!(
+            value.get("outcome").and_then(|v| v.as_str()),
+            Some(outcome_tag(outcome)),
+            "the serialized tag is not what the match arm names it"
+        );
+    }
+
+    // The refusals must carry their reason, or the console has nothing to show
+    // and would fall back to a generic message — which reads as an empty
+    // answer, the one thing these two variants exist to prevent.
+    for outcome in &fixture {
+        if outcome_tag(outcome) == "related" {
+            continue;
+        }
+        let value = serde_json::to_value(outcome).expect("serialize an outcome");
+        let reason = value.get("reason").and_then(|v| v.as_str()).unwrap_or("");
+        assert!(
+            !reason.trim().is_empty(),
+            "{} must carry a non-empty reason",
+            outcome_tag(outcome)
+        );
+    }
+}
+
+/// The contract version is pinned, so a bump is a deliberate act.
+#[test]
+fn the_contract_version_is_one() {
+    assert_eq!(RELATIONS_VIEW_VERSION, 1);
+}

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -5594,3 +5594,96 @@ some seventh way would satisfy them all while naming the wrong axis.
   — meaningless, but hashed into the reference's identity, so two references for
   the same query would compare unequal. They share `QueryKind`,
   `SemanticVersions`, the refusal ordering and the reproducibility horizon.
+
+### The console is the second `Related` consumer — 2026-08-21
+
+`mission_context` was the first, and it is invisible: it ranks proposals and
+nobody sees the identity context that moved the ranking. The operator console is
+the first place a human reads a World answer directly, which makes it the first
+place a *presentation* can be wrong in a way no Rust test would catch.
+
+**Topology.** `Browser → Next.js server route → kirra-world-explain-service
+(loopback) → QueryEngine`. The browser never speaks to Kirra World. The
+alternative — pointing the browser at the World service — requires setting
+`KIRRA_WORLD_EXPLAIN_ALLOW_NONLOCAL=1`, and that flag exists precisely because
+the World process has no authentication of its own; flipping it converts an
+on-box service into an exposed one to save a network hop. The console already
+owns browser-facing auth, session handling, origin policy and future access
+control, so the proxy is where that ownership is exercised rather than a layer
+of ceremony over a direct call.
+
+#### A second definition of the contract, and what pays for it
+
+`console/lib/world/relations.ts` is a hand-written TypeScript restatement of
+types whose source of truth is Rust. That is a real duplication and the usual
+answer is codegen. Codegen was deliberately deferred: it adds a subsystem before
+anyone knows whether Kirra World will have one JS consumer or twenty, and the
+fixture buys the property that matters now — **a Rust change that adds, removes,
+renames or reshapes a field reds a test** — at a fraction of the machinery.
+
+`contracts/world_relations_v1.json` sits at the repository root because neither
+tree owns it: a Rust test writes it, a Node test reads it, and neither reaches
+into the other's directory.
+
+Two properties make it load-bearing rather than decorative, and both were built
+only after checking that the obvious version of the fixture did **not** have
+them:
+
+* **Every provenance state.** The first draft hand-wrote four rows next to a
+  four-arm match. Adding a fifth `ProvenanceStanding` variant in Rust red
+  nothing: the fixture kept its four rows, the console kept its four
+  presentations, and the new state would have reached the browser at runtime —
+  where the decoder throws, which is honest but is a production failure, not a
+  build failure. A macro now writes the row list and the exhaustive match from
+  one invocation, so a new variant fails to compile in the file that says what
+  to do about it, and the row it forces in moves the fixture, which reds the
+  console.
+* **Every outcome variant.** The same hole one level up: the fixture pinned only
+  `related`, leaving `not_an_entity` and `unavailable` free to drift. Those two
+  are exactly the answers that must never be rendered as *related to nothing*,
+  so they are the two whose wire shape the console can least afford to get
+  wrong. Same macro treatment, same compile-time break.
+
+The decoder **fails closed** in both directions. An unknown provenance state
+throws rather than mapping to a fallback, because every available fallback is a
+stronger or a weaker claim than the truth in at least one direction. An unknown
+outcome tag throws for the same reason. Unknown extra *fields* are tolerated —
+`deny_unknown_fields` governs what the producer accepts, whereas an extra field
+arriving here means the producer is merely ahead of the console, and refusing to
+render a relation because an unused field appeared would take the console down
+for an additive change.
+
+#### The UI invariant
+
+> **The console may simplify presentation, but it may never collapse a weaker
+> provenance state into a stronger one.**
+
+`Degraded` may not render as `Resolved`; `Dangling` may not render as merely "no
+details"; `Plural` may not display one carrier as if it were authoritative. Each
+state therefore carries its own label, its own glyph and its own sentence, and
+**colour is not the carrier of the distinction** — it does not survive
+greyscale, a screenshot, or a reader who cannot separate the hues. The
+conformance test asserts the four labels and the four glyphs are distinct as
+text, and asserts the specific sentences that refuse each collapse.
+
+The Rust and TypeScript halves of the contract check different things on
+purpose. Rust checks that the fixture is what the types serialize to; the
+console checks that every shape in the fixture has somewhere to go. Neither
+alone is sufficient: a fully-propagated Rust rename leaves the Rust tree green
+and is caught only by the console, and a console presentation deleted for a
+state Rust still emits is caught only by the console.
+
+#### The mutation battery
+
+| Mutation | Result |
+|---|---|
+| rename `decision_marker` in Rust, propagate every Rust caller, regenerate the fixture | Rust green; **console red**, naming the field |
+| add a fifth `ProvenanceStanding` variant | **compile error** in the fixture generator |
+| …then add its fixture row, as the author would | fixture moves; **console red** — no presentation for it |
+| drop an outcome variant from the fixture macro | **compile error** — the match is non-exhaustive |
+| drop the `unavailable` document from the fixture on disk | **console red** on two tests |
+
+The first row is the one worth keeping in mind: a rename carried carefully
+through every Rust caller produces a completely green Rust workspace. The
+console is the only thing that notices, which is the whole argument for the
+fixture existing.


### PR DESCRIPTION
The first JavaScript consumer of Kirra World, and the first place a human reads a World answer directly rather than through a Rust caller.

## Topology

```
Browser → Next.js server route → kirra-world-explain-service (loopback) → QueryEngine
```

The browser never speaks to Kirra World. Pointing it there would require `KIRRA_WORLD_EXPLAIN_ALLOW_NONLOCAL=1`, and that flag exists precisely because the World process has no authentication of its own — setting it converts an on-box service into an exposed one to save a network hop. The console already owns browser-facing auth, session handling, origin policy and future access control, so the proxy is where that ownership is exercised rather than a layer of ceremony over a direct call.

## Why the TypeScript contract is hand-written

`console/lib/world/relations.ts` is a second definition of types whose source of truth is Rust. That is a real duplication and the usual answer is codegen. Codegen was deliberately deferred: it adds a subsystem before anyone knows whether Kirra World will have one JS consumer or twenty.

What pays for the duplication instead is `contracts/world_relations_v1.json` — emitted by a Rust test, decoded by a Node test with the same decoder the page uses. It sits at the repository root because neither tree owns it: the Rust side is not reaching into `console/` and the console is not reaching into `crates/`.

## Two holes the fixture did not close until they were measured

Both were found by running the mutation, not by reading the code. Both are now closed by a macro that writes the fixture rows and an exhaustive `match` from **one** invocation.

**A fifth `ProvenanceStanding` variant used to red nothing.** The fixture kept its four hand-written rows, the console kept its four presentations, and the new state would have reached the browser at runtime — where the decoder throws, which is honest, but that is a production failure rather than a build failure. It now fails to compile in the file that says what to do about it, and the row it forces in moves the fixture, which reds the console.

**The fixture pinned only the `related` outcome.** `not_an_entity` and `unavailable` were free to drift — and those two are exactly the answers that must never be rendered as *related to nothing*, so they are the two whose wire shape the console can least afford to get wrong. Same macro treatment, same compile-time break.

## Fail-closed, in both directions

An unknown provenance state **throws** rather than mapping to a fallback: every available fallback is a stronger or a weaker claim than the truth in at least one direction. An unknown outcome tag throws for the same reason.

Unknown extra *fields* are tolerated, deliberately. `deny_unknown_fields` governs what the producer accepts; an extra field arriving here means the producer is merely ahead of the console, and refusing to render a relation because an unused field appeared would take the console down for an additive change.

## The UI invariant

> **The console may simplify presentation, but it may never collapse a weaker provenance state into a stronger one.**

`Degraded` may not render as `Resolved`. `Dangling` may not render as merely "no details". `Plural` may not display one carrier as if it were authoritative.

Each state carries its own label, its own glyph and its own sentence, and **colour is not the carrier of the distinction** — it does not survive greyscale, a screenshot, or a reader who cannot separate the hues. The conformance test asserts the four labels and the four glyphs are distinct as text, and asserts the specific sentences that refuse each collapse.

| State | Label | Glyph |
|---|---|---|
| `resolved` | Evidence available | ● |
| `degraded` | Evidence compacted | ◐ |
| `dangling` | Evidence unresolvable | ○ |
| `plural` | Evidence ambiguous | ◎ |

## Mutations, run against the shipped code

| Mutation | Result |
|---|---|
| rename `decision_marker` in Rust, propagate every Rust caller, regenerate the fixture | Rust green; **console red**, naming the field |
| add a fifth `ProvenanceStanding` variant | **compile error** in the fixture generator |
| …then add its fixture row, as the author would | fixture moves; **console red** — no presentation for it |
| drop an outcome variant from the fixture macro | **compile error** — the match is non-exhaustive |
| drop the `unavailable` document from the fixture on disk | **console red** on two tests |

The first row is the one worth remembering: a rename carried carefully through every Rust caller leaves the entire Rust workspace green. The console is the only thing that notices, which is the whole argument for the fixture existing.

## Scope

In: server-side proxy route, typed TS contract, Rust-produced fixture + TS conformance test, relationship panel, four provenance presentations, transport failure/unavailable state.

Out, and stayed out: no new World endpoint, no direct browser→World networking, no mutations, no generic World-query UI. There is no adjudication control on this page — deciding identity is `KIRRA-WM-PROMOTION-001` territory and requires an authenticated operator; a console button would be the second way to do it and the unauthenticated one.

`/identity` is registered in the nav (unflagged — it never renders mock data; with no World service configured it reports the answer as unavailable rather than inventing one) and added to the smoke route sweep.

## Verification

- `cargo test --workspace` — 274 result groups, 0 failed
- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets` — clean for this change
- `npm run typecheck`, `npm run lint`, `npm run test:contract` (9/9), `npm run build`
- `npm run smoke` — 19 routes + quick-nav clean, `/identity` included
- The gate sweep, including `check_kirra_world_bidirectional_fence`, `check_query_boundedness`, `check_explain_artifact_neutral`, `check_world_semantics`, `check_workflow_pr_coverage` — all pass

One pre-existing unrelated warning is left alone: an unused `StoreError` import in `crates/kirra-world-store/tests/claim_at_generation.rs`. It is not gated by any `-D warnings` lane (those are scoped to the detached tool workspaces), and fixing it here would widen this diff into an unrelated crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_