### PR TITLE
Rule the last two open §8 questions: Explain/Freshness discharged, ChangesSince gated

### DIFF
--- a/crates/kirra-world-service/tests/query_discharge.rs
+++ b/crates/kirra-world-service/tests/query_discharge.rs
@@ -1,0 +1,290 @@
+//! **`KIRRA-WM-EXPLAIN-FRESHNESS-DISCHARGE-001` — the two controls the ruling
+//! needed that the existing suites do not carry.**
+//!
+//! The ruling:
+//!
+//! > **`Explain` and `Freshness` are DISCHARGED — as an operation and as a
+//! > classifier respectively — not outstanding queries.**
+//!
+//! Most of the argument for it is already under test elsewhere, and this file
+//! deliberately does not restate that. `explain_current_subject`'s bounds come
+//! from this crate's constants rather than from the data
+//! (`the_walk_is_bounded_by_this_crates_constants_not_by_the_data`) and it is a
+//! pure function of the store (`two_calls_against_an_unchanged_store_are_
+//! identical`); the ruled freshness table is exercised across both dispositions
+//! and refuses what it has not ruled (`tests/freshness_policy.rs`, eleven cases).
+//!
+//! Two things were NOT covered, and they are the two the ruling turns on.
+//!
+//! # 1. The existing explain bound test would survive the change that matters
+//!
+//! `the_walk_is_bounded_by_this_crates_constants_not_by_the_data` proves the
+//! DATA cannot widen the walk. It would keep passing if the operation grew a
+//! caller-supplied `depth` parameter and the test passed a small value — and a
+//! caller-supplied bound is exactly what turns an operation back into a query
+//! surface. The module docs give the reason it must not: *"there is no argument
+//! a caller could set to make the work larger, so there is nothing to abuse."*
+//!
+//! So the control here is on that axis rather than on the word *Explain*: the
+//! signature admits a store and a subject NAME, and nothing else.
+//!
+//! # 2. Freshness is ruled in one place, and nothing checked the answer agrees
+//!
+//! The existing cases assert specific dispositions by hand — an old
+//! `last_seen_at` is `Stale`, an equally old `colour` is `Timeless`. Every one
+//! of those expectations is written out beside the row it tests, so the table
+//! and the read path can drift apart while both halves of each test agree with
+//! each other.
+//!
+//! [`the_validity_on_an_answer_agrees_with_the_ruled_table`] derives its
+//! expectation from [`resolve_policy`] instead. That is the discharge argument
+//! stated as a test: a `Freshness(FieldRef, At)` query would be a SECOND place
+//! freshness is decided, and this fails the moment a second place disagrees
+//! with the first.
+
+use kirra_explain_types::ExplanationArtifact;
+use kirra_world_service::explain_subject::{explain_current_subject, ExplainError};
+use kirra_world_service::freshness::{
+    resolve_policy, FreshnessPolicy, FreshnessSource, SemanticClass, RULED,
+};
+use kirra_world_service::query::{Ask, QueryEngine};
+use kirra_world_service::read_view::WorldLookup;
+use kirra_world_store::{
+    ClaimStatus, EventId, NewEvent, ObservationId, Validity, WorldStore, WriterClass,
+};
+
+const T0: i64 = 1_700_000_000_000;
+const SUBJECT: &str = "package_17";
+
+/// Inside every `Bounded` row in the table. One millisecond, so the fixture
+/// cannot pass by accident on a row whose bound is small.
+const YOUNG: i64 = T0 + 1;
+/// Past every `Bounded` row in the table.
+const OLD: i64 = T0 + 60 * 60 * 1_000;
+
+// ---------------------------------------------------------------------------
+// harness
+// ---------------------------------------------------------------------------
+
+fn tmp(name: &str) -> std::path::PathBuf {
+    static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let n = NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "kirra-discharge-{name}-{}-{n}.sqlite",
+        std::process::id()
+    ));
+    cleanup(&p);
+    p
+}
+
+fn cleanup(path: &std::path::Path) {
+    for suffix in ["", "-wal", "-shm"] {
+        let mut q = path.as_os_str().to_os_string();
+        q.push(suffix);
+        let _ = std::fs::remove_file(std::path::PathBuf::from(q));
+    }
+}
+
+fn claim(store: &mut WorldStore, tag: &str, kind: &str, predicate: &str) {
+    store
+        .append(&NewEvent {
+            event_id: &EventId::new(format!("ev-{tag}")).expect("event id"),
+            observation_id: &ObservationId::new(format!("obs-{tag}")).expect("obs"),
+            txn_time_ms: T0,
+            valid_from_ms: T0,
+            valid_to_ms: None,
+            source: "warehouse-scanner",
+            source_version: "1.0.0",
+            writer_class: WriterClass::Sensor,
+            claim_status: ClaimStatus::Confirmed,
+            provenance: &[],
+            frame_id: None,
+            map_id: None,
+            kind,
+            subject: SUBJECT,
+            predicate: Some(predicate),
+            subject_ref: None,
+            object: None,
+            payload: "{}",
+            payload_schema: 1,
+            retention_class: "raw",
+            trust: None,
+        })
+        .expect("append");
+}
+
+// ---------------------------------------------------------------------------
+// 1. Explain is an OPERATION: the caller supplies a name and nothing else
+// ---------------------------------------------------------------------------
+
+/// **The signature pin.**
+///
+/// A `fn` item coerces to a `fn` pointer only if the signature matches exactly,
+/// so this stops compiling the moment `explain_current_subject` grows a
+/// parameter — a depth, a page, a generation, a handle. Any of those would make
+/// the work caller-settable, which is the property that distinguishes the
+/// operation this ruling calls discharged from the query surface it declines to
+/// become.
+///
+/// It is a `const` rather than a comment because a comment cannot fail.
+const EXPLAIN_TAKES_A_STORE_AND_A_SUBJECT_NAME: fn(
+    &WorldStore,
+    &str,
+) -> Result<ExplanationArtifact, ExplainError> = explain_current_subject;
+
+/// The pin is exercised, not merely declared.
+///
+/// A `const` fn pointer nobody calls proves the signature typechecks and
+/// nothing about the operation being reachable through it. This calls the
+/// operation THROUGH the pinned pointer, so the pin is on the live route.
+#[test]
+fn the_explain_operation_is_reachable_through_the_pinned_signature() {
+    let path = tmp("explain-pin");
+    let store = WorldStore::open(&path).expect("open");
+
+    // An empty store: the interesting part is the CALL, and `NothingRecorded`
+    // is the honest empty this operation is documented to return.
+    match EXPLAIN_TAKES_A_STORE_AND_A_SUBJECT_NAME(&store, SUBJECT) {
+        Err(ExplainError::NothingRecorded) => {}
+        other => panic!("expected NothingRecorded from an empty store, got {other:?}"),
+    }
+
+    drop(store);
+    cleanup(&path);
+}
+
+// ---------------------------------------------------------------------------
+// 2. Freshness is decided ONCE, and the answer carries that decision
+// ---------------------------------------------------------------------------
+
+/// What the ruled table SAYS an answer of this age should be.
+///
+/// The state machine from the `freshness` module docs, written once here and
+/// applied to every row — as opposed to an expectation written out beside each
+/// row, which is what lets a table and a read path drift while every test
+/// agrees with itself.
+fn expected(policy: FreshnessPolicy, age_ms: i64) -> Validity {
+    match policy {
+        FreshnessPolicy::Timeless => Validity::Timeless,
+        FreshnessPolicy::Bounded { max_age_ms } => {
+            if age_ms <= i64::try_from(max_age_ms).expect("bound fits an i64") {
+                Validity::Fresh
+            } else {
+                Validity::Stale
+            }
+        }
+    }
+}
+
+/// **A `Freshness` query would be a second place freshness is decided.**
+///
+/// This is that claim as a control: for every ruled class a sensor can write,
+/// at a clock inside its bound and at a clock past it, the validity riding on
+/// the ANSWER equals what [`resolve_policy`] independently returns.
+///
+/// It fails if the read path stops consulting the table, if the table stops
+/// reaching the read path, and if a second classification appears anywhere and
+/// disagrees with the first.
+#[test]
+fn the_validity_on_an_answer_agrees_with_the_ruled_table() {
+    let path = tmp("agreement");
+    let mut store = WorldStore::open(&path).expect("open");
+
+    // EVERY ruled row, with no exception mechanism.
+    //
+    // A first draft had one — a named list of rows "a sensor claim cannot
+    // produce", holding the adjudicated-identity row. Emptying that list was
+    // the check on whether the exemption was real, and every test still passed:
+    // the store does not constrain the `kind` string, so the row appends like
+    // any other and was never uncovered. An exemption that exempts nothing, and
+    // a guard comparing two lists that move together, are worse than no
+    // scaffolding at all, so both were deleted rather than documented.
+    //
+    // What that leaves is honest about its own reach: the identity row is
+    // written HERE as a sensor claim, which is not how production writes it
+    // (`RecordMerge`, with an `AdjudicationAuthority`). This proves the read
+    // path agrees with the TABLE for that class — the claim the ruling makes —
+    // not that the production write path emits such a row.
+    let ruled: Vec<SemanticClass> = RULED.iter().map(|(class, _)| *class).collect();
+
+    for (n, class) in ruled.iter().enumerate() {
+        claim(
+            &mut store,
+            &format!("row{n}"),
+            class.kind,
+            class
+                .predicate
+                .expect("every ruled row here has a predicate"),
+        );
+    }
+    store.fold().expect("fold");
+
+    // Non-vacuity, asserted rather than hoped for: the fixture must span both
+    // dispositions AND both sides of a bound, or the loop below could pass
+    // while `expected` collapsed to a constant.
+    let mut seen: Vec<Validity> = Vec::new();
+    let mut checked = 0_usize;
+
+    for now_ms in [YOUNG, OLD] {
+        let age = now_ms - T0;
+        let composed = QueryEngine::new(&store, FreshnessSource::Ruled)
+            .execute(Ask {
+                subject: SUBJECT.to_owned(),
+                now_ms,
+            })
+            .expect("every claim in the fixture is ruled, so the query answers");
+
+        let WorldLookup::Answered(answers) = composed.lookup() else {
+            panic!("the fixture must answer, got {:?}", composed.lookup());
+        };
+
+        for class in &ruled {
+            let policy = resolve_policy(FreshnessSource::Ruled, class.kind, class.predicate)
+                .expect("the class came from RULED, so it resolves");
+            let answer = answers
+                .iter()
+                .find(|a| a.predicate() == class.predicate)
+                .unwrap_or_else(|| panic!("no answer for {:?}", class.predicate));
+
+            let want = expected(policy, age);
+            assert_eq!(
+                answer.validity(),
+                want,
+                "at age {age}ms the answer for {}/{:?} carries {:?}, but the ruled \
+                 table says {want:?}. The read path and the table disagree, which \
+                 is the second-decision-point this ruling exists to keep out.",
+                class.kind,
+                class.predicate,
+                answer.validity(),
+            );
+            seen.push(want);
+            checked += 1;
+        }
+    }
+
+    // Guards the one coverage failure the loop above cannot report itself: a
+    // filter reintroduced on the CHECK loop, which silently shrinks what is
+    // asserted. (A row that is iterated but never written fails earlier and
+    // louder, at the `no answer for ...` lookup — that case is covered, just
+    // not by this assertion.)
+    assert_eq!(
+        checked,
+        RULED.len() * 2,
+        "every ruled row must be checked at both clocks — {checked} checks for \
+         {} rows means a row was not reached",
+        RULED.len(),
+    );
+
+    for required in [Validity::Fresh, Validity::Stale, Validity::Timeless] {
+        assert!(
+            seen.contains(&required),
+            "the fixture never produced {required:?}, so the agreement above \
+             could hold with `expected` collapsed to a constant. Non-vacuity \
+             requires all three."
+        );
+    }
+
+    drop(store);
+    cleanup(&path);
+}

