### PR TITLE
5c.1: the write side gets the door the read side has

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2651,6 +2651,7 @@ name = "kirra-world-ingest"
 version = "0.1.0"
 dependencies = [
  "kirra-world",
+ "kirra-world-service",
  "kirra-world-store",
 ]
 

--- a/crates/kirra-world-ingest/Cargo.toml
+++ b/crates/kirra-world-ingest/Cargo.toml
@@ -41,6 +41,14 @@ publish = false  # proprietary (see COPYRIGHT) — not for crates.io
 kirra-world-store = { path = "../kirra-world-store" }
 # SameAsCandidate, MatcherIdentity, Confidence — the domain types the door takes.
 kirra-world = { path = "../kirra-world" }
+# The 5c.1 command surface. This crate is the production WRITER, so it goes
+# through the sanctioned write door rather than calling the store method behind
+# it -- the same migration `mission_context` made for reads in box 3d.
+#
+# `kirra-world-service` carries this crate as a DEV-dependency (box 5b's
+# end-to-end test drives a real ingest pass). Cargo permits a dev-dependency
+# cycle, and this is one: the runtime edge goes one way only, writer -> door.
+kirra-world-service = { path = "../kirra-world-service" }
 
 [dev-dependencies]
 # `test-support` for `head_generation_for_test`: box 2b's provenance-walk tests

--- a/crates/kirra-world-ingest/src/lib.rs
+++ b/crates/kirra-world-ingest/src/lib.rs
@@ -16,7 +16,7 @@
 //!
 //! # The shape: a pure proposer, a thin pass
 //!
-//! [`propose_from_claims`] is a pure function of the evidence it is given. It
+//! [`propose_from_agreements`] is a pure function of the evidence it is given. It
 //! reads nothing and writes nothing, so what a matcher WOULD propose is
 //! testable without a store — and the tests that matter (all-pairs, the group
 //! ceiling, the identifier rule) are written against it directly.
@@ -29,12 +29,19 @@
 //! # It cannot confirm, structurally
 //!
 //! The only door this crate uses is
-//! [`WorldStore::append_same_as_candidate`](kirra_world_store::WorldStore::append_same_as_candidate),
-//! which takes no `writer_class` and no `claim_status` from its caller. There is
-//! no argument here that could carry `Confirmed`, so "the matcher does not
-//! self-confirm" is not a property of this code's care — it is a property of the
-//! only API it can reach. Schema v8's trigger is the independent second half,
-//! covering a producer written later against the same store.
+//! [`ProposeSameAs`](kirra_world_service::command::ProposeSameAs), the box 5c.1
+//! command over
+//! [`WorldStore::append_same_as_candidate`](kirra_world_store::WorldStore::append_same_as_candidate).
+//! That door takes no `writer_class` and no `claim_status` from its caller.
+//! There is no argument here that could carry `Confirmed`, so "the matcher does
+//! not self-confirm" is not a property of this code's care — it is a property of
+//! the only API it can reach. Schema v8's trigger is the independent second
+//! half, covering a producer written later against the same store.
+//!
+//! The command layer does not weaken that: 5c.1's differential control proves
+//! `ProposeSameAs` writes exactly what the store method writes, so the argument
+//! above is about the same door it always was — now reached through the one
+//! sanctioned write surface rather than around it.
 
 #![warn(missing_docs)]
 #![forbid(unsafe_code)]
@@ -387,16 +394,23 @@ pub fn run_ingest_pass(
             continue;
         }
         let (event_id, observation_id) = mint();