--- a/docs/design/WM_SCOPE.md
+++ b/docs/design/WM_SCOPE.md
@@ -5744,14 +5744,23 @@ is the rule this tier exists to stop violating.
 
 1. Are `Explain` and `Freshness` **discharged in another form** — an operation
    and a classifier respectively — rather than outstanding queries?
+   > **Settled 2026-08-26** by `KIRRA-WM-EXPLAIN-FRESHNESS-DISCHARGE-001`,
+   > recorded below. Both discharged.
 2. Is `Related` **complete at v1** without `Predicate`/`Depth`, with `Depth`
    ruled permanently out under `KIRRA-WM-TRANSITIVITY-001` and `At` left as an
    additive extension when a consumer needs history?
+   > **Settled 2026-08-21** by `KIRRA-WM-RELATED-V1-001`, recorded below.
 3. Does `ChangesSince` get designed as a bounded family now, or stay gated on a
    consumer with `changed_since` remaining fenced-and-unbounded?
+   > **Settled 2026-08-26** by `KIRRA-WM-CHANGES-SINCE-GATED-001`, recorded
+   > below. Gated.
 
-Until those are ruled, the honest state of 5c.2 is *"four candidates, three of
-them waiting on a consumer"* — not *"one of eight queries done"*.
+All three are now ruled. With `Explain` and `Freshness` discharged and
+`ChangesSince` gated, the honest state of 5c.2 is **three candidates, all three
+waiting on a consumer** — `WhatIsAt`, `Resolve`, `Capabilities` — which is not
+a smaller version of *"seven of eight queries left"*. It is a different
+statement: there is no query work available that rule 1 permits, so the next
+move on 5c.2 is finding a consumer rather than writing a query.
 
 ### KIRRA-WM-RELATED-V1-001 — `Related` is complete at v1 — 2026-08-21
 