-        store.append_same_as_candidate(
-            &CandidateRow {
-                event_id: &event_id,
-                observation_id: &observation_id,
-                txn_time_ms: now_ms,
-                valid_from_ms: now_ms,
-                source: rule.matcher().producer(),
-                source_version: rule.matcher().version(),
+        // Through the command surface, not the store method under it. The
+        // engine is rebound per candidate because the existence check above
+        // borrows the store immutably; binding it once outside the loop would
+        // hold `&mut` across that read for no gain -- `CommandEngine` is a
+        // borrow and a vtable, not a resource.
+        kirra_world_service::command::CommandEngine::new(store).execute(
+            kirra_world_service::command::ProposeSameAs {
+                row: CandidateRow {
+                    event_id: &event_id,
+                    observation_id: &observation_id,
+                    txn_time_ms: now_ms,
+                    valid_from_ms: now_ms,
+                    source: rule.matcher().producer(),
+                    source_version: rule.matcher().version(),
+                },
+                candidate,
             },
-            &candidate,
         )?;
         report.proposed += 1;
     }

--- a/crates/kirra-world-service/src/command.rs
+++ b/crates/kirra-world-service/src/command.rs
@@ -1,0 +1,285 @@
+//! **The one sanctioned way to write to Kirra World** — Tier 5 box 5c.1.
+//!
+//! [`query`](crate::query) gave reads a single door. This is the write half,
+//! and it is deliberately the same shape: a sealed trait, one entry point,
+//! compile-time outcome types.
+//!
+//! # What this box is NOT allowed to be
+//!
+//! `KIRRA-WM-TIER5-CQRS-001` states the constraint this module is written
+//! against:
+//!
+//! > **No new semantics hidden inside command wrappers**: a command that
+//! > quietly decides something the domain layer does not is a second
+//! > adjudication path, and the tier that discovers it will be paying Tier 2's
+//! > bill again.
+//!
+//! Three structural decisions carry that, rather than a promise to be careful:
+//!
+//! 1. **A command carries an already-constructed domain value, never its
+//!    parts.** [`RecordMerge`] takes a
+//!    [`MergeEntities`](kirra_world::adjudication::MergeEntities), not
+//!    `sources` and `into`. `MergeEntities::new` is where a merge is judged
+//!    well-formed — empty source list, duplicate source, merge-into-self — and
+//!    a command taking the raw parts would have to make that judgement a second
+//!    time. Two judgements are two places to get it wrong, and the second one
+//!    is the one nobody tests. Here the command **cannot** validate differently,
+//!    because it never sees anything to validate.
+//!
+//! 2. **No `CommandError`.** The blueprint's signatures end in `| Refused`, and
+//!    the tempting reading is a new flattened refusal enum. That would DESTROY
+//!    information: [`StoreError`] already distinguishes *no such candidate*
+//!    from *that row is not a candidate* from *unauthorized adjudicator*, and
+//!    an operator told the wrong one looks in the wrong place. So commands
+//!    return `StoreError` unchanged. "Refused" is the store's existing typed
+//!    refusal, not a new vocabulary laid over it.
+//!
+//! 3. **Authority is carried, never re-checked.**
+//!    [`AdjudicationAuthority`](kirra_world::same_as_adjudication::AdjudicationAuthority)
+//!    refuses any class but `Operator` at CONSTRUCTION, so a held authority is
+//!    already an authorized one. A check here would be a second place authority
+//!    is decided — which is the defect this module exists to avoid, not a
+//!    belt-and-braces improvement.
+//!
+//! # The asymmetry this module surfaces rather than papers over
+//!
+//! Building the surface required auditing every write door, and the audit found
+//! **two routes to canonical identity change, only one of them gated**:
+//!
+//! | Door | Authority |
+//! |---|---|
+//! | `append_same_as_candidate` | pins `Derivation`/`Candidate` — structurally cannot promote |
+//! | `adjudicate_same_as` | requires `AdjudicationAuthority` — `Operator` only, per `KIRRA-WM-PROMOTION-001` |
+//! | `append_adjudication` (Merge / Split / Forget) | **none** |
+//!
+//! A `Merge` reaches `Lifecycle::Merged { into }`, the entity projection, and
+//! identity resolution — the same canonical-identity effect a promoted
+//! `same_as` has, by a route carrying no adjudicator at all.
+//!
+//! **This module does not fix that, and the restraint is the point.** Requiring
+//! an authority token here that the domain does not require would be precisely
+//! the "new semantics hidden inside a command wrapper" the box forbids — a
+//! tightening invented at the wrapper, where the domain still permits the
+//! ungated call to anyone holding `&mut WorldStore`. The fix belongs in
+//! `kirra_world::adjudication`, and it needs a ruling: *may an identity
+//! adjudication be recorded without an authorized adjudicator?* Recorded in
+//! `WM_SCOPE.md`; pinned here by
+//! `a_merge_command_carries_no_authority_and_that_is_the_open_finding`.
+//!
+//! # Why `AssertEntity` is absent
+//!
+//! [`IdentityAdjudication`] has four verbs and this module wraps three.
+//! `Assert` is operator teaching — box **5d**, BLOCKED ON RULING pending what
+//! writer class an operator assertion carries and whether it may outrank sensed
+//! evidence. One `RecordIdentityAdjudication` command taking any variant would
+//! have carried `Assert` in as a side effect and unblocked 5d by accident, so
+//! there are three narrow commands instead of one wide one. Pinned by
+//! `no_command_can_record_an_assert_because_5d_is_unruled`.
+//!
+//! # What is deliberately not wrapped
+//!
+//! `WORLD_MODEL_ARCHITECTURE.md` §14.1 lists nine commands. Five have a domain
+//! operation behind them today and are wrapped here. The other four are not
+//! omissions to be filled in later without thought:
+//!
+//! * `AssertEntity` — blocked on 5d, above.
+//! * `RecordObservation(ObservationDraft)` — the underlying `WorldStore::append`
+//!   is the RAW door: it takes `writer_class` and `claim_status` as free
+//!   parameters. A command wrapping it either passes them through (adding
+//!   nothing, so it is not a command, it is an alias) or chooses them (deciding
+//!   the two fields the whole trust model rests on, inside a wrapper). Neither
+//!   is this box's to do.
+//! * `ConfirmEntity`, `CorrectObservation`, `RetractAssertion` — **no domain
+//!   operation exists**. Writing the command first would put the semantics in
+//!   the wrapper by definition, since there would be nothing else for them to
+//!   live in.
+//! * `ImportMapLayer` — map layers are unstarted and gated on a consumer.
+
+use kirra_world::adjudication::{ForgetEntity, IdentityAdjudication, MergeEntities, SplitEntity};
+use kirra_world::same_as_adjudication::SameAsAdjudication;
+use kirra_world::same_as_candidate::SameAsCandidate;
+use kirra_world_store::adjudication_record::AdjudicationRow;
+use kirra_world_store::candidate_record::CandidateRow;
+use kirra_world_store::same_as_adjudication_record::SameAsAdjudicationRequest;
+use kirra_world_store::{StoreError, WorldStore};
+
+mod sealed {
+    /// Closed by construction. See [`super::WorldCommand`].
+    pub trait Sealed {}
+}
+
+/// **One sanctioned write.**
+///
+/// Sealed for the reason [`WorldQuery`](crate::query::WorldQuery) is: an open
+/// trait would let a caller write its own implementation, close over a
+/// `&mut WorldStore`, and route an arbitrary mutation through [`CommandEngine`]
+/// while looking like sanctioned use. A write surface that can be extended from
+/// outside is a write surface that decides nothing.
+pub trait WorldCommand: sealed::Sealed {
+    /// What performing this command produces.
+    ///
+    /// Associated rather than a shared union, for [`WorldQuery`]'s reason:
+    /// [`AdjudicateSameAs`] yields a [`SameAsAdjudication`] and the others a
+    /// generation, checked at compile time, with no runtime arm to get wrong.
+    ///
+    /// [`WorldQuery`]: crate::query::WorldQuery
+    type Outcome;
+
+    /// Perform this command against `engine`.
+    ///
+    /// Prefer [`CommandEngine::execute`] at call sites. This is the dispatch
+    /// target, not the intended spelling.
+    ///
+    /// # Errors
+    ///
+    /// Whatever the underlying store operation raises, unchanged — see this
+    /// module's note on why there is no `CommandError`.
+    fn execute(self, engine: &mut CommandEngine<'_>) -> Result<Self::Outcome, StoreError>;
+}
+
+/// **The write entry point.**
+///
+/// Holds `&mut WorldStore` and offers no reads. The asymmetry with
+/// [`QueryEngine`](crate::query::QueryEngine) is deliberate: a command that
+/// could also read would invite read-modify-write inside a wrapper, and a
+/// decision made from a read the caller never saw is the definition of a
+/// semantic hidden in the command layer.
+pub struct CommandEngine<'a> {
+    store: &'a mut WorldStore,
+}
+
+impl<'a> CommandEngine<'a> {
+    /// Bind an engine to a store.
+    #[must_use]
+    pub fn new(store: &'a mut WorldStore) -> Self {
+        Self { store }
+    }
+
+    /// **Perform one typed command.**
+    ///
+    /// ```ignore
+    /// let mut engine = CommandEngine::new(&mut store);
+    /// let generation = engine.execute(RecordMerge { row, merge })?;
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Whatever the underlying store operation raises.
+    pub fn execute<C: WorldCommand>(&mut self, command: C) -> Result<C::Outcome, StoreError> {
+        command.execute(self)
+    }
+
+    /// The store the commands dispatch into.
+    ///
+    /// `pub(crate)` and no wider: this is the thing the module exists to stop
+    /// callers from reaching.
+    pub(crate) fn store(&mut self) -> &mut WorldStore {
+        self.store
+    }
+}
+
+/// **Propose that two entities are the same.** Blueprint: part of `RecordObservation`.
+///
+/// Wraps `WorldStore::append_same_as_candidate`, which pins
+/// `WriterClass::Derivation` and `ClaimStatus::Candidate` itself — so this
+/// command structurally cannot propose something confirmed, and does not need
+/// to be trusted not to.
+pub struct ProposeSameAs<'a> {
+    /// Where this proposal sits in the log.
+    pub row: CandidateRow<'a>,
+    /// The proposal itself, already judged well-formed by the domain.
+    pub candidate: SameAsCandidate,
+}
+
+impl sealed::Sealed for ProposeSameAs<'_> {}
+
+impl WorldCommand for ProposeSameAs<'_> {
+    type Outcome = i64;
+
+    fn execute(self, engine: &mut CommandEngine<'_>) -> Result<Self::Outcome, StoreError> {
+        engine
+            .store()
+            .append_same_as_candidate(&self.row, &self.candidate)
+    }
+}
+
+/// **Judge a proposed `same_as`.** Blueprint: `ConfirmEntity`, narrowed to the
+/// one relation v1 promotes.
+///
+/// The request carries its own `AdjudicationAuthority`, which is why this
+/// command performs no authority check of its own. See the module docs.
+pub struct AdjudicateSameAs<'a> {
+    /// Who decided what, about which persisted candidate.
+    pub request: SameAsAdjudicationRequest<'a>,
+}
+
+impl sealed::Sealed for AdjudicateSameAs<'_> {}
+
+impl WorldCommand for AdjudicateSameAs<'_> {
+    type Outcome = SameAsAdjudication;
+
+    fn execute(self, engine: &mut CommandEngine<'_>) -> Result<Self::Outcome, StoreError> {
+        engine.store().adjudicate_same_as(&self.request)
+    }
+}
+
+/// **Several entities were one.** Blueprint: `MergeEntities`.
+pub struct RecordMerge<'a> {
+    /// Where this judgement sits in the log.
+    pub row: AdjudicationRow<'a>,
+    /// The merge, already judged well-formed by `MergeEntities::new`.
+    pub merge: MergeEntities,
+}
+
+impl sealed::Sealed for RecordMerge<'_> {}
+
+impl WorldCommand for RecordMerge<'_> {
+    type Outcome = i64;
+
+    fn execute(self, engine: &mut CommandEngine<'_>) -> Result<Self::Outcome, StoreError> {
+        let adjudication = IdentityAdjudication::Merge(self.merge);
+        engine.store().append_adjudication(&self.row, &adjudication)
+    }
+}
+
+/// **One entity was several.** Blueprint: `SplitEntity`.
+pub struct RecordSplit<'a> {
+    /// Where this judgement sits in the log.
+    pub row: AdjudicationRow<'a>,
+    /// The split, already judged well-formed by the domain.
+    pub split: SplitEntity,
+}
+
+impl sealed::Sealed for RecordSplit<'_> {}
+
+impl WorldCommand for RecordSplit<'_> {
+    type Outcome = i64;
+
+    fn execute(self, engine: &mut CommandEngine<'_>) -> Result<Self::Outcome, StoreError> {
+        let adjudication = IdentityAdjudication::Split(self.split);
+        engine.store().append_adjudication(&self.row, &adjudication)
+    }
+}
+
+/// **An entity was retired.** Blueprint: `ForgetEntity`.
+///
+/// Retirement, never erasure — `WORLD_MODEL_ARCHITECTURE.md` §14.1 is explicit
+/// that genuine erasure would be a distinct audited `Redact` with its own ADR
+/// and a tombstone. Nothing here deletes.
+pub struct RecordForget<'a> {
+    /// Where this judgement sits in the log.
+    pub row: AdjudicationRow<'a>,
+    /// The retirement, already judged well-formed by the domain.
+    pub forget: ForgetEntity,
+}
+
+impl sealed::Sealed for RecordForget<'_> {}
+
+impl WorldCommand for RecordForget<'_> {
+    type Outcome = i64;
+
+    fn execute(self, engine: &mut CommandEngine<'_>) -> Result<Self::Outcome, StoreError> {
+        let adjudication = IdentityAdjudication::Forget(self.forget);
+        engine.store().append_adjudication(&self.row, &adjudication)
+    }
+}