@@ -5995,3 +6004,158 @@ unblock box 5d: operator teaching remains blocked on what writer class an
 operator assertion carries and whether it may outrank sensed evidence, and no
 command records an `Assert` — still pinned by
 `no_command_can_record_an_assert_because_5d_is_unruled`.
+
+### KIRRA-WM-EXPLAIN-FRESHNESS-DISCHARGE-001 — two of the eight are already answered — 2026-08-26
+
+Ruled, closing open question 1 from the §8 re-audit:
+
+> **`Explain` and `Freshness` are DISCHARGED — as an operation and as a
+> classifier respectively — not outstanding queries. Neither is to be added as
+> a `WorldQuery` family.**
+
+The blueprint lists eight query signatures. Two of them describe work this tree
+already does, in a form that is not a query and was not chosen by accident. The
+ruling matters because a checklist does not know that: left open, both rows read
+as gaps, and closing them **as specified** would undo the rulings that put the
+work where it is.
+
+#### `Explain` — an operation, because nobody outside can hold its argument
+
+The signature is `Explain(FactHandle)`. `KIRRA-WM-EXPLAIN-NEUTRALITY` guarantees
+no external party ever holds a World coordinate, so there is no caller who could
+construct a `FactHandle` to pass in — a query taking one would be a query nobody
+outside the boundary can call, and the way to make it callable is to hand out
+the coordinate the neutrality ruling exists to withhold.
+
+`explain_current_subject(store, subject)` is the discharged form. It takes a
+subject NAME and chooses page size, graph depth, node ceiling and pin itself,
+and its module docs give the reason that is the point rather than a limitation:
+
+> *"There is no argument a caller could set to make the work larger, so there is
+> nothing to abuse."*
+
+#### `Freshness` — a classifier, because a second one is the defect
+
+`Freshness(FieldRef, At)` asks a question every answer already carries.
+`KIRRA-WM-FRESHNESS-POLICY-001` rules freshness centrally by claim kind and
+rides the result on each answer, and that ruling exists **because the first
+place it was decided was decided by nobody** — `None` meant `Timeless`, so the
+engine asserted "this fact's age does not matter" about every fact in the store
+whenever a caller supplied no budget.
+
+A `Freshness` query would be a second place the same question is answered. Two
+places that agree are redundant; two that disagree reproduce the original defect
+with an API in front of it.
+
+#### The two controls this needed, and the one it did not
+
+Most of the argument was already under test, and this ruling deliberately did
+not restate it: `the_walk_is_bounded_by_this_crates_constants_not_by_the_data`
+and `two_calls_against_an_unchanged_store_are_identical` for the operation, and
+eleven cases in `tests/freshness_policy.rs` for the classifier. Two gaps were
+real, and `crates/kirra-world-service/tests/query_discharge.rs` closes them.
+
+**1. The existing explain-bound test would survive the change that matters.**
+It proves the DATA cannot widen the walk. It would keep passing if the operation
+grew a caller-supplied `depth` and the test passed a small value — and a
+caller-supplied bound is exactly what turns an operation back into a query
+surface. The replacement is a signature pin on that axis rather than on the word
+*Explain*: a `fn` pointer that admits a store and a subject name and nothing
+else. Mutation-verified — adding a `_depth: usize` parameter does not fail the
+assertion, it fails **compilation**, naming both signatures.
+
+**2. Nothing checked that the answer agrees with the table.** The existing
+freshness cases write each expectation out beside the row it tests, so the table
+and the read path can drift apart while both halves of every test go on agreeing
+with each other. `the_validity_on_an_answer_agrees_with_the_ruled_table` derives
+its expectation from `resolve_policy` instead, across every ruled row at a clock
+inside its bound and a clock past it. That is the discharge argument as a
+control: it fails the moment a second decision point disagrees with the first.
+
+The mutation that proves it is the original defect re-introduced —
+the `Ask` path still calls `policy_for`, and then ignores what it returns:
+
+```
+at age 1ms the answer for mission/Some("last_seen_at") carries Timeless, but the
+ruled table says Fresh. The read path and the table disagree, which is the
+second-decision-point this ruling exists to keep out.
+```
+
+Note what that mutation leaves intact. A guard asking *"does the read path
+consult the table"* would have passed it.
+
+#### One piece of scaffolding was deleted rather than documented
+
+The first draft of the agreement test carried a named exception list — rows
+*"a sensor claim cannot produce"* — holding the adjudicated-identity row, plus a
+guard asserting the list was exactly the uncovered set. Emptying the list was the
+check on whether the exemption was real, and **every test still passed**: the
+store does not constrain the `kind` string, so the row appends like any other and
+was never uncovered. The guard, meanwhile, compared two lists that move together.
+
+Both were deleted and all four ruled rows are now covered directly. Recorded
+because an exemption that exempts nothing is worse than no exemption — it reads
+as a considered carve-out. It is a cousin of the wrong-axis guards this tier has
+hit three times, not another instance: those fired on the wrong property, this
+one could not fail at all. The shared root is the same, which is why the check
+that caught it is the same one — **ask what would have to be true for the guard
+to fire, and then make that true**.
+
+What the coverage does **not** claim: the identity row is written in that test
+as a sensor claim, which is not how production writes it (`RecordMerge`, with an
+`AdjudicationAuthority`). It proves the read path agrees with the table for that
+class, not that the production write path emits such a row.
+
+### KIRRA-WM-CHANGES-SINCE-GATED-001 — `ChangesSince` is not designed yet — 2026-08-26
+
+Ruled, closing open question 3 from the §8 re-audit:
+
+> **`ChangesSince` stays gated on a consumer. `WorldStore::changed_since`
+> remains classified `unbounded` and fenced. A typed `ChangesSince` may only be
+> added as a NEW bounded family — a page and a cursor, like `History` — and only
+> alongside its first production consumer.**
+
+This is the one of the three that could have been built. It was not, and the
+reason is rule 1, which this tier exists to stop violating: every new declaration
+needs a production consumer, and there is no consumer asking what changed.
+
+The technical half is that a typed `ChangesSince` **cannot wrap** the method that
+shares its name. `changed_since` is classified `unbounded` in
+`ci/store_boundedness_baseline.json` — *"the result grows with how long ago the
+caller asks about"* — and its SQL carries no `LIMIT`. Wrapping it would be the
+exact defect class of #1440 and #1441: the answer bounded, the work not, and
+nothing showing it.
+
+There is no live hole today. Rule 5 forbids consumer crates from calling
+`changed_since`, and none does.
+
+#### The control already exists, and was verified rather than assumed
+
+No new guard was added, because adding one would have been a second mechanism
+for a property an existing gate already carries — and a redundant guard is how
+a tree ends up with guards nobody checks. `check_query_boundedness.py` rule 2
+forbids **anything in the boundary crate** from calling an unbounded store
+method, and `query.rs` is in the boundary crate.
+
+Verified by mutation rather than by reading the gate. Both plausible shapes of
+the forbidden change were written and run:
+
+```
+crates/kirra-world-service/src/query.rs:395 — the answer boundary calls the
+UNBOUNDED store method `changed_since`.
+```
+
+The second mutation is the one worth recording: a `ChangesSince { since_ms,
+page }` request that *looks* bounded and truncates the result in Rust. It reds
+identically, because the gate keys on the **call**, not on whether the result
+looks bounded — which is the axis this ruling needs it to be on. A guard keyed
+on the request type's shape would have passed it.
+
+#### What the ruling permits, with a precedent already in the tree
+
+This is a gate on the unbounded route, not a ban on the feature. The permitted
+path is the one `citations_of` already took: it was a whole-array read, was
+bounded *by argument* with a SQL `LIMIT` and one extra probe row so truncation is
+reported rather than inferred, and is classified `bounded` today. A
+`ChangesSince` built that way, with a consumer, passes the same gate that refuses
+the wrapper.


### PR DESCRIPTION
`KIRRA-WM-EXPLAIN-FRESHNESS-DISCHARGE-001` and `KIRRA-WM-CHANGES-SINCE-GATED-001` close open questions 1 and 3 from the §8 re-audit. With `KIRRA-WM-RELATED-V1-001` already settling question 2, all three are ruled.

## Ruling A — `Explain` and `Freshness` are discharged

Both describe work this tree already does, in a form that is not a query and was not chosen by accident. Closing them **as specified** would undo the rulings that put the work where it is:

- `Explain(FactHandle)` cannot be built without undoing `KIRRA-WM-EXPLAIN-NEUTRALITY` — no external party ever holds a World coordinate, so nobody outside could construct the argument. Making it callable means handing out the coordinate the neutrality ruling exists to withhold. `explain_current_subject(store, subject)` takes a subject NAME and chooses page size, depth, node ceiling and pin itself.
- `Freshness(FieldRef, At)` would be a SECOND place freshness is decided. `KIRRA-WM-FRESHNESS-POLICY-001` exists because the first place was decided by nobody — `None` meant `Timeless`, so the engine asserted "this fact's age does not matter" about every fact in the store.

## Ruling B — `ChangesSince` stays gated on a consumer

This is the one of the three that could have been built. A typed family cannot wrap `WorldStore::changed_since` (classified `unbounded`, no `LIMIT`) — it would have to be a new bounded family with a page and a cursor, and building that with no consumer is the rule-1 violation this tier exists to stop. Nothing is live today: rule 5 keeps consumer crates off `changed_since` and none calls it.