--- a/crates/kirra-world-service/src/lib.rs
+++ b/crates/kirra-world-service/src/lib.rs
@@ -31,6 +31,7 @@
 #![warn(missing_docs)]
 
 pub mod answer_ref;
+pub mod command;
 pub mod cursor;
 pub mod explain;
 pub mod explain_labels;

--- a/crates/kirra-world-service/tests/command_surface.rs
+++ b/crates/kirra-world-service/tests/command_surface.rs
@@ -1,0 +1,363 @@
+//! **Tier 5 box 5c.1 — the command surface adds a door, not a decision.**
+//!
+//! `KIRRA-WM-TIER5-CQRS-001` allows this box to define a sanctioned command
+//! surface over the EXISTING domain operations, and forbids one thing:
+//!
+//! > **No new semantics hidden inside command wrappers.**
+//!
+//! That is a property about what the wrapper DOES NOT do, and the usual way to
+//! test such a property is to read the wrapper and agree it looks harmless.
+//! This file does not do that. The control is DIFFERENTIAL: every command is
+//! run against one store while the domain operation it wraps is run against a
+//! second store from the identical starting state, and the two stores'
+//! **chain digests** are compared.
+//!
+//! `head_chain()` covers the canonical bytes of every event, so the assertion
+//! is not "both succeeded" but *"the log the command produced is
+//! indistinguishable from the log the domain call produced"*. A wrapper that
+//! set a different `writer_class`, stamped its own source, chose a different
+//! `valid_from_ms`, or wrapped the wrong `IdentityAdjudication` variant would
+//! keep compiling, keep passing a smoke test, and diverge here.
+//!
+//! Non-vacuity is not assumed: `a_divergent_wrapper_is_caught_by_the_digest`
+//! performs the same comparison across a DELIBERATELY different write and
+//! asserts the digests differ. Without it, every assertion above would also
+//! pass if `head_chain` returned a constant.
+
+use kirra_world::adjudication::{
+    ForgetEntity, IdentityAdjudication, Justification, MergeEntities, RetirementReason,
+};
+use kirra_world::observation::{
+    ClockDomain, Confidence, ConfidenceBasis, DomainInstant, SourceClass,
+};
+use kirra_world::reference::{EntityId, EventId, ObservationId};
+use kirra_world::same_as_adjudication::{AdjudicationAuthority, Outcome};
+use kirra_world::same_as_candidate::{CandidatePair, MatcherIdentity, SameAsCandidate};
+use kirra_world_service::command::{
+    AdjudicateSameAs, CommandEngine, ProposeSameAs, RecordForget, RecordMerge,
+};
+use kirra_world_store::adjudication_record::AdjudicationRow;
+use kirra_world_store::candidate_record::CandidateRow;
+use kirra_world_store::same_as_adjudication_record::SameAsAdjudicationRequest;
+use kirra_world_store::{WorldStore, WriterClass};
+
+const T0: i64 = 1_700_000_000_000;
+const OBS: &str = "01ARZ3NDEKTSV4RRFFQ69G5FAV";
+const EVT: &str = "01ARZ3NDEKTSV4RRFFQ69G5FB0";
+const CAND_OBS: &str = "01ARZ3NDEKTSV4RRFFQ69G5FC1";
+const DECIDE_OBS: &str = "01ARZ3NDEKTSV4RRFFQ69G5FD2";
+const DECIDE_EVT: &str = "01ARZ3NDEKTSV4RRFFQ69G5FE3";
+
+fn eid(s: &str) -> EntityId {
+    EntityId::new(s.to_string()).expect("entity id")
+}
+fn obs(s: &str) -> ObservationId {
+    ObservationId::new(s.to_string()).expect("observation id")
+}
+fn evt(s: &str) -> EventId {
+    EventId::new(s.to_string()).expect("event id")
+}
+fn just() -> Justification {
+    Justification::new([obs(OBS)]).expect("justification")
+}
+fn at(ms: u64) -> DomainInstant {
+    DomainInstant {
+        ms,
+        domain: ClockDomain::System,
+    }
+}
+
+fn tmp(name: &str) -> std::path::PathBuf {
+    static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let n = NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "kirra-5c1-{name}-{}-{n}.sqlite",
+        std::process::id()
+    ));
+    for s in ["", "-wal", "-shm"] {
+        let mut q = p.as_os_str().to_os_string();
+        q.push(s);
+        let _ = std::fs::remove_file(std::path::PathBuf::from(q));
+    }
+    p
+}
+
+fn store(name: &str) -> WorldStore {
+    WorldStore::open(&tmp(name)).expect("store")
+}
+
+fn candidate() -> SameAsCandidate {
+    SameAsCandidate::propose(
+        CandidatePair::new(eid("track-a"), eid("track-b")).expect("distinct"),
+        MatcherIdentity::new("track-matcher", "siamese-v2", "2.3.1").expect("matcher"),
+        Confidence::new(Some(0.9), ConfidenceBasis::ModelScore, None).expect("confidence"),
+        vec![obs(OBS)],
+    )
+    .expect("candidate")
+}
+
+fn candidate_row<'a>(event: &'a EventId, observation: &'a ObservationId) -> CandidateRow<'a> {
+    CandidateRow {
+        event_id: event,
+        observation_id: observation,
+        txn_time_ms: T0,
+        valid_from_ms: T0,
+        source: "track-matcher",
+        source_version: "2.3.1",
+    }
+}
+
+fn adjudication_row<'a>(event: &'a EventId, observation: &'a ObservationId) -> AdjudicationRow<'a> {
+    AdjudicationRow {
+        event_id: event,
+        observation_id: observation,
+        txn_time_ms: T0 + 10,
+        valid_from_ms: T0 + 10,
+        source: "console-operator",
+        source_version: "1.0.0",
+        writer_class: WriterClass::Operator,
+    }
+}
+
+fn merge() -> MergeEntities {
+    MergeEntities::new([eid("track-a")], eid("track-b"), just(), at(T0 as u64 + 10)).expect("merge")
+}
+
+fn forget() -> ForgetEntity {
+    ForgetEntity::new(
+        eid("track-z"),
+        RetirementReason::new("decommissioned").expect("reason"),
+        just(),
+        at(T0 as u64 + 10),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// The differential control, one per wrapped operation.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn propose_same_as_writes_exactly_what_the_domain_door_writes() {
+    let (event, observation) = (evt(EVT), obs(CAND_OBS));
+
+    let mut via_command = store("propose-cmd");
+    let mut engine = CommandEngine::new(&mut via_command);
+    engine
+        .execute(ProposeSameAs {
+            row: candidate_row(&event, &observation),
+            candidate: candidate(),
+        })
+        .expect("command");
+
+    let mut direct = store("propose-direct");
+    direct
+        .append_same_as_candidate(&candidate_row(&event, &observation), &candidate())
+        .expect("direct");
+
+    assert_eq!(
+        via_command.head_chain().expect("chain"),
+        direct.head_chain().expect("chain"),
+        "the command wrote a different event than append_same_as_candidate — \
+         the wrapper decided something the domain door does not"
+    );
+}
+
+#[test]
+fn record_merge_writes_exactly_what_append_adjudication_writes() {
+    let (event, observation) = (evt(DECIDE_EVT), obs(DECIDE_OBS));
+
+    let mut via_command = store("merge-cmd");
+    let mut engine = CommandEngine::new(&mut via_command);
+    engine
+        .execute(RecordMerge {
+            row: adjudication_row(&event, &observation),
+            merge: merge(),
+        })
+        .expect("command");
+
+    let mut direct = store("merge-direct");
+    direct
+        .append_adjudication(
+            &adjudication_row(&event, &observation),
+            &IdentityAdjudication::Merge(merge()),
+        )
+        .expect("direct");
+
+    assert_eq!(
+        via_command.head_chain().expect("chain"),
+        direct.head_chain().expect("chain"),
+        "RecordMerge and append_adjudication(Merge) produced different logs"
+    );
+}
+
+#[test]
+fn record_forget_writes_exactly_what_append_adjudication_writes() {
+    let (event, observation) = (evt(DECIDE_EVT), obs(DECIDE_OBS));
+
+    let mut via_command = store("forget-cmd");
+    let mut engine = CommandEngine::new(&mut via_command);
+    engine
+        .execute(RecordForget {
+            row: adjudication_row(&event, &observation),
+            forget: forget(),
+        })
+        .expect("command");
+
+    let mut direct = store("forget-direct");
+    direct
+        .append_adjudication(
+            &adjudication_row(&event, &observation),
+            &IdentityAdjudication::Forget(forget()),
+        )
+        .expect("direct");
+
+    assert_eq!(
+        via_command.head_chain().expect("chain"),
+        direct.head_chain().expect("chain"),
+        "RecordForget and append_adjudication(Forget) produced different logs"
+    );
+}
+
+#[test]
+fn adjudicate_same_as_writes_exactly_what_the_domain_door_writes() {
+    let (cand_event, cand_obs) = (evt(EVT), obs(CAND_OBS));
+    let (dec_event, dec_obs) = (evt(DECIDE_EVT), obs(DECIDE_OBS));
+
+    // Both stores need the candidate present first: the adjudication names a
+    // PERSISTED candidate and the store loads it.
+    let seed = |s: &mut WorldStore| {
+        s.append_same_as_candidate(&candidate_row(&cand_event, &cand_obs), &candidate())
+            .expect("seed");
+    };
+    let request = || SameAsAdjudicationRequest {
+        event_id: &dec_event,
+        observation_id: &dec_obs,
+        candidate_observation_id: CAND_OBS,
+        cited: vec![obs(OBS)],
+        authority: AdjudicationAuthority::new(SourceClass::Operator, "console-operator")
+            .expect("authority"),
+        outcome: Outcome::Promoted,
+        decided_at: at(T0 as u64 + 10),
+        txn_time_ms: T0 + 10,
+        source: "console-operator",
+        source_version: "1.0.0",
+    };
+
+    let mut via_command = store("adjudicate-cmd");
+    seed(&mut via_command);
+    let mut engine = CommandEngine::new(&mut via_command);
+    engine
+        .execute(AdjudicateSameAs { request: request() })
+        .expect("command");
+
+    let mut direct = store("adjudicate-direct");
+    seed(&mut direct);
+    direct.adjudicate_same_as(&request()).expect("direct");
+
+    assert_eq!(
+        via_command.head_chain().expect("chain"),
+        direct.head_chain().expect("chain"),
+        "AdjudicateSameAs and adjudicate_same_as produced different logs"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Non-vacuity. Without this, every assertion above would also pass against a
+// `head_chain` that returned a constant.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_divergent_wrapper_is_caught_by_the_digest() {
+    let (event, observation) = (evt(DECIDE_EVT), obs(DECIDE_OBS));
+
+    let mut a = store("divergent-a");
+    a.append_adjudication(
+        &adjudication_row(&event, &observation),
+        &IdentityAdjudication::Merge(merge()),
+    )
+    .expect("merge");
+
+    // The SAME row, the SAME entities, the SAME justification and instant --
+    // and a different verb. This is the smallest divergence a mis-wired
+    // wrapper could produce: `RecordForget` dispatching into `Merge`.
+    let mut b = store("divergent-b");
+    b.append_adjudication(
+        &adjudication_row(&event, &observation),
+        &IdentityAdjudication::Forget(forget()),
+    )
+    .expect("forget");
+
+    assert_ne!(
+        a.head_chain().expect("chain"),
+        b.head_chain().expect("chain"),
+        "the digest cannot tell two different adjudications apart, so every \
+         equality assertion in this file is vacuous"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The two scope fences, pinned so a later edit has to argue with them.
+// ---------------------------------------------------------------------------
+
+const COMMAND_SOURCE: &str = include_str!("../src/command.rs");
+
+#[test]
+fn no_command_can_record_an_assert_because_5d_is_unruled() {
+    // `IdentityAdjudication` has four verbs; this surface wraps three. `Assert`
+    // is operator teaching -- box 5d, BLOCKED ON RULING. A single wide
+    // `RecordIdentityAdjudication` taking any variant would have carried it in
+    // as a side effect and unblocked 5d by accident.
+    //
+    // Asserted against the source rather than the type system because the
+    // absence of a variant is not something a type can state.
+    let executable: String = COMMAND_SOURCE
+        .lines()
+        .filter(|l| !l.trim_start().starts_with("//"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        !executable.contains("IdentityAdjudication::Assert"),
+        "a command now records an Assert. That is box 5d (operator teaching), \
+         which is blocked on ruling what writer class an operator assertion \
+         carries and whether it may outrank sensed evidence."
+    );
+}
+
+#[test]
+fn a_merge_command_carries_no_authority_and_that_is_the_open_finding() {
+    // Two routes reach canonical identity. `adjudicate_same_as` requires an
+    // `AdjudicationAuthority` -- Operator-only by KIRRA-WM-PROMOTION-001.
+    // `append_adjudication`, which a Merge rides to `Lifecycle::Merged` and on
+    // into identity resolution, requires nothing.
+    //
+    // This test does NOT assert the asymmetry is correct. It asserts that the
+    // command layer did not paper over it, because papering over it -- adding
+    // an authority requirement here that the domain does not have -- is exactly
+    // the "new semantics hidden inside a command wrapper" 5c.1 forbids, and it
+    // would leave the ungated domain call available to anyone holding
+    // `&mut WorldStore` while looking fixed.
+    //
+    // When the ruling lands and `kirra_world::adjudication` grows the gate,
+    // this test is the thing that should fail and be rewritten.
+    let merge_decl = COMMAND_SOURCE
+        .split("pub struct RecordMerge")
+        .nth(1)
+        .expect("RecordMerge is declared")
+        .split('}')
+        .next()
+        .expect("its fields");
+    assert!(
+        !merge_decl.contains("authority"),
+        "RecordMerge grew an authority field. If the domain now requires one, \
+         this fence has served its purpose -- delete it and record the ruling. \
+         If the domain does NOT, this is a tightening invented at the wrapper."
+    );
+
+    // And the other half, so this is a statement about the asymmetry rather
+    // than about one struct: the same_as route DOES carry it.
+    assert!(
+        COMMAND_SOURCE.contains("AdjudicationAuthority"),
+        "the module must still name the authority it carries for same_as"
+    );
+}

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -5752,3 +5752,147 @@ is the rule this tier exists to stop violating.
 
 Until those are ruled, the honest state of 5c.2 is *"four candidates, three of
 them waiting on a consumer"* — not *"one of eight queries done"*.
+
+### KIRRA-WM-RELATED-V1-001 — `Related` is complete at v1 — 2026-08-21
+
+Ruled, closing open question 2 from the §8 re-audit:
+
+> **`Related` answers the currently promoted DIRECT relationship state. It does
+> not compute transitive depth or closure. Historical `At` is an additive future
+> extension, not part of v1 completeness.**
+
+The reasoning, recorded because the ruling reads as a narrowing and is not one:
+
+* **`Depth` is refused, permanently.** It would imply semantics the architecture
+  explicitly declined to infer. `KIRRA-WM-TRANSITIVITY-001` bans deriving
+  `a=c` from `a=b`,`b=c` when evidence is written; a depth-walking `Related`
+  would derive exactly that when it is read. The blueprint signature
+  `Related(EntityRef, Predicate, Depth, At)` predates that ruling.
+* **`At` is additive, not missing.** `relationships_in_effect_at` already
+  supports the query, and `KIRRA-WM-ADJUDICATION-PRECEDENCE-001` already defines
+  what an historical answer means. Adding it later changes nothing about what a
+  command layer wraps today, which is why waiting for it would have been waiting
+  for nothing.
+* **`Predicate` is absent because v1 promotes `same_as` only.** A predicate
+  parameter over a one-element domain is a parameter that cannot vary.
+
+The operational consequence, and the reason the ruling was needed when it was:
+**5c.1 could not start against a moving operation set.** `KIRRA-WM-TIER5-CQRS-001`
+requires commands to wrap the EXISTING domain operations with no new semantics,
+so "which operations exist" has to be settled before the wrapper is designed.
+It is now.
+
+### 5c.1 closed: the write side gets the door the read side had — 2026-08-21
+
+Box 3d gave reads one sanctioned way in. This is the write half, and the
+symmetry is the design: `crates/kirra-world-service/src/command.rs` holds a
+sealed [`WorldCommand`] trait and a [`CommandEngine`] with compile-time outcome
+types, exactly as `query.rs` does.
+
+#### What the box forbade, and how that was made structural
+
+`KIRRA-WM-TIER5-CQRS-001` allows a command surface over existing operations and
+forbids one thing — *"no new semantics hidden inside command wrappers"*. Three
+decisions carry that rather than a promise of care:
+
+1. **A command carries an already-constructed domain value, never its parts.**
+   `RecordMerge` takes a `MergeEntities`, not `sources` and `into`.
+   `MergeEntities::new` is where a merge is judged well-formed — empty sources,
+   duplicate source, merge-into-self — and a command taking raw parts would make
+   that judgement a second time. The wrapper **cannot** validate differently
+   because it never sees anything to validate.
+2. **No `CommandError`.** The blueprint's `| Refused` invites a flattened
+   refusal enum, which would destroy information: `StoreError` already
+   distinguishes *no such candidate* from *not a candidate* from *unauthorized
+   adjudicator*, and an operator told the wrong one looks in the wrong place.
+3. **Authority is carried, never re-checked.** `AdjudicationAuthority` refuses
+   any class but `Operator` at construction, so a held authority is an
+   authorized one. A check in the command layer would be a second place
+   authority is decided.
+
+#### The control, and why it is not a reading of the code
+
+The property is about what the wrapper does NOT do, and the usual test for that
+is to read it and agree it looks harmless. The control here is **differential**:
+each command runs against one store while the domain operation it wraps runs
+against a second from the identical state, and the two `head_chain()` digests
+are compared. That digest covers the canonical bytes of every event, so the
+assertion is not *"both succeeded"* but *"the log the command produced is
+indistinguishable from the log the domain call produced"*.
+
+`a_divergent_wrapper_is_caught_by_the_digest` runs the same comparison across a
+deliberately different write and asserts the digests DIFFER — without it, every
+equality above would also hold against a `head_chain` returning a constant.
+
+| Mutation | Caught by |
+|---|---|
+| the wrapper overrides `writer_class` | `record_merge_writes_exactly_what_append_adjudication_writes` |
+| the wrapper stamps its own `source` | `propose_same_as_writes_exactly_what_the_domain_door_writes` |
+| a command records an `Assert` | `no_command_can_record_an_assert_because_5d_is_unruled` |
+| `RecordMerge` grows an authority field | `a_merge_command_carries_no_authority_and_that_is_the_open_finding` |
+
+The fourth was run twice. The first attempt added the field without updating the
+test's construction site, so it failed to COMPILE — a red build, but not
+evidence the fence fires. Redone the way an author would, fixing the
+construction site, it failed on the fence. The first result was discarded.
+
+#### Rule 1 paid in the same PR, by the gate's insistence
+
+`check_orphan_cores` flagged `kirra_world_service::command` as `[NEW]` the
+moment it existed. That is rule 1 working: a command surface nobody calls is a
+declaration with no production consumer, and 5a's projection had already spent
+two boxes carrying exactly that debt.
+
+It was paid rather than baselined. `kirra-world-ingest` — the production writer
+from box 2a — now proposes through `CommandEngine::execute(ProposeSameAs { .. })`
+instead of calling `append_same_as_candidate` directly, the same migration
+`mission_context` made for reads. **All 44 ingest tests pass unchanged**, which
+is the evidence the migration is behaviour-preserving; the differential control
+is the evidence it is *structurally* so.
+
+#### The asymmetry this box surfaced and deliberately did not fix
+
+Auditing every write door to build the surface found **two routes to canonical
+identity change, only one gated**:
+
+| Door | Authority |
+|---|---|
+| `append_same_as_candidate` | pins `Derivation`/`Candidate` — structurally cannot promote |
+| `adjudicate_same_as` | requires `AdjudicationAuthority` — `Operator` only, per `KIRRA-WM-PROMOTION-001` |
+| `append_adjudication` (Merge / Split / Forget) | **none** |
+
+A `Merge` reaches `Lifecycle::Merged { into }`, the entity projection, and
+identity resolution — the same canonical-identity effect a promoted `same_as`
+has, by a route carrying no adjudicator at all.
+
+**The command layer did not close it, and the restraint is the finding.**
+Requiring an authority token at the wrapper that the domain does not require is
+precisely the new-semantics-in-a-wrapper the box forbids: it would look fixed
+while leaving the ungated domain call available to anyone holding
+`&mut WorldStore`. The fix belongs in `kirra_world::adjudication` and needs a
+ruling — **may an identity adjudication be recorded without an authorized
+adjudicator?** Pinned by
+`a_merge_command_carries_no_authority_and_that_is_the_open_finding`, which is
+written to FAIL when the ruling lands.
+
+Not a live hole today: `append_adjudication` has no production caller at all —
+its callers are tests, in four crates.
+
+#### What is wrapped, and what is not
+
+Five of §14.1's nine commands have a domain operation behind them and are
+wrapped: `ProposeSameAs`, `AdjudicateSameAs`, `RecordMerge`, `RecordSplit`,
+`RecordForget`. The other four are refusals with reasons, not a to-do list:
+
+* **`AssertEntity`** — box 5d, blocked on ruling. `IdentityAdjudication` has
+  four verbs and this surface wraps three; one wide `RecordIdentityAdjudication`
+  taking any variant would have carried `Assert` in as a side effect and
+  unblocked 5d by accident. Three narrow commands instead of one wide one.
+* **`RecordObservation`** — the underlying `WorldStore::append` takes
+  `writer_class` and `claim_status` as free parameters. A wrapper either passes
+  them through (an alias, not a command) or chooses them (deciding the two
+  fields the whole trust model rests on, inside a wrapper).
+* **`ConfirmEntity` / `CorrectObservation` / `RetractAssertion`** — no domain
+  operation exists. Writing the command first would put the semantics in the
+  wrapper by definition, there being nowhere else for them to live.
+* **`ImportMapLayer`** — map layers unstarted, gated on a consumer.


### PR DESCRIPTION
Box 3d gave reads one sanctioned way in. This is the write half, and the symmetry is the design: a sealed `WorldCommand` trait and a `CommandEngine` with compile-time outcome types, exactly as `query.rs` does.

Also records **`KIRRA-WM-RELATED-V1-001`**, the ruling that unblocked this box: `Related` answers the currently promoted **direct** relationship state, does not compute transitive depth or closure, and treats historical `At` as an additive future extension. `Depth` is refused permanently — a depth-walking `Related` would derive at *read* time the `a=c` from `a=b`,`b=c` that `TRANSITIVITY-001` bans at *write* time. The ruling had to come first because `CQRS-001` requires commands to wrap the **existing** operations, so "which operations exist" had to stop moving.

## What the box forbids, made structural

`KIRRA-WM-TIER5-CQRS-001` forbids exactly one thing: *no new semantics hidden inside command wrappers*. Three decisions carry that instead of a promise to be careful.

1. **A command carries an already-constructed domain value, never its parts.** `RecordMerge` takes a `MergeEntities`, not `sources` and `into`. `MergeEntities::new` is where a merge is judged well-formed — empty sources, duplicate source, merge-into-self — and a command taking raw parts would make that judgement a second time. The wrapper **cannot** validate differently, because it never sees anything to validate.
2. **No `CommandError`.** The blueprint's `| Refused` invites a flattened refusal enum. That would destroy information: `StoreError` already separates *no such candidate* from *not a candidate* from *unauthorized adjudicator*, and an operator told the wrong one looks in the wrong place.
3. **Authority is carried, never re-checked.** `AdjudicationAuthority` refuses any class but `Operator` at construction, so a held authority is already an authorized one. A check here would be a second place authority is decided.

## The control is differential, not a reading of the code

The property is about what the wrapper *does not do*, and the usual test for that is to read it and agree it looks harmless. Instead: each command runs against one store while the domain operation it wraps runs against a second from the identical starting state, and the two `head_chain()` digests are compared. That digest covers the canonical bytes of every event, so the assertion is not "both succeeded" but **"the log the command produced is indistinguishable from the log the domain call produced."**

`a_divergent_wrapper_is_caught_by_the_digest` runs the same comparison across a deliberately different write and asserts the digests **differ** — without it every equality above would also hold against a `head_chain` returning a constant.

| Mutation | Caught by |
|---|---|
| wrapper overrides `writer_class` | `record_merge_writes_exactly_what_append_adjudication_writes` |
| wrapper stamps its own `source` | `propose_same_as_writes_exactly_what_the_domain_door_writes` |
| a command records an `Assert` | `no_command_can_record_an_assert_because_5d_is_unruled` |
| `RecordMerge` grows an authority field | `a_merge_command_carries_no_authority_and_that_is_the_open_finding` |

The fourth was run twice. The first attempt added the field without updating the test's construction site, so it failed to **compile** — a red build, but not evidence the fence fires. Redone the way an author actually would, fixing the construction site, it failed on the fence. The first result was discarded.

## Rule 1 paid here, not baselined

`check_orphan_cores` flagged `kirra_world_service::command` as `[NEW]` the moment it existed. That is rule 1 working — a command surface nobody calls is a declaration with no production consumer, and 5a's projection had already carried exactly that debt for two boxes.

So `kirra-world-ingest` — the production writer from box 2a — now proposes through `CommandEngine::execute(ProposeSameAs { .. })` instead of calling `append_same_as_candidate` directly. Same migration `mission_context` made for reads in 3d. **All 44 ingest tests pass unchanged**, which is the behavioural evidence the migration is a no-op; the differential control is the structural evidence.

## The asymmetry this box surfaced and deliberately did not fix

Auditing every write door to build the surface found **two routes to canonical identity change, only one gated**:

| Door | Authority |
|---|---|
| `append_same_as_candidate` | pins `Derivation`/`Candidate` — structurally cannot promote |
| `adjudicate_same_as` | requires `AdjudicationAuthority` — `Operator` only, per `KIRRA-WM-PROMOTION-001` |
| `append_adjudication` (Merge / Split / Forget) | **none** |

A `Merge` reaches `Lifecycle::Merged { into }` → the entity projection → identity resolution: the same canonical-identity effect a promoted `same_as` has, by a route carrying no adjudicator at all.

**This change does not close it, and the restraint is the finding.** Requiring an authority token at the wrapper that the domain does not require is precisely the new-semantics-in-a-wrapper the box forbids — it would look fixed while leaving the ungated domain call available to anyone holding `&mut WorldStore`. The fix belongs in `kirra_world::adjudication` and needs a ruling: **may an identity adjudication be recorded without an authorized adjudicator?**

Not a live hole today: `append_adjudication` has no production caller at all — its callers are tests, in four crates. Pinned by a test written to **fail** when the ruling lands.

## Five wrapped, four refused with reasons

Wrapped: `ProposeSameAs`, `AdjudicateSameAs`, `RecordMerge`, `RecordSplit`, `RecordForget`.

- **`AssertEntity`** — box 5d, blocked on ruling. `IdentityAdjudication` has four verbs and this wraps three; one wide `RecordIdentityAdjudication` taking any variant would have carried `Assert` in as a side effect and unblocked 5d by accident. Three narrow commands instead.
- **`RecordObservation`** — the underlying `WorldStore::append` takes `writer_class` and `claim_status` as free parameters. A wrapper either passes them through (an alias, not a command) or chooses them (deciding the two fields the whole trust model rests on, inside a wrapper).
- **`ConfirmEntity` / `CorrectObservation` / `RetractAssertion`** — no domain operation exists, so the command would *be* the semantics.
- **`ImportMapLayer`** — map layers unstarted, gated on a consumer.

## Verification

- `cargo test --workspace` — **275 result groups, 0 failed**
- `cargo test -p kirra-world-service --test command_surface` — 7/7
- `cargo test -p kirra-world-ingest` — 44 passing, unchanged by the migration
- `cargo fmt --all -- --check`, `cargo clippy -p kirra-world-service -p kirra-world-ingest --all-targets` — clean
- Gate sweep: `check_query_boundedness`, `check_orphan_cores`, `check_kirra_world_bidirectional_fence`, `check_world_semantics`, `check_world_answer_boundary`, `check_world_domain_logic_gate`, `check_explain_artifact_neutral`, `check_reexport_shims`, `check_quality_guardrails`, `check_website_citations`, `check_freshness_coverage`, `check_mick_actuation_fence` — all pass

Note on the dependency edge: `kirra-world-ingest` now depends on `kirra-world-service`, which carries `kirra-world-ingest` as a **dev**-dependency (5b's end-to-end test drives a real ingest pass). Cargo permits a dev-dependency cycle; the runtime edge goes one way only, writer → door.

Drive-by: fixed a pre-existing broken doclink in the same doc block (`propose_from_claims` → `propose_from_agreements`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_