The ruling is a gate on the unbounded route, not a ban on the feature. The permitted path is the one `citations_of` already took.

## The two controls this needed

Most of the discharge argument was already under test and is cited rather than restated (`the_walk_is_bounded_by_this_crates_constants_not_by_the_data`, `two_calls_against_an_unchanged_store_are_identical`, eleven cases in `tests/freshness_policy.rs`). Two gaps were real; `crates/kirra-world-service/tests/query_discharge.rs` closes them.

**A signature pin on `explain_current_subject`.** The existing bound test proves the DATA cannot widen the walk — it would keep passing if the operation grew a caller-supplied `depth` and the test passed a small value, and a caller-supplied bound is exactly what turns an operation back into a query surface. Mutation-verified: adding `_depth: usize` does not fail an assertion, it fails **compilation**, naming both signatures.

**An agreement test deriving its expectation from `resolve_policy`**, across every ruled row at a clock inside its bound and a clock past it. The existing cases write each expectation out beside the row it tests, so table and read path can drift while every test goes on agreeing with itself. The mutation that proves it is the original defect re-introduced — the `Ask` path still calls `policy_for` and then ignores what it returns:

```
at age 1ms the answer for mission/Some("last_seen_at") carries Timeless, but the
ruled table says Fresh. The read path and the table disagree, which is the
second-decision-point this ruling exists to keep out.
```

A guard asking *"does the read path consult the table"* would have passed that.

## The control ruling B did NOT need

No new guard. `check_query_boundedness` rule 2 already forbids anything in the boundary crate from calling an unbounded store method, and `query.rs` is in the boundary crate. Verified by mutation rather than by reading the gate — both plausible shapes red, including the one that pages the result in Rust and *looks* bounded, because the gate keys on the **call**. A guard keyed on the request type's shape would have passed it.

## One piece of scaffolding deleted rather than documented

The first draft of the agreement test carried a named exception list — rows "a sensor claim cannot produce" — plus a guard asserting the list was exactly the uncovered set. Emptying the list was the check on whether the exemption was real, and **every test still passed**: the store does not constrain the `kind` string, so the row appends like any other. The guard, meanwhile, compared two lists that move together.

Both deleted; all four ruled rows now covered directly. Recorded in the doc because an exemption that exempts nothing reads as a considered carve-out.

## Where this leaves 5c.2

Three candidates — `WhatIsAt`, `Resolve`, `Capabilities` — all three gated on a consumer by rule 1. That is not a smaller version of "seven of eight queries left": there is no query work available that rule 1 permits, so the next move is finding a consumer rather than writing a query.

## Verification

- `cargo test -p kirra-world-service` — all targets green, including the 2 new cases
- gates green: query-boundedness, freshness-coverage, world-answer-boundary, world-semantics, explain-artifact-neutrality, orphan-cores, bidirectional fence, world-domain-logic, re-export shims, website-citations
- `cargo fmt --check` and `cargo clippy --all-targets` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMCmUGL26v2Hk6eufnShxW)